### PR TITLE
test(ci): assert the Smithery status split instead of the old fatal group

### DIFF
--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -719,7 +719,18 @@ def test_smithery_publish_is_gated_on_server_card_and_catalog_parity():
     assert "(.tools | length) == $tool_count" in workflow
     assert '(.inputSchema | type == "object")' in workflow
     assert "Wait for Smithery release" in workflow
-    assert "FAILURE_SCAN|AUTH_REQUIRED|AUTH_TIMEOUT" in workflow
+    # The terminal statuses are split deliberately (#4687). Our MCP endpoint
+    # authenticates every request by design and the published configSchema marks
+    # `bearerToken` required, so Smithery's scanner CANNOT enumerate our tools
+    # and settles the release as AUTH_REQUIRED. The release itself succeeded;
+    # only the optional post-publish scan did not. Treating that as fatal failed
+    # every release and auto-opened a release-blocker for a server that had in
+    # fact published.
+    assert "AUTH_REQUIRED|AUTH_TIMEOUT" in workflow, "auth statuses must be handled as their own non-fatal case"
+    assert "FAILURE|FAILURE_SCAN|CANCELLED|INTERNAL_ERROR" in workflow, "real failures must still fail the job"
+    # Guard the split itself: if AUTH_REQUIRED is ever folded back in with the
+    # fatal statuses, releases start failing again for a publish that worked.
+    assert "FAILURE_SCAN|AUTH_REQUIRED" not in workflow, "AUTH_REQUIRED must not be grouped with the fatal statuses"
     assert "Verify Smithery catalog inventory" in workflow
     assert 'if [ "$ACTUAL" = "$EXPECTED_TOOL_COUNT" ]; then' in workflow
 


### PR DESCRIPTION
**`main` has been red since #4687.** This unblocks it.

That PR split `AUTH_REQUIRED` / `AUTH_TIMEOUT` out of the fatal terminal statuses. `test_deployment.py` pinned the old combined literal `FAILURE_SCAN|AUTH_REQUIRED|AUTH_TIMEOUT`, which no longer exists in the workflow.

**My miss.** When making that change I ran `test_ci_workflow_contract` and `test_release_storefront_contract` and never ran `test_deployment.py` — which asserts against the same workflow file. Two suites pinning one file, and I only checked the ones whose names matched what I was editing.

## Rewritten to assert behaviour, not a literal

- `AUTH_REQUIRED|AUTH_TIMEOUT` handled as their own **non-fatal** case. Our MCP endpoint authenticates every request by design, and the published `configSchema` marks `bearerToken` required — so Smithery's scanner cannot enumerate our tools and settles the release `AUTH_REQUIRED`. The release itself succeeded; only the optional post-publish scan did not.
- `FAILURE|FAILURE_SCAN|CANCELLED|INTERNAL_ERROR` still fail the job.
- A **negative assertion** that `AUTH_REQUIRED` is never regrouped with the fatal statuses. Folding it back in silently returns to failing every release for a publish that worked — which is exactly what #4687 fixed, and exactly what a future refactor might undo.

## Verification

**153 passed, 5 skipped** across the deployment / CI-workflow / release-storefront / smithery / registries suites. `ruff` clean.