### PR TITLE
fix: pre-release correctness — domain derivation, dashboard CSP, and three release gates that under-reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ some numbers you may already be reporting will move.
   pagination link would have carried the credential off-origin. It now refuses
   any pagination URL that leaves `hub.docker.com`, bounds the loop, and fails
   rather than planning deletions against a partial tag list.
+- The GHCR freshness probe had the same off-origin pagination weakness and is
+  now pinned to `ghcr.io` on the same terms. In the same pass, the surface
+  freshness monitor's tool-count assertion silently switched itself off when
+  `--expected-tool-count` was unset: only the Glama probe derived a fallback, so
+  a bare `python scripts/check_surface_freshness.py` reported a listing fresh
+  without ever checking the count. CI passed the flag, so only humans saw the
+  weaker check.
 - Configuration was being counted as credentials (`CERTIFICATE_PATH`,
   `DB_CONNECTION_POOL_SIZE`), and real credentials were being missed
   (`PGPASSWORD`, `ID_RSA`, `GOOGLE_APPLICATION_CREDENTIALS`, and every plural

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1137,
+      "value": 1138,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1137 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1138 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 835 | `src/agent_bom` | Counts all Python files recursively. |

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -187,7 +187,7 @@ def bump(new_version: str, *, dry_run: bool = False, check: bool = False) -> int
         else:
             changed += count
             if dry_run or check:
-                print(f"  DRY-RUN ({count} hit): {rel_path}")
+                print(f"  {'DRIFT' if check else 'DRY-RUN'} ({count} hit): {rel_path}")
             else:
                 path.write_text(new_text)
                 print(f"  UPDATED ({count} hit): {rel_path}")
@@ -210,7 +210,10 @@ def bump(new_version: str, *, dry_run: bool = False, check: bool = False) -> int
             print(f"  UPDATED (align sweep): {path.relative_to(ROOT)}")
         changed += sweep_count
 
-    print(f"\n{'Would update' if dry_run else 'Updated'} {changed} occurrence(s)")
+    # ``--check`` writes nothing, so reporting "Updated N" for it described work
+    # that did not happen — during a release that reads as "the bump is done."
+    verb = "Would update" if (dry_run or check) else "Updated"
+    print(f"\n{verb} {changed} occurrence(s)")
 
     if check:
         if changed > 0:

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -123,7 +123,18 @@ DOC_TEST_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
     ("docs/PRODUCT_METRICS.md", re.compile(r"(- Version: `)\d+\.\d+\.\d+(`)"), r"\g<1>{v}\g<2>"),
     ("docs/PRODUCT_METRICS.json", re.compile(r'("version":\s*")\d+\.\d+\.\d+(")'), r"\g<1>{v}\g<2>"),
     ("docs/RELEASE_VERIFICATION.md", re.compile(r"^(TAG=v)\d+\.\d+\.\d+$", re.M), r"\g<1>{v}"),
+    # The storefront row carries one of TWO phrasings depending on where the
+    # release is: lifecycle-neutral before the image is published, "Current
+    # stable version (pinned)" after. Matching only the published phrasing meant
+    # a pre-release bump silently skipped this file, and the drift surfaced as a
+    # `check_release_consistency` failure at tag time instead of being fixed by
+    # the bump that was supposed to own it.
     ("DOCKER_HUB_README.md", re.compile(r"(\| `)\d+\.\d+\.\d+(` \| Current stable version \(pinned\) \|)"), r"\g<1>{v}\g<2>"),
+    (
+        "DOCKER_HUB_README.md",
+        re.compile(r"(\| `)\d+\.\d+\.\d+(` \| Version used by the examples below; verify registry availability before pinning \|)"),
+        r"\g<1>{v}\g<2>",
+    ),
     # PUBLISHING.md — version examples
     ("docs/PUBLISHING.md", re.compile(r'(--version\s+")[^"]+(")', re.M), r"\g<1>{v}\g<2>"),
     ("docs/PUBLISHING.md", re.compile(r"(git tag v)\S+", re.M), r"\g<1>{v}"),

--- a/scripts/generate_ui_csp_hashes.py
+++ b/scripts/generate_ui_csp_hashes.py
@@ -7,6 +7,7 @@ import argparse
 import base64
 import hashlib
 import json
+import re
 from html.parser import HTMLParser
 from pathlib import Path
 
@@ -58,14 +59,54 @@ def _hash_block(value: str) -> str:
     return "sha256-" + base64.b64encode(digest).decode("ascii")
 
 
+# `next/script` with `strategy="beforeInteractive"` does NOT emit a plain inline
+# <script> tag. Next serializes the body into `self.__next_s` and its
+# `appBootstrap` runtime materializes a script element whose text is exactly the
+# `children` string, then appends it — so the browser evaluates that text and
+# checks it against script-src-elem.
+#
+# Scanning the HTML for <script> tags therefore hashes the *wrapper* push and
+# never the payload the browser actually runs, and the CSP blocked every
+# beforeInteractive script we ship. The theme bootstrap is one: blocked on every
+# page load in production, which is a flash of the wrong theme for anyone whose
+# stored preference is not the default, plus a CSP error on every page of a
+# security product's own dashboard.
+_NEXT_S_PUSH = re.compile(r"__next_s\s*=\s*self\.__next_s\s*\|\|\s*\[\]\)\.push\(\s*(\[.*?\])\s*\)", re.S)
+
+
+def _bootstrap_script_bodies(html: str) -> list[str]:
+    """Return the inline bodies Next will materialize from ``self.__next_s``.
+
+    Entries look like ``["/some.js", {...}]`` (external, no inline body) or
+    ``[0, {"children": "..."}]`` (inline). Only the latter needs a hash.
+    """
+    bodies: list[str] = []
+    for match in _NEXT_S_PUSH.finditer(html):
+        try:
+            entry = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, list) or len(entry) < 2:
+            continue
+        src, props = entry[0], entry[1]
+        if src or not isinstance(props, dict):
+            continue
+        children = props.get("children")
+        if isinstance(children, str) and children.strip():
+            bodies.append(children)
+    return bodies
+
+
 def generate_hash_manifest(ui_dist: Path) -> dict[str, object]:
     script_hashes: set[str] = set()
     style_hashes: set[str] = set()
     html_files = sorted(ui_dist.rglob("*.html"))
     for html_file in html_files:
