### PR TITLE
feat(graph): draw the collapsed estate as a topology, not a grid of cards

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1140,
+      "value": 1141,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1140 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1141 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 835 | `src/agent_bom` | Counts all Python files recursively. |

--- a/src/agent_bom/graph/rollup.py
+++ b/src/agent_bom/graph/rollup.py
@@ -19,8 +19,9 @@ follow-up consumes.
 from __future__ import annotations
 
 from collections import defaultdict, deque
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from agent_bom.graph.completeness import graph_completeness
 from agent_bom.graph.container import UnifiedGraph
@@ -339,6 +340,87 @@ def _container_for(node: UnifiedNode, child_map: dict[str, list[str]]) -> bool:
     return _node_type_value(node) in _CONTAINER_TYPES or bool(child_map.get(node.id))
 
 
+# Cap on aggregated cross-container edges returned. Ordered by weight, so the
+# cut keeps the heaviest relationships — the ones a reviewer would look at first.
+_MAX_CROSS_CONTAINER_EDGES = 400
+
+
+def _container_of(node_ids: Iterable[str], children: dict[str, list[str]]) -> dict[str, str]:
+    """Map every descendant to the visible container it rolls up into."""
+    owner: dict[str, str] = {}
+    for container_id in node_ids:
+        owner[container_id] = container_id
+        for descendant in _descendants(container_id, children):
+            owner.setdefault(descendant, container_id)
+    return owner
+
+
+def cross_container_edges(
+    graph: UnifiedGraph,
+    container_ids: Sequence[str],
+    children: dict[str, list[str]],
+) -> list[dict[str, Any]]:
+    """Aggregate NON-containment edges into container-to-container relationships.
+
+    The roll-up collapses thousands of nodes into a handful of containers, but
+    it collapsed the edges to nothing: the canvas received containers with an
+    empty edge list and drew a grid of disconnected cards. The view then had to
+    tell the reader that "aggregate cards are not rendered relationship
+    evidence" -- a security graph admitting it is not showing a graph.
+
+    Containment is not the interesting relationship here; it is the tree the
+    roll-up already expresses through nesting. What a reviewer needs at estate
+    scale is the OTHER edges -- an account whose workload reaches another
+    account's data store, an identity that assumes a role across a boundary.
+    Those exist in the graph; nothing was projecting them onto the collapsed
+    view.
+
+    Self-edges (both endpoints inside one container) are dropped: they are
+    internal detail the container already stands for, and drawing them would
+    put a loop on every card.
+    """
+    owner = _container_of(container_ids, children)
+    if not owner:
+        return []
+
+    aggregated: dict[tuple[str, str], dict[str, Any]] = {}
+    for edge in graph.edges:
+        if _edge_is_containment(graph, edge):
+            continue
+        source_container = owner.get(edge.source)
+        target_container = owner.get(edge.target)
+        if not source_container or not target_container:
+            continue
+        if source_container == target_container:
+            continue
+        key = (source_container, target_container)
+        entry = aggregated.get(key)
+        relationship = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
+        if entry is None:
+            aggregated[key] = {
+                "source": source_container,
+                "target": target_container,
+                "count": 1,
+                "relationships": {relationship},
+            }
+            continue
+        entry["count"] = int(entry["count"]) + 1
+        cast(set, entry["relationships"]).add(relationship)
+
+    rows = [
+        {
+            "source": entry["source"],
+            "target": entry["target"],
+            "count": entry["count"],
+            "relationships": sorted(cast(set, entry["relationships"])),
+        }
+        for entry in aggregated.values()
+    ]
+    # Heaviest first, then deterministic by endpoint so the truncation is stable.
+    rows.sort(key=lambda row: (-int(row["count"]), str(row["source"]), str(row["target"])))
+    return rows[:_MAX_CROSS_CONTAINER_EDGES]
+
+
 def rollup_view(
     graph: UnifiedGraph,
     *,
@@ -457,6 +539,10 @@ def rollup_view(
         "mode": "rollup",
         "filters": _filters_dict(filters),
         "top_level": [c.to_dict() for c in top_level],
+        # Container-to-container relationships, so the collapsed view renders as
+        # a graph rather than a grid of disconnected cards. Containment is
+        # excluded: it is the nesting the roll-up already expresses.
+        "edges": cross_container_edges(graph, [c.id for c in top_level], children),
         "orphan_summary": orphan_summary,
         "summary": {
             "total_nodes": len(graph.nodes),
@@ -558,6 +644,10 @@ def drill_down(
         },
         "filters": _filters_dict(filters),
         "children": [c.to_dict() for c in child_entries],
+        # Same edges one level down. This is where they matter most: an org has
+        # one root, so nothing crosses at the top, while its accounts reach each
+        # other constantly.
+        "edges": cross_container_edges(graph, [c.id for c in child_entries], children),
         "summary": {
             "direct_child_count": len(direct),
             "returned_child_count": len(child_entries),

--- a/tests/test_graph_rollup_topology.py
+++ b/tests/test_graph_rollup_topology.py
@@ -1,0 +1,119 @@
+"""The collapsed graph must render as a topology, not a grid of cards.
+
+`rollup_view` / `drill_down` collapse thousands of nodes into a handful of
+containers, but they collapsed the EDGES to nothing: `buildRollupFlowGraph`
+returned `edges: []`, the canvas drew disconnected cards, and the view told the
+reader that "aggregate cards are not rendered relationship evidence" — a
+security graph admitting it was not showing a graph.
+
+Containment is not the interesting relationship at this level; it is the nesting
+the roll-up already expresses. What matters is the OTHER edges — an account
+whose workload reaches another account's data, an identity assuming a role
+across a boundary. Those exist in the graph and were simply never projected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.rollup import cross_container_edges, drill_down, rollup_view
+from agent_bom.graph.types import EntityType, RelationshipType
+
+
+def _graph() -> UnifiedGraph:
+    """Two accounts under one org, with a cross-account edge and internal noise."""
+    graph = UnifiedGraph(scan_id="t", tenant_id="default")
+    for node_id, entity in (
+        ("org", EntityType.ORG),
+        ("acct-a", EntityType.ACCOUNT),
+        ("acct-b", EntityType.ACCOUNT),
+        ("wl-a", EntityType.CLOUD_RESOURCE),
+        ("wl-a2", EntityType.CLOUD_RESOURCE),
+        ("db-b", EntityType.DATA_STORE),
+    ):
+        graph.add_node(UnifiedNode(id=node_id, entity_type=entity, label=node_id))
+    for source, target in (("org", "acct-a"), ("org", "acct-b"), ("acct-a", "wl-a"), ("acct-a", "wl-a2"), ("acct-b", "db-b")):
+        graph.add_edge(UnifiedEdge(source=source, target=target, relationship=RelationshipType.CONTAINS))
+    # Two cross-account reads, plus one edge internal to acct-a.
+    graph.add_edge(UnifiedEdge(source="wl-a", target="db-b", relationship=RelationshipType.CAN_ACCESS))
+    graph.add_edge(UnifiedEdge(source="wl-a2", target="db-b", relationship=RelationshipType.CAN_ACCESS))
+    graph.add_edge(UnifiedEdge(source="wl-a", target="wl-a2", relationship=RelationshipType.DEPENDS_ON))
+    return graph
+
+
+def test_cross_container_edges_aggregate_by_container() -> None:
+    graph = _graph()
+    children = {"org": ["acct-a", "acct-b"], "acct-a": ["wl-a", "wl-a2"], "acct-b": ["db-b"]}
+
+    edges = cross_container_edges(graph, ["acct-a", "acct-b"], children)
+
+    assert len(edges) == 1, edges
+    edge = edges[0]
+    assert (edge["source"], edge["target"]) == ("acct-a", "acct-b")
+    # Both underlying reads collapse into one weighted relationship.
+    assert edge["count"] == 2
+    assert "can_access" in edge["relationships"]
+
+
+def test_edges_internal_to_one_container_are_dropped() -> None:
+    """A container already stands for its own internals; a self-loop is noise."""
+    graph = _graph()
+    children = {"org": ["acct-a", "acct-b"], "acct-a": ["wl-a", "wl-a2"], "acct-b": ["db-b"]}
+
+    edges = cross_container_edges(graph, ["acct-a", "acct-b"], children)
+
+    assert not [e for e in edges if e["source"] == e["target"]]
+    # wl-a -> wl-a2 lives entirely inside acct-a and must not appear.
+    assert sum(int(e["count"]) for e in edges) == 2
+
+
+def test_containment_is_never_emitted_as_a_relationship() -> None:
+    """Containment is the nesting, not a link to draw between siblings."""
+    graph = _graph()
+    children = {"org": ["acct-a", "acct-b"], "acct-a": ["wl-a", "wl-a2"], "acct-b": ["db-b"]}
+
+    edges = cross_container_edges(graph, ["acct-a", "acct-b"], children)
+
+    for edge in edges:
+        assert "contains" not in edge["relationships"], edge
+
+
+def test_drilldown_response_carries_edges() -> None:
+    """The level the operator actually looks at must ship its relationships.
+
+    An org has one root, so nothing crosses at the top — the edges matter one
+    level down, between accounts. A response that omits them is what produced
+    the card grid.
+    """
+    graph = _graph()
+
+    view = drill_down(graph, "org")
+
+    assert view["mode"] == "drilldown"
+    assert len(view["children"]) == 2
+    edges = view.get("edges")
+    assert edges, "drill-down returned no cross-container edges"
+    assert {(e["source"], e["target"]) for e in edges} == {("acct-a", "acct-b")}
+
+
+def test_rollup_response_exposes_an_edges_key() -> None:
+    """Present even when empty, so the client never has to guess the shape."""
+    graph = _graph()
+
+    view = rollup_view(graph)
+
+    assert "edges" in view
+    assert isinstance(view["edges"], list)
+
+
+@pytest.mark.parametrize("missing", ["source", "target"])
+def test_edges_referencing_absent_containers_are_dropped(missing: str) -> None:
+    """An edge to a container that is not on screen cannot be drawn."""
+    graph = _graph()
+    children = {"acct-a": ["wl-a", "wl-a2"], "acct-b": ["db-b"]}
+    visible = ["acct-b"] if missing == "source" else ["acct-a"]
+
+    assert cross_container_edges(graph, visible, children) == []

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -1293,7 +1293,7 @@ function GraphPageInner() {
         rollupView.mode === "drilldown"
           ? (rollupView.children ?? [])
           : (rollupView.top_level ?? []);
-      const rollupFlow = buildRollupFlowGraph(items);
+      const rollupFlow = buildRollupFlowGraph(items, { edges: rollupView.edges });
       return {
         nodes: rollupFlow.nodes,
         edges: rollupFlow.edges,
@@ -3771,8 +3771,9 @@ function RollupNavigationPanel({
             </p>
             {active && (
               <p className="mt-1 text-[11px] text-emerald-800 dark:text-emerald-200/80">
-                Aggregate cards help navigate scope; they are not rendered
-                relationship evidence. Open node view for the real topology.
+                Containers are collapsed by containment; the links between them
+                are real relationships, aggregated. Open node view for
+                individual nodes.
               </p>
             )}
             {error && (

--- a/ui/e2e/security-graph-cockpit.spec.ts
+++ b/ui/e2e/security-graph-cockpit.spec.ts
@@ -460,7 +460,12 @@ test(`large estates lead with non-overlapping clusters in ${theme}`, async ({ pa
   await expect(page).toHaveURL(/rollup=1/);
   await rollupRequest;
   await expect(page.getByText("Scope navigation", { exact: true })).toBeVisible();
-  await expect(page.getByText(/not rendered relationship evidence/i)).toBeVisible();
+  // The roll-up used to emit no edges, so this banner had to disclaim that the
+  // cards were "not rendered relationship evidence". It now draws the real
+  // aggregated relationships between containers, so the banner says so and the
+  // old disclaimer must NOT come back.
+  await expect(page.getByText(/real relationships, aggregated/i)).toBeVisible();
+  await expect(page.getByText(/not rendered relationship evidence/i)).toHaveCount(0);
   await expect(page.getByTestId("graph-compression-summary")).toHaveCount(0);
   await expect(page.getByText(/2 containers at this level.*1241 nodes in snapshot/)).toBeVisible();
   const cards = page.locator('[data-rollup-container="true"]');

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -540,6 +540,9 @@ export interface GraphRollupResponse {
   top_level?: GraphRollupContainer[];
   orphan_summary?: GraphRollupOrphanSummary;
   children?: GraphRollupContainer[];
+  /** Container-to-container relationships, aggregated. Containment is excluded
+   *  — that is the nesting the roll-up already expresses. */
+  edges?: GraphRollupEdge[];
   node?: {
     id: string;
     label: string;
@@ -547,6 +550,14 @@ export interface GraphRollupResponse {
     severity: string;
   } | null;
   summary: GraphRollupSummary;
+}
+
+export interface GraphRollupEdge {
+  source: string;
+  target: string;
+  /** How many underlying edges collapsed into this one. */
+  count: number;
+  relationships: string[];
 }
 
 export interface GraphSearchResponse {

--- a/ui/lib/graph-rollup-view.ts
+++ b/ui/lib/graph-rollup-view.ts
@@ -119,7 +119,7 @@ function rollupEdgeWidth(count: number): number {
 
 export function buildRollupFlowGraph(
   containers: GraphRollupContainer[],
-  options?: { columns?: number; edges?: GraphRollupEdge[] },
+  options?: { columns?: number; edges?: GraphRollupEdge[] | undefined },
 ): { nodes: Node<LineageNodeData>[]; edges: Edge[] } {
   const columns = Math.max(1, options?.columns ?? DEFAULT_COLUMNS);
   const nodes: Node<LineageNodeData>[] = containers.map((container, index) => {

--- a/ui/lib/graph-rollup-view.ts
+++ b/ui/lib/graph-rollup-view.ts
@@ -1,7 +1,7 @@
 import type { Edge, Node } from "@xyflow/react";
 
 import type { LineageNodeData, LineageNodeType } from "@/components/lineage-nodes";
-import type { GraphRollupContainer } from "@/lib/api-types";
+import type { GraphRollupContainer, GraphRollupEdge } from "@/lib/api-types";
 import { lineageNodeTypeForEntity } from "@/lib/graph-entity-mapping";
 
 const FLOW_NODE_TYPES: Record<LineageNodeType, string> = {
@@ -108,9 +108,18 @@ function rollupContainerToNodeData(
   };
 }
 
+/** Stroke width scaled to how many underlying edges collapsed into this one, so
+ *  a 35-edge relationship reads as heavier than a 1-edge one at a glance. */
+function rollupEdgeWidth(count: number): number {
+  if (count >= 25) return 3;
+  if (count >= 10) return 2.25;
+  if (count >= 3) return 1.6;
+  return 1;
+}
+
 export function buildRollupFlowGraph(
   containers: GraphRollupContainer[],
-  options?: { columns?: number },
+  options?: { columns?: number; edges?: GraphRollupEdge[] },
 ): { nodes: Node<LineageNodeData>[]; edges: Edge[] } {
   const columns = Math.max(1, options?.columns ?? DEFAULT_COLUMNS);
   const nodes: Node<LineageNodeData>[] = containers.map((container, index) => {
@@ -125,5 +134,23 @@ export function buildRollupFlowGraph(
       ...(container.has_children ? { className: "cursor-pointer" } : {}),
     };
   });
-  return { nodes, edges: [] };
+  // The roll-up used to return no edges at all, so the canvas drew a grid of
+  // disconnected cards and the view had to tell the reader that "aggregate
+  // cards are not rendered relationship evidence" — a security graph admitting
+  // it was not showing a graph. The API now aggregates the non-containment
+  // edges between containers; drawing them is what makes this a topology.
+  const present = new Set(nodes.map((node) => node.id));
+  const edges: Edge[] = (options?.edges ?? [])
+    .filter((edge) => present.has(edge.source) && present.has(edge.target))
+    .map((edge) => ({
+      id: `rollup:${edge.source}->${edge.target}`,
+      source: edge.source,
+      target: edge.target,
+      // The relationship names, not just a number: "accessed x35" says what the
+      // weight is made of, where a bare 35 does not.
+      label: edge.count > 1 ? `${edge.relationships[0] ?? "related"} ×${edge.count}` : (edge.relationships[0] ?? "related"),
+      animated: false,
+      style: { strokeWidth: rollupEdgeWidth(edge.count) },
+    }));
+  return { nodes, edges };
 }


### PR DESCRIPTION
**The graph page never showed a graph.**

`DEFAULT_GRAPH_ROLLUP_NODE_THRESHOLD` is **200**, so any real estate — ours is 6,809 nodes — always entered roll-up mode. And `buildRollupFlowGraph` ended with:

```ts
return { nodes, edges: [] };
```

The canvas got containers with **no relationships** and drew a grid of disconnected cards. The view then said so out loud:

> *"Aggregate cards help navigate scope; they are not rendered relationship evidence. Open node view for the real topology."*

A security graph telling a prospect that its main view isn't showing the graph.

## The relationships were there the whole time

Nothing projected them onto the collapsed view. `cross_container_edges` aggregates every **non-containment** edge onto the containers its endpoints roll up into. Drilling one level into the org on the demo estate:

```
400 container-to-container relationships
account:github:northstar-health → account:aws:100000000005    accessed ×35
account:github:northstar-health → account:azure:sub-0005      accessed ×32
account:github:northstar-health → account:gcp:northstar-006   accessed ×31
```

That's the sentence a reviewer wants: *this CI account reaches those cloud accounts, that many times.*

## Deliberate choices

- **Containment is excluded.** It's the nesting the roll-up already expresses through drill-down; drawing it between siblings is noise.
- **Self-edges dropped.** A container stands for its own internals — an edge with both endpoints inside one would put a loop on every card.
- **Bounded at 400, ordered by weight**, so truncation keeps the heaviest relationships and stays deterministic.
- **Stroke width scales with collapsed count**, and the label carries the relationship name — `accessed ×35` says what the weight is made of; a bare `35` doesn't.
- **Edges to off-screen containers are filtered client-side** — an edge to a container that isn't rendered can't be drawn.

Top-level roll-up exposes an `edges` key too, **always present even when empty**, so a client never guesses the shape. It's empty for our estate because the org is a single root — which is precisely why the drill-down level is the one that matters.

The disclaimer is now true rather than an apology: *containers are collapsed by containment, and the links between them are real relationships, aggregated.*

## Verification

- `tests/test_graph_rollup_topology.py` — 7 tests: aggregation by container, self-edges dropped, containment never emitted as a relationship, drill-down carries edges, the `edges` key always present, and edges to absent containers dropped (parametrised over source/target)
- Graph suites: **1,297 passed**, 29 skipped
- UI suite: **1,048 passed** · `tsc` clean
- `ruff` · `mypy` clean

Cut from `main`, which is red until #4703 lands — any inherited `test_deployment.py` failure is that, not this.