### PR TITLE
feat(demo): name estate resources after workloads, not coordinates

### DIFF
--- a/src/agent_bom/demo_estate/enterprise_scale.py
+++ b/src/agent_bom/demo_estate/enterprise_scale.py
@@ -100,6 +100,111 @@ _RESOURCE_MIX: dict[str, tuple[tuple[str, str], ...]] = {
     ),
 }
 
+# What the workloads are FOR. Resource names were previously
+# ``f"{provider}-{service}-{account:02d}-{slot:03d}"`` -> ``aws-iam-03-020``,
+# which is a coordinate, not a name. Nothing in the estate could be reasoned
+# about: an over-privileged role called ``aws-iam-03-020`` tells an operator
+# nothing about blast radius, and a whole inventory of them reads as generated
+# rather than discovered — which is exactly the impression a demo must avoid.
+#
+# These are the workloads a payer/provider AI platform actually runs, so a role
+# named ``prior-auth-reviewer`` failing least-privilege is a sentence a reviewer
+# can act on. Kept as one pool per resource CLASS rather than per provider, so
+# the same business capability shows up across clouds the way it does in a real
+# multi-cloud estate.
+_WORKLOAD_NAMES: dict[str, tuple[str, ...]] = {
+    "compute": (
+        "member-eligibility-api",
+        "claims-intake-worker",
+        "prior-auth-reviewer",
+        "care-gap-scorer",
+        "provider-directory-sync",
+        "appeals-drafter",
+        "clinical-notes-indexer",
+        "risk-adjustment-batch",
+        "formulary-lookup",
+        "benefits-quote-engine",
+    ),
+    "storage": (
+        "member-exports",
+        "claims-archive",
+        "clinical-attachments",
+        "eob-statements",
+        "provider-rosters",
+        "audit-evidence",
+        "model-artifacts",
+        "training-corpora",
+    ),
+    "identity": (
+        "member-eligibility-api",
+        "claims-etl",
+        "prior-auth-reviewer",
+        "care-gap-scorer",
+        "phi-export-approver",
+        "provider-directory-sync",
+        "clinical-analytics-reader",
+        "appeals-drafter",
+        "risk-adjustment-batch",
+        "break-glass-admin",
+    ),
+    "data": (
+        "patient-summary",
+        "claims-ledger",
+        "eligibility-spans",
+        "encounters",
+        "provider-network",
+        "authorizations",
+        "pharmacy-fills",
+        "care-gaps",
+        "quality-measures",
+        "risk-scores",
+    ),
+    "serverless": (
+        "eligibility-webhook",
+        "claim-status-callback",
+        "phi-redactor",
+        "fhir-normalizer",
+        "eob-renderer",
+        "consent-checker",
+        "member-match",
+        "coverage-notifier",
+        "attachment-virus-scan",
+        "audit-log-shipper",
+    ),
+    # No environment token in these: the suffix is appended below, and a pool
+    # entry carrying its own would read "member-ai-prod-development".
+    "cluster": (
+        "member-ai",
+        "claims-platform",
+        "clinical-intelligence",
+        "provider-services",
+        "population-health",
+        "revenue-cycle",
+    ),
+}
+
+# Which name pool a resource type draws from. A type with no entry falls back to
+# the compute pool rather than silently reverting to a coordinate.
+_RESOURCE_NAME_POOL: dict[str, str] = {
+    "instance": "compute",
+    "virtual_machine": "compute",
+    "warehouse": "compute",
+    "bucket": "storage",
+    "storage_account": "storage",
+    "stage": "storage",
+    "share": "storage",
+    "iam_role": "identity",
+    "service_principal": "identity",
+    "service_account": "identity",
+    "role": "identity",
+    "database": "data",
+    "sql_database": "data",
+    "table": "data",
+    "function": "serverless",
+    "function_app": "serverless",
+    "cluster": "cluster",
+}
+
 _REGIONS: dict[str, tuple[str, ...]] = {
     "aws": ("us-east-1", "us-west-2", "eu-west-1"),
     "azure": ("eastus", "westeurope", "centralus"),
@@ -261,6 +366,26 @@ def _stable_index(*parts: str) -> int:
     return int.from_bytes(digest[:4], "big")
 
 
+def _workload_name(provider: str, scope: str, resource_type: str, environment: str, slot: int) -> str:
+    """Name a resource after the workload it serves, not its coordinates.
+
+    Deterministic: the same (provider, account, type, slot) always yields the
+    same name, so snapshots, the drift lens and every pinned test stay stable.
+
+    The environment suffix carries real information — ``claims-etl-prod`` and
+    ``claims-etl-staging`` are genuinely different blast radii — and the numeric
+    tail only appears when a pool wraps within one account, so the common case
+    reads as a name rather than a serial number.
+    """
+    pool_key = _RESOURCE_NAME_POOL.get(resource_type, "compute")
+    pool = _WORKLOAD_NAMES[pool_key]
+    offset = _stable_index(provider, scope, resource_type) % len(pool)
+    index = (offset + slot) % len(pool)
+    wrap = (offset + slot) // len(pool)
+    base = f"{pool[index]}-{environment}"
+    return base if wrap == 0 else f"{base}-{wrap + 1}"
+
+
 def _account_scope(provider: str, index: int) -> str:
     if provider == "aws":
         return f"{100000000000 + index:012d}"
@@ -300,7 +425,7 @@ def _build_assets(profile: ScaleProfile, tenant_id: str) -> tuple[EstateAsset, .
                 # Environment cycles per slot so every account carries all three;
                 # a provider missing an environment collapses its drill-down.
                 environment = ENVIRONMENTS[slot % len(ENVIRONMENTS)]
-                name = f"{provider}-{service}-{account_index:02d}-{slot:03d}"
+                name = _workload_name(provider, scope, resource_type, environment, slot)
                 region = regions[_stable_index(provider, scope, name) % len(regions)]
                 assets.append(
                     EstateAsset(

--- a/tests/test_enterprise_estate_scale.py
+++ b/tests/test_enterprise_estate_scale.py
@@ -218,3 +218,62 @@ def test_the_shipped_estate_keeps_every_shape_guarantee(shipped: EnterpriseEstat
 
     unverified = [e.event_id for e in shipped.observations if not verify_observation_hash(e)]
     assert not unverified, f"{len(unverified)} observations fail their own provenance check at scale"
+
+
+def test_resources_are_named_after_workloads_not_coordinates() -> None:
+    """An inventory of coordinates cannot be reasoned about.
+
+    Resource names were ``f"{provider}-{service}-{account:02d}-{slot:03d}"`` —
+    ``aws-iam-03-020``. That is a position in a loop, not a name: an
+    over-privileged role called ``aws-iam-03-020`` tells an operator nothing
+    about blast radius, and a whole estate of them reads as generated rather
+    than discovered.
+
+    Asserted as "no asset carries the coordinate shape" rather than against a
+    name list, so adding workloads cannot quietly reintroduce the pattern.
+    """
+    import re
+
+    from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+
+    estate = build_demo_estate(tenant_id="default")
+    coordinate = re.compile(r"^(aws|azure|gcp|snowflake)-[a-z]+-\d{2}-\d{3}$")
+    offenders = [a.display_name for a in estate.assets if coordinate.match(a.display_name)]
+
+    assert not offenders, f"{len(offenders)} assets still carry coordinate names, e.g. {offenders[:5]}"
+
+
+def test_workload_names_stay_unique_and_deterministic() -> None:
+    """Names must not collide, and must not move between builds.
+
+    Naming by workload means a pool can wrap within an account; if that dropped
+    uniqueness, two different resources would share an asset id and silently
+    collapse into one row. The drift lens also compares snapshots by id, so a
+    name that changes between builds would read as churn.
+    """
+    from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+
+    first = build_demo_estate(tenant_id="default")
+    second = build_demo_estate(tenant_id="default")
+
+    ids = [a.asset_id for a in first.assets]
+    assert len(ids) == len(set(ids)), f"{len(ids) - len(set(ids))} duplicate asset ids"
+    assert [a.display_name for a in first.assets] == [a.display_name for a in second.assets]
+
+
+def test_the_narrative_assets_keep_their_names() -> None:
+    """Generated naming must not rename the hero incident chain.
+
+    The chain is referenced by id across the graph, the correlations and the
+    demo story; renaming those assets would break the one path the demo is
+    built to walk.
+    """
+    from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+
+    ids = {a.asset_id for a in build_demo_estate(tenant_id="default").assets}
+    for expected in (
+        "cloud_resource:aws:iam:role:member-copilot-prod",
+        "kubernetes:workload:member-ai-prod/ai-prod/member-copilot",
+        "snowflake:table:nh_prod/analytics/phi/patient_summary",
+    ):
+        assert expected in ids, f"narrative asset lost: {expected}"


### PR DESCRIPTION
Resources were named `f"{provider}-{service}-{account:02d}-{slot:03d}"`:

```
aws-iam-03-020     snowflake-data-00-004     azure-storage-05-041
```

That's a position in a loop, not a name. **Nothing in the estate could be reasoned about** — an over-privileged role called `aws-iam-03-020` tells an operator nothing about blast radius, and 3,860 of them read as *generated* rather than *discovered*, which is the one impression a demo estate has to avoid.

## After

| Type | Before | After |
|---|---|---|
| `iam_role` | `aws-iam-03-020` | `prior-auth-reviewer-development`, `clinical-analytics-reader-development` |
| `bucket` | `aws-s3-01-007` | `member-exports-prod`, `provider-rosters-staging` |
| `table` | `snowflake-data-00-004` | `care-gaps-staging`, `encounters-staging` |
| `cluster` | `gcp-gke-02-013` | `member-ai-prod`, `population-health-development` |
| `function` | `aws-lambda-04-022` | `attachment-virus-scan-staging`, `eob-renderer-staging` |

Names come from workload pools a payer/provider AI platform actually runs, so a least-privilege failure on `phi-export-approver-prod` is a sentence a reviewer can act on.

## Details that matter

- **Pools are keyed by resource class, not provider** — the same business capability appears across clouds, the way it does in a real multi-cloud estate.
- **The environment suffix carries information.** `claims-etl-prod` and `claims-etl-staging` are genuinely different blast radii.
- **The numeric tail only appears when a pool wraps inside one account**, so the common case reads as a name rather than a serial number.
- **Cluster pool entries carry no environment token of their own** — that was producing `member-ai-prod-development`.
- **Deterministic** by `(provider, account, type, slot)`, so snapshots, the drift lens and pinned tests stay stable across builds.

## Gated on the property, not a name list

- No asset may carry the coordinate shape — a regex, so adding workloads can't quietly reintroduce it
- **Ids stay unique** — a wrapping pool must not collapse two resources onto one asset id
- Names are **stable between builds** — the drift lens compares by id, so churn would read as change
- **The hero incident chain keeps its ids** (`member-copilot-prod`, `member-ai-prod/ai-prod/member-copilot`, `nh_prod/analytics/phi/patient_summary`) — the graph, correlations and demo story all reference those

**132 passed** across the eight estate/demo suites · `ruff` · `mypy` clean.