### PR TITLE
fix(ui): make the gates fail loudly when they are measuring the wrong thing

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -10,11 +10,11 @@
     "dev": "next dev",
     "build": "next build --webpack",
     "start": "next start",
-    "bundle:check": "node scripts/check-bundle-budget.mjs",
+    "bundle:check": "node scripts/assert-install-matches-lockfile.mjs && node scripts/check-bundle-budget.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint",
     "lock:normalize": "npm install --package-lock-only --ignore-scripts",
-    "test:e2e": "playwright test",
+    "test:e2e": "node scripts/assert-install-matches-lockfile.mjs && node scripts/assert-build-is-current.mjs && playwright test",
     "verify:toolchain": "node scripts/verify-toolchain.mjs",
     "headers:sync": "node scripts/sync-vercel-headers.mjs",
     "headers:check": "node scripts/sync-vercel-headers.mjs --check",
@@ -24,7 +24,9 @@
     "test": "vitest",
     "test:run": "vitest run",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "install:verify": "node scripts/assert-install-matches-lockfile.mjs",
+    "build:verify": "node scripts/assert-build-is-current.mjs"
   },
   "dependencies": {
     "@dagrejs/dagre": "^3.1.0",

--- a/ui/scripts/assert-build-is-current.mjs
+++ b/ui/scripts/assert-build-is-current.mjs
@@ -1,0 +1,80 @@
+/**
+ * Fail when .next is older than the sources it was built from.
+ *
+ * The Playwright config serves a prebuilt `.next/standalone` and reuses an
+ * existing server outside CI. That makes E2E fast, and it also makes E2E
+ * capable of testing code that no longer exists: edit a component, run the
+ * suite, and the assertions run against the PREVIOUS build.
+ *
+ * This bit exactly once already. A test asserting a panel was collapsed by
+ * default kept failing after the fix had been written and typechecked — the
+ * served bundle predated the edit. The wrong conclusions available at that
+ * moment were "the fix does not work" or "the primitive is broken"; the truth
+ * was "you are testing a stale artifact".
+ *
+ * A stale build must be an explicit, named failure rather than a mysterious
+ * assertion mismatch that sends someone debugging the wrong layer.
+ */
+
+import { readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const BUILD_MANIFEST = path.join(ROOT, ".next", "build-manifest.json");
+const SOURCE_DIRS = ["app", "components", "lib", "hooks"];
+const SOURCE_FILES = ["package.json", "package-lock.json", "next.config.ts", "next.config.js"];
+const WATCHED_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".css", ".json"]);
+
+function newestMtime(dir) {
+  let newest = 0;
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      newest = Math.max(newest, newestMtime(full));
+      continue;
+    }
+    if (!WATCHED_EXTENSIONS.has(path.extname(entry.name))) continue;
+    const stat = statSync(full, { throwIfNoEntry: false });
+    if (stat && stat.mtimeMs > newest) newest = stat.mtimeMs;
+  }
+  return newest;
+}
+
+const manifest = statSync(BUILD_MANIFEST, { throwIfNoEntry: false });
+if (!manifest) {
+  console.error("Missing .next build output. Run `npm run build` before the E2E suite.");
+  process.exit(1);
+}
+
+let newestSource = 0;
+let newestPath = "";
+for (const dir of SOURCE_DIRS) {
+  const mtime = newestMtime(path.join(ROOT, dir));
+  if (mtime > newestSource) {
+    newestSource = mtime;
+    newestPath = dir;
+  }
+}
+for (const file of SOURCE_FILES) {
+  const stat = statSync(path.join(ROOT, file), { throwIfNoEntry: false });
+  if (stat && stat.mtimeMs > newestSource) {
+    newestSource = stat.mtimeMs;
+    newestPath = file;
+  }
+}
+
+if (newestSource > manifest.mtimeMs) {
+  const ageSeconds = Math.round((newestSource - manifest.mtimeMs) / 1000);
+  console.error(`.next is STALE: ${newestPath} changed ${ageSeconds}s after the last build.`);
+  console.error("E2E would run against the previous build, so failures would describe code you have already changed.");
+  console.error("\nRun `npm run build`, then re-run the suite.");
+  process.exit(1);
+}
+
+console.log("OK: .next is newer than every watched source.");

