### PR TITLE
feat(ci): actually run the accuracy measurements we already had

### DIFF
--- a/.github/workflows/accuracy-nightly.yml
+++ b/.github/workflows/accuracy-nightly.yml
@@ -1,0 +1,54 @@
+name: Accuracy Nightly
+
+# Two different accuracy questions, and PR CI answers neither of them fully.
+#
+# `make preflight` gates offline CVE range-matching accuracy on every PR
+# (scripts/cve_matching_accuracy.py --check), which catches a matcher
+# regression against a committed corpus without touching the network.
+#
+# It cannot catch the other failure: upstream advisory data changing, or our
+# OSV query/parsing pipeline breaking against the live API. Those tests exist
+# (tests/test_accuracy_baseline.py, 12 of them) but carry `pytest.mark.network`,
+# and every CI invocation runs `-m "not network and not slow"` — so they have
+# never executed in CI. A suite that is deselected reads exactly like a suite
+# that passes, which is how "no known vulnerabilities" became an assumption
+# rather than a measurement.
+#
+# This runs them nightly against the live network, where a failure means the
+# upstream world moved rather than the PR being wrong — which is why it does not
+# belong on the PR path.
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  accuracy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install
+        run: uv sync --all-extras
+
+      - name: Refresh the advisory database
+        # A green scan on a stale DB is a false clean — that is the whole reason
+        # this job exists. Measuring accuracy against stale advisories would
+        # reproduce the exact defect it is meant to detect.
+        run: uv run agent-bom db update
+
+      - name: Offline CVE range-matching accuracy
+        run: uv run python scripts/cve_matching_accuracy.py --check
+
+      - name: Live advisory pipeline regression tests
+        run: uv run pytest tests/test_accuracy_baseline.py -v --tb=short -m "network"

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ preflight:  ## Run the drift gates that CI's "Version Alignment" job runs — do
 	@echo "→ enterprise demo surfaces";             python scripts/check_enterprise_demo_surfaces.py
 	@echo "→ release/README consistency";           python scripts/check_release_consistency.py
 	@echo "→ product metrics snapshot";             python scripts/product_metrics_snapshot.py --check
+	@echo "→ CVE matching accuracy";                python scripts/cve_matching_accuracy.py --check
 	@echo "→ env-var reference";                    python scripts/generate_env_var_reference.py --check
 	@echo "→ SDK patterns.json";                    python sdks/shared/generate-patterns.py --check
 	@echo "→ documentation SVGs";                    python scripts/generate_doc_architecture_svgs.py --check

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-08",
+  "generated_on": "2026-08-09",
   "version": "0.99.0",
   "metrics": [
     {
@@ -22,7 +22,7 @@
     },
     {
       "name": "GitHub workflow files",
-      "value": 38,
+      "value": 39,
       "source": ".github/workflows",
       "notes": "Counts .yml and .yaml workflow definitions."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-08`
+- Generated on: `2026-08-09`
 - Version: `0.99.0`
 
 | Metric | Value | Source | Notes |
@@ -13,7 +13,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP tools | 77 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
-| GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
+| GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 837 | `src/agent_bom` | Counts all Python files recursively. |


### PR DESCRIPTION
The backlog item was *"add a precision/recall harness to CI"*. **The harness already existed.** `scripts/cve_matching_accuracy.py` computes precision, recall and F1 against a committed 218-advisory corpus, offline, with a `--check` gate mode and a recorded baseline in `docs/CVE_MATCHING_ACCURACY.json`.

Nothing in `.github/workflows` referenced it. It had never run in CI.

The live-advisory regression tests have the same shape: `tests/test_accuracy_baseline.py` exists and its 12 tests pass, but the file is `pytest.mark.network` and **every** CI invocation runs `-m "not network and not slow"`. Those have never executed in CI either.

A deselected suite reads exactly like a passing one. That is how "no known vulnerabilities" stayed an assumption instead of a measurement — and how a stale vuln DB produced two false cleans on our own repo (gitpython had 5 HIGH, nanoid 1).

So this wires up what was already built rather than building it a second time.

## What runs where, and why

**On every PR** — `make preflight` now gates offline CVE range-matching accuracy. No network, so it belongs on the PR path.

Current corpus: 218 advisories, 207 evaluated, **precision 1.0, recall 1.0**, 19,161 true positives, 0 false negatives, 0 false positives.

**Nightly** — `agent-bom db update` **first**, then the offline gate, then the live network tests.

The `db update` ordering is not incidental. Measuring accuracy against stale advisories would reproduce the exact defect the job exists to detect. And upstream advisory data moving is not a reason to fail someone's PR, which is why the live half is nightly rather than blocking.

## The gate proved itself during this change

Adding the workflow file changed the tracked workflow count, and `--check` caught the stale `PRODUCT_METRICS` snapshot **locally, before commit**. That is precisely the failure mode fixed in #4729 — previously it would have surfaced 18 minutes into CI, after push.

## Scope note

This closes the CI-wiring gap, which was the real gap. It does not expand the corpus — 11 advisories are still skipped as `unsound_oracle` and are reported rather than laundered into the headline. Growing the corpus is worth doing, but it is a separate piece of work from making the existing measurement actually run.