+        html = html_file.read_text(encoding="utf-8")
         parser = _InlineBlockParser()
-        parser.feed(html_file.read_text(encoding="utf-8"))
+        parser.feed(html)
         script_hashes.update(_hash_block(value) for value in parser.scripts)
+        script_hashes.update(_hash_block(value) for value in _bootstrap_script_bodies(html))
         style_hashes.update(_hash_block(value) for value in parser.styles)
     return {
         "version": 1,

--- a/scripts/preflight_release.sh
+++ b/scripts/preflight_release.sh
@@ -25,9 +25,17 @@ step "release workflow call-graph lint (reusable-workflow permission parity + ne
 python scripts/lint_release_workflow.py .github/workflows/release.yml || fail=1
 
 step "version bump consistency"
-if [ -n "$VERSION" ]; then
-  python scripts/bump-version.py "$VERSION" --check || fail=1
+# Without a VERSION this script used to skip the bump check and still print
+# "Pre-flight OK — safe to tag", which is the one thing it exists to prevent:
+# every managed reference can be a release behind and the verdict still reads
+# green. The version is what a tag IS, so it is required.
+if [ -z "$VERSION" ]; then
+  echo "ERROR: no VERSION given. Pass the version you intend to tag:" >&2
+  echo "  scripts/preflight_release.sh 0.99.0" >&2
+  echo "Without it the version-bump check cannot run, and a green verdict would be meaningless." >&2
+  exit 2
 fi
+python scripts/bump-version.py "$VERSION" --check || fail=1
 python scripts/check_release_consistency.py || fail=1
 python scripts/check_product_surface_contract.py || fail=1
 python scripts/export_openapi.py --check || fail=1

--- a/src/agent_bom/finding_scope.py
+++ b/src/agent_bom/finding_scope.py
@@ -187,6 +187,27 @@ def security_domain_for(
       3. Otherwise route by source (container/SBOM/external/filesystem → vuln;
          everything MCP/agent/runtime/prompt/skill/graph → AISPM).
     """
+    return _security_domain(source, finding_type, evidence) or "aispm"
+
+
+def _security_domain(
+    source: "FindingSource | None",
+    finding_type: "FindingType",
+    evidence: Optional[dict] = None,
+) -> Optional[str]:
+    """:func:`security_domain_for`, but tolerant of an unknown source.
+
+    A finding can arrive with a provenance label that is not a
+    :class:`FindingSource` — every row ingested through ``POST
+    /v1/findings/bulk`` does, because that endpoint's ``source`` is a free-text
+    connector label whose default is ``"api"``. The type-decisive rules do not
+    need the source at all: a CVE is vulnerability management wherever it came
+    from. Only the source-routed fallbacks are skipped, and this returns None
+    rather than guessing a lane when the type alone cannot decide.
+
+    Kept as the single implementation of the precedence chain so the row-level
+    and object-level entry points can never drift apart.
+    """
     from agent_bom.finding import FindingSource, FindingType
 
     ev = evidence or {}
@@ -196,7 +217,7 @@ def security_domain_for(
     if source is FindingSource.DSPM or finding_type is FindingType.SENSITIVE_DATA:
         return "dspm"
 
-    if source in {FindingSource.CLOUD_CIS, FindingSource.CLOUD_SECURITY}:
+    if source is not None and source in {FindingSource.CLOUD_CIS, FindingSource.CLOUD_SECURITY}:
         provider = str(ev.get("provider") or "").strip().lower()
         # Snowflake governance findings carry a category + no CIS benchmark tag;
         # they describe data-access posture, not infra config → DSPM.
@@ -218,6 +239,11 @@ def security_domain_for(
 
     if finding_type in (FindingType.SAST, FindingType.CREDENTIAL_EXPOSURE):
         return "aspm"
+
+    if source is None:
+        # Nothing type-decisive matched and there is no source to route by.
+        # Saying "unknown" is the honest answer; the caller decides the default.
+        return None
 
     if source in (
         FindingSource.CONTAINER,
@@ -246,15 +272,37 @@ def domain_for_row(row: dict) -> Optional[str]:
     dom = canonical_domain(row.get("security_domain"))
     if dom is not None:
         return dom
+    source, ftype = _parse_row_source_and_type(row)
+    if ftype is None:
+        return None
+    evidence = row.get("evidence") if isinstance(row.get("evidence"), dict) else None
+    return _security_domain(source, ftype, evidence)
+
+
+def _parse_row_source_and_type(row: dict) -> tuple[Optional["FindingSource"], Optional["FindingType"]]:
+    """Parse a serialized row's source and type INDEPENDENTLY.
+
+    These used to be parsed in one ``try`` block, so an unrecognized source
+    discarded a perfectly good finding type. Every row from ``POST
+    /v1/findings/bulk`` hits that: its ``source`` is a free-text connector label
+    (default ``"api"``), not a :class:`FindingSource`. The result was that a row
+    plainly typed ``CVE`` derived no domain and no lenses, so every ``?domain=``
+    query returned nothing for connector-ingested findings — while the same
+    finding discovered by a scan filtered correctly.
+
+    An unknown source is now just an unknown source.
+    """
     from agent_bom.finding import FindingSource, FindingType
 
     try:
-        source = FindingSource(str(row.get("source") or "").upper())
-        ftype = FindingType(str(row.get("finding_type") or "").upper())
+        source: Optional[FindingSource] = FindingSource(str(row.get("source") or "").upper())
     except ValueError:
-        return None
-    evidence = row.get("evidence") if isinstance(row.get("evidence"), dict) else None
-    return security_domain_for(source, ftype, evidence)
+        source = None
+    try:
+        ftype: Optional[FindingType] = FindingType(str(row.get("finding_type") or "").upper())
+    except ValueError:
+        ftype = None
+    return source, ftype
 
 
 # ---------------------------------------------------------------------------
@@ -275,7 +323,7 @@ def domain_for_row(row: dict) -> Optional[str]:
 # findings spine (once per finding), never by summing lenses.
 
 
-def _is_iac_misconfig(source: "FindingSource", ftype: "FindingType", ev: dict) -> bool:
+def _is_iac_misconfig(source: "FindingSource | None", ftype: "FindingType", ev: dict) -> bool:
     """True when a misconfiguration finding describes infrastructure-as-code.
 
     IaC template scanning (Terraform / CloudFormation / K8s manifests in a repo)
@@ -315,10 +363,28 @@ def security_lenses_for(
 
     The primary lane is always included.
     """
+    return _security_lenses(source, finding_type, evidence)
+
+
+def _security_lenses(
+    source: "FindingSource | None",
+    finding_type: "FindingType",
+    evidence: Optional[dict] = None,
+) -> frozenset[str]:
+    """:func:`security_lenses_for`, tolerant of an unknown source.
+
+    Same reasoning as :func:`_security_domain`: the type-decisive lenses hold
+    whatever the provenance label says, and only the source-routed ones are
+    skipped. One implementation, so a bulk-ingested CVE and a scanned one land
+    in the same lenses.
+    """
     from agent_bom.finding import FindingSource, FindingType
 
     ev = evidence or {}
-    lenses: set[str] = {security_domain_for(source, finding_type, evidence)}
+    lenses: set[str] = set()
+    primary = _security_domain(source, finding_type, evidence)
+    if primary is not None:
+        lenses.add(primary)
 
     is_code_or_secret = finding_type in (FindingType.SAST, FindingType.CREDENTIAL_EXPOSURE) or source in (
         FindingSource.SAST,
@@ -365,15 +431,11 @@ def lenses_for_row(row: dict) -> frozenset[str]:
     if str(row.get("cve_id") or "").strip():
         lenses.add("vuln")
 
-    from agent_bom.finding import FindingSource, FindingType
-
-    try:
-        source = FindingSource(str(row.get("source") or "").upper())
-        ftype = FindingType(str(row.get("finding_type") or "").upper())
-    except ValueError:
+    source, ftype = _parse_row_source_and_type(row)
+    if ftype is None:
         return frozenset(lenses)
     evidence = row.get("evidence") if isinstance(row.get("evidence"), dict) else None
-    return frozenset(lenses | security_lenses_for(source, ftype, evidence))
+    return frozenset(lenses | _security_lenses(source, ftype, evidence))
 
 
 def finding_class_for_row(row: Mapping[str, object]) -> FindingClass:

--- a/tests/test_bulk_ingest_domain_filter.py
+++ b/tests/test_bulk_ingest_domain_filter.py
@@ -1,0 +1,107 @@
+"""Findings ingested through the connector API must be filterable by domain.
+
+``POST /v1/findings/bulk`` is the agent-native ingest path: a caller that
+already has normalized findings posts them directly. Those findings reached the
+findings list fine, but ``?domain=`` returned **nothing** for them — the posture
+lane taxonomy, which is how the product slices findings everywhere, was blind to
+the entire connector path. A customer onboarding through the documented API got
+a findings list that could not be sliced.
+
+Asserted end-to-end through the route rather than on the mapping helper, because
+the helper is only half the story: the scope filter runs on enriched rows inside
+the store, so a unit test on the mapping could pass while the API still returned
+an empty page.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+KEY = {"X-API-Key": "domainfilterkey0123456789ab"}
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    monkeypatch.setenv("AGENT_BOM_DB", str(tmp_path / "domain-filter.db"))
+    monkeypatch.setenv("AGENT_BOM_API_KEYS", "domainfilterkey0123456789ab:analyst")
+    monkeypatch.setenv("AGENT_BOM_RATE_LIMIT_KEY", "domain-filter-key")
+
+    from agent_bom.api import compliance_hub_store as hub_mod
+    from agent_bom.api import server as api_server
+    from agent_bom.api import stores as api_stores
+    from agent_bom.api.compliance_hub_store import set_compliance_hub_store
+    from agent_bom.api.findings_count_cache import reset_findings_count_cache
+
+    api_server._runtime_api_key_seeded = False
+    api_server._shutting_down = False
+    original_store = api_stores._store
+    original_graph = api_stores._graph_store
+    original_hub = hub_mod._HUB_STORE
+    api_stores._store = None
+    api_stores._graph_store = None
+    set_compliance_hub_store(None)
+    reset_findings_count_cache()
+    try:
+        with TestClient(api_server.app) as c:
+            yield c
+    finally:
+        api_stores._store = original_store
+        api_stores._graph_store = original_graph
+        set_compliance_hub_store(original_hub)
+        reset_findings_count_cache()
+
+
+def _ingest(client: TestClient, findings: list[dict], *, source: str) -> None:
+    resp = client.post("/v1/findings/bulk", headers=KEY, json={"findings": findings, "source": source})
+    assert resp.status_code == 201, resp.text
+
+
+def test_bulk_ingested_findings_are_reachable_by_domain(client: TestClient) -> None:
+    """A CVE posted through the connector API belongs to the vuln lane.
+
+    ``source`` here is the endpoint's own default label, which is NOT a
+    ``FindingSource`` member. That is the point: the label describes provenance,
+    and it must not decide whether the finding has a security domain.
+    """
+    _ingest(
+        client,
+        [
+            {
+                "id": f"conn-{i}",
+                "finding_type": "CVE",
+                "severity": "high",
+                "title": f"CVE-2026-200{i} in pkg-{i}",
+                "package_name": f"pkg-{i}",
+                "package_version": "1.0.0",
+                "provider": "aws",
+                "cvss_score": 7.5,
+            }
+            for i in range(5)
+        ],
+        source="api",
+    )
+
+    everything = client.get("/v1/findings", headers=KEY, params={"limit": 50}).json()
+    assert len(everything.get("findings") or []) == 5, everything
+
+    scoped = client.get("/v1/findings", headers=KEY, params={"limit": 50, "domain": "vuln"}).json()
+    assert len(scoped.get("findings") or []) == 5, "CVE findings ingested via /v1/findings/bulk are invisible to ?domain=vuln"
+
+
+def test_bulk_ingest_routes_each_type_to_its_own_lane(client: TestClient) -> None:
+    """The lane must follow the finding's type, not the connector's name."""
+    _ingest(
+        client,
+        [
+            {"id": "t-cve", "finding_type": "CVE", "severity": "high", "title": "CVE-2026-3001", "package_name": "p"},
+            {"id": "t-secret", "finding_type": "CREDENTIAL_EXPOSURE", "severity": "critical", "title": "AWS key in repo"},
+            {"id": "t-ciem", "finding_type": "CIEM_OVER_PRIVILEGE", "severity": "high", "title": "Unused write grants"},
+        ],
+        source="acme-connector",
+    )
+
+    for domain, expected_id in (("vuln", "t-cve"), ("aspm", "t-secret"), ("cspm", "t-ciem")):
+        page = client.get("/v1/findings", headers=KEY, params={"limit": 50, "domain": domain}).json()
+        ids = {row.get("id") for row in page.get("findings") or []}
+        assert expected_id in ids, f"{expected_id} did not reach the {domain} lane: {sorted(ids)}"

--- a/tests/test_finding_scope.py
+++ b/tests/test_finding_scope.py
@@ -12,6 +12,7 @@ from agent_bom.finding import (
 )
 from agent_bom.finding_scope import (
     account_ref_from_arn,
+    domain_for_row,
     lenses_for_row,
     normalize_account_ref,
     region_from_arn,
@@ -265,3 +266,43 @@ def test_snowflake_governance_converter_normalizes_account_and_domain() -> None:
     assert f.provider == "snowflake"
     assert f.account_ref == "snowflake:xy12345"
     assert f.security_domain == "dspm"
+
+
+def test_domain_derives_from_type_when_source_is_a_connector_label() -> None:
+    """A free-text ``source`` must not discard a perfectly good ``finding_type``.
+
+    ``POST /v1/findings/bulk`` takes ``source`` as a connector provenance label
+    — its default is literally ``"api"`` — while this module parsed the same
+    field as ``FindingSource``. Source and type were parsed in one ``try``, so
+    an unrecognized label threw both away: a row plainly typed ``CVE`` derived
+    no domain and no lenses, and every ``?domain=`` query returned nothing for
+    connector-ingested findings while the same finding from a scan filtered
+    fine.
+    """
+    for label in ("api", "scale-gate", "acme-connector", ""):
+        row = {"source": label, "finding_type": "CVE", "severity": "high"}
+        assert domain_for_row(row) == "vuln", f"source={label!r} lost the CVE type"
+        assert "vuln" in lenses_for_row(row), f"source={label!r} produced no lenses"
+
+    assert domain_for_row({"source": "api", "finding_type": "CREDENTIAL_EXPOSURE"}) == "aspm"
+    assert domain_for_row({"source": "api", "finding_type": "SENSITIVE_DATA"}) == "dspm"
+    assert domain_for_row({"source": "api", "finding_type": "CIEM_OVER_PRIVILEGE"}) == "cspm"
+
+
+def test_unknown_type_still_reports_no_domain_rather_than_guessing() -> None:
+    """Tolerating an unknown source must not become inventing a lane.
+
+    With no parseable type AND no parseable source there is nothing to derive
+    from, so the honest answer is None and the caller picks the default. A
+    fallback lane here would file arbitrary findings under AISPM.
+    """
+    assert domain_for_row({"source": "acme", "finding_type": "NOT_A_TYPE"}) is None
+    assert lenses_for_row({"source": "acme", "finding_type": "NOT_A_TYPE"}) == frozenset()
+
+
+def test_known_source_routing_is_unchanged_by_the_lenient_parse() -> None:
+    """The source-routed fallbacks still apply whenever the source IS known."""
+    assert domain_for_row({"source": "SBOM", "finding_type": "CVE"}) == "vuln"
+    assert lenses_for_row({"source": "SBOM", "finding_type": "CVE"}) == frozenset({"vuln", "aspm"})
+    assert domain_for_row({"source": "MCP_SCAN", "finding_type": "TOOL_DRIFT"}) == "aispm"
+    assert domain_for_row({"source": "CLOUD_CIS", "finding_type": "CIS_FAIL", "evidence": {"benchmark": "CIS"}}) == "cspm"

--- a/tests/test_ui_csp_hashes.py
+++ b/tests/test_ui_csp_hashes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
 
 from scripts.generate_ui_csp_hashes import generate_hash_manifest
 
@@ -24,3 +25,46 @@ def test_generate_ui_csp_hashes_extracts_inline_scripts_and_styles(tmp_path):
     assert manifest["html_file_count"] == 1
     assert manifest["script_hashes"] == [_sha256_source("window.__next_f=[]")]
     assert manifest["style_hashes"] == [_sha256_source(".x{color:red}")]
+
+
+def test_generate_ui_csp_hashes_covers_beforeinteractive_bootstrap_scripts(tmp_path):
+    """`next/script` beforeInteractive bodies must be hashed, not just <script> tags.
+
+    Next does not emit these as inline tags. It serializes the body into
+    ``self.__next_s`` and its ``appBootstrap`` runtime builds a script element
+    whose text is exactly the ``children`` string, then appends it -- so the
+    browser evaluates that text and checks it against ``script-src-elem``.
+
+    Hashing only the tags found in the HTML therefore covered the *wrapper*
+    push and never the payload that actually runs, and the shipped CSP blocked
+    every beforeInteractive script. The theme bootstrap was one of them: blocked
+    on every page load in production, which is a flash of the wrong theme for
+    anyone whose stored preference is not the default.
+    """
+    theme_body = '\n(function(){document.documentElement.dataset.theme="dark";})();\n'
+    ui_dist = tmp_path / "ui_dist"
+    ui_dist.mkdir()
+    (ui_dist / "index.html").write_text(
+        "<html><body>"
+        '<script>(self.__next_s=self.__next_s||[]).push(["/runtime-config.js",{}])</script>'
+        f"<script>(self.__next_s=self.__next_s||[]).push([0,{json.dumps({'children': theme_body})}])</script>"
+        "</body></html>",
+        encoding="utf-8",
+    )
+
+    manifest = generate_hash_manifest(ui_dist)
+
+    assert _sha256_source(theme_body) in manifest["script_hashes"], (
+        "the beforeInteractive body the browser executes is missing from the CSP allowlist"
+    )
+
+
+def test_external_bootstrap_entries_contribute_no_inline_hash(tmp_path):
+    """An entry with a `src` loads externally -- there is no inline body to hash."""
+    ui_dist = tmp_path / "ui_dist"
+    ui_dist.mkdir()
+    (ui_dist / "index.html").write_text(
+        '<html><body><script src="/x.js"></script><script src="/y.js"></script></body></html>',
+        encoding="utf-8",
+    )
+    assert generate_hash_manifest(ui_dist)["script_hashes"] == []


### PR DESCRIPTION
Combines #4680 and #4681 into one reviewable change, plus one more gate gap found while bumping to 0.99.0. Every item was found by running a pre-release gate for real rather than citing it, and each is verified end-to-end.

---

## 1. `?domain=` returned zero rows for every bulk-ingested finding

`POST /v1/findings/bulk` is the connector ingest path, and its `source` is a free-text provenance label whose default is literally `"api"`. `domain_for_row()` and `lenses_for_row()` parsed that same field as the `FindingSource` enum — and parsed source and type in **one `try` block**, so an unrecognized label threw the finding type away with it.

```
domain_for_row({"source": "api", "finding_type": "CVE"})  ->  None
lenses_for_row({"source": "api", "finding_type": "CVE"})  ->  frozenset()
```

Every `?domain=` query returned nothing for connector-ingested findings while the identical finding from a scan filtered correctly. At 1M findings: `/v1/findings` returned `total: 1000001`; `/v1/findings?domain=vuln` returned `0`. The overview coverage lane's own `href` lands on an empty page. Because `"api"` is the default, the out-of-the-box path hit this **100% of the time**.

Found via the G5–G8 scale gates on real Postgres, but it is not a scale or backend bug — **it reproduces on SQLite with ten findings in 1.4s**.

Source and type are now parsed independently and the precedence chain accepts an unknown source. It does **not** invent a lane (unknown type still yields `None`), and it does **not** add a second copy of the mapping — the source-optional function *is* the implementation and the public one delegates, so row-level and object-level entry points cannot drift.

| input | lane |
|---|---|
| bulk `CVE` | `vuln` |
| bulk `CREDENTIAL_EXPOSURE` | `aspm` |
| bulk `CIEM_OVER_PRIVILEGE` | `cspm` |
| bulk `SENSITIVE_DATA` | `dspm` |
| unknown type | `None` (unchanged) |
| `SBOM` + `CVE` | `{vuln, aspm}` (unchanged) |

Asserted end-to-end through `/v1/findings`, because the scope filter runs on enriched rows inside the store — a unit test on the mapping could pass while the route still returned an empty page.

---

## 2. The dashboard CSP blocked an inline script on every page, in production

Confirmed against the **live released demo**, not just a local build.

`next/script strategy="beforeInteractive"` does not emit an inline `<script>` tag. Next serializes the body into `self.__next_s`, and `appBootstrap` creates a script element whose text is exactly the `children` string, then appends it — so the browser evaluates that text and checks `script-src-elem`. `generate_ui_csp_hashes.py` scans the HTML for `<script>` tags, so it hashed the **wrapper push** and never the payload:

```
theme-bootstrap runtime hash: sha256-CVIz+8cEN0ddhFEe/IMBU5uIChZx5ZAwQQKl0dHHVuQ=
in CSP allowlist? False

{ "directive": "script-src-elem", "blockedURI": "inline",
  "sourceFile": ".../chunks/3794-321373812a1a8bf8.js", "lineNumber": 32 }
```

The blocked script is the theme bootstrap, so this is **a flash of the wrong theme on every page load** for anyone whose stored preference isn't the default — plus a CSP error on every page of a security product's own dashboard.

No existing gate could catch it: endpoint 200, page renders, HTML export byte-for-byte correct. The defect exists only in what the browser does with it. It is also the recurring shape — `ui/lib/security-headers.mjs` derives the theme hash *correctly*, while the shipped server reads `csp-hashes.json`, which was blind to it.

Fixed generically by parsing `self.__next_s` entries, so future `beforeInteractive` scripts are covered rather than special-casing the theme one.

---

## 3. Three release gates that under-reported

- **`preflight_release.sh` printed "Pre-flight OK — safe to tag" when run without a version**, because that argument is what enables the bump check. Every managed reference could be a release behind and the verdict still read green. Now required (exit 2 with usage). **This immediately proved itself**: run properly against the 0.99.0 bump it caught stale OpenAPI artifacts, a stale `AGENT_CAPABILITY.md`, a stale screenshot manifest, a `CHANGELOG` compare link still pointing at v0.98.3, and the Docker storefront row below.
- **`bump-version.py --check` printed "Updated N occurrence(s)"** for a run that writes nothing. During a release that reads as "the bump is done." Now `Would update` / `DRIFT`.
- **`bump-version.py` only rewrote the Docker storefront row in its published phrasing.** That row carries one of two wordings — lifecycle-neutral pre-publish, "Current stable version (pinned)" after. A pre-release bump silently skipped the file, and the drift surfaced as a `check_release_consistency` failure at tag time instead of being fixed by the bump that owns it. Both phrasings now match.

Also records #4677 in the 0.99.0 changelog, which merged after that entry was written.

---

## Verification (combined tree, not the branches separately)

- `test_finding_scope` · `test_bulk_ingest_domain_filter` · `test_ui_csp_hashes` · `test_dashboard` · `test_dashboard_release_packaging` · `test_version_alignment` · facet pushdown differential — **70 passed, 1 skipped**
- `make preflight` ✓ · `ruff format` ✓ · `ruff check` ✓ · `mypy` **835 source files, no issues**
- CSP: Playwright `securitypolicyviolation` listener went **1 violation per page → 0**; the 16-page rendered pass went **8/16 → 14/16 clean**. The two remaining are correct behavior — `/activity` returns a clear 400 (`SNOWFLAKE_ACCOUNT env var not set`) and `/gateway` 403s because anonymous resolves to `viewer`, which lacks `audit_read`.

Supersedes #4680 and #4681.