### PR TITLE
fix(demo): make the AI BOM read the estate instead of reporting zero

### DIFF
--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -12,6 +12,7 @@ from agent_bom.api.pipeline import _now
 from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
 from agent_bom.demo_estate.showcase_graph import (
     SHOWCASE_TENANT,
+    seed_showcase_fleet_and_runtime,
     seed_showcase_graph_if_empty,
     seed_showcase_identities,
 )
@@ -223,6 +224,16 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
     except Exception:
         _logger.warning("demo estate identity seeding failed", exc_info=True)
         summary["identity_error"] = True
+
+    # The AI BOM page reads the fleet registry and the MCP observation store —
+    # neither of which the graph/findings seeds touch, so it rendered every
+    # count as 0 on a fully populated estate. Same isolation as the identity
+    # seed above: its failure must not block the rest of the bootstrap.
+    try:
+        summary["fleet_runtime"] = seed_showcase_fleet_and_runtime(tenant_id=tenant_id)
+    except Exception:
+        _logger.warning("demo estate fleet/runtime seeding failed", exc_info=True)
+        summary["fleet_runtime_error"] = True
 
     # Seed the runtime gateway feed (proxy alerts + metrics + firewall
     # decisions) so the gateway/proxy/runtime dashboards show the AI-firewall in

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -215,6 +215,110 @@ def seed_showcase_identities(tenant_id: str = SHOWCASE_TENANT) -> dict[str, Any]
     return {"seeded": True, "identities": len(identities), "jit_grants": len(grants)}
 
 
