### PR TITLE
fix(demo): day-scoped evidence must survive the UTC day advancing

### DIFF
--- a/.github/workflows/main-failure-alert.yml
+++ b/.github/workflows/main-failure-alert.yml
@@ -14,6 +14,66 @@ on:
 permissions: {}
 
 jobs:
+  # A tracker that can only ever open is not a tracker — it is a permanent
+  # accusation. #4712 sat open as a `release-blocker` for days after its cause
+  # (a stale PRODUCT_METRICS snapshot) had been fixed, because nothing here ever
+  # closed it. Since the release gate is "no tag while a release-blocker is
+  # open", an issue that cannot self-close can never be satisfied and has to be
+  # closed by hand — which is exactly how a real regression gets closed by
+  # reflex. The supply-chain drift trackers already self-close on green; this
+  # makes the CI tracker behave the same way.
+  resolve:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      issues: write
+      actions: read
+      contents: read
+    steps:
+      - name: Close the regression issue once main is green again
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const workflow = context.payload.workflow_run.name;
+            const htmlUrl = context.payload.workflow_run.html_url;
+            const sha = context.payload.workflow_run.head_sha.slice(0, 7);
+            const title = `ci-regression: ${workflow} failing on main`;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              labels: "ci-regression",
+              per_page: 100,
+            });
+            const match = existing.find((issue) => issue.title === title);
+            if (!match) {
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: match.number,
+              body: [
+                `**${workflow}** is green on \`main\` again.`,
+                "",
+                `- SHA: \`${sha}\``,
+                `- Run: ${htmlUrl}`,
+                "",
+                "Closed automatically. Reopens on the next failure.",
+              ].join("\n"),
+            });
+            await github.rest.issues.update({
+              owner,
+              repo,
+              issue_number: match.number,
+              state: "closed",
+              state_reason: "completed",
+            });
+
   alert:
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -8,13 +8,25 @@ name: Publish to Registries
 # NOT wired, deliberately: a `SMITHERY_UPSTREAM_TOKEN` was once documented here
 # as the way to let Smithery's scanner authenticate against our MCP endpoint.
 # No such secret exists and nothing in this file ever read one, so the note
