### PR TITLE
chore(deps): bump github/codeql-action to v4.37.5 across every workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,16 +33,16 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           languages: python
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/autobuild@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           category: /language:python
 
@@ -60,14 +60,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           languages: actions
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/autobuild@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           category: /language:actions

--- a/.github/workflows/container-rescan.yml
+++ b/.github/workflows/container-rescan.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Upload SARIF to GitHub Security tab
         if: always() && steps.sarif.outputs.exists == 'true'
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           sarif_file: ${{ steps.sarif.outputs.path }}
           category: ${{ matrix.sarif_category }}

--- a/.github/workflows/post-merge-self-scan.yml
+++ b/.github/workflows/post-merge-self-scan.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload dep scan SARIF
         if: always() && hashFiles('sarif/self-dep.sarif') != ''
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           sarif_file: sarif/self-dep.sarif
           category: agent-bom-self-dep
@@ -247,7 +247,7 @@ jobs:
 
       - name: Upload SAST SARIF
         if: always() && hashFiles('sarif/self-sast.sarif') != ''
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           sarif_file: sarif/self-sast.sarif
           category: agent-bom-self-sast

--- a/.github/workflows/pr-security-gate.yml
+++ b/.github/workflows/pr-security-gate.yml
@@ -86,13 +86,13 @@ jobs:
           EOF
 
       - name: Upload dependency self-scan config placeholder
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           sarif_file: sarif/empty-agent-bom.sarif
           category: agent-bom-self-dep
 
       - name: Upload SAST self-scan config placeholder
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           sarif_file: sarif/empty-agent-bom.sarif
           category: agent-bom-self-sast
@@ -319,7 +319,7 @@ jobs:
 
       - name: Upload SARIF to code-scanning
         if: always() && hashFiles('self-scan.sarif') != ''
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           sarif_file: self-scan.sarif
           category: agent-bom-self-scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -743,7 +743,7 @@ jobs:
 
       - name: Upload Trivy SARIF to GitHub Security tab
         if: always() && hashFiles('trivy-published-image.sarif') != ''
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           sarif_file: trivy-published-image.sarif
           category: release-published-image-trivy
@@ -1135,7 +1135,7 @@ jobs:
 
       - name: Upload release self-scan SARIF
         if: always() && hashFiles('sarif/release-self-dep.sarif') != ''
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           sarif_file: sarif/release-self-dep.sarif
           category: agent-bom-release-gate


### PR DESCRIPTION
Consolidates **#4695, #4696, #4697 and #4698** — four dependabot PRs bumping four sub-actions of the *same* action to the *same* version.

Splitting them meant four CI runs and four reviews for one upgrade, plus a window where the pinned SHAs disagreed with each other across workflows depending on merge order.

## What moves

`init`, `autobuild`, `analyze` and `upload-sarif` — every reference, in all **five** workflow files that pin them (`codeql`, `release`, `container-rescan`, `pr-security-gate`, `post-merge-self-scan`).

```
f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
→ d1ba80a13dd99fba24a470575428917156a28b43  # v4.37.5
```

The old SHA no longer appears anywhere in `.github/workflows/`. The new SHA is taken from dependabot's own diff rather than resolved by hand, so the pin is exactly what it verified.

`actionlint` clean on every touched workflow.

## Note on CI

This branch is cut from `main`, which is currently red — `test_deployment.py::test_smithery_publish_is_gated_on_server_card_and_catalog_parity` fails here for that reason, not because of this change. **#4700 fixes it**; merge that first and this goes green. Everything else passes (255 passed, 6 skipped across the workflow/deployment/CI suites).