### PR TITLE
fix(demo): drift incidents must reach the store the surfaces read

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 837,
+      "value": 838,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 837 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 838 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -305,6 +305,18 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
         _logger.warning("demo estate gateway feed seeding failed", exc_info=True)
         summary["gateway_feed_error"] = True
 
+    # build_showcase_graph computes drift incidents into a private store it hands
+    # back to its caller, while every drift surface reads the process-global
+    # drift store. Without this the demo described drift in its own graph and
+    # reported 0 incidents on every tile above it.
+    try:
+        from agent_bom.demo_estate.showcase_drift import seed_showcase_drift_incidents
+
+        summary["drift_incidents"] = seed_showcase_drift_incidents(tenant_id=tenant_id)
+    except Exception:
+        _logger.warning("demo estate drift seeding failed", exc_info=True)
+        summary["drift_error"] = True
+
     try:
         from agent_bom.demo_estate.showcase_catalog import seed_showcase_catalog_if_empty
 

--- a/src/agent_bom/demo_estate/showcase_drift.py
+++ b/src/agent_bom/demo_estate/showcase_drift.py
@@ -1,0 +1,114 @@
+"""Seed behavioural-drift incidents into the store the product actually reads.
+
+``build_showcase_graph`` already constructs drift incidents, but into a private
+``_DriftStore`` it hands straight back to the caller. Every surface that reports
+drift — the governance overlay (``graph/governance_overlay.py``), the gateway's
+drift lookup, and the drift tiles above them — reads the process-global
+``get_drift_incident_store()`` instead. So the demo estate computed a full set of
+incidents that nothing could ever see, and the drift surfaces reported 0 on an
+estate whose own graph described the drift.
+
+Same shape as the identity, fleet, governance and gateway seeds before it: the
+evidence existed and simply never reached the store the reader queries.
+
+Incidents are keyed by ``incident_id`` and written through ``upsert``, so
+re-seeding on every boot updates rather than duplicates.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from agent_bom.demo_estate.showcase_graph import SHOWCASE_TENANT
+
+_logger = logging.getLogger(__name__)
+
+_DEMO_INCIDENT_PREFIX = "demo-drift-"
+
+# Each tuple: (suffix, blueprint_id, status, drift_score, violations, warnings,
+#              days_ago_first, hours_ago_last, occurrences, top_violations)
+#
+# The blueprint ids match the seeded governance blueprints so a viewer can move
+# from an incident to the blueprint it violates without hitting a dead end.
+_INCIDENTS: tuple[tuple[str, str, str, float, int, int, int, int, int, list[dict[str, Any]]], ...] = (
+    (
+        "clinical-unauthorized-tool",
+        "bp-clinical-summarization",
+        "drift_detected",
+        0.82,
+        3,
+        1,
+        6,
+        2,
+        7,
+        [
+            {"tool_name": "ehr.write_note", "type": "unauthorized_tool", "detail": "not in the approved composition"},
+            {"tool_name": "warehouse-server.export_csv", "type": "unauthorized_tool", "detail": "bulk export outside blueprint"},
+        ],
+    ),
+    (
+        "prior-auth-model-swap",
+        "bp-prior-auth",
+        "drift_detected",
+        0.64,
+        2,
+        2,
+        4,
+        9,
+        4,
+        [
+            {"tool_name": "payer.submit_draft", "type": "unapproved_model", "detail": "invoked with a model outside the approved set"},
+        ],
+    ),
+    (
+        "patient-intake-ungoverned",
+        "bp-patient-chat",
+        "review",
+        0.41,
+        1,
+        3,
+        2,
+        5,
+        2,
+        [
+            {"tool_name": "scheduling.availability", "type": "draft_blueprint_in_use", "detail": "draft blueprint serving live traffic"},
+        ],
+    ),
+)
+
+
+def seed_showcase_drift_incidents(*, tenant_id: str = SHOWCASE_TENANT, now: datetime | None = None) -> dict[str, Any]:
+    """Write the demo estate's drift incidents into the real store (idempotent)."""
+    from agent_bom.api.drift_incident_store import DriftIncident, get_drift_incident_store
+
+    store = get_drift_incident_store()
+    anchor = now or datetime.now(timezone.utc)
+
+    existing = store.list(tenant_id, include_resolved=True, limit=200)
+    # An operator's own drift incidents must never be joined by demo rows.
+    if existing and not any(i.incident_id.startswith(_DEMO_INCIDENT_PREFIX) for i in existing):
+        return {"seeded": 0, "reason": "operator_incidents_present"}
+
+    seeded = 0
+    for suffix, blueprint_id, status, score, violations, warnings, days_ago, hours_ago, occurrences, top in _INCIDENTS:
+        store.upsert(
+            DriftIncident(
+                incident_id=f"{_DEMO_INCIDENT_PREFIX}{suffix}",
+                tenant_id=tenant_id,
+                blueprint_id=blueprint_id,
+                status=status,
+                drift_score=score,
+                violation_count=violations,
+                warning_count=warnings,
+                top_violations=list(top),
+                first_detected_at=(anchor - timedelta(days=days_ago)).isoformat(),
+                last_detected_at=(anchor - timedelta(hours=hours_ago)).isoformat(),
+                occurrences=occurrences,
+            )
+        )
+        seeded += 1
+
+    _logger.info("demo estate drift incidents seeded %s", seeded)
+    return {"seeded": seeded, "tenant_id": tenant_id}

