### PR TITLE
fix(mcp): serve the OAuth authorization server we advertise

### DIFF
--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-07`
+- Generated on: `2026-08-08`
 - Version: `0.99.0`
 
 | Metric | Value | Source | Notes |
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 836 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 837 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/api/oauth_as.py
+++ b/src/agent_bom/api/oauth_as.py
@@ -268,7 +268,17 @@ class OAuthAuthorizationServer:
         supported_scopes: list[str] | None = None,
         allow_host_derived_issuer: bool = True,
     ) -> None:
-        self._configured_issuer = issuer.rstrip("/") if issuer else None
+        # Kept verbatim rather than rstripped. RFC 8414 §3.3 / RFC 9728 require
+        # the ``issuer`` this AS returns to be byte-identical to the identifier
+        # the client used to find it, and the MCP SDK advertises us through
+        # pydantic ``AnyHttpUrl``, which renders a bare host WITH a trailing
+        # slash (``https://host/``). Stripping it here made the two documents
+        # disagree by one character — enough for a strict client to reject the
+        # AS after a successful authorize. Endpoint URLs below are built from a
+        # stripped base so a configured slash never yields ``//oauth/token``.
+        # Callers that configure a slash-free issuer (the gateway) are
+        # unaffected: stripping was a no-op for them.
+        self._configured_issuer = issuer or None
         # When False, the issuer is never derived (TOFU-cached) from the
         # client-controlled request base URL. A non-loopback listener without an
         # explicit issuer would otherwise let the first caller poison token
@@ -310,12 +320,16 @@ class OAuthAuthorizationServer:
 
     def metadata(self, request_base_url: str | None = None) -> dict[str, Any]:
         issuer = self.resolve_issuer(request_base_url)
+        # ``issuer`` is echoed exactly as configured (see __init__); endpoints
+        # are built from a stripped base so a trailing slash cannot produce
+        # ``https://host//oauth/token``.
+        base = issuer.rstrip("/")
         return {
             "issuer": issuer,
-            "authorization_endpoint": f"{issuer}/oauth/authorize",
-            "token_endpoint": f"{issuer}/oauth/token",
-            "registration_endpoint": f"{issuer}/oauth/register",
-            "jwks_uri": f"{issuer}/oauth/jwks.json",
+            "authorization_endpoint": f"{base}/oauth/authorize",
+            "token_endpoint": f"{base}/oauth/token",
+            "registration_endpoint": f"{base}/oauth/register",
+            "jwks_uri": f"{base}/oauth/jwks.json",
             "scopes_supported": list(self.supported_scopes),
             "response_types_supported": ["code"],
             "response_modes_supported": ["query"],

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -194,6 +194,43 @@ class _StaticBearerTokenVerifier:
             operator_token_expires_at,
             "AGENT_BOM_MCP_OPERATOR_TOKEN_EXPIRES_AT",
         )
+        self._authorization_server: Any = None
+
+    def accept_tokens_issued_by(self, authorization_server: Any) -> None:
+        """Also honour access tokens minted by our own OAuth 2.1 AS.
+
+        A client that completes the PKCE flow holds a token this verifier has
+        never seen. Without this it authenticates successfully and then every
+        MCP call returns 401 — authorize succeeds on their side and fails a
+        moment later on ours, which is the shape of the reported Smithery
+        failure. Advertising an authorization server whose tokens we then
+        reject is worse than advertising none.
+        """
+        self._authorization_server = authorization_server
+
+    def _verify_issued_token(self, token: str):
+        """Validate an AS-issued RS256 token against our own signing key."""
+        from mcp.server.auth.provider import AccessToken
+
+        server = self._authorization_server
+        if server is None or not token:
+            return None
+        try:
+            claims = server.signing_key.verify(token, issuer=server.resolve_issuer())
+        except Exception:  # noqa: BLE001 - any failure is simply "not our token"
+            return None
+        # Scope comes from the token, never from the caller. The AS is pinned to
+        # ``read`` (see build_mcp_authorization_server), so a registered client
+        # cannot reach a write tool by asking for a broader scope.
+        scopes = [scope for scope in str(claims.get("scope") or "").split(" ") if scope]
+        expires_at = claims.get("exp")
+        return AccessToken(
+            token=token,
+            client_id=str(claims.get("client_id") or claims.get("sub") or "agent-bom-oauth-client"),
+            scopes=scopes or ["read"],
+            expires_at=int(expires_at) if isinstance(expires_at, int | float) else None,
+            resource=None,
+        )
 
     async def verify_token(self, token: str):
         from mcp.server.auth.provider import AccessToken
@@ -224,7 +261,7 @@ class _StaticBearerTokenVerifier:
                 expires_at=_mcp_token_expiry_epoch(self._token_expires_at),
                 resource=None,
             )
-        return None
+        return self._verify_issued_token(token)
 
 
 def _parse_mcp_token_expiry(value: str | None, env_name: str) -> datetime | None:

--- a/src/agent_bom/mcp_server_factory.py
+++ b/src/agent_bom/mcp_server_factory.py
@@ -46,6 +46,104 @@ def _public_base_url(host: str, port: int) -> str:
     return f"http://{host}:{port}"
 
 
+def build_mcp_authorization_server(issuer: str):
+    """The OAuth 2.1 AS this MCP server both advertises and honours.
+
+    ``issuer`` must be the exact string the SDK publishes in the
+    protected-resource document's ``authorization_servers`` — see
+    ``_mount_oauth_authorization_server``.
+
+    Scopes are pinned to ``read``. The AS can therefore never mint a token that
+    reaches a write tool: those require the separately-configured operator
+    token, and a dynamically-registered third-party client must not be able to
+    self-assert administrative authority by asking for the scope.
+    """
+    from agent_bom.api.oauth_as import OAuthAuthorizationServer
+
+    return OAuthAuthorizationServer(
+        issuer=issuer,
+        supported_scopes=["read"],
+        # The issuer is explicit, so never let a client's Host header define it.
+        allow_host_derived_issuer=False,
+    )
+
+
+def _mount_oauth_authorization_server(mcp: Any, server: Any) -> None:
+    """Serve the AS endpoints the protected-resource document points at.
+
+    FastMCP mounts ``create_auth_routes`` only when an ``auth_server_provider``
+    is configured. We run as a resource server (static bearer + token
+    verifier), so it published ``/.well-known/oauth-protected-resource`` naming
+    an authorization server whose ``/authorize`` and ``/token`` returned 404.
+    Discovery resolved and the flow then died, which is why Smithery's scanner
+    settles as AUTH_REQUIRED and its catalog advertises a fraction of our tools.
+
+    These are thin transport adapters: every decision lives in
+    ``OAuthAuthorizationServer``, the same object the gateway serves through its
+    FastAPI router, so there is one implementation and two bindings rather than
+    two authorization servers.
+
+    ``custom_route`` handlers are deliberately unauthenticated — they ARE the
+    bootstrap that issues the token, so requiring one would be circular. Note
+    the SDK mounts custom routes last, at the lowest matching precedence, so
+    these cannot and must not shadow a built-in route.
+    """
+    from starlette.responses import JSONResponse, RedirectResponse, Response
+
+    from agent_bom.api.oauth_as import OAuthError, _basic_auth_from_header
+
+    @mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])
+    async def _as_metadata(request: Any) -> Response:
+        try:
+            return JSONResponse(server.metadata(str(request.base_url).rstrip("/")))
+        except OAuthError as exc:
+            return JSONResponse(exc.to_dict(), status_code=exc.status)
+
+    @mcp.custom_route("/oauth/jwks.json", methods=["GET"])
+    async def _as_jwks(_request: Any) -> Response:
+        return JSONResponse(server.jwks())
+
+    @mcp.custom_route("/oauth/register", methods=["POST"])
+    async def _as_register(request: Any) -> Response:
+        try:
+            payload = await request.json()
+        except Exception:  # noqa: BLE001 - a non-JSON body is a client error, not a crash
+            return JSONResponse(
+                {"error": "invalid_client_metadata", "error_description": "body must be JSON"},
+                status_code=400,
+            )
+        try:
+            registered = server.register_client(payload if isinstance(payload, dict) else {})
+        except OAuthError as exc:
+            return JSONResponse(exc.to_dict(), status_code=exc.status)
+        return JSONResponse(registered, status_code=201)
+
+    @mcp.custom_route("/oauth/authorize", methods=["GET"])
+    async def _as_authorize(request: Any) -> Response:
+        try:
+            location = server.authorize(dict(request.query_params))
+        except OAuthError as exc:
+            if exc.redirect_location:
+                return RedirectResponse(exc.redirect_location, status_code=302)
+            return JSONResponse(exc.to_dict(), status_code=exc.status)
+        return RedirectResponse(location, status_code=302)
+
+    @mcp.custom_route("/oauth/token", methods=["POST"])
+    async def _as_token(request: Any) -> Response:
+        form = dict(await request.form())
+        try:
+            issued = server.token(
+                form,
+                basic_auth=_basic_auth_from_header(request.headers.get("authorization")),
+                request_base_url=str(request.base_url).rstrip("/"),
+            )
+        except OAuthError as exc:
+            headers = {"WWW-Authenticate": "Basic"} if exc.status == 401 else None
+            return JSONResponse(exc.to_dict(), status_code=exc.status, headers=headers)
+        # Tokens must never be cached (OAuth 2.1 §token-response).
+        return JSONResponse(issued, headers={"Cache-Control": "no-store", "Pragma": "no-cache"})
+
+
 def create_fastmcp_server(
     *,
     host: str,
@@ -77,6 +175,22 @@ def create_fastmcp_server(
         token_verifier=token_verifier,
         instructions=_server_instructions(version),
     )
+    if auth_settings is not None:
+        # The issuer is taken from AuthSettings AFTER pydantic has normalized
+        # it, not from the raw string, because that normalized form is exactly
+        # what the SDK writes into the protected-resource document's
+        # ``authorization_servers`` — and ``AnyHttpUrl`` renders a bare host
+        # with a trailing slash. Deriving the AS issuer independently produced
+        # two documents disagreeing by one character.
+        authorization_server = build_mcp_authorization_server(str(auth_settings.issuer_url))
+        _mount_oauth_authorization_server(mcp, authorization_server)
+        # Without this the flow completes and then every call 401s: the client
+        # holds a valid AS-issued token that the static verifier has never
+        # heard of. Advertising an AS whose tokens we reject is worse than not
+        # advertising one.
+        accept_issued = getattr(token_verifier, "accept_tokens_issued_by", None)
+        if callable(accept_issued):
+            accept_issued(authorization_server)
     # Set the actual agent-bom version (FastMCP defaults to SDK version)
     mcp._mcp_server.version = version
     return mcp

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -49,9 +49,22 @@ def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path):
         # process-global; the demo bootstrap seeds them, so clear them here to
         # keep the seeded gateway feed from leaking into later tests.
         from agent_bom.api.routes.proxy import _reset_proxy_runtime_for_tests
+        from agent_bom.demo_estate.bootstrap import reset_daily_evidence_day
 
         _reset_proxy_runtime_for_tests()
         api_stores._get_firewall_decision_store().reset()
+        # The governance seed writes 5 blueprints and a fortnight of LLM spend
+        # into two more process-global singletons. Leaving them populated made
+        # test_graph_governance_overlay fail with `assert 6 == 1` — its overlay
+        # call omits `blueprint_store`, so it read the demo's 5 blueprints plus
+        # its own 1 identity. That is a real leak, not that test's bug, and with
+        # pytest-randomly it only surfaces when the two land in this order.
+        from agent_bom.api import blueprint_store as blueprint_store_mod
+        from agent_bom.api import cost_store as cost_store_mod
+
+        blueprint_store_mod.set_blueprint_store(None)
+        cost_store_mod._COST_STORE = None
+        reset_daily_evidence_day()
 
 
 def _demo_report(client: TestClient) -> dict:

--- a/tests/test_graph_governance_overlay.py
+++ b/tests/test_graph_governance_overlay.py
@@ -138,7 +138,16 @@ def test_overlay_is_resilient_to_missing_matches_and_empty_stores():
     # Identity whose agent has no matching node still adds the node (unlinked).
     store = InMemoryAgentIdentityStore()
     issue_identity(store, agent_id="ghost-agent", tenant_id="default")
-    stats = apply_governance_overlay(graph, tenant_id="default", identity_store=store, drift_store=_FakeDriftStore([]))
+    # Explicit empty store: omitting it read whatever the process-global
+    # blueprint store happened to hold, so an unrelated demo-estate test
+    # seeding 5 blueprints earlier in the run turned this into 6 == 1.
+    stats = apply_governance_overlay(
+        graph,
+        tenant_id="default",
+        identity_store=store,
+        drift_store=_FakeDriftStore([]),
+        blueprint_store=_EmptyBlueprintStore(),
+    )
     assert stats["nodes_added"] == 1
     assert not [e for e in graph.edges if e.relationship == RelationshipType.AUTHENTICATES_AS]
 

--- a/tests/test_mcp_oauth_authorization_server.py
+++ b/tests/test_mcp_oauth_authorization_server.py
@@ -1,0 +1,211 @@
+"""The MCP server must serve the authorization server it advertises.
+
+`/.well-known/oauth-protected-resource` returned 200 naming an authorization
+server whose `/.well-known/oauth-authorization-server`, `/authorize` and
+`/token` all returned 404. FastMCP mounts `create_auth_routes` only when an
+`auth_server_provider` is configured; agent-bom runs as a resource server
+(static bearer + token verifier), so discovery resolved and the flow then died.
+
+Smithery's scanner settles as AUTH_REQUIRED because of it, and the public
+catalog advertises a fraction of the tools the server actually serves.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from agent_bom.mcp_server_factory import build_mcp_authorization_server
+
+
+def _pkce() -> tuple[str, str]:
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+    challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+@pytest.fixture()
+def issuer() -> str:
+    # Exactly what pydantic AnyHttpUrl renders for a bare host, trailing slash
+    # included — the string the SDK publishes in authorization_servers.
+    return "https://agent-bom.example.com/"
+
+
+def test_metadata_issuer_matches_the_advertised_identifier_exactly(issuer: str) -> None:
+    """RFC 8414/9728 compare issuer strings byte-for-byte.
+
+    The SDK advertises us through pydantic ``AnyHttpUrl``, which renders a bare
+    host WITH a trailing slash. The AS used to strip it, so the two documents
+    disagreed by one character — enough for a strict client to reject the server
+    after a successful authorize, and indistinguishable from a working flow on a
+    lenient one.
+    """
+    from mcp.shared.auth import ProtectedResourceMetadata
+    from pydantic import AnyHttpUrl, TypeAdapter
+
+    url = TypeAdapter(AnyHttpUrl).validate_python("https://agent-bom.example.com")
+    advertised = ProtectedResourceMetadata(resource=url, authorization_servers=[url], scopes_supported=[])
+    advertised_issuer = str(advertised.authorization_servers[0])
+
+    metadata = build_mcp_authorization_server(advertised_issuer).metadata()
+
+    assert metadata["issuer"] == advertised_issuer
+
+
+def test_endpoints_never_double_slash_on_a_slashed_issuer(issuer: str) -> None:
+    """Echoing the slash must not leak into the endpoint URLs."""
+    metadata = build_mcp_authorization_server(issuer).metadata()
+
+    for key in ("authorization_endpoint", "token_endpoint", "registration_endpoint", "jwks_uri"):
+        assert "//" not in metadata[key].removeprefix("https://"), (key, metadata[key])
+        assert metadata[key].startswith("https://agent-bom.example.com/oauth/")
+
+
+def test_a_token_from_the_full_pkce_flow_is_accepted_by_the_mcp_verifier(issuer: str) -> None:
+    """The regression that matters: authorize succeeds, then every call 401s.
+
+    A client completing the flow holds a token the static bearer verifier has
+    never seen. Mounting the AS without teaching the verifier about its own
+    tokens moves the failure one step later instead of fixing it.
+    """
+    import asyncio
+
+    from agent_bom.mcp_server import _StaticBearerTokenVerifier
+
+    server = build_mcp_authorization_server(issuer)
+    verifier = _StaticBearerTokenVerifier("static-token")
+    verifier.accept_tokens_issued_by(server)
+
+    registered = server.register_client({"redirect_uris": ["https://client.example/cb"], "client_name": "probe"})
+    code_verifier, code_challenge = _pkce()
+    location = server.authorize(
+        {
+            "response_type": "code",
+            "client_id": registered["client_id"],
+            "redirect_uri": "https://client.example/cb",
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "state": "xyz",
+        }
+    )
+    code = parse_qs(urlparse(location).query)["code"][0]
+    issued = server.token(
+        {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": "https://client.example/cb",
+            "client_id": registered["client_id"],
+            "code_verifier": code_verifier,
+        }
+    )
+
+    access = asyncio.run(verifier.verify_token(issued["access_token"]))
+
+    assert access is not None, "a token this server itself issued was rejected"
+    assert access.scopes == ["read"]
+
+
+def test_the_static_bearer_token_still_works(issuer: str) -> None:
+    """The AS must not displace the configured bearer token."""
+    import asyncio
+
+    from agent_bom.mcp_server import _StaticBearerTokenVerifier
+
+    verifier = _StaticBearerTokenVerifier("static-token")
+    verifier.accept_tokens_issued_by(build_mcp_authorization_server(issuer))
+
+    assert asyncio.run(verifier.verify_token("static-token")) is not None
+    assert asyncio.run(verifier.verify_token("wrong-token")) is None
+
+
+def test_a_foreign_token_is_not_accepted(issuer: str) -> None:
+    """Only tokens signed by THIS server's key may pass."""
+    import asyncio
+
+    from agent_bom.mcp_server import _StaticBearerTokenVerifier
+
+    # A second AS with the same issuer but its own ephemeral signing key: the
+    # token is well-formed and claims the right issuer, and must still fail.
+    other = build_mcp_authorization_server(issuer)
+    registered = other.register_client({"redirect_uris": ["https://client.example/cb"]})
+    code_verifier, code_challenge = _pkce()
+    location = other.authorize(
+        {
+            "response_type": "code",
+            "client_id": registered["client_id"],
+            "redirect_uri": "https://client.example/cb",
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+    )
+    foreign = other.token(
+        {
+            "grant_type": "authorization_code",
+            "code": parse_qs(urlparse(location).query)["code"][0],
+            "redirect_uri": "https://client.example/cb",
+            "client_id": registered["client_id"],
+            "code_verifier": code_verifier,
+        }
+    )["access_token"]
+
+    verifier = _StaticBearerTokenVerifier("static-token")
+    verifier.accept_tokens_issued_by(build_mcp_authorization_server(issuer))
+
+    assert asyncio.run(verifier.verify_token(foreign)) is None, "a token signed by a different key was accepted"
+
+
+def test_every_advertised_endpoint_is_actually_mounted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole defect in one assertion: we advertised routes we did not serve.
+
+    FastMCP only mounts `create_auth_routes` when an `auth_server_provider` is
+    configured. agent-bom configures a token verifier instead, so the
+    protected-resource document named an authorization server whose endpoints
+    all returned 404 — discovery resolved, and the flow died one step later.
+    """
+    from agent_bom.mcp_server import _StaticBearerTokenVerifier
+    from agent_bom.mcp_server_factory import create_fastmcp_server
+
+    monkeypatch.setenv("AGENT_BOM_MCP_PUBLIC_URL", "https://agent-bom.example.com")
+
+    mcp = create_fastmcp_server(
+        host="0.0.0.0",
+        port=8080,
+        bearer_token="secret",
+        version="0.99.0",
+        token_verifier_factory=lambda token: _StaticBearerTokenVerifier(token),
+    )
+    mounted = {getattr(route, "path", "") for route in mcp.streamable_http_app().routes}
+
+    assert "/.well-known/oauth-protected-resource" in mounted
+    for path in (
+        "/.well-known/oauth-authorization-server",
+        "/oauth/authorize",
+        "/oauth/token",
+        "/oauth/register",
+        "/oauth/jwks.json",
+    ):
+        assert path in mounted, f"{path} is advertised but not served"
+
+
+def test_no_authorization_server_is_mounted_when_auth_is_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unauthenticated local server must not sprout an OAuth surface."""
+    from agent_bom.mcp_server import _StaticBearerTokenVerifier
+    from agent_bom.mcp_server_factory import create_fastmcp_server
+
+    monkeypatch.delenv("AGENT_BOM_MCP_PUBLIC_URL", raising=False)
+
+    mcp = create_fastmcp_server(
+        host="127.0.0.1",
+        port=8080,
+        bearer_token=None,
+        version="0.99.0",
+        token_verifier_factory=lambda token: _StaticBearerTokenVerifier(token),
+    )
+    mounted = {getattr(route, "path", "") for route in mcp.streamable_http_app().routes}
+
+    assert "/oauth/token" not in mounted
+    assert "/.well-known/oauth-authorization-server" not in mounted


### PR DESCRIPTION
Closes the Smithery row of #4722.

`/.well-known/oauth-protected-resource` returned 200 naming an authorization server whose `/.well-known/oauth-authorization-server`, `/authorize`, `/token`, `/register` and `/jwks.json` all returned **404**. Discovery resolved and the flow then died — so Smithery's scanner settles as `AUTH_REQUIRED` and its public catalog advertises **36 of the 77** tools this server actually serves. Anyone evaluating agent-bom through Smithery sees under half the product.

## Diagnosed from the SDK, not inferred

FastMCP mounts `create_auth_routes` **only** when an `auth_server_provider` is configured. We configure a `token_verifier` instead, so it ran as a resource server with `issuer_url == resource_server_url` — advertising itself as its own authorization server.

Worth recording: the SDK is **1.26.0**, not 1.29.0 as previously noted. The pin is `mcp>=1.26,<2`.

## Three parts — mounting alone would have moved the failure, not fixed it

**1. Mount.** Endpoints are served via `FastMCP.custom_route`, which the SDK documents for exactly this case and leaves unauthenticated — correct, since the AS bootstrap is what issues the token. These are thin transport adapters over the same `OAuthAuthorizationServer` the gateway already serves through FastAPI: one implementation with two bindings, not two authorization servers.

**2. Issuer.** Verified by serializing the SDK's own model: `ProtectedResourceMetadata` renders a bare host through pydantic `AnyHttpUrl` and emits `authorization_servers: ["https://host/"]` **with** a trailing slash, while our AS stripped it. RFC 8414/9728 compare issuer identifiers byte-for-byte, so the two documents disagreed by one character — a strict client rejects, a lenient one proceeds. That asymmetry is the *"authorize succeeds on their side, fails a moment later on ours"* signature. The configured issuer is now echoed verbatim, and endpoint URLs are built from a stripped base so a slash can never produce `//oauth/token`. The gateway configures slash-free issuers, so its output is unchanged byte-for-byte.

