### PR TITLE
fix: unblock main, and make the estate readable

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-05",
+  "generated_on": "2026-08-06",
   "version": "0.99.0",
   "metrics": [
     {
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1139,
+      "value": 1140,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-05`
+- Generated on: `2026-08-06`
 - Version: `0.99.0`
 
 | Metric | Value | Source | Notes |
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1139 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1140 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 835 | `src/agent_bom` | Counts all Python files recursively. |

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -12,6 +12,7 @@ from agent_bom.api.pipeline import _now
 from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
 from agent_bom.demo_estate.showcase_graph import (
     SHOWCASE_TENANT,
+    seed_showcase_fleet_and_runtime,
     seed_showcase_graph_if_empty,
     seed_showcase_identities,
 )
@@ -223,6 +224,16 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
     except Exception:
         _logger.warning("demo estate identity seeding failed", exc_info=True)
         summary["identity_error"] = True
+
+    # The AI BOM page reads the fleet registry and the MCP observation store —
+    # neither of which the graph/findings seeds touch, so it rendered every
+    # count as 0 on a fully populated estate. Same isolation as the identity
+    # seed above: its failure must not block the rest of the bootstrap.
+    try:
+        summary["fleet_runtime"] = seed_showcase_fleet_and_runtime(tenant_id=tenant_id)
+    except Exception:
+        _logger.warning("demo estate fleet/runtime seeding failed", exc_info=True)
+        summary["fleet_runtime_error"] = True
 
     # Seed the runtime gateway feed (proxy alerts + metrics + firewall
     # decisions) so the gateway/proxy/runtime dashboards show the AI-firewall in

--- a/src/agent_bom/demo_estate/enterprise_scale.py
+++ b/src/agent_bom/demo_estate/enterprise_scale.py
@@ -100,6 +100,111 @@ _RESOURCE_MIX: dict[str, tuple[tuple[str, str], ...]] = {
     ),
 }
 
+# What the workloads are FOR. Resource names were previously
+# ``f"{provider}-{service}-{account:02d}-{slot:03d}"`` -> ``aws-iam-03-020``,
+# which is a coordinate, not a name. Nothing in the estate could be reasoned
+# about: an over-privileged role called ``aws-iam-03-020`` tells an operator
+# nothing about blast radius, and a whole inventory of them reads as generated
+# rather than discovered — which is exactly the impression a demo must avoid.
+#
+# These are the workloads a payer/provider AI platform actually runs, so a role
+# named ``prior-auth-reviewer`` failing least-privilege is a sentence a reviewer
+# can act on. Kept as one pool per resource CLASS rather than per provider, so
+# the same business capability shows up across clouds the way it does in a real
+# multi-cloud estate.
+_WORKLOAD_NAMES: dict[str, tuple[str, ...]] = {
+    "compute": (
+        "member-eligibility-api",
+        "claims-intake-worker",
+        "prior-auth-reviewer",
+        "care-gap-scorer",
+        "provider-directory-sync",
+        "appeals-drafter",
+        "clinical-notes-indexer",
+        "risk-adjustment-batch",
+        "formulary-lookup",
+        "benefits-quote-engine",
+    ),
+    "storage": (
+        "member-exports",
+        "claims-archive",
+        "clinical-attachments",
+        "eob-statements",
+        "provider-rosters",
+        "audit-evidence",
+        "model-artifacts",
+        "training-corpora",
+    ),
+    "identity": (
+        "member-eligibility-api",
+        "claims-etl",
+        "prior-auth-reviewer",
+        "care-gap-scorer",
+        "phi-export-approver",
+        "provider-directory-sync",
+        "clinical-analytics-reader",
+        "appeals-drafter",
+        "risk-adjustment-batch",
+        "break-glass-admin",
+    ),
+    "data": (
+        "patient-summary",
+        "claims-ledger",
+        "eligibility-spans",
+        "encounters",
+        "provider-network",
+        "authorizations",
+        "pharmacy-fills",
+        "care-gaps",
+        "quality-measures",
+        "risk-scores",
+    ),
+    "serverless": (
+        "eligibility-webhook",
+        "claim-status-callback",
+        "phi-redactor",
+        "fhir-normalizer",
+        "eob-renderer",
+        "consent-checker",
+        "member-match",
+        "coverage-notifier",
+        "attachment-virus-scan",
+        "audit-log-shipper",
+    ),
+    # No environment token in these: the suffix is appended below, and a pool
+    # entry carrying its own would read "member-ai-prod-development".
+    "cluster": (
+        "member-ai",
+        "claims-platform",
+        "clinical-intelligence",
+        "provider-services",
+        "population-health",
+        "revenue-cycle",
+    ),
+}
+
+# Which name pool a resource type draws from. A type with no entry falls back to
+# the compute pool rather than silently reverting to a coordinate.
+_RESOURCE_NAME_POOL: dict[str, str] = {
+    "instance": "compute",
+    "virtual_machine": "compute",
+    "warehouse": "compute",
+    "bucket": "storage",
+    "storage_account": "storage",
+    "stage": "storage",
+    "share": "storage",
+    "iam_role": "identity",
+    "service_principal": "identity",
+    "service_account": "identity",
+    "role": "identity",
+    "database": "data",
+    "sql_database": "data",
+    "table": "data",
+    "function": "serverless",
+    "function_app": "serverless",
+    "cluster": "cluster",
+}
+
 _REGIONS: dict[str, tuple[str, ...]] = {
     "aws": ("us-east-1", "us-west-2", "eu-west-1"),
     "azure": ("eastus", "westeurope", "centralus"),
@@ -261,6 +366,26 @@ def _stable_index(*parts: str) -> int:
     return int.from_bytes(digest[:4], "big")
 
 
+def _workload_name(provider: str, scope: str, resource_type: str, environment: str, slot: int) -> str:
+    """Name a resource after the workload it serves, not its coordinates.
+
+    Deterministic: the same (provider, account, type, slot) always yields the
+    same name, so snapshots, the drift lens and every pinned test stay stable.
+
+    The environment suffix carries real information — ``claims-etl-prod`` and
+    ``claims-etl-staging`` are genuinely different blast radii — and the numeric
+    tail only appears when a pool wraps within one account, so the common case
+    reads as a name rather than a serial number.
+    """
+    pool_key = _RESOURCE_NAME_POOL.get(resource_type, "compute")
+    pool = _WORKLOAD_NAMES[pool_key]
+    offset = _stable_index(provider, scope, resource_type) % len(pool)
+    index = (offset + slot) % len(pool)
+    wrap = (offset + slot) // len(pool)
+    base = f"{pool[index]}-{environment}"
+    return base if wrap == 0 else f"{base}-{wrap + 1}"
+
+
 def _account_scope(provider: str, index: int) -> str:
     if provider == "aws":
         return f"{100000000000 + index:012d}"
@@ -300,7 +425,7 @@ def _build_assets(profile: ScaleProfile, tenant_id: str) -> tuple[EstateAsset, .
                 # Environment cycles per slot so every account carries all three;
                 # a provider missing an environment collapses its drill-down.
                 environment = ENVIRONMENTS[slot % len(ENVIRONMENTS)]
-                name = f"{provider}-{service}-{account_index:02d}-{slot:03d}"
+                name = _workload_name(provider, scope, resource_type, environment, slot)
                 region = regions[_stable_index(provider, scope, name) % len(regions)]
                 assets.append(
                     EstateAsset(

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -215,6 +215,110 @@ def seed_showcase_identities(tenant_id: str = SHOWCASE_TENANT) -> dict[str, Any]
     return {"seeded": True, "identities": len(identities), "jit_grants": len(grants)}
 
 
+def seed_showcase_fleet_and_runtime(tenant_id: str = SHOWCASE_TENANT) -> dict[str, Any]:
+    """Populate the LIVE fleet and MCP-observation stores from the estate.
+
+    ``/v1/agent-bom/manifest`` — the AI BOM page — is built from exactly two
+    stores: the fleet registry and the MCP observation store. The demo bootstrap
+    seeded the graph, the findings and the identities, but never those two, so
+    the AI BOM read **0 agents / 0 MCP servers / 0 tools** on an estate holding
+    48 agents, 25 servers and 97 tools. The page's own promise is "live
+    inventory from connected agents… not a static upload", and it was showing
+    nothing at all.
+
+    Same contract as :func:`seed_showcase_identities`: idempotent, independent
+    of the graph seed, and only ever under demo-estate mode, so a restart or an
+    already-seeded graph still leaves the AI BOM populated.
+    """
+    from agent_bom.api.fleet_store import FleetAgent, FleetLifecycleState
+    from agent_bom.api.mcp_observation_store import MCPObservation
+    from agent_bom.api.stores import _get_fleet_store, _get_mcp_observation_store
+    from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+
+    fleet_store = _get_fleet_store()
+    observation_store = _get_mcp_observation_store()
+    if any(a.agent_id.startswith("demo-fleet-") for a in fleet_store.list_by_tenant(tenant_id)):
+        return {"seeded": False, "reason": "fleet_present"}
+
+    estate = build_demo_estate(tenant_id=tenant_id)
+    by_type: dict[str, list[Any]] = {}
+    for asset in estate.assets:
+        by_type.setdefault(asset.resource_type, []).append(asset)
+
+    servers = by_type.get("server", [])
+    tools_by_server: dict[str, list[Any]] = {}
+    for tool in by_type.get("tool", []):
+        tools_by_server.setdefault(str(tool.tags.get("mcp_server") or ""), []).append(tool)
+
+    now = datetime.now(timezone.utc).isoformat()
+    agents = by_type.get("agent", [])
+    for index, asset in enumerate(agents):
+        # Deterministic spread so the fleet reads like a managed estate rather
+        # than one uniform block. A real fleet is mostly approved with a tail of
+        # in-flight and problem agents; every row in one state is the tell that
+        # nothing is actually being governed.
+        bucket = index % 10
+        if bucket == 0:
+            state = FleetLifecycleState.QUARANTINED
+        elif bucket in (1, 2):
+            state = FleetLifecycleState.PENDING_REVIEW
+        elif bucket == 3:
+            state = FleetLifecycleState.DISCOVERED
+        else:
+            state = FleetLifecycleState.APPROVED
+        fleet_store.put(
+            FleetAgent(
+                agent_id=f"demo-fleet-{asset.asset_id}",
+                name=asset.display_name,
+                agent_type=str(asset.tags.get("agent_framework") or "mcp-client"),
+                lifecycle_state=state,
+                owner=str(asset.tags.get("owner") or "platform-engineering"),
+                environment=asset.environment or "production",
+                tags=[t for t in (asset.environment, asset.provider) if t],
+                trust_score=round(0.55 + ((index % 9) / 20.0), 2),
+                server_count=len(servers[index % max(1, len(servers)) : index % max(1, len(servers)) + 2]),
+                tenant_id=tenant_id,
+                last_discovery=now,
+                last_scan=now,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+    for index, asset in enumerate(servers):
+        tools = tools_by_server.get(asset.asset_id, [])
+        observation_store.put(
+            MCPObservation(
+                tenant_id=tenant_id,
+                observation_id=f"demo-obs-{asset.asset_id}",
+                server_stable_id=asset.asset_id,
+                server_name=asset.display_name,
+                agent_name=agents[index % len(agents)].display_name if agents else "",
+                transport=str(asset.tags.get("transport") or "streamable-http"),
+                url=asset.native_id if str(asset.native_id).startswith("http") else None,
+                auth_mode=str(asset.tags.get("auth_mode") or "bearer"),
+                credential_env_vars=[],
+                observed_via=["demo-estate"],
+                scan_sources=["demo-estate"],
+                source_agents=[a.display_name for a in agents[index % max(1, len(agents)) : index % max(1, len(agents)) + 2]],
+                configured_locally=False,
+                fleet_present=True,
+                gateway_registered=index % 3 != 0,
+                runtime_observed=index % 4 != 0,
+                observed_scopes=sorted({str(t.tags.get("scope") or "read") for t in tools}) or ["read"],
+                first_seen=now,
+                last_seen=now,
+            )
+        )
+
+    return {
+        "seeded": True,
+        "fleet_agents": len(agents),
+        "mcp_observations": len(servers),
+        "tools": sum(len(v) for v in tools_by_server.values()),
+    }
+
+
 def _annotate_demo_identity_risk(graph: UnifiedGraph) -> None:
     """Pin privilege / exposure signals the identity record cannot carry.
 

--- a/tests/test_demo_estate_ai_bom_manifest.py
+++ b/tests/test_demo_estate_ai_bom_manifest.py
@@ -1,0 +1,103 @@
+"""The AI BOM page must not read zero on a populated estate.
+
+``/v1/agent-bom/manifest`` is built from exactly two stores: the fleet registry
+and the MCP observation store. The demo bootstrap seeded the graph, the findings
+and the identities — but neither of those — so the AI BOM rendered
+``0 agents / 0 MCP servers`` while the estate held 48 agents and 25 servers. The
+page's own promise is "live inventory from connected agents … not a static
+upload", and it was showing nothing at all.
+
+Asserted through ``build_control_plane_agent_manifest`` — the function the route
+calls — rather than on the seeder's return value, because the seeder reporting
+"48 seeded" is exactly what was true while the page still showed zero.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+
+@pytest.fixture()
+def seeded_stores(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    monkeypatch.setenv("AGENT_BOM_DEMO_ESTATE", "1")
+    monkeypatch.setenv("AGENT_BOM_DB", str(tmp_path / "demo.db"))
+    monkeypatch.setenv("AGENT_BOM_GRAPH_DB", str(tmp_path / "graph.db"))
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path))
+
+    from agent_bom.api import stores as api_stores
+    from agent_bom.demo_estate.showcase_graph import SHOWCASE_TENANT, seed_showcase_fleet_and_runtime
+
+    api_stores._store = None
+    seed_showcase_fleet_and_runtime(tenant_id=SHOWCASE_TENANT)
+    yield SHOWCASE_TENANT
+
+
+def _manifest(tenant_id: str) -> dict:
+    from agent_bom.agent_manifest import build_control_plane_agent_manifest
+    from agent_bom.api.stores import _get_fleet_store, _get_mcp_observation_store
+
+    return build_control_plane_agent_manifest(
+        _get_fleet_store().list_by_tenant(tenant_id),
+        _get_mcp_observation_store().list_by_tenant(tenant_id),
+        tenant_id=tenant_id,
+    )
+
+
+def test_ai_bom_manifest_reports_the_estates_agents_and_servers(seeded_stores: str) -> None:
+    manifest = _manifest(seeded_stores)
+    summary = manifest.get("summary") or {}
+
+    assert summary.get("agents", 0) > 0, "the AI BOM reports zero agents on a populated estate"
+    assert summary.get("mcp_servers", 0) > 0, "the AI BOM reports zero MCP servers on a populated estate"
+    assert len(manifest.get("agents") or []) == summary["agents"]
+    assert len(manifest.get("mcp_servers") or []) == summary["mcp_servers"]
+
+
+def test_fleet_is_not_all_one_lifecycle_state(seeded_stores: str) -> None:
+    """A governed fleet has a distribution, not one repeated value.
+
+    Every agent sharing a lifecycle state is the tell that nothing is actually
+    being governed — it reads as seeded, which is the impression the estate
+    exists to avoid.
+    """
+    manifest = _manifest(seeded_stores)
+    spread = Counter(agent["status"] for agent in manifest["agents"])
+
+    assert len(spread) >= 3, f"fleet lifecycle has no variety: {dict(spread)}"
+    # The majority should be the healthy state; a demo where most agents are
+    # quarantined is as unrealistic as one where none are.
+    assert spread.most_common(1)[0][0] == "approved", dict(spread)
+
+
+def test_agents_and_servers_carry_operator_context(seeded_stores: str) -> None:
+    """Rows must be readable, not bare identifiers.
+
+    An inventory of unnamed rows cannot be reasoned about, and the estate has
+    real names — the failure mode is dropping them on the way to the page.
+    """
+    manifest = _manifest(seeded_stores)
+
+    for agent in manifest["agents"][:10]:
+        assert agent["name"], agent
+        assert agent["environment"], f"{agent['name']} has no environment"
+        assert agent["owner"], f"{agent['name']} has no owner"
+        assert isinstance(agent["trust_score"], (int, float))
+
+    for server in manifest["mcp_servers"][:10]:
+        assert server["name"], server
+        assert server["transport"], f"{server['name']} has no transport"
+        assert server["auth_mode"], f"{server['name']} has no auth mode"
+
+
+def test_seeding_twice_does_not_duplicate_the_fleet(seeded_stores: str) -> None:
+    """The bootstrap runs on every start; a second pass must be a no-op."""
+    from agent_bom.demo_estate.showcase_graph import seed_showcase_fleet_and_runtime
+
+    before = _manifest(seeded_stores)["summary"]["agents"]
+    result = seed_showcase_fleet_and_runtime(tenant_id=seeded_stores)
+    after = _manifest(seeded_stores)["summary"]["agents"]
+
+    assert result["seeded"] is False, result
+    assert after == before, (before, after)

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -719,7 +719,18 @@ def test_smithery_publish_is_gated_on_server_card_and_catalog_parity():
     assert "(.tools | length) == $tool_count" in workflow
     assert '(.inputSchema | type == "object")' in workflow
     assert "Wait for Smithery release" in workflow
-    assert "FAILURE_SCAN|AUTH_REQUIRED|AUTH_TIMEOUT" in workflow
+    # The terminal statuses are split deliberately (#4687). Our MCP endpoint
+    # authenticates every request by design and the published configSchema marks
+    # `bearerToken` required, so Smithery's scanner CANNOT enumerate our tools
+    # and settles the release as AUTH_REQUIRED. The release itself succeeded;
+    # only the optional post-publish scan did not. Treating that as fatal failed
+    # every release and auto-opened a release-blocker for a server that had in
+    # fact published.
+    assert "AUTH_REQUIRED|AUTH_TIMEOUT" in workflow, "auth statuses must be handled as their own non-fatal case"
+    assert "FAILURE|FAILURE_SCAN|CANCELLED|INTERNAL_ERROR" in workflow, "real failures must still fail the job"
+    # Guard the split itself: if AUTH_REQUIRED is ever folded back in with the
+    # fatal statuses, releases start failing again for a publish that worked.
+    assert "FAILURE_SCAN|AUTH_REQUIRED" not in workflow, "AUTH_REQUIRED must not be grouped with the fatal statuses"
     assert "Verify Smithery catalog inventory" in workflow
     assert 'if [ "$ACTUAL" = "$EXPECTED_TOOL_COUNT" ]; then' in workflow
 

--- a/tests/test_enterprise_estate_scale.py
+++ b/tests/test_enterprise_estate_scale.py
@@ -218,3 +218,62 @@ def test_the_shipped_estate_keeps_every_shape_guarantee(shipped: EnterpriseEstat
 
     unverified = [e.event_id for e in shipped.observations if not verify_observation_hash(e)]
     assert not unverified, f"{len(unverified)} observations fail their own provenance check at scale"
+
+
+def test_resources_are_named_after_workloads_not_coordinates() -> None:
+    """An inventory of coordinates cannot be reasoned about.
+
+    Resource names were ``f"{provider}-{service}-{account:02d}-{slot:03d}"`` —
+    ``aws-iam-03-020``. That is a position in a loop, not a name: an
+    over-privileged role called ``aws-iam-03-020`` tells an operator nothing
+    about blast radius, and a whole estate of them reads as generated rather
+    than discovered.
+
+    Asserted as "no asset carries the coordinate shape" rather than against a
+    name list, so adding workloads cannot quietly reintroduce the pattern.
+    """
+    import re
+
+    from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+
+    estate = build_demo_estate(tenant_id="default")
+    coordinate = re.compile(r"^(aws|azure|gcp|snowflake)-[a-z]+-\d{2}-\d{3}$")
+    offenders = [a.display_name for a in estate.assets if coordinate.match(a.display_name)]
+
+    assert not offenders, f"{len(offenders)} assets still carry coordinate names, e.g. {offenders[:5]}"
+
+
+def test_workload_names_stay_unique_and_deterministic() -> None:
+    """Names must not collide, and must not move between builds.
+
+    Naming by workload means a pool can wrap within an account; if that dropped
+    uniqueness, two different resources would share an asset id and silently
+    collapse into one row. The drift lens also compares snapshots by id, so a
+    name that changes between builds would read as churn.
+    """
+    from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+
+    first = build_demo_estate(tenant_id="default")
+    second = build_demo_estate(tenant_id="default")
+
+    ids = [a.asset_id for a in first.assets]
+    assert len(ids) == len(set(ids)), f"{len(ids) - len(set(ids))} duplicate asset ids"
+    assert [a.display_name for a in first.assets] == [a.display_name for a in second.assets]
+
+
+def test_the_narrative_assets_keep_their_names() -> None:
+    """Generated naming must not rename the hero incident chain.
+
+    The chain is referenced by id across the graph, the correlations and the
+    demo story; renaming those assets would break the one path the demo is
+    built to walk.
+    """
+    from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+
+    ids = {a.asset_id for a in build_demo_estate(tenant_id="default").assets}
+    for expected in (
+        "cloud_resource:aws:iam:role:member-copilot-prod",
+        "kubernetes:workload:member-ai-prod/ai-prod/member-copilot",
+        "snowflake:table:nh_prod/analytics/phi/patient_summary",
+    ):
+        assert expected in ids, f"narrative asset lost: {expected}"

--- a/ui/components/overview-cockpit.tsx
+++ b/ui/components/overview-cockpit.tsx
@@ -437,7 +437,7 @@ function SecurityCoverageLanes({ coverage }: { coverage?: OverviewCoverageLane[]
     <div className="pt-1" data-testid="overview-security-coverage">
       <h3 className="mb-1 text-xs font-semibold text-[color:var(--foreground)]">Security disciplines</h3>
       <p className="mb-2 text-[11px] leading-4 text-[color:var(--text-tertiary)]">
-        Coverage by discipline — lenses can overlap, so a repo CVE counts under both Vuln mgmt and ASPM. Lanes are not additive.
+        Open findings per posture discipline — not assets or accounts. Lenses overlap, so one repo CVE counts under both Vuln mgmt and ASPM; lanes are not additive and will not sum to the total.
       </p>
       <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
         {coverage.map((lane) => {
@@ -452,8 +452,20 @@ function SecurityCoverageLanes({ coverage }: { coverage?: OverviewCoverageLane[]
             >
               <div className="flex items-baseline justify-between gap-2">
                 <span className="text-xs font-semibold text-[color:var(--foreground)]">{lane.label}</span>
-                <span className="text-lg font-bold tabular-nums text-[color:var(--foreground)]">
-                  {total > 0 ? lane.count : "—"}
+                {/* The unit is not decoration. A bare "1610" under a heading
+                    called CSPM reads as assets, accounts, VMs or data stores
+                    depending on the reader — every one of which is wrong. These
+                    are FINDINGS in that posture lane, which is also what the
+                    severity chips below sum to. */}
+                <span className="flex items-baseline gap-1">
+                  <span className="text-lg font-bold tabular-nums text-[color:var(--foreground)]">
+                    {total > 0 ? lane.count.toLocaleString() : "—"}
+                  </span>
+                  {total > 0 ? (
+                    <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-[color:var(--text-tertiary)]">
+                      {lane.count === 1 ? "finding" : "findings"}
+                    </span>
+                  ) : null}
                 </span>
               </div>
               {/* Stacked severity strip — widths reflect share of the lane count. */}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8053,9 +8053,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,7 +43,8 @@
     "brace-expansion": "5.0.9",
     "postcss": "8.5.23",
     "minimatch@3.1.5": "10.2.5",
-    "sharp": "^0.35.0"
+    "sharp": "^0.35.0",
+    "js-yaml": "^4.3.1"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^16.2.12",

--- a/ui/tests/overview-cockpit.test.tsx
+++ b/ui/tests/overview-cockpit.test.tsx
@@ -121,8 +121,13 @@ describe("OverviewCockpit", () => {
     const section = screen.getByTestId("overview-security-coverage");
     expect(section).toBeInTheDocument();
     // Lanes are labeled as overlapping disciplines so a user never sums them.
-    expect(screen.getByText(/lenses can overlap/i)).toBeInTheDocument();
+    expect(screen.getByText(/lenses overlap/i)).toBeInTheDocument();
     expect(screen.getByText(/not additive/i)).toBeInTheDocument();
+    // The magnitude must carry its unit. A bare number under a heading called
+    // CSPM reads as assets, accounts or data stores depending on the reader —
+    // all wrong. These are findings, which is what the severity chips sum to.
+    expect(screen.getByText(/open findings per posture discipline/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/^findings?$/i).length).toBeGreaterThan(0);
     // Each lane links to its domain-filtered findings view.
     expect(screen.getByTestId("coverage-lane-cspm")).toHaveAttribute("href", "/findings?domain=cspm");
     // Unrated is surfaced as its own chip when present.


### PR DESCRIPTION
Replaces #4700 (closed only to get clean check runs after a GitHub Actions outage — no code changed).

**Merge this first — `main` is currently red and this unblocks it.**

## 1. `main` is red, and it's my regression

#4687 split `AUTH_REQUIRED` / `AUTH_TIMEOUT` out of Smithery's fatal terminal statuses. `test_deployment.py` pinned the old literal `FAILURE_SCAN|AUTH_REQUIRED|AUTH_TIMEOUT`, which stopped existing.

**My miss:** I ran `test_ci_workflow_contract` and `test_release_storefront_contract` and never ran `test_deployment.py` — two suites assert against the same workflow file and I only ran the ones whose names matched what I was editing. Reproduced on clean `main` to confirm.

Rewritten to assert behaviour rather than a literal, including a **negative** assertion that `AUTH_REQUIRED` is never regrouped with the fatal statuses — folding it back in silently returns to failing every release for a publish that worked.

## 2. The AI BOM read zero on a populated estate

`0 agents / 0 MCP servers` while the estate held 48 agents and 25 servers. The manifest is built from the fleet registry and MCP observation store, and the demo bootstrap seeds the graph, findings and identities — but **neither of those**.

```
before:  agents 0   mcp_servers 0
after:   agents 48  mcp_servers 25   runtime_observed 18   gateway_registered 16
```

Fleet lifecycle spreads to **28 approved · 10 pending review · 5 quarantined · 5 discovered**. Every agent in one state is the tell that nothing is being governed.

Asserted through `build_control_plane_agent_manifest` — the function the route calls — not the seeder's return value: "48 seeded" was already true while the page showed zero.

## 3. Resources were named after their loop position

`aws-iam-03-020`, `snowflake-data-00-004`. A coordinate is not a name — an over-privileged role called `aws-iam-03-020` says nothing about blast radius, and 3,860 of them read as generated rather than discovered.

Now `phi-export-approver-prod`, `member-exports-prod`, `care-gaps-staging`, `member-ai-prod`. **Zero coordinate-named assets remain.**

Gated on the property: no asset matches the coordinate regex, ids stay unique (a wrapping pool must not collapse two resources onto one id), names are stable between builds, and the hero incident chain keeps its ids.

## 4. The coverage lanes showed a magnitude with no unit

`CSPM 1610`, `DSPM 107` — under a three-letter heading a bare number reads as assets, accounts or data stores. All wrong. They are **findings**, which is what the severity chips sum to (`300+633+358+258+61 = 1610`).

`DSPM 107` meant 107 findings in the data lane, **not** 107 connected data stores. Now labelled, with the caption stating "not assets or accounts".

## Verification

- deployment / AI BOM / estate scale: **84 passed**
- estate + correlation: **73 passed** · bootstrap, seeding, surfaces, projection: **66 passed**
- **Full UI suite: 168 files, 1,048 tests**
- `ruff` · `mypy` (835 files) · `make preflight` — clean