### PR TITLE
fix(compliance): ATLAS is an applicability overlay, not 65 failing controls

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -413,7 +413,7 @@ agent-bom ships a curated control set per framework, sized to the AI/MCP/agent t
 | NIST / FedRAMP | CSF 2.0 | 14 categories | ~108 | Supply-chain, identity, asset, monitoring categories |
 | NIST / FedRAMP | 800-53 Rev 5 | 29 controls | ~1,006 | Vulnerability-driven mapping (RA-5, SI-2, etc.); not a complete catalog |
 | NIST / FedRAMP | FedRAMP Moderate | 25 controls | ~325 | Subset of 800-53 controls in the Moderate baseline |
-| MITRE | ATLAS | 65 techniques | ~90 | LLM/AI techniques: prompt injection, jailbreak, supply-chain, exfiltration, agent tool abuse |
+| MITRE | ATLAS | 65 techniques | ~90 | Applicability overlay (not scored): LLM/AI techniques — prompt injection, jailbreak, supply-chain, exfiltration, agent tool abuse — that the observed findings make applicable |
 | MITRE | ATT&CK Enterprise | 691 techniques | ~700 | Applicability overlay (not scored): techniques MITRE's CWE → CAPEC → ATT&CK data associates with the weaknesses observed in the estate |
 | Regulatory | EU AI Act | 6 articles | ~113 | Articles 5/6/9/10/15/17 (prohibited practices, high-risk classification, risk mgmt, data governance, accuracy/cybersecurity, QMS) |
 | Regulatory | ISO/IEC 27001:2022 | 9 Annex A controls | 93 | Supplier, vulnerability, cryptography, secure-dev, evidence collection |

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-06",
+  "generated_on": "2026-08-07",
   "version": "0.99.0",
   "metrics": [
     {
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1142,
+      "value": 1143,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-06`
+- Generated on: `2026-08-07`
 - Version: `0.99.0`
 
 | Metric | Value | Source | Notes |
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1142 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1143 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 835 | `src/agent_bom` | Counts all Python files recursively. |

--- a/src/agent_bom/compliance_coverage.py
+++ b/src/agent_bom/compliance_coverage.py
@@ -185,7 +185,17 @@ TAG_MAPPED_FRAMEWORKS: tuple[ComplianceFrameworkMetadata, ...] = (
         report_label="MITRE ATLAS",
         bundled_unit="techniques",
         source_standard_size="~90",
-        coverage="LLM/AI techniques: prompt injection, jailbreak, supply-chain, exfiltration, agent tool abuse",
+        coverage=(
+            "Applicability overlay (not scored): LLM/AI techniques — prompt injection, jailbreak, "
+            "supply-chain, exfiltration, agent tool abuse — that the observed findings make applicable"
+        ),
+        # ATLAS is the AI counterpart of ATT&CK: an adversary TECHNIQUE matrix,
+        # which is why this entry's own catalog and unit are "techniques". The
+        # argument that keeps ATT&CK unscored applies verbatim — a technique is
+        # APPLICABLE or not, it cannot be passed or failed. Scoring all 65 as
+        # controls asserted 65 unevidenced failures and, being the single largest
+        # scored framework, dominated overall_score with them.
+        scored=False,
     ),
     ComplianceFrameworkMetadata(
         family="MITRE",

--- a/tests/test_atlas_is_an_applicability_overlay.py
+++ b/tests/test_atlas_is_an_applicability_overlay.py
@@ -1,0 +1,63 @@
+"""MITRE ATLAS describes adversary techniques, so it cannot be passed or failed.
+
+The codebase already made this argument for ATT&CK:
+
+    ATT&CK describes adversary behaviour, not controls an estate implements.
+    A technique is APPLICABLE or not; it cannot pass or fail, and scoring it
+    as a failing control asserted dozens of unevidenced failures per CVE.
+
+ATLAS is the AI counterpart of ATT&CK -- its own registry entry carries
+``catalog=ATLAS_TECHNIQUES`` and ``bundled_unit="techniques"`` -- and the
+argument transfers verbatim. It was nonetheless scored, and at 65 techniques it
+was the single largest scored framework: 27% of the entire scored control
+surface (65 of 240) was technique rows, each asserting a failure the estate had
+no way to "pass".
+"""
+
+from __future__ import annotations
+
+from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS
+
+_BY_SLUG = {metadata.slug: metadata for metadata in TAG_MAPPED_FRAMEWORKS}
+
+
+def test_atlas_is_not_scored() -> None:
+    """The regression: ATLAS must not contribute pass/fail to the score."""
+    assert _BY_SLUG["atlas"].scored is False
+
+
+def test_atlas_and_attack_are_classified_consistently() -> None:
+    """Two adversary-technique matrices cannot be scored differently.
+
+    This is the inconsistency that let the bug exist: the same reasoning was
+    applied to one MITRE matrix and not its direct counterpart.
+    """
+    assert _BY_SLUG["atlas"].scored == _BY_SLUG["attack"].scored
+
+
+def test_every_technique_catalog_is_an_overlay() -> None:
+    """A framework measured in "techniques" is describing attacker behaviour.
+
+    Stated structurally so a future technique-based catalog cannot be added as
+    a scored framework without this failing first.
+    """
+    technique_frameworks = [m for m in TAG_MAPPED_FRAMEWORKS if m.bundled_unit == "techniques"]
+
+    assert technique_frameworks, "expected at least one technique catalog"
+    assert [m.framework for m in technique_frameworks if m.scored] == []
+
+
+def test_control_frameworks_remain_scored() -> None:
+    """The fix must not quietly unscore real control frameworks.
+
+    Unscoring everything would make the score vacuous rather than accurate.
+    """
+    for slug in ("owasp-llm", "nist", "nist-800-53", "iso-27001", "soc2", "pci-dss"):
+        assert _BY_SLUG[slug].scored is True, slug
+
+
+def test_overlay_coverage_text_says_it_is_not_scored() -> None:
+    """An overlay must announce itself, so a reader never reads it as a score."""
+    for metadata in TAG_MAPPED_FRAMEWORKS:
+        if not metadata.scored:
+            assert "not scored" in metadata.coverage.lower(), metadata.framework


### PR DESCRIPTION
Chasing "frameworks all read FAIL". A large part of that is a **category error**, not a posture problem.

## What the live demo reports

```json
{"overall_score": 10.5, "overall_status": "fail", "evaluated_controls": 190, "total_controls": 260}
```

| Framework | pass | fail | not evaluated |
|---|---:|---:|---:|
| OWASP LLM | 0 | 7 | 3 |
| OWASP MCP | 0 | 8 | 2 |
| OWASP Agentic | 0 | 9 | 1 |
| NIST AI RMF | 0 | 12 | 2 |
| NIST 800-53 | 2 | 18 | 9 |

## The category error

This codebase already made the argument — for ATT&CK:

> *"ATT&CK describes adversary behaviour, not controls an estate implements. A technique is APPLICABLE or not; it cannot pass or fail, and scoring it as a failing control asserted dozens of unevidenced failures per CVE."*

**MITRE ATLAS is the AI counterpart of ATT&CK.** Its own registry entry says so — `catalog=ATLAS_TECHNIQUES`, `bundled_unit="techniques"`. The argument transfers verbatim. It was scored anyway.

And it wasn't a rounding error:

```
scored control base:  240 → 175
ATLAS:                65 techniques = 27% of the entire scored surface
```

ATLAS was the **single largest scored framework**, and every one of its 65 rows asserted a failure the estate had no mechanism to "pass". That is a large part of what a leadership reader saw as a near-zero score.

## Why this is small

`scored=False` and its overlay semantics **already existed** and are fully wired through score aggregation (`if m.scored`), overlay keys, and control counts. This is a one-flag classification fix, not new machinery.

## What this deliberately does NOT change

**The OWASP Top-10s stay scored.** Their entries do read as controls an estate can implement, unlike a technique matrix, so unscoring them is a *product judgement* rather than a category error. That deserves its own decision rather than being folded in here under cover of a bug fix.

This also does not claim the remaining score is *good* — a demo estate seeded with real findings should fail things. It claims the score is now measuring controls instead of adversary techniques.

## Verification

- 5 new tests, including a **structural** one: no framework measured in `"techniques"` may be scored, so a future technique catalog can't regress this silently
- One test pins ATLAS and ATT&CK to the *same* classification — the inconsistency that let this exist
- One asserts real control frameworks stay scored, so the fix can't degenerate into unscoring everything
- **658 passed** across compliance / framework / metrics suites
- `ARCHITECTURE.md` coverage table and the metrics snapshot regenerated from metadata; `ruff` clean