**3. Accept the tokens we mint.** This is the part that would have been missed. `_StaticBearerTokenVerifier` only HMAC-compared the static bearer and operator tokens, so a client completing PKCE held a valid AS-issued token the server had never heard of — and every MCP call would 401. It now also validates RS256 tokens against the AS signing key.

Security: scope comes from the token, never the caller, and the AS is pinned to `read`. A dynamically-registered third-party client cannot reach a write tool by asking for a broader scope — those still require the separately-configured operator token. A token signed by a different key is rejected even when it claims the right issuer (covered by a test).

## Also fixes a global-state leak this surfaced

The demo estate fixture never reset the blueprint or cost store singletons, so its 5 seeded blueprints leaked into `test_graph_governance_overlay` — whose "empty stores" case omitted `blueprint_store` and read the singleton. 5 blueprints + 1 identity = the `assert 6 == 1` **currently failing main**. Reproduced deterministically before fixing, and fixed on both sides: the fixture resets the stores, and the test injects an explicit empty one rather than trusting a shared global.

`docs/PRODUCT_METRICS.md` is regenerated alongside the JSON — the gate validates only the JSON, so the markdown twin had drifted a module behind.

## Deployment note

The AS warns when its signing key is ephemeral: issued tokens are invalidated on restart and are not shared across replicas. The hosted MCP deployment needs `AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM` set. That's a deployment secret, not a code change.

## Verification

7 new tests, including the two that matter: every advertised endpoint is actually mounted, and a token from a full PKCE flow is accepted end-to-end by the MCP verifier.

Green: `make preflight`, `ruff`, `mypy` (837 files), and 136 tests across the OAuth, gateway-broker, MCP-public-URL, governance-overlay, demo-estate and MCP-posture suites — all run **with** `pytest-randomly` active, not with `-p no:randomly`.