### PR TITLE
fix(mcp): advertise the reachable URL in the OAuth challenge, not the bind address

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1141,
+      "value": 1142,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1141 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1142 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 835 | `src/agent_bom` | Counts all Python files recursively. |

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -246,6 +246,11 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_MCP_MAX_TOOL_METRICS` | `int` | `128` | — |
 | `AGENT_BOM_MCP_TOOL_TIMEOUT_SECONDS` | `float` | `30.0` | — |
 
+## MCP server: how remote clients are told to reach us
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_MCP_PUBLIC_URL` | `str` | `''` | The externally reachable base URL of a hosted MCP deployment, used for the OAuth issuer / resource-server URL advertised in the 401 challenge.  The server otherwise derives that from the socket it binds. Behind any proxy (Railway, Cloud Run |
+
 ## Multi-provider LLM harness (issue #3206)
 | Env var | Type | Default | Description |
 |---|---|---|---|

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -718,6 +718,18 @@ A2A_AUTH_SHARED_TOKEN_MIN_AGENTS = _int("AGENT_BOM_A2A_AUTH_SHARED_TOKEN_MIN_AGE
 A2A_AUTH_REQUIRE_SIGNED_TOKENS = _bool("AGENT_BOM_A2A_AUTH_REQUIRE_SIGNED_TOKENS", True)
 
 
+
+# ── MCP server: how remote clients are told to reach us ───────────────────
+# The externally reachable base URL of a hosted MCP deployment, used for the
+# OAuth issuer / resource-server URL advertised in the 401 challenge.
+#
+# The server otherwise derives that from the socket it binds. Behind any proxy
+# (Railway, Cloud Run, a load balancer) that is http://0.0.0.0:8080 — an address
+# no client can route to — so OAuth discovery HANGS rather than failing fast.
+# Blank falls back to the bind address, which is correct for local runs where
+# the two are the same thing.
+MCP_PUBLIC_URL = _str("AGENT_BOM_MCP_PUBLIC_URL", "")
+
 # ── MCP / agent→MCP auth posture ──────────────────────────────────────────
 # Governance thresholds for the MCP server auth posture evaluator
 # (agent_bom.mcp_auth_posture). This is the complement of the A2A evaluator:

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -718,7 +718,6 @@ A2A_AUTH_SHARED_TOKEN_MIN_AGENTS = _int("AGENT_BOM_A2A_AUTH_SHARED_TOKEN_MIN_AGE
 A2A_AUTH_REQUIRE_SIGNED_TOKENS = _bool("AGENT_BOM_A2A_AUTH_REQUIRE_SIGNED_TOKENS", True)
 
 
-
 # ── MCP server: how remote clients are told to reach us ───────────────────
 # The externally reachable base URL of a hosted MCP deployment, used for the
 # OAuth issuer / resource-server URL advertised in the 401 challenge.

--- a/src/agent_bom/mcp_server_factory.py
+++ b/src/agent_bom/mcp_server_factory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import Any, Callable
 
 from pydantic import AnyHttpUrl, TypeAdapter
@@ -20,6 +21,31 @@ def _server_instructions(version: str) -> str:
     )
 
 
+def _public_base_url(host: str, port: int) -> str:
+    """The URL clients should be told to come back to, not the socket we bind.
+
+    ``AuthSettings`` is advertised to callers: a 401 answers with
+    ``WWW-Authenticate: Bearer ... resource_metadata="<issuer>/.well-known/
+    oauth-protected-resource"``, and an OAuth client follows that URL to
+    discover how to authenticate.
+
+    Deriving it from the bind address publishes whatever the process listens on.
+    Behind any proxy -- Railway, Cloud Run, a load balancer -- that is
+    ``http://0.0.0.0:8080``, an address no client can route to. The discovery
+    request then hangs rather than failing fast, which is why the hosted server
+    reported ``AUTH TIMED OUT`` after five minutes instead of a clean rejection:
+    the registry was waiting on a metadata document at 0.0.0.0.
+
+    ``AGENT_BOM_MCP_PUBLIC_URL`` is the deployment's externally reachable base
+    URL. Falling back to the bind address keeps local runs working unchanged,
+    where the two genuinely are the same thing.
+    """
+    public = (os.environ.get("AGENT_BOM_MCP_PUBLIC_URL") or "").strip()
+    if public:
+        return public.rstrip("/")
+    return f"http://{host}:{port}"
+
+
 def create_fastmcp_server(
     *,
     host: str,
@@ -35,7 +61,7 @@ def create_fastmcp_server(
     auth_settings = None
     token_verifier = None
     if bearer_token:
-        resource_url: AnyHttpUrl = _HTTP_URL_ADAPTER.validate_python(f"http://{host}:{port}")
+        resource_url: AnyHttpUrl = _HTTP_URL_ADAPTER.validate_python(_public_base_url(host, port))
         auth_settings = AuthSettings(
             issuer_url=resource_url,
             resource_server_url=resource_url,

--- a/tests/test_mcp_oauth_public_url.py
+++ b/tests/test_mcp_oauth_public_url.py
@@ -1,0 +1,73 @@
+"""A 401 must point clients at a URL they can actually reach.
+
+`AuthSettings` is advertised, not internal: an unauthenticated request answers
+with `WWW-Authenticate: Bearer ... resource_metadata="<issuer>/.well-known/
+oauth-protected-resource"`, and an OAuth client follows that URL to learn how to
+authenticate.
+
+It was derived from the socket the process binds. Behind any proxy that is
+`http://0.0.0.0:8080` — an address no client can route to — so discovery hung
+instead of failing fast. The hosted server reported `AUTH TIMED OUT` after five
+minutes rather than a clean rejection, and the registry listing stayed frozen on
+a months-old build.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.mcp_server_factory import _public_base_url
+
+_ENV = "AGENT_BOM_MCP_PUBLIC_URL"
+
+
+def test_bind_address_is_used_when_no_public_url_is_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Local runs are unchanged — there the bind address IS the public one."""
+    monkeypatch.delenv(_ENV, raising=False)
+
+    assert _public_base_url("127.0.0.1", 8000) == "http://127.0.0.1:8000"
+
+
+def test_public_url_overrides_the_bind_address(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Behind a proxy the bind address is unroutable and must not be advertised."""
+    monkeypatch.setenv(_ENV, "https://agent-bom-mcp.up.railway.app")
+
+    assert _public_base_url("0.0.0.0", 8080) == "https://agent-bom-mcp.up.railway.app"
+
+
+def test_trailing_slash_is_normalised(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`<issuer>/.well-known/...` must not become `<issuer>//.well-known/...`."""
+    monkeypatch.setenv(_ENV, "https://agent-bom-mcp.up.railway.app/")
+
+    assert _public_base_url("0.0.0.0", 8080) == "https://agent-bom-mcp.up.railway.app"
+
+
+@pytest.mark.parametrize("value", ["", "   "])
+def test_blank_env_falls_back_rather_than_advertising_nothing(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """An unset-but-present variable must not produce an empty issuer.
+
+    A blank issuer would advertise `/.well-known/oauth-protected-resource` with
+    no host, which is worse than the bind address: it cannot even be diagnosed
+    from the response.
+    """
+    monkeypatch.setenv(_ENV, value)
+
+    assert _public_base_url("0.0.0.0", 8080) == "http://0.0.0.0:8080"
+
+
+def test_auth_settings_carry_the_public_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: the value reaches the settings a client is told to follow."""
+    monkeypatch.setenv(_ENV, "https://mcp.example.test")
+
+    server = __import__("agent_bom.mcp_server_factory", fromlist=["create_fastmcp_server"]).create_fastmcp_server(
+        host="0.0.0.0",
+        port=8080,
+        bearer_token="test-token",
+        version="0.0.0-test",
+        token_verifier_factory=lambda token: object(),
+    )
+
+    settings = server.settings.auth
+    assert settings is not None
+    assert str(settings.resource_server_url).rstrip("/") == "https://mcp.example.test"
+    assert str(settings.issuer_url).rstrip("/") == "https://mcp.example.test"


### PR DESCRIPTION
Found while diagnosing #4699 (Smithery advertising 36 of 77 tools). **It is not a registry problem — it is our server handing clients an unroutable address.**

## What the hosted server actually returns

```
$ curl -i https://agent-bom-mcp.up.railway.app/mcp
HTTP/2 401
www-authenticate: Bearer error="invalid_token",
  resource_metadata="http://0.0.0.0:8080/.well-known/oauth-protected-resource"
```

`0.0.0.0:8080` is the socket the process binds. `AuthSettings` is **advertised**, so an OAuth client follows that pointer to discover how to authenticate — and a request to `0.0.0.0` hangs rather than failing fast.

```python
resource_url = validate(f"http://{host}:{port}")   # the BIND address
AuthSettings(issuer_url=resource_url, resource_server_url=resource_url, ...)
```

Behind any proxy — Railway, Cloud Run, a load balancer — the bind address is never the public one.

## Why this matters beyond one registry

Smithery's Releases tab shows the symptom precisely:

```
agent-bom-mcp.up.railway.app   ✕ AUTH TIMED OUT   5m 5s     1 day ago
agent-bom-mcp.up.railway.app   ✕ CANCELLED       22h 17m    2 days ago
```

**`AUTH TIMED OUT` after five minutes, not "rejected"** — the registry was waiting on a metadata document at `0.0.0.0`. So the listing stayed frozen on a months-old build showing **36 of the 77 tools** the server serves, and every release since has failed the same way.

But this isn't Smithery-specific: **any** remote MCP client doing OAuth discovery against a proxied deployment hit the same dead pointer.

## The fix

`AGENT_BOM_MCP_PUBLIC_URL` names the deployment's externally reachable base URL. Falling back to the bind address keeps local runs identical, where the two genuinely are the same thing.

Two guards, both deliberate:
- **A blank or whitespace-only value falls back** rather than advertising an empty issuer. `/.well-known/oauth-protected-resource` with no host is *worse* than the bind address — it can't even be diagnosed from the response.
- **A trailing slash is stripped**, so the discovery URL can't become `<issuer>//.well-known/...`.

## Verification

- 6 new tests: bind-address default, override, trailing-slash normalisation, blank/whitespace fallback (parametrised), and an end-to-end check that the value reaches the `AuthSettings` a client is told to follow
- MCP suites: **182 passed**, 5 skipped
- `ruff` · `mypy` clean

## Deployment note

The Railway deployment needs `AGENT_BOM_MCP_PUBLIC_URL=https://agent-bom-mcp.up.railway.app` set for this to take effect. Without it the behaviour is unchanged, so merging is safe on its own.