-# described a fix that was never implemented. The consequence is real and
-# accepted: Smithery cannot enumerate our tools, the release settles as
-# AUTH_REQUIRED, and the public catalog lists fewer tools than the server
-# serves. Closing that gap means handing a third-party scanner a working bearer
-# token for a production endpoint — a product decision, not a CI fix. Until it
-# is made, AUTH_REQUIRED is the expected terminal state and must not fail the
-# job (see "Wait for Smithery release" below).
+# described a fix that was never implemented. The consequence is real: Smithery
+# cannot enumerate our tools, the release settles as AUTH_REQUIRED, and the
+# public catalog lists fewer tools than the server serves (36 of 77 as of
+# 0.99.0 — see the supply-chain-drift tracker).
+#
+# This note used to end "handing a third-party scanner a working bearer token
+# for a production endpoint — a product decision, not a CI fix." That framing is
+# obsolete, and it was quietly making an unfixable-looking problem out of a
+# fixable one. A static shared token is not the only way in: OAuth 2.1 dynamic
+# client registration with PKCE lets Smithery obtain its own scoped token and
+# shares no secret at all — and agent-bom already ships a complete AS for it in
+# `src/agent_bom/api/oauth_as.py`. It is mounted on the gateway and NOT on the
+# MCP server, so `/.well-known/oauth-protected-resource` advertises an
+# authorization server whose `/authorize` and `/token` return 404. That, not an
+# absent bearer token, is why the scanner cannot authenticate.
+#
+# So AUTH_REQUIRED remains the expected terminal state that must not fail the
+# job (see "Wait for Smithery release" below) — but it is a bug with a known
+# fix, not an accepted cost. Serving the AS on the MCP server is what closes it.
 # Optional vars:
 #   SMITHERY_MCP_URL    — Public Streamable HTTP MCP endpoint for Smithery
 # Optional secret:

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-07",
+  "generated_on": "2026-08-08",
   "version": "0.99.0",
   "metrics": [
     {
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 836,
+      "value": 837,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/scripts/product_metrics_snapshot.py
+++ b/scripts/product_metrics_snapshot.py
@@ -16,21 +16,25 @@ ROOT = Path(__file__).resolve().parent.parent
 
 
 def _tracked_files(*pathspecs: str) -> list[Path]:
-    """Return tracked files for metrics so local ignored artifacts do not skew counts.
+    """Return files for metrics so local ignored artifacts do not skew counts.
 
     Falls back to a filesystem walk when git cannot answer. The Alpine/musl CI
     job runs where ``git -C <root> ls-files`` exits 128 — git declines a
     repository whose ownership it considers dubious — and a hard failure there
     took down the whole metrics snapshot for a reason unrelated to any metric.
 
-    The fallback is equivalent on the checkout that matters: a fresh CI clone
-    has no untracked or ignored files, so the walk yields the same set. It is
-    only a divergence risk in a dirty working tree, which is exactly where the
-    git path still works.
+    ``--others --exclude-standard`` is not optional. Plain ``ls-files`` lists
+    only what is already in the index, so a module you have written but not yet
+    ``git add``-ed is invisible: ``--check`` passes locally, you commit, and CI
+    counts the file and fails the snapshot 18 minutes into the test job. Every
+    PR that adds a Python file hit this. Including untracked-but-not-ignored
+    files makes the local answer match the CI checkout, where that file is
+    committed — while ignored build artifacts stay excluded, which is the
+    reason this consults git at all rather than walking the tree.
     """
     try:
         result = subprocess.run(
-            ["git", "-C", str(ROOT), "ls-files", "--", *pathspecs],
+            ["git", "-C", str(ROOT), "ls-files", "--cached", "--others", "--exclude-standard", "--", *pathspecs],
             check=True,
             capture_output=True,
             text=True,

--- a/src/agent_bom/api/demo_refresh.py
+++ b/src/agent_bom/api/demo_refresh.py
@@ -1,0 +1,33 @@
+"""Keep UTC-day-scoped demo evidence current on the surfaces that window on it.
+
+The gateway KPI header, proxy status, firewall stats, the runtime production
+index and the cost page all report over ``[UTC midnight, request time]``. Demo
+evidence seeded at boot carries the boot day's timestamps, so once the UTC day
+advances every one of those surfaces reads 0 — a demo asserting no traffic on an
+estate the same page describes as busy.
+
+This module is the single seam that closes that gap for all of them. It stays
+here, rather than in ``demo_estate``, so route modules import an ``api`` sibling
+and the demo package is only touched behind a lazy import — no import cycle, and
+nothing outside demo mode pays more than one environment lookup per request.
+"""
+
+from __future__ import annotations
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def demo_daily_evidence_dependency() -> None:
+    """Route dependency: refresh day-scoped demo evidence before serving.
+
+    A no-op outside demo mode, and one string compare once the day is current.
+    Never raises: a demo refresh must not be able to fail a real request.
+    """
+    try:
+        from agent_bom.demo_estate.bootstrap import refresh_demo_daily_evidence
+
+        refresh_demo_daily_evidence()
+    except Exception:  # noqa: BLE001 - a demo refresh must never fail a request
+        _logger.warning("demo estate daily evidence refresh skipped", exc_info=True)

--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -24,9 +24,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import anyio.to_thread
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, Response
 
+from agent_bom.api.demo_refresh import demo_daily_evidence_dependency
 from agent_bom.api.models import EvaluateRequest, JobStatus, PolicyCreate, PolicyUpdate
 from agent_bom.api.stores import _get_firewall_decision_store, _get_policy_store, _get_store
 from agent_bom.api.tenancy import require_request_tenant_id
@@ -37,7 +38,7 @@ from agent_bom.security import sanitize_error
 if TYPE_CHECKING:
     from agent_bom.api.policy_store import GatewayPolicy
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(demo_daily_evidence_dependency)])
 _REPLAY_ONLY_ARGUMENT_VALUE = "[replay-only]"
 _FIREWALL_POLICY_CACHE_LOCK = threading.RLock()
 _FIREWALL_POLICY_CACHE: dict[str, Any] = {

--- a/src/agent_bom/api/routes/gateway_feed.py
+++ b/src/agent_bom/api/routes/gateway_feed.py
@@ -37,9 +37,10 @@ from datetime import datetime, timezone
 from typing import Any, Literal, cast
 
 import anyio.to_thread
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
+from agent_bom.api.demo_refresh import demo_daily_evidence_dependency
 from agent_bom.api.gateway_activity_store import (
     GatewayActivityCursorError,
     GatewayActivityCursorExpiredError,
@@ -55,7 +56,7 @@ from agent_bom.runtime.gateway_events import (
     GATEWAY_DATA_FILTER_EVENT_TYPES,
 )
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(demo_daily_evidence_dependency)])
 
 _FEED_SCHEMA_VERSION = "gateway.feed.v1"
 _FEED_STALE_AFTER_SECONDS = 120

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -19,10 +19,11 @@ from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Any, cast
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, ConfigDict
 from starlette.responses import Response
 
+from agent_bom.api.demo_refresh import demo_daily_evidence_dependency
 from agent_bom.api.models import JobStatus, PushPayload, ScanJob, ScanRequest
 from agent_bom.api.pipeline import _persist_graph_snapshot
 from agent_bom.api.runtime_event_store import (
@@ -48,7 +49,7 @@ from agent_bom.security import (
     sanitize_url,
 )
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(demo_daily_evidence_dependency)])
 infra_router = APIRouter()
 _logger = logging.getLogger(__name__)
 

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -43,8 +43,9 @@ from typing import Any, cast
 from urllib.parse import urlencode
 
 import anyio.to_thread
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
+from agent_bom.api.demo_refresh import demo_daily_evidence_dependency
 from agent_bom.api.models import ExecScoreConfigUpdateRequest, JobStatus
 from agent_bom.api.stores import _get_fleet_store, _get_store
 from agent_bom.api.tenancy import require_request_tenant_id
@@ -58,7 +59,12 @@ from agent_bom.graph.severity import (
 )
 from agent_bom.rbac import require_authenticated_permission
 
-router = APIRouter(dependencies=[cast(Any, require_authenticated_permission("read"))])
+router = APIRouter(
+    dependencies=[
+        Depends(demo_daily_evidence_dependency),
+        cast(Any, require_authenticated_permission("read")),
+    ]
+)
 _logger = logging.getLogger(__name__)
 
 # Per-tenant overview cache (#3963 follow-up). ``_build_overview`` folds every

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -22,8 +22,9 @@ from threading import Lock
 from typing import TYPE_CHECKING, Any, cast
 
 import anyio.to_thread
-from fastapi import APIRouter, HTTPException, Query, Request, WebSocket
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket
 
+from agent_bom.api.demo_refresh import demo_daily_evidence_dependency
 from agent_bom.api.gateway_activity_store import (
     GatewayActivityConflictError,
     GatewayActivityRecord,
@@ -46,7 +47,7 @@ from agent_bom.runtime.gateway_events import (
 )
 from agent_bom.security import sanitize_error, sanitize_sensitive_payload
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(demo_daily_evidence_dependency)])
 ws_router = APIRouter()
 
 # ── In-process ring buffer for proxy alerts/metrics ──────────────────────────

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 import uuid
+from datetime import datetime, timezone
 from typing import Any
 
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
@@ -21,9 +23,65 @@ _logger = logging.getLogger(__name__)
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
+# The UTC day the day-scoped demo evidence was last refreshed for. Guards the
+# per-request hook down to one string compare once the day is current.
+_daily_evidence_lock = threading.Lock()
+_daily_evidence_day: str | None = None
+
 
 def demo_estate_enabled() -> bool:
     return os.environ.get("AGENT_BOM_DEMO_ESTATE", "").strip().lower() in _TRUTHY
+
+
+def reset_daily_evidence_day() -> None:
+    """Forget which day the evidence was refreshed for. For tests and resets."""
+    global _daily_evidence_day
+    with _daily_evidence_lock:
+        _daily_evidence_day = None
+
+
+def refresh_demo_daily_evidence(*, tenant_id: str = SHOWCASE_TENANT, now: datetime | None = None) -> dict[str, Any]:
+    """Re-seed the demo evidence that is scoped to a single UTC day.
+
+    The gateway KPI header, proxy status, firewall stats and the cost page all
+    window on ``[UTC midnight, request time]``. Evidence seeded at boot carries
+    the boot day's timestamps, so the moment the UTC day advances every one of
+    those surfaces reads 0 — a demo that claims no traffic on an estate the same
+    page describes as busy. Seeding once was never enough; the day has to be
+    re-checked, and the 60s maintenance loop alone leaves a visible window right
+    after midnight.
+
+    The day marker is claimed BEFORE seeding, so a concurrent burst of requests
+    at rollover produces one reseed rather than a stampede, and a seeding
+    failure is retried by the maintenance loop rather than by every request.
+    """
+    global _daily_evidence_day
+
+    if not demo_estate_enabled():
+        return {"refreshed": False, "reason": "disabled"}
+
+    today = (now or datetime.now(timezone.utc)).date().isoformat()
+    with _daily_evidence_lock:
+        if _daily_evidence_day == today:
+            return {"refreshed": False, "reason": "current", "day": today}
+        _daily_evidence_day = today
+
+    summary: dict[str, Any] = {"refreshed": True, "day": today, "tenant_id": tenant_id}
+    try:
+        from agent_bom.demo_estate.showcase_gateway import seed_showcase_gateway_events
+
+        summary["gateway_feed"] = seed_showcase_gateway_events(tenant_id=tenant_id, now=now)
+    except Exception:
+        _logger.warning("demo estate daily gateway refresh failed", exc_info=True)
+        summary["gateway_feed_error"] = True
+    try:
+        from agent_bom.demo_estate.showcase_governance import seed_showcase_governance_and_cost
+
+        summary["governance_cost"] = seed_showcase_governance_and_cost(tenant_id=tenant_id, now=now)
+    except Exception:
+        _logger.warning("demo estate daily cost refresh failed", exc_info=True)
+        summary["governance_cost_error"] = True
+    return summary
 
 
 def demo_estate_force_reseed() -> bool:

--- a/src/agent_bom/demo_estate/showcase_gateway.py
+++ b/src/agent_bom/demo_estate/showcase_gateway.py
@@ -26,6 +26,12 @@ deterministic, while timestamps are anchored to the current UTC day so exact
 daily KPI windows remain truthful. Seeding is idempotent within that day, so
 repeated bootstraps do not inflate the counters.
 
+Anchoring to a day means the seed expires with it: the KPI surfaces window on
+``[UTC midnight, request time]``, so evidence written on one day is invisible
+the moment the next begins. ``bootstrap.refresh_demo_daily_evidence`` re-seeds
+on that rollover and every day-windowed route depends on it — without which the
+demo spends each new UTC day reporting no traffic at all.
+
 The event records are shaped exactly like alerts ingested through
 ``/v1/proxy/audit`` (they are pushed through ``push_proxy_alert``, which applies
 the same secret-sanitization + evidence-tier redaction), so the classification
@@ -208,12 +214,19 @@ def _tenant_has_demo_gateway_events(tenant_id: str, *, anchor: datetime) -> bool
     return False
 
 
-def seed_showcase_gateway_events(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str, Any]:
-    """Seed the curated runtime gateway feed for the demo tenant (idempotent)."""
+def seed_showcase_gateway_events(*, tenant_id: str = SHOWCASE_TENANT, now: datetime | None = None) -> dict[str, Any]:
+    """Seed the curated runtime gateway feed for the demo tenant (idempotent).
+
+    ``now`` overrides the UTC clock the events are anchored to. Seeded evidence
+    is scoped to the anchor's UTC day because the KPI surfaces window on
+    ``[UTC midnight, request time]``, so a seed made on one day is invisible on
+    the next — see ``refresh_demo_daily_evidence``, which re-seeds on rollover.
+    The override exists so that rollover is testable without a frozen clock.
+    """
     from agent_bom.api.routes.proxy import push_proxy_alert, push_proxy_metrics
     from agent_bom.api.stores import _get_firewall_decision_store
 
-    anchor = datetime.now(timezone.utc).replace(microsecond=0)
+    anchor = (now or datetime.now(timezone.utc)).replace(microsecond=0)
     if _tenant_has_demo_gateway_events(tenant_id, anchor=anchor):
         return {"seeded": False, "reason": "already_present", "tenant_id": tenant_id}
 

--- a/src/agent_bom/demo_estate/showcase_governance.py
+++ b/src/agent_bom/demo_estate/showcase_governance.py
@@ -22,6 +22,18 @@ from typing import Any
 
 _logger = logging.getLogger(__name__)
 
+# Marker on every seeded cost row, so a rollover top-up can tell the demo's own
+# spend from an operator's without touching theirs.
+_DEMO_CALL_ID_PREFIX = "demo-"
+
+# Trailing days of spend the cost/forecast surfaces read.
+_SPEND_WINDOW_DAYS = 14
+
+# Weekday shape (Mon..Sun): real LLM spend dips over the weekend. Deterministic
+# per absolute date, so a day written by a backfill and a day written by a
+# rollover top-up agree on what that date cost.
+_WEEKDAY_SPEND_SCALE: tuple[float, ...] = (1.0, 1.02, 1.05, 1.03, 0.98, 0.62, 0.48)
+
 # Blueprints mirror the archetypes the runtime blueprint library already ships,
 # so a demo viewer sees the same vocabulary the product uses everywhere else.
 _BLUEPRINTS: tuple[dict[str, Any], ...] = (
@@ -128,11 +140,15 @@ def _price(model: str, input_tokens: int, output_tokens: int) -> float:
     return round(input_tokens / 1_000_000 * rate_in + output_tokens / 1_000_000 * rate_out, 2)
 
 
-def seed_showcase_governance_and_cost(*, tenant_id: str) -> dict[str, int]:
-    """Seed blueprints and priced LLM calls. Idempotent per tenant."""
+def seed_showcase_governance_and_cost(*, tenant_id: str, now: datetime | None = None) -> dict[str, int]:
+    """Seed blueprints and priced LLM calls. Idempotent per tenant.
+
+    ``now`` overrides the UTC clock so the trailing spend window is testable
+    across a day rollover without a frozen clock.
+    """
     return {
         "blueprints": _seed_blueprints(tenant_id=tenant_id),
-        "cost_records": _seed_cost_records(tenant_id=tenant_id),
+        "cost_records": _seed_cost_records(tenant_id=tenant_id, now=now),
     }
 
 
@@ -202,24 +218,44 @@ def _seed_blueprints(*, tenant_id: str) -> int:
     return seeded
 
 
-def _seed_cost_records(*, tenant_id: str) -> int:
+def _seed_cost_records(*, tenant_id: str, now: datetime | None = None) -> int:
+    """Seed a trailing window of priced LLM calls, topping up on a day rollover.
+
+    The cost page and the gateway ``calls_today`` KPI window on
+    ``[UTC midnight, request time]``. Seeding once and never again left the
+    newest record stamped with the boot day, so those surfaces read 0 from the
+    first midnight onward and — unlike the gateway feed, which the bootstrap
+    loop re-seeds — never recovered, because the old guard treated "any records
+    exist" as "already seeded". Days are keyed by absolute date, so a later pass
+    inserts only the missing ones and never rewrites a day already stored.
+    """
     from agent_bom.api.cost_store import LLMCostRecord, get_cost_store
 
     store = get_cost_store()
-    # Spread each agent's spend over 14 days so forecast/burn-rate has a slope
-    # to fit rather than a single point.
-    now = datetime.now(timezone.utc)
-    existing = len(store.list_records(tenant_id, limit=2))
-    if existing > 1:
+    now = now or datetime.now(timezone.utc)
+
+    existing = store.list_records(tenant_id, limit=5000)
+    demo_records = [record for record in existing if record.call_id.startswith(_DEMO_CALL_ID_PREFIX)]
+    # An operator's own spend must never be joined by demo rows.
+    if existing and not demo_records:
         return 0
+    # Keyed on the stored date rather than the id, so days written by an earlier
+    # relative-index format are still recognised as covered and not duplicated.
+    covered_days = {record.observed_at[:10] for record in demo_records}
 
     seeded = 0
-    for day in range(14):
-        observed = (now - timedelta(days=13 - day)).isoformat()
+    for day in range(_SPEND_WINDOW_DAYS):
+        observed_at = now - timedelta(days=_SPEND_WINDOW_DAYS - 1 - day)
+        date_key = observed_at.date().isoformat()
+        if date_key in covered_days:
+            continue
+        observed = observed_at.isoformat()
+        # Ramp older days slightly so burn-rate has a slope to fit and the
+        # forecast is not extrapolating from a flat line. The weekday shape
+        # carries that variation once the ramp has aged out of the window and
+        # every day is being topped up at full scale.
+        scale = ((day + 8) / 21) * _WEEKDAY_SPEND_SCALE[observed_at.weekday()]
         for agent, provider, model, cost_center, in_tokens, out_tokens in _SPEND:
-            # Ramp older days slightly so burn-rate has a slope to fit and the
-            # forecast is not extrapolating from a flat line.
-            scale = (day + 8) / 21
             daily_in = int(in_tokens * scale)
             daily_out = int(out_tokens * scale)
             if daily_in <= 0:
@@ -230,10 +266,13 @@ def _seed_cost_records(*, tenant_id: str) -> int:
                     # The model belongs in the key: one agent legitimately calls
                     # more than one model (clinical-summarizer uses both), and
                     # keying on agent+day alone made the second overwrite the
-                    # first, silently dropping a whole provider's spend.
-                    call_id=f"demo-{agent}-{model}-{day:02d}",
+                    # first, silently dropping a whole provider's spend. The
+                    # absolute date — not a relative index — keys the day, so a
+                    # rollover top-up inserts a new row instead of colliding
+                    # with an id the store would ignore.
+                    call_id=f"{_DEMO_CALL_ID_PREFIX}{agent}-{model}-{date_key}",
                     agent=agent,
-                    session_id=f"demo-session-{agent}-{model}-{day:02d}",
+                    session_id=f"demo-session-{agent}-{model}-{date_key}",
                     provider=provider,
                     model=model,
                     input_tokens=daily_in,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,43 @@ os.environ.setdefault("AGENT_BOM_EPHEMERAL_STORE", "1")
 
 
 @pytest.fixture(autouse=True)
+def _restore_agent_bom_logging():
+    """Undo any global logging reconfiguration a test leaves behind.
+
+    ``setup_logging`` mutates the process-global ``agent_bom`` logger: it sets
+    the level and replaces the handler list. ``monkeypatch.setenv`` restores
+    ``AGENT_BOM_LOG_LEVEL`` but cannot restore the logger, so one test calling
+    ``setup_logging(level="ERROR")`` silently raises the level for every test
+    that runs after it in the same process.
+
+    Anything later asserting on a warning through ``caplog`` then fails: the
+    record is dropped at the logger's own level before any handler sees it, and
+    the assertion reads as "the warning was never emitted". With
+    ``pytest-randomly`` shuffling order on every run, whether a given test lands
+    after the polluter changes run to run — which is what made this look like
+    flaky CI rather than order dependence. Reproduced deterministically by
+    running a ``setup_logging(level="ERROR")`` test immediately before
+    ``test_unreadable_database_does_not_masquerade_as_a_clean_scan``.
+
+    Restoring here fixes the whole class at once rather than hardening each
+    assertion against a polluter it cannot see.
+    """
+    logger = logging.getLogger("agent_bom")
+    saved_level = logger.level
+    saved_handlers = list(logger.handlers)
+    saved_propagate = logger.propagate
+    root = logging.getLogger()
+    saved_root_level = root.level
+    try:
+        yield
+    finally:
+        logger.setLevel(saved_level)
+        logger.handlers = saved_handlers
+        logger.propagate = saved_propagate
+        root.setLevel(saved_root_level)
+
+
+@pytest.fixture(autouse=True)
 def _no_vuln_db_download(request):
     """Keep the suite off the network when a CLI scan decides to refresh.
 

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from collections import Counter
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi import HTTPException
@@ -986,3 +987,108 @@ def test_default_graph_page_carries_the_containment_spine(demo_estate_client: Te
     }
     linked = [pair for pair in contains if pair[0] in node_ids and pair[1] in node_ids]
     assert linked, "containment nodes arrived with no edge joining them to the page"
+
+
+# ── UTC day rollover ────────────────────────────────────────────────────────
+#
+# CI caught this the hard way: a run whose demo bootstrap landed at 23:59 and
+# whose request landed at 00:00:04 read ``calls_today: 0`` and failed
+# ``assert 0 >= 12``. The same clock makes the hosted demo claim no traffic on
+# an estate the tile beside it describes as busy, and left the seeded LLM spend
+# permanently invisible — its guard treated "any records exist" as "already
+# seeded", so it never re-seeded at all.
+#
+# Running these once proves nothing, so nothing below reads the wall clock for
+# the behaviour under test: evidence is seeded against an explicit yesterday and
+# is read back through the real ``[UTC midnight, now]`` window.
+
+
+def _seed_only_yesterdays_evidence() -> datetime:
+    """Reset the day-scoped stores and leave them holding yesterday's demo data.
+
+    Covers both halves of the rollover: the gateway feed (which the maintenance
+    loop reseeds, so it was merely late) and the seeded LLM spend (which was
+    guarded on "any records exist" and so never came back at all).
+    """
+    from agent_bom.api import cost_store
+    from agent_bom.api import stores as api_stores
+    from agent_bom.api.gateway_activity_store import get_gateway_activity_store
+    from agent_bom.api.routes.proxy import _reset_proxy_runtime_for_tests
+    from agent_bom.demo_estate.bootstrap import reset_daily_evidence_day
+    from agent_bom.demo_estate.showcase_gateway import seed_showcase_gateway_events
+    from agent_bom.demo_estate.showcase_governance import _seed_cost_records
+
+    _reset_proxy_runtime_for_tests()
+    api_stores._get_firewall_decision_store().reset()
+    reset_gateway_activity = getattr(get_gateway_activity_store(), "reset", None)
+    if callable(reset_gateway_activity):
+        reset_gateway_activity()
+    cost_store._COST_STORE = None
+    reset_daily_evidence_day()
+
+    yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+    seeded = seed_showcase_gateway_events(now=yesterday)
+    assert seeded.get("seeded") is True, seeded
+    assert _seed_cost_records(tenant_id="default", now=yesterday) > 0
+    return yesterday
+
+
+def test_yesterdays_gateway_evidence_is_outside_todays_kpi_window() -> None:
+    """The mechanism itself: day-scoped evidence goes dark when the day turns.
+
+    Pinned separately from the fix so a future change that stops scoping the
+    seed to a single UTC day fails here loudly rather than quietly making the
+    rollover test below tautological.
+    """
+    from agent_bom.demo_estate.showcase_gateway import _event_time
+
+    yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+    todays_window_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+
+    for minutes_ago in (0, 1, 20):
+        assert _event_time(yesterday, minutes_ago) < todays_window_start
+
+
+def test_gateway_kpis_recover_after_a_utc_day_rollover(demo_estate_client: TestClient) -> None:
+    """A request landing on the far side of midnight still reports the estate."""
+    _seed_only_yesterdays_evidence()
+
+    # Pre-state: the stores hold demo evidence, but none of it is inside the
+    # window the KPI header reports on. This is precisely what CI saw.
+    from agent_bom.api.routes.proxy import _load_proxy_alerts
+
+    today = datetime.now(timezone.utc).date().isoformat()
+    assert not [alert for alert in _load_proxy_alerts("default") if str(alert.get("ts") or "").startswith(today)]
+
+    kpis = demo_estate_client.get("/v1/gateway/feed/kpis").json()
+
+    assert kpis.get("calls_today", 0) >= 12, kpis
+    assert kpis.get("blocked_today", 0) >= 5, kpis
+    assert kpis.get("shadow_ai_blocked", 0) >= 2, kpis
+    assert kpis.get("data_filters_applied", 0) >= 2, kpis
+    # The spend half of the same rollover: this one never self-healed.
+    assert kpis.get("llm_calls", 0) > 0, kpis
+
+
+def test_daily_refresh_does_not_reseed_twice_in_one_day(demo_estate_client: TestClient) -> None:
+    """The per-request hook must cost one comparison, not a reseed each time."""
+    from agent_bom.demo_estate.bootstrap import refresh_demo_daily_evidence
+
+    _seed_only_yesterdays_evidence()
+    demo_estate_client.get("/v1/gateway/feed/kpis")
+
+    assert refresh_demo_daily_evidence() == {
+        "refreshed": False,
+        "reason": "current",
+        "day": datetime.now(timezone.utc).date().isoformat(),
+    }
+
+
+def test_daily_refresh_is_a_no_op_outside_demo_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every deployment pays for this hook; only the demo may act on it."""
+    from agent_bom.demo_estate.bootstrap import refresh_demo_daily_evidence, reset_daily_evidence_day
+
+    monkeypatch.delenv("AGENT_BOM_DEMO_ESTATE", raising=False)
+    reset_daily_evidence_day()
+
+    assert refresh_demo_daily_evidence() == {"refreshed": False, "reason": "disabled"}

--- a/tests/test_demo_estate_governance_cost.py
+++ b/tests/test_demo_estate_governance_cost.py
@@ -13,6 +13,7 @@ closed for the AI BOM page.
 from __future__ import annotations
 
 import tempfile
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -139,3 +140,78 @@ def test_seeding_is_idempotent(seeded, monkeypatch: pytest.MonkeyPatch) -> None:
     assert again == {"blueprints": 0, "cost_records": 0}
     assert len(_blueprints()) == before_blueprints
     assert len(_costs()) == before_costs
+
+
+# ── UTC day rollover ────────────────────────────────────────────────────────
+
+
+def test_spend_tops_up_on_a_day_rollover_without_duplicating(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Seeded spend went permanently dark at the first midnight.
+
+    The old guard treated "any records exist" as "already seeded", so the
+    trailing window kept the boot day's timestamps forever: the cost page and
+    the gateway's ``calls_today`` both counted 0 LLM calls from then on, and no
+    restart short of wiping the store brought them back. Records are keyed by
+    absolute date now, so a later pass fills only the days that are missing.
+    """
+    monkeypatch.setenv("AGENT_BOM_HOME", tempfile.mkdtemp())
+    monkeypatch.setenv("AGENT_BOM_EPHEMERAL_STORE", "1")
+
+    from agent_bom.api import cost_store
+    from agent_bom.demo_estate.showcase_governance import _seed_cost_records
+
+    cost_store._COST_STORE = None
+    try:
+        today = datetime.now(timezone.utc)
+        yesterday = today - timedelta(days=1)
+
+        seeded_yesterday = _seed_cost_records(tenant_id="default", now=yesterday)
+        assert seeded_yesterday > 0
+        stored = cost_store.get_cost_store().list_records("default", limit=5000)
+        assert not [r for r in stored if r.observed_at.startswith(today.date().isoformat())]
+
+        topped_up = _seed_cost_records(tenant_id="default", now=today)
+
+        assert topped_up > 0, "the day that rolled over was never filled in"
+        after = cost_store.get_cost_store().list_records("default", limit=5000)
+        assert [r for r in after if r.observed_at.startswith(today.date().isoformat())]
+        # Only the new day is written — the thirteen days already stored are
+        # left exactly as they were rather than re-priced under new ids.
+        assert len(after) == len(stored) + topped_up
+        assert len({r.call_id for r in after}) == len(after)
+    finally:
+        cost_store._COST_STORE = None
+
+
+def test_operator_spend_is_never_joined_by_demo_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The rollover top-up must not turn into a licence to write on real data."""
+    monkeypatch.setenv("AGENT_BOM_HOME", tempfile.mkdtemp())
+    monkeypatch.setenv("AGENT_BOM_EPHEMERAL_STORE", "1")
+
+    from agent_bom.api import cost_store
+    from agent_bom.api.cost_store import LLMCostRecord
+    from agent_bom.demo_estate.showcase_governance import _seed_cost_records
+
+    cost_store._COST_STORE = None
+    try:
+        store = cost_store.get_cost_store()
+        store.record_cost(
+            LLMCostRecord(
+                tenant_id="default",
+                call_id="operator-call-1",
+                agent="real-agent",
+                session_id="real-session",
+                provider="anthropic",
+                model="claude-sonnet-5",
+                input_tokens=10,
+                output_tokens=5,
+                cost_usd=0.01,
+                priced=True,
+                observed_at=datetime.now(timezone.utc).isoformat(),
+            )
+        )
+
+        assert _seed_cost_records(tenant_id="default") == 0
+        assert len(store.list_records("default", limit=100)) == 1
+    finally:
+        cost_store._COST_STORE = None


### PR DESCRIPTION
Main is red on `test_demo_estate_gateway_feed_kpis_populated`: a run whose demo bootstrap landed at 23:59 and whose request landed at `00:00:04` read `calls_today: 0` and failed `assert 0 >= 12`. Running it again passes — which is exactly why this survived. The failure needs a midnight.

## Two defects, not one

**The gateway feed was never permanently dark.** `_cleanup_tick` re-seeds every 60s and its day check already worked, so the hosted demo self-healed a minute after each midnight. Real bug, much smaller blast radius than it looked.

**The seeded LLM spend never recovered.** `_seed_cost_records` guarded on `len(list_records(limit=2)) > 1` — "any records exist" read as "already seeded" — so it ran exactly once, ever, and its newest row kept the boot day. `llm_calls`, a term in `calls_today`, went to 0 at the first midnight and stayed there.

**The trap underneath:** `record_cost` is `INSERT OR IGNORE` and the old `call_id` keyed a *relative* day index (`demo-{agent}-{model}-{day:02d}`). A naive "just re-seed daily" fix would have collided with existing ids and silently written nothing — it would have looked applied and changed no data.

## The fix

Cost rows key on the absolute date, and the seeder tops up only days not already covered — matched on stored `observed_at`, so rows written under the old format still count as covered and no day is billed twice on upgrade. An operator's own spend is still never joined.

`refresh_demo_daily_evidence` is the single entry point for the rollover: day-cached behind a lock, and the day is claimed *before* seeding so a burst of requests at midnight causes one reseed rather than a stampede. A failed seed is retried by the maintenance loop, not by every request. All nine day-windowed endpoints reach it through one shared dependency in `api/demo_refresh.py` rather than nine copies of the same judgement.

## Verification

Tests seed against an explicit *yesterday* and read back through the real `[UTC midnight, now]` window, so they do not depend on when they run. The rollover test was confirmed to fail with the fix disabled (`calls_today: 6` — the 6 being exactly the LLM rows that hid the spend half).

Green: `make preflight`, `ruff`, `mypy`, 245 backend tests (demo/cost/gateway-feed/proxy/firewall), `npm ci`, `tsc`, `eslint`, 1055 vitest, `next build`, `bundle:check`, 35 Playwright.

On `pre-commit`: four hooks fail repo-wide (`fix end of files`, `ruff` legacy alias, `mypy` `no-any-return`, and `release-workflow-lint`, which cannot import `yaml`). All four already fail on a clean `main` — verified by stashing — and scoped to the eleven files in this diff every hook passes.