--- a/tests/test_demo_estate_drift_incidents.py
+++ b/tests/test_demo_estate_drift_incidents.py
@@ -1,0 +1,81 @@
+"""Demo drift incidents must reach the store the product reads.
+
+`build_showcase_graph` computed drift incidents into a private `_DriftStore` it
+handed straight back to its caller, while every drift surface — the governance
+overlay, the gateway drift lookup, and the tiles above them — reads the
+process-global `get_drift_incident_store()`. The estate therefore described
+drift in its own graph and reported 0 incidents everywhere a viewer would look.
+
+Same defect class as the identity, fleet, governance and gateway seeds before
+it: evidence computed and never surfaced.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.demo_estate.showcase_drift import seed_showcase_drift_incidents
+
+
+@pytest.fixture()
+def drift_store(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    monkeypatch.setenv("AGENT_BOM_HOME", str(tmp_path))
+    monkeypatch.setenv("AGENT_BOM_EPHEMERAL_STORE", "1")
+    from agent_bom.api import drift_incident_store as mod
+
+    mod.set_drift_incident_store(None)
+    try:
+        yield mod.get_drift_incident_store()
+    finally:
+        mod.set_drift_incident_store(None)
+
+
+def test_seeding_populates_the_store_the_surfaces_query(drift_store) -> None:
+    result = seed_showcase_drift_incidents(tenant_id="default")
+
+    assert result["seeded"] > 0
+    incidents = drift_store.list("default", limit=50)
+    assert len(incidents) == result["seeded"]
+
+
+def test_incidents_reference_seeded_blueprints(drift_store) -> None:
+    """An incident pointing at a blueprint that does not exist is a dead end."""
+    from agent_bom.demo_estate.showcase_governance import _BLUEPRINTS
+
+    seed_showcase_drift_incidents(tenant_id="default")
+    known = {str(b["id"]) for b in _BLUEPRINTS}
+
+    for incident in drift_store.list("default", limit=50):
+        assert incident.blueprint_id in known, incident.blueprint_id
+
+
+def test_seeding_is_idempotent(drift_store) -> None:
+    """Bootstrap runs on every boot; a second pass must not duplicate rows."""
+    seed_showcase_drift_incidents(tenant_id="default")
+    before = len(drift_store.list("default", limit=50))
+
+    seed_showcase_drift_incidents(tenant_id="default")
+
+    assert len(drift_store.list("default", limit=50)) == before
+
+
+def test_operator_incidents_are_never_joined_by_demo_rows(drift_store) -> None:
+    from agent_bom.api.drift_incident_store import DriftIncident
+
+    drift_store.upsert(
+        DriftIncident(
+            incident_id="real-incident-1",
+            tenant_id="default",
+            blueprint_id="bp-operator-own",
+            status="drift_detected",
+            drift_score=0.9,
+            violation_count=1,
+            warning_count=0,
+            top_violations=[],
+            first_detected_at="2026-08-01T00:00:00+00:00",
+            last_detected_at="2026-08-01T01:00:00+00:00",
+        )
+    )
+
+    assert seed_showcase_drift_incidents(tenant_id="default")["seeded"] == 0
+    assert len(drift_store.list("default", limit=50)) == 1


### PR DESCRIPTION
The demo reported **0 drift incidents** on an estate whose own graph described drift. The narrative had no ending — a viewer saw agents, blueprints and policies, then an empty tile.

## The evidence existed; it was written where nothing looks

`build_showcase_graph` does compute drift incidents — into a private `_DriftStore` it hands straight back to its caller. Every surface that reports drift reads the process-global `get_drift_incident_store()` instead:

- the governance overlay — `graph/governance_overlay.py:82`
- the gateway drift lookup — `gateway_server.py:435`
- the drift tiles above them

Same defect class as the identity, fleet, governance and gateway seeds before it, and the same one that has run through this entire release: **computed, not surfaced.**

## The fix

Seeds three incidents into the real store via `upsert`, so a reboot updates rather than duplicates. Keyed `demo-drift-*` so an operator's own incidents are never joined — and if the tenant already holds non-demo incidents, the seed declines entirely.

Blueprint ids match the seeded governance blueprints. An incident pointing at a blueprint that doesn't exist is a dead end for anyone clicking through, and a test pins that relationship rather than trusting it.

The incidents themselves carry a spread worth showing: an unauthorized-tool violation at 0.82, an unapproved-model swap at 0.64, and a draft blueprint serving live traffic at 0.41 in `review` — so the tile shows a range of severity and status, not three identical rows.

## Verification

Measured against a booted demo estate, not asserted: **3 incidents in the real store and 5 `drift_incident` nodes rendered by the governance overlay**, where both previously read 0.

4 new tests (store population, blueprint referential integrity, idempotency, operator-data safety), plus the governance-overlay suite still green.