### PR TITLE
fix(ui): stop rendering a nested count object as "[object Object]"

### DIFF
--- a/ui/components/nhi-governance-panel.tsx
+++ b/ui/components/nhi-governance-panel.tsx
@@ -37,8 +37,32 @@ export function NhiGovernancePanel({ scanId }: { scanId?: string | undefined }) 
     };
   }, [scanId]);
 
-  const counts = posture?.counts ?? {};
+  const rawCounts = posture?.counts ?? {};
   const identities = Array.isArray(posture?.identities) ? posture.identities : [];
+
+  // `/v1/graph/nhi/governance` returns scalar rollups alongside at least one
+  // NESTED breakdown (`by_risk_band` → {critical, medium, low}). Rendering a
+  // value with String() turned that object into the literal text
+  // "[object Object]" on the Identity page. Flatten one level so a breakdown
+  // becomes its own pills — which is the useful reading anyway: "critical 1"
+  // says something, "[object Object]" says the page is broken.
+  const counts: Array<{ key: string; label: string; value: string }> = [];
+  for (const [key, value] of Object.entries(rawCounts)) {
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      const prefix = key.replace(/^by_/, "").replaceAll("_", " ");
+      for (const [childKey, childValue] of Object.entries(value as Record<string, unknown>)) {
+        if (childValue === null || typeof childValue === "object") continue;
+        counts.push({
+          key: `${key}.${childKey}`,
+          label: `${prefix} · ${childKey.replaceAll("_", " ")}`,
+          value: String(childValue),
+        });
+      }
+      continue;
+    }
+    if (value === null || value === undefined) continue;
+    counts.push({ key, label: key.replaceAll("_", " "), value: String(value) });
+  }
 
   return (
     <section
@@ -63,18 +87,18 @@ export function NhiGovernancePanel({ scanId }: { scanId?: string | undefined }) 
       ) : (
         <>
           <div className="mt-3 flex flex-wrap gap-2">
-            {Object.entries(counts).slice(0, 6).map(([key, value]) => (
+            {counts.slice(0, 8).map((entry) => (
               <div
-                key={key}
+                key={entry.key}
                 className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1.5"
               >
                 <p className="text-[10px] uppercase tracking-[0.12em] text-[color:var(--text-tertiary)]">
-                  {key.replaceAll("_", " ")}
+                  {entry.label}
                 </p>
-                <p className="font-mono text-sm text-[color:var(--foreground)]">{String(value)}</p>
+                <p className="font-mono text-sm text-[color:var(--foreground)]">{entry.value}</p>
               </div>
             ))}
-            {!loading && Object.keys(counts).length === 0 ? (
+            {!loading && counts.length === 0 ? (
               <p className="text-xs text-[color:var(--text-tertiary)]">
                 No NHI count rollups for this snapshot.
               </p>


### PR DESCRIPTION
The Identity page renders a stat tile reading literally **`[object Object]`**.

**This is a product defect, not a demo one** — it renders for any tenant whose governance response carries the breakdown.

`/v1/graph/nhi/governance` returns scalar rollups alongside one nested breakdown:

```json
"counts": { "over_granted": 2, "dormant": 2, "orphaned": 2,
            "by_risk_band": { "critical": 1, "medium": 62, "low": 211 } }
```

The panel mapped every count through `String(value)`, which turns an object into that text.

Nested counts now flatten one level into their own pills — `risk band · critical 1`. That's the useful rendering regardless: a per-band number tells an operator something; `[object Object]` tells them the page is broken.

Guarded generally rather than special-cased on `by_risk_band`: any object-valued count expands, array/nested-object children are skipped, and null/undefined are dropped instead of rendering as text.

`tsc --noEmit` clean · `cockpits` suite 3 passed.

---

Found during a UI pass over the live 0.99.0 demo. It also shows why my earlier 16-page rendered-UI sweep missed it: that sweep ran against the **pre-0.99.0 estate**, which had no NHI risk-band data, so the `[object Object]` marker it explicitly checks for never appeared. The check was right; the data wasn't there yet.