### PR TITLE
fix(ci): stop failing the release because Smithery cannot scan an authenticated endpoint

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -3,11 +3,18 @@ name: Publish to Registries
 # Auto-publishes to Smithery and ClawHub after a successful Release workflow.
 # Secrets needed (add via Settings → Secrets):
 #   SMITHERY_API_TOKEN  — Smithery service token (smithery.ai → API tokens)
-#   SMITHERY_UPSTREAM_TOKEN — bearer token Smithery presents to our own MCP
-#     endpoint. Without it Smithery cannot enumerate tools and the release
-#     settles as AUTH_REQUIRED, which is why the public catalog listed 36 of
-#     the 77 tools the server actually serves.
 #   CLAWHUB_TOKEN       — ClawHub auth token (clawhub.ai → Settings)
+#
+# NOT wired, deliberately: a `SMITHERY_UPSTREAM_TOKEN` was once documented here
+# as the way to let Smithery's scanner authenticate against our MCP endpoint.
+# No such secret exists and nothing in this file ever read one, so the note
+# described a fix that was never implemented. The consequence is real and
+# accepted: Smithery cannot enumerate our tools, the release settles as
+# AUTH_REQUIRED, and the public catalog lists fewer tools than the server
+# serves. Closing that gap means handing a third-party scanner a working bearer
+# token for a production endpoint — a product decision, not a CI fix. Until it
+# is made, AUTH_REQUIRED is the expected terminal state and must not fail the
+# job (see "Wait for Smithery release" below).
 # Optional vars:
 #   SMITHERY_MCP_URL    — Public Streamable HTTP MCP endpoint for Smithery
 # Optional secret:
@@ -268,7 +275,23 @@ jobs:
             echo "Smithery release attempt ${ATTEMPT}/18 — ${STATUS}"
             case "$STATUS" in
               SUCCESS) exit 0 ;;
-              FAILURE|FAILURE_SCAN|AUTH_REQUIRED|AUTH_TIMEOUT|CANCELLED|INTERNAL_ERROR)
+              # The agent-bom MCP endpoint authenticates every request — that is
+              # the point of it, and the published configSchema marks
+              # `bearerToken` as required so a Smithery user supplies their own.
+              # Smithery's scanner therefore cannot enumerate our tools, and
+              # reports AUTH_REQUIRED / AUTH_TIMEOUT. The RELEASE ITSELF
+              # succeeded; only the optional post-publish scan did not.
+              #
+              # Failing here failed the whole Publish to Registries job on every
+              # release and opened a release-blocker issue for a server that had
+              # in fact published. The alternative — handing a third-party
+              # scanner our production bearer token so it can pass — is not a
+              # trade worth making for a green check.
+              AUTH_REQUIRED|AUTH_TIMEOUT)
+                echo "::warning::Smithery published the release but could not scan it (${STATUS}); the endpoint requires a caller-supplied bearerToken by design"
+                exit 0
+                ;;
+              FAILURE|FAILURE_SCAN|CANCELLED|INTERNAL_ERROR)
                 echo "::error::Smithery release did not complete successfully (${STATUS})"
                 exit 1
                 ;;


### PR DESCRIPTION
Closes #4686.

`Publish to Registries` failed on `main` for v0.99.0 and auto-opened a **release-blocker** issue. **The release had in fact published.**

## What actually happened

```
Smithery release attempt 1/18 — WORKING
Smithery release attempt 2/18 — AUTH_REQUIRED
##[error]Smithery release did not complete successfully (AUTH_REQUIRED)
```

`AUTH_REQUIRED` is a Smithery **release status**, not an HTTP auth failure. Our `PUT .../releases` succeeded and returned a release id. Smithery then tried to connect to the agent-bom MCP endpoint to enumerate tools, had no credential, and settled the release as `AUTH_REQUIRED`.

**That endpoint authenticating every request is the point of it.** The `configSchema` we publish marks `bearerToken` as `required` precisely so each Smithery user supplies their own:

> "Bearer token for the agent-bom MCP endpoint. Required — the endpoint authenticates every request and will not enumerate tools without it."

So `AUTH_REQUIRED` is the **expected terminal state** for this server. Failing on it fails every release for a publish that worked, and files a release-blocker each time.

## The fix

`AUTH_REQUIRED` and `AUTH_TIMEOUT` now warn and pass. `FAILURE`, `FAILURE_SCAN`, `CANCELLED` and `INTERNAL_ERROR` still fail — those are real.

## A comment that described a fix nobody wrote

The header documented a `SMITHERY_UPSTREAM_TOKEN` as the remedy:

> "bearer token Smithery presents to our own MCP endpoint. Without it Smithery cannot enumerate tools and the release settles as AUTH_REQUIRED, which is why the public catalog listed 36 of the 77 tools the server actually serves."

**No such secret exists**, and `grep` finds that name exactly once in the file — in that comment. Nothing ever read it. The condition looked handled while failing every release.

The comment now states the accepted consequence and the real trade: closing the gap means handing a third-party scanner a working bearer token for a production endpoint. That's a product decision, not a CI fix, and I haven't made it for you.

## Worth your attention separately

The catalog under-listing is real — **Smithery shows fewer tools than the server serves**. This PR does not fix that; it stops the symptom from failing releases. If you want the full tool list public, that's the `SMITHERY_UPSTREAM_TOKEN` decision, and it needs both a secret *and* wiring into the publish payload.

## Verification

- `actionlint` clean on the workflow
- YAML parses; jobs intact (`release`, `smithery`, `glama`, `clawhub`)
- `test_ci_workflow_contract` + `test_release_storefront_contract`: 22 passed