+def seed_showcase_fleet_and_runtime(tenant_id: str = SHOWCASE_TENANT) -> dict[str, Any]:
+    """Populate the LIVE fleet and MCP-observation stores from the estate.
+
+    ``/v1/agent-bom/manifest`` — the AI BOM page — is built from exactly two
+    stores: the fleet registry and the MCP observation store. The demo bootstrap
+    seeded the graph, the findings and the identities, but never those two, so
+    the AI BOM read **0 agents / 0 MCP servers / 0 tools** on an estate holding
+    48 agents, 25 servers and 97 tools. The page's own promise is "live
+    inventory from connected agents… not a static upload", and it was showing
+    nothing at all.
+
+    Same contract as :func:`seed_showcase_identities`: idempotent, independent
+    of the graph seed, and only ever under demo-estate mode, so a restart or an
+    already-seeded graph still leaves the AI BOM populated.
+    """
+    from agent_bom.api.fleet_store import FleetAgent, FleetLifecycleState
+    from agent_bom.api.mcp_observation_store import MCPObservation
+    from agent_bom.api.stores import _get_fleet_store, _get_mcp_observation_store
+    from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+
+    fleet_store = _get_fleet_store()
+    observation_store = _get_mcp_observation_store()
+    if any(a.agent_id.startswith("demo-fleet-") for a in fleet_store.list_by_tenant(tenant_id)):
+        return {"seeded": False, "reason": "fleet_present"}
+
+    estate = build_demo_estate(tenant_id=tenant_id)
+    by_type: dict[str, list[Any]] = {}
+    for asset in estate.assets:
+        by_type.setdefault(asset.resource_type, []).append(asset)
+
+    servers = by_type.get("server", [])
+    tools_by_server: dict[str, list[Any]] = {}
+    for tool in by_type.get("tool", []):
+        tools_by_server.setdefault(str(tool.tags.get("mcp_server") or ""), []).append(tool)
+
+    now = datetime.now(timezone.utc).isoformat()
+    agents = by_type.get("agent", [])
+    for index, asset in enumerate(agents):
+        # Deterministic spread so the fleet reads like a managed estate rather
+        # than one uniform block. A real fleet is mostly approved with a tail of
+        # in-flight and problem agents; every row in one state is the tell that
+        # nothing is actually being governed.
+        bucket = index % 10
+        if bucket == 0:
+            state = FleetLifecycleState.QUARANTINED
+        elif bucket in (1, 2):
+            state = FleetLifecycleState.PENDING_REVIEW
+        elif bucket == 3:
+            state = FleetLifecycleState.DISCOVERED
+        else:
+            state = FleetLifecycleState.APPROVED
+        fleet_store.put(
+            FleetAgent(
+                agent_id=f"demo-fleet-{asset.asset_id}",
+                name=asset.display_name,
+                agent_type=str(asset.tags.get("agent_framework") or "mcp-client"),
+                lifecycle_state=state,
+                owner=str(asset.tags.get("owner") or "platform-engineering"),
+                environment=asset.environment or "production",
+                tags=[t for t in (asset.environment, asset.provider) if t],
+                trust_score=round(0.55 + ((index % 9) / 20.0), 2),
+                server_count=len(servers[index % max(1, len(servers)) : index % max(1, len(servers)) + 2]),
+                tenant_id=tenant_id,
+                last_discovery=now,
+                last_scan=now,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+    for index, asset in enumerate(servers):
+        tools = tools_by_server.get(asset.asset_id, [])
+        observation_store.put(
+            MCPObservation(
+                tenant_id=tenant_id,
+                observation_id=f"demo-obs-{asset.asset_id}",
+                server_stable_id=asset.asset_id,
+                server_name=asset.display_name,
+                agent_name=agents[index % len(agents)].display_name if agents else "",
+                transport=str(asset.tags.get("transport") or "streamable-http"),
+                url=asset.native_id if str(asset.native_id).startswith("http") else None,
+                auth_mode=str(asset.tags.get("auth_mode") or "bearer"),
+                credential_env_vars=[],
+                observed_via=["demo-estate"],
+                scan_sources=["demo-estate"],
+                source_agents=[a.display_name for a in agents[index % max(1, len(agents)) : index % max(1, len(agents)) + 2]],
+                configured_locally=False,
+                fleet_present=True,
+                gateway_registered=index % 3 != 0,
+                runtime_observed=index % 4 != 0,
+                observed_scopes=sorted({str(t.tags.get("scope") or "read") for t in tools}) or ["read"],
+                first_seen=now,
+                last_seen=now,
+            )
+        )
+
+    return {
+        "seeded": True,
+        "fleet_agents": len(agents),
+        "mcp_observations": len(servers),
+        "tools": sum(len(v) for v in tools_by_server.values()),
+    }
+
+
 def _annotate_demo_identity_risk(graph: UnifiedGraph) -> None:
     """Pin privilege / exposure signals the identity record cannot carry.
 

--- a/tests/test_demo_estate_ai_bom_manifest.py
+++ b/tests/test_demo_estate_ai_bom_manifest.py
@@ -1,0 +1,103 @@
+"""The AI BOM page must not read zero on a populated estate.
+
+``/v1/agent-bom/manifest`` is built from exactly two stores: the fleet registry
+and the MCP observation store. The demo bootstrap seeded the graph, the findings
+and the identities — but neither of those — so the AI BOM rendered
+``0 agents / 0 MCP servers`` while the estate held 48 agents and 25 servers. The
+page's own promise is "live inventory from connected agents … not a static
+upload", and it was showing nothing at all.
+
+Asserted through ``build_control_plane_agent_manifest`` — the function the route
+calls — rather than on the seeder's return value, because the seeder reporting
+"48 seeded" is exactly what was true while the page still showed zero.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+
+@pytest.fixture()
+def seeded_stores(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    monkeypatch.setenv("AGENT_BOM_DEMO_ESTATE", "1")
+    monkeypatch.setenv("AGENT_BOM_DB", str(tmp_path / "demo.db"))
+    monkeypatch.setenv("AGENT_BOM_GRAPH_DB", str(tmp_path / "graph.db"))
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path))
+
+    from agent_bom.api import stores as api_stores
+    from agent_bom.demo_estate.showcase_graph import SHOWCASE_TENANT, seed_showcase_fleet_and_runtime
+
+    api_stores._store = None
+    seed_showcase_fleet_and_runtime(tenant_id=SHOWCASE_TENANT)
+    yield SHOWCASE_TENANT
+
+
+def _manifest(tenant_id: str) -> dict:
+    from agent_bom.agent_manifest import build_control_plane_agent_manifest
+    from agent_bom.api.stores import _get_fleet_store, _get_mcp_observation_store
+
+    return build_control_plane_agent_manifest(
+        _get_fleet_store().list_by_tenant(tenant_id),
+        _get_mcp_observation_store().list_by_tenant(tenant_id),
+        tenant_id=tenant_id,
+    )
+
+
+def test_ai_bom_manifest_reports_the_estates_agents_and_servers(seeded_stores: str) -> None:
+    manifest = _manifest(seeded_stores)
+    summary = manifest.get("summary") or {}
+
+    assert summary.get("agents", 0) > 0, "the AI BOM reports zero agents on a populated estate"
+    assert summary.get("mcp_servers", 0) > 0, "the AI BOM reports zero MCP servers on a populated estate"
+    assert len(manifest.get("agents") or []) == summary["agents"]
+    assert len(manifest.get("mcp_servers") or []) == summary["mcp_servers"]
+
+
+def test_fleet_is_not_all_one_lifecycle_state(seeded_stores: str) -> None:
+    """A governed fleet has a distribution, not one repeated value.
+
+    Every agent sharing a lifecycle state is the tell that nothing is actually
+    being governed — it reads as seeded, which is the impression the estate
+    exists to avoid.
+    """
+    manifest = _manifest(seeded_stores)
+    spread = Counter(agent["status"] for agent in manifest["agents"])
+
+    assert len(spread) >= 3, f"fleet lifecycle has no variety: {dict(spread)}"
+    # The majority should be the healthy state; a demo where most agents are
+    # quarantined is as unrealistic as one where none are.
+    assert spread.most_common(1)[0][0] == "approved", dict(spread)
+
+
+def test_agents_and_servers_carry_operator_context(seeded_stores: str) -> None:
+    """Rows must be readable, not bare identifiers.
+
+    An inventory of unnamed rows cannot be reasoned about, and the estate has
+    real names — the failure mode is dropping them on the way to the page.
+    """
+    manifest = _manifest(seeded_stores)
+
+    for agent in manifest["agents"][:10]:
+        assert agent["name"], agent
+        assert agent["environment"], f"{agent['name']} has no environment"
+        assert agent["owner"], f"{agent['name']} has no owner"
+        assert isinstance(agent["trust_score"], (int, float))
+
+    for server in manifest["mcp_servers"][:10]:
+        assert server["name"], server
+        assert server["transport"], f"{server['name']} has no transport"
+        assert server["auth_mode"], f"{server['name']} has no auth mode"
+
+
+def test_seeding_twice_does_not_duplicate_the_fleet(seeded_stores: str) -> None:
+    """The bootstrap runs on every start; a second pass must be a no-op."""
+    from agent_bom.demo_estate.showcase_graph import seed_showcase_fleet_and_runtime
+
+    before = _manifest(seeded_stores)["summary"]["agents"]
+    result = seed_showcase_fleet_and_runtime(tenant_id=seeded_stores)
+    after = _manifest(seeded_stores)["summary"]["agents"]
+
+    assert result["seeded"] is False, result
+    assert after == before, (before, after)

--- a/ui/components/nhi-governance-panel.tsx
+++ b/ui/components/nhi-governance-panel.tsx
@@ -37,8 +37,32 @@ export function NhiGovernancePanel({ scanId }: { scanId?: string | undefined }) 
     };
   }, [scanId]);
 
