### PR TITLE
chore(deps): take @dagrejs/dagre 3.1.0 and restore bundle headroom

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ui",
       "version": "0.99.0",
       "dependencies": {
-        "@dagrejs/dagre": "^3.0.0",
+        "@dagrejs/dagre": "^3.1.0",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.14.9",
         "@xyflow/react": "^12.11.2",
@@ -539,18 +539,18 @@
       }
     },
     "node_modules/@dagrejs/dagre": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
-      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.1.0.tgz",
+      "integrity": "sha512-22SWJOfiQVCSFF0qN43SMiYS7Ch9Z6HZoO8+5PycGzGgmtdXIvHoZ2DoT5BweVGf+wwHxBFZu4eO0do0RIYQaw==",
       "license": "MIT",
       "dependencies": {
-        "@dagrejs/graphlib": "4.0.1"
+        "@dagrejs/graphlib": "4.0.3"
       }
     },
     "node_modules/@dagrejs/graphlib": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
-      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.3.tgz",
+      "integrity": "sha512-9kvysNliOxG5m3lr1Qq5uCc+SYxx+BaLDM2SDGkgoZvKJ1bSESzbZ3gn4rSxqX1xR07swcSdeuGyKYQhAURxAA==",
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,7 +27,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@dagrejs/dagre": "^3.0.0",
+    "@dagrejs/dagre": "^3.1.0",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.14.9",
     "@xyflow/react": "^12.11.2",

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -70,7 +70,13 @@ const BUDGETS = {
   // The enterprise evidence story adds one intentionally client-rendered route
   // and measures 3633.2 KiB in Linux CI. Keep ~15 KiB of bounded headroom at
   // 3648 KiB; largest-chunk and shared-runtime budgets remain unchanged.
-  totalClientJsBytes: 3_735_552,
+  // @dagrejs/dagre 3.0.0 -> 3.1.0 measures 3654.7 KiB in Linux CI — 6.7 KiB
+  // over the 3648 KiB line. dagre is the layout engine behind the graph and
+  // DAG views, so staying current on it is worth the space, but the overrun is
+  // the LIBRARY's, not a new route of ours. Restore ~16 KiB to 3664 KiB on the
+  // same terms as every raise above: bounded headroom for routine bundler
+  // variance, largest-chunk and shared-runtime budgets unchanged.
+  totalClientJsBytes: 3_751_936,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };


### PR DESCRIPTION
Replaces #4702 (closed only to get clean check runs after a GitHub Actions outage — no code changed). Supersedes dependabot #4694, which failed `UI Validate`:

```
FAIL total client JS: 3654.7 KiB / budget 3648.0 KiB
```

**6.7 KiB over.** dagre is the layout engine behind the graph and DAG views, so staying current is worth the space — but the overrun is the **library's**, not a new route of ours. Worth recording, because every prior raise in that file was our own feature earning the space.

## The raise

`3648 → 3664 KiB`, on exactly the terms of every raise above it: ~16 KiB of bounded headroom so routine bundler variance stops failing the gate. **Largest-chunk and shared-runtime budgets are unchanged**, so this cannot mask a regression in either.

```
PASS total client JS:      3654.7 KiB / budget 3664.0 KiB
PASS largest chunk:         379.8 KiB / budget  927.7 KiB
PASS shared app runtime:    416.9 KiB / budget  439.5 KiB
```

Measured locally at **3654.7 KiB — the same number Linux CI produced** — so the remaining 9.3 KiB of headroom is real, not platform variance.

Full UI suite: **168 files, 1,048 tests passed**.