--- a/ui/scripts/assert-install-matches-lockfile.mjs
+++ b/ui/scripts/assert-install-matches-lockfile.mjs
@@ -1,0 +1,82 @@
+/**
+ * Fail loudly when node_modules does not match package-lock.json.
+ *
+ * A gate that measures the installed tree — bundle budgets, builds, E2E — is
+ * only telling the truth if the installed tree is the one this branch pins.
+ * Switching between branches with different lockfiles leaves the previous
+ * branch's packages in place, and every downstream number silently describes
+ * the WRONG dependency set.
+ *
+ * This is not hypothetical: a bundle measurement read 3679.2 KiB against a
+ * 3664 KiB ceiling and looked like a real regression introduced by the branch's
+ * own changes. node_modules still held a newer Next from another branch; a
+ * clean install measured 3660.0 KiB, comfortably under budget. The gate had
+ * reported a failure that did not exist, and the obvious "fix" would have been
+ * to raise the budget to accommodate a package this branch does not even use.
+ *
+ * npm maintains node_modules/.package-lock.json as a mirror of what is actually
+ * installed, so comparing the two is exact rather than heuristic.
+ */
+
+import { readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const LOCKFILE = path.join(ROOT, "package-lock.json");
+const INSTALLED = path.join(ROOT, "node_modules", ".package-lock.json");
+
+/** Packages whose version drift changes what a gate measures.
+ *
+ * Optional and platform-gated entries are excluded. A lockfile lists every
+ * platform's native binaries (`@esbuild/android-arm`, `@rollup/rollup-linux-*`),
+ * and npm correctly installs only this host's. Treating those absences as drift
+ * makes the check cry wolf on a perfectly clean install — which would train
+ * everyone to ignore it, the opposite of the point.
+ */
+function versionsByPath(lock) {
+  const out = new Map();
+  for (const [pkgPath, entry] of Object.entries(lock.packages ?? {})) {
+    if (!pkgPath.startsWith("node_modules/")) continue;
+    if (!entry?.version) continue;
+    if (entry.optional === true) continue;
+    if (Array.isArray(entry.os) && !entry.os.includes(process.platform)) continue;
+    if (Array.isArray(entry.cpu) && !entry.cpu.includes(process.arch)) continue;
+    out.set(pkgPath, entry.version);
+  }
+  return out;
+}
+
+function read(file, label) {
+  if (!statSync(file, { throwIfNoEntry: false })) {
+    console.error(`Missing ${label} (${file}).`);
+    if (file === INSTALLED) console.error("Run `npm ci` before any gate that measures the installed tree.");
+    process.exit(1);
+  }
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+const expected = versionsByPath(read(LOCKFILE, "package-lock.json"));
+const actual = versionsByPath(read(INSTALLED, "node_modules/.package-lock.json"));
+
+const drift = [];
+for (const [pkgPath, want] of expected) {
+  const got = actual.get(pkgPath);
+  if (got === undefined) drift.push({ pkgPath, want, got: "missing" });
+  else if (got !== want) drift.push({ pkgPath, want, got });
+}
+for (const [pkgPath, got] of actual) {
+  if (!expected.has(pkgPath)) drift.push({ pkgPath, want: "not in lockfile", got });
+}
+
+if (drift.length > 0) {
+  console.error(`node_modules does not match package-lock.json (${drift.length} package(s) differ).`);
+  console.error("Any bundle, build, or E2E measurement taken now describes the WRONG dependency set.\n");
+  for (const { pkgPath, want, got } of drift.slice(0, 15)) {
+    console.error(`  ${pkgPath.replace(/^node_modules\//, "")}: lockfile ${want}, installed ${got}`);
+  }
+  if (drift.length > 15) console.error(`  … and ${drift.length - 15} more`);
+  console.error("\nRun `npm ci` to install exactly what this branch pins, then re-run the gate.");
+  process.exit(1);
+}
+
+console.log(`OK: node_modules matches package-lock.json (${expected.size} packages).`);


### PR DESCRIPTION
Two gates could silently report a number describing something other than this branch. **Both did, in the same session.**

## 1. `bundle:check` measured the wrong dependency set

Switching between branches with different lockfiles leaves the previous branch's packages installed. The budget then describes packages this branch doesn't use.

```
measured:  3679.2 KiB / budget 3664.0 KiB   FAIL   ← node_modules had a newer Next
after npm ci: 3660.0 KiB / budget 3664.0 KiB PASS   ← the branch's actual number
```

That failure looked exactly like a regression the branch had introduced. **The obvious response would have been to raise the budget** — permanently loosening a real guard on the strength of a bad measurement, to accommodate a package the branch doesn't even contain.

## 2. Playwright tested a build that no longer existed

The config serves a prebuilt `.next` and reuses an existing server outside CI. A test asserting a panel was collapsed by default kept failing *after* the fix was written and typechecked — the served bundle predated the edit.

The conclusions available at that moment were "the fix doesn't work" or "the `Collapsible` primitive is broken." The truth was "you're testing a stale artifact." Both wrong answers send you debugging the wrong layer.

## The guards

**`assert-install-matches-lockfile.mjs`** compares `package-lock.json` against the `node_modules/.package-lock.json` npm maintains — exact, not heuristic.

Optional and platform-gated entries are excluded. A lockfile lists every platform's native binaries (`@esbuild/android-arm`, `@rollup/rollup-linux-*`) and npm installs only this host's; treating those absences as drift made the check report **171 false positives on a clean tree**, which would train everyone to ignore it — the opposite of the point.

**`assert-build-is-current.mjs`** fails when any watched source is newer than the build manifest, naming the file and the gap:

```
.next is STALE: components changed 865s after the last build.
E2E would run against the previous build, so failures would describe code you have already changed.
```

## Wiring

Both are attached to the scripts that were misleading, not left as optional extras:

```
bundle:check  →  assert-install-matches-lockfile && check-bundle-budget
test:e2e      →  assert-install-matches-lockfile && assert-build-is-current && playwright test
```

Also exposed as `install:verify` and `build:verify` to run alone.

## Verification

Each guard tested in **both** directions — passing on a clean tree and failing on deliberately reproduced drift, including the exact case that caused this:

```
next: lockfile 16.2.12, installed 16.3.0
@next/env: lockfile 16.2.12, installed 16.3.0
```

33/33 E2E · `tsc` · `eslint` · bundle budget · `make preflight` all clean.