-  const counts = posture?.counts ?? {};
+  const rawCounts = posture?.counts ?? {};
   const identities = Array.isArray(posture?.identities) ? posture.identities : [];
+
+  // `/v1/graph/nhi/governance` returns scalar rollups alongside at least one
+  // NESTED breakdown (`by_risk_band` → {critical, medium, low}). Rendering a
+  // value with String() turned that object into the literal text
+  // "[object Object]" on the Identity page. Flatten one level so a breakdown
+  // becomes its own pills — which is the useful reading anyway: "critical 1"
+  // says something, "[object Object]" says the page is broken.
+  const counts: Array<{ key: string; label: string; value: string }> = [];
+  for (const [key, value] of Object.entries(rawCounts)) {
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      const prefix = key.replace(/^by_/, "").replaceAll("_", " ");
+      for (const [childKey, childValue] of Object.entries(value as Record<string, unknown>)) {
+        if (childValue === null || typeof childValue === "object") continue;
+        counts.push({
+          key: `${key}.${childKey}`,
+          label: `${prefix} · ${childKey.replaceAll("_", " ")}`,
+          value: String(childValue),
+        });
+      }
+      continue;
+    }
+    if (value === null || value === undefined) continue;
+    counts.push({ key, label: key.replaceAll("_", " "), value: String(value) });
+  }
 
   return (
     <section
@@ -63,18 +87,18 @@ export function NhiGovernancePanel({ scanId }: { scanId?: string | undefined }) 
       ) : (
         <>
           <div className="mt-3 flex flex-wrap gap-2">
-            {Object.entries(counts).slice(0, 6).map(([key, value]) => (
+            {counts.slice(0, 8).map((entry) => (
               <div
-                key={key}
+                key={entry.key}
                 className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1.5"
               >
                 <p className="text-[10px] uppercase tracking-[0.12em] text-[color:var(--text-tertiary)]">
-                  {key.replaceAll("_", " ")}
+                  {entry.label}
                 </p>
-                <p className="font-mono text-sm text-[color:var(--foreground)]">{String(value)}</p>
+                <p className="font-mono text-sm text-[color:var(--foreground)]">{entry.value}</p>
               </div>
             ))}
-            {!loading && Object.keys(counts).length === 0 ? (
+            {!loading && counts.length === 0 ? (
               <p className="text-xs text-[color:var(--text-tertiary)]">
                 No NHI count rollups for this snapshot.
               </p>


### PR DESCRIPTION
The AI BOM page rendered **0 agents / 0 MCP servers / 0 models / 0 packages / 0 findings** on an estate holding **48 agents, 25 MCP servers and 97 tools**.

Its own heading promises *"live inventory from connected agents, cloud accounts, endpoints, and runtime — not a static upload."* It was showing nothing.

## Root cause

`/v1/agent-bom/manifest` is built from exactly two stores:

```python
fleet_agents = _get_fleet_store().list_by_tenant(tenant_id)
observations = _get_mcp_observation_store().list_by_tenant(tenant_id)
return build_control_plane_agent_manifest(fleet_agents, observations, ...)
```

The demo bootstrap seeds the **graph**, the **findings** and the **identities** — and never touched either of those. So every count on the page was structurally zero regardless of estate size.

## The fix

`seed_showcase_fleet_and_runtime` follows the same contract as the existing `seed_showcase_identities`: idempotent, isolated behind its own `try/except` so a failure can't block the rest of the bootstrap, and only under demo-estate mode.

```
before:  agents 0   mcp_servers 0
after:   agents 48  mcp_servers 25   runtime_observed 18   gateway_registered 16
```

**Variety is deliberate, not decoration.** Fleet lifecycle spreads to **28 approved · 10 pending review · 5 quarantined · 5 discovered**. Every agent sharing one state is the tell that nothing is actually being governed — the exact impression the estate exists to avoid. Servers likewise vary across runtime-observed and gateway-registered.

Rows carry operator context — real names (`member-copilot-00`, `Care Gap Analytics MCP`), owner, environment, trust score, transport, auth mode — because an inventory of bare identifiers can't be reasoned about.

## Verification

Asserted through `build_control_plane_agent_manifest` — the function the route actually calls — **not** on the seeder's return value, because "48 seeded" was already true while the page showed zero.

- `test_demo_estate_ai_bom_manifest.py` — 4 tests: manifest is non-empty, lifecycle has ≥3 states with `approved` dominant, rows carry name/owner/environment/transport/auth, and re-seeding is a no-op (the bootstrap runs on every start).
- demo estate + showcase seeding suites: **50 passed**
- `ruff` · `mypy` clean

## Known gap deliberately NOT fixed here

`summary.tools` is still **0**. `_observed_server()` emits no `tools` key and `MCPObservation` carries no tools field — so the tool count is structurally zero for **any** control-plane tenant, not just the demo. That's a store schema change and doesn't belong in this PR, but it means the AI BOM still under-reports what the servers expose.