### PR TITLE
fix: the roll-up and the compliance tiles both showed less than they computed

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -405,13 +405,13 @@ def containment_drilldown_graph(
     adapter implements only part of the protocol) takes the same fallback, so
     its answer is unchanged rather than a 501.
     """
-    from agent_bom.graph.rollup import ROLLUP_CONTAINMENT_RELATIONSHIP_TYPES, ROLLUP_CONTAINMENT_RELATIONSHIPS
+    from agent_bom.graph.rollup import ROLLUP_CONTAINMENT_RELATIONSHIP_TYPES, ROLLUP_RELATIONSHIPS
 
     def _full_load() -> UnifiedGraph:
         return store.load_graph(
             tenant_id=tenant_id,
             scan_id=scan_id,
-            relationship_types=ROLLUP_CONTAINMENT_RELATIONSHIPS,
+            relationship_types=ROLLUP_RELATIONSHIPS,
         )
 
     budget = node_budget if node_budget is not None else _drilldown_subtree_budget()
@@ -434,7 +434,46 @@ def containment_drilldown_graph(
         return _full_load()
     if truncated:
         return _full_load()
+    _attach_sibling_relationships(store, graph, tenant_id=tenant_id, scan_id=scan_id)
     return graph
+
+
+def _attach_sibling_relationships(
+    store: Any,
+    graph: UnifiedGraph,
+    *,
+    tenant_id: str,
+    scan_id: str,
+) -> None:
+    """Add the non-containment edges *between* the subtree's nodes.
+
+    The walk above deliberately follows containment only — following ``USES``
+    would leave the subtree and stop being a drill-down. But ``drill_down`` also
+    aggregates the relationships *between* the children it returns, and those
+    are exactly the edges the walk excluded, so the drill-down drew a row of
+    disconnected cards for the same reason the top level did.
+
+    Scoped to the subtree's own node ids, so the read stays proportional to the
+    answer rather than to the estate — the property
+    :func:`containment_drilldown_graph` exists to protect. Edges with one
+    endpoint outside the subtree come back from the store (the query matches on
+    either endpoint) and are dropped here; the roll-up would discard them
+    anyway, having nothing at this level to attribute them to.
+
+    A backend that cannot answer a scoped edge query keeps the subtree it
+    already has: fewer relationships drawn, never a failed drill-down.
+    """
+    node_ids = set(graph.nodes)
+    if not node_ids:
+        return
+    unsupported: tuple[type[BaseException], ...] = (*_unsupported_traversal_errors(), AttributeError)
+    try:
+        edges = store.edges_for_node_ids(tenant_id=tenant_id, scan_id=scan_id, node_ids=node_ids)
+    except unsupported:
+        return
+    for edge in edges:
+        if edge.source in node_ids and edge.target in node_ids:
+            graph.add_edge(edge)
 
 
 def _drilldown_subtree_budget() -> int:

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -57,7 +57,7 @@ from agent_bom.graph import (
     UnifiedNode,
 )
 from agent_bom.graph.completeness import bounded_walk_reason, graph_completeness
-from agent_bom.graph.rollup import ROLLUP_CONTAINMENT_RELATIONSHIPS
+from agent_bom.graph.rollup import ROLLUP_CONTAINMENT_RELATIONSHIPS, ROLLUP_RELATIONSHIPS
 from agent_bom.graph.scope import GraphScopeKind, select_observed_scope
 from agent_bom.graph.semantic_clusters import SEMANTIC_CLUSTER_KINDS, build_semantic_clusters, semantic_cluster_stats
 from agent_bom.security import sanitize_error
@@ -3937,10 +3937,11 @@ async def delete_preset(request: Request, name: str) -> dict:
 # Estate-scale roll-up (CONTAINS) — backend for the UI graph-nav drill-down
 # ═══════════════════════════════════════════════════════════════════════════
 
-# Containment-only edge load for /v1/graph/rollup (default mode). Taken from the
-# roll-up itself rather than restated here, so the set fetched can never be
-# narrower than the set rolled up.
-_ROLLUP_CONTAINMENT_RELATIONSHIPS = ROLLUP_CONTAINMENT_RELATIONSHIPS
+# Edge load for /v1/graph/rollup (default mode). Taken from the roll-up itself
+# rather than restated here, so the set fetched can never be narrower than the
+# set rolled up — which is precisely what a containment-only fetch made it: the
+# roll-up draws the NON-containment edges, so it received nothing to draw.
+_ROLLUP_RELATIONSHIPS = ROLLUP_RELATIONSHIPS
 
 
 @router.get("/graph/rollup", tags=["graph"])
@@ -3997,7 +3998,7 @@ async def get_graph_rollup(
                 "tenant_id": tenant,
             }
             if mode != "attack_path":
-                load_kwargs["relationship_types"] = _ROLLUP_CONTAINMENT_RELATIONSHIPS
+                load_kwargs["relationship_types"] = _ROLLUP_RELATIONSHIPS
             graph = await _graph_store_call(graph_store.load_graph, **load_kwargs)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc

--- a/src/agent_bom/graph/rollup.py
+++ b/src/agent_bom/graph/rollup.py
@@ -60,6 +60,14 @@ ROLLUP_CONTAINMENT_RELATIONSHIP_TYPES: frozenset[RelationshipType] = frozenset(
     RelationshipType(value) for value in ROLLUP_CONTAINMENT_RELATIONSHIPS
 )
 
+# What a roll-up must *fetch*, which is not what it walks. The containment set
+# above builds the tree; ``cross_container_edges`` then aggregates the edges
+# that are NOT in it, so a fetch narrowed to containment starves exactly the
+# relationships the collapsed view draws. Spelled out as every relationship
+# rather than passed as "no filter" because "no filter" also pulls attack paths
+# and interaction risks, which no roll-up reads.
+ROLLUP_RELATIONSHIPS: frozenset[str] = frozenset(rel.value for rel in RelationshipType)
+
 # Container entity types form the readable top-level scaffold of the estate.
 # A node of one of these types is a candidate roll-up container; everything else
 # is a leaf that aggregates into its nearest container ancestor.
@@ -771,6 +779,7 @@ def _filters_dict(filters: Optional[RollupFilters]) -> dict[str, Any]:
 __all__ = [
     "ROLLUP_CONTAINMENT_RELATIONSHIPS",
     "ROLLUP_CONTAINMENT_RELATIONSHIP_TYPES",
+    "ROLLUP_RELATIONSHIPS",
     "RollupAggregate",
     "RollupContainer",
     "RollupFilters",

--- a/tests/test_graph_rollup_edges_reach_the_endpoint.py
+++ b/tests/test_graph_rollup_edges_reach_the_endpoint.py
@@ -1,0 +1,152 @@
+"""The roll-up's aggregated relationships must survive the endpoint's own fetch.
+
+#4706 taught the roll-up to aggregate every **non-containment** edge onto the
+containers its endpoints roll up into, so the collapsed estate renders as a
+topology instead of a grid of disconnected cards. Every test it shipped built a
+:class:`UnifiedGraph` in memory and called ``rollup_view`` directly, so all of
+them passed.
+
+The endpoint never gave that code anything to aggregate. ``/v1/graph/rollup``
+loads the snapshot with ``relationship_types=ROLLUP_CONTAINMENT_RELATIONSHIPS``
+— precisely the edges ``cross_container_edges`` is documented to discard — and
+the drill-down walks the subtree with the same filter. So on every real request
+the aggregation ran over an empty set, ``edges`` came back ``[]``, and the
+canvas drew the grid the feature existed to remove. On the demo estate: 22,959
+edges in the snapshot, 6,697 fetched, **0** rendered.
+
+These tests exercise the *endpoint*, against a persisted snapshot, which is the
+only place the defect was ever observable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.rollup import rollup_view
+from agent_bom.graph.types import EntityType, RelationshipType
+
+# The tenant the API middleware establishes for an unauthenticated test request.
+API_TENANT = "default"
+SCAN = "rollup-edges-scan"
+
+
+def _estate(tenant: str = API_TENANT) -> UnifiedGraph:
+    """org -> account -> app -> resource, with relationships that cross containers.
+
+    Three non-containment shapes, one per thing that must survive the fetch:
+
+    * ``res-a-1 -> res-b-1`` (``USES``) — two resources in *different* accounts,
+      so it aggregates to ``acct-a -> acct-b`` at the top level and to
+      ``app-a-1 -> app-a-2`` nowhere; it is the estate-scale relationship a
+      reviewer is looking for.
+    * ``app-a-1 -> app-a-2`` (``USES``) — inside one account, so the top level
+      collapses it into a self-edge and drops it, while a drill-down into
+      ``acct-a`` is exactly where it becomes visible.
+    * ``agent-0 -> res-a-1`` (``USES``) — from an orphan outside the containment
+      tree, so it joins a top-level orphan card to a container.
+    """
+    graph = UnifiedGraph(scan_id=SCAN, tenant_id=tenant)
+
+    def node(node_id: str, entity_type: EntityType, **attrs: object) -> None:
+        graph.add_node(UnifiedNode(id=node_id, entity_type=entity_type, label=node_id, **attrs))  # type: ignore[arg-type]
+
+    def edge(source: str, target: str, relationship: RelationshipType) -> None:
+        graph.add_edge(UnifiedEdge(source=source, target=target, relationship=relationship))
+
+    node("org-0", EntityType.ORG)
+    node("agent-0", EntityType.AGENT, severity="high")
+    for account in ("a", "b"):
+        acct = f"acct-{account}"
+        node(acct, EntityType.ACCOUNT)
+        edge("org-0", acct, RelationshipType.CONTAINS)
+        for app_index in (1, 2):
+            app = f"app-{account}-{app_index}"
+            node(app, EntityType.APPLICATION)
+            edge(acct, app, RelationshipType.CONTAINS)
+            res = f"res-{account}-{app_index}"
+            node(res, EntityType.CLOUD_RESOURCE, severity="critical" if app_index == 1 else "low")
+            edge(app, res, RelationshipType.CONTAINS)
+
+    edge("res-a-1", "res-b-1", RelationshipType.USES)
+    edge("app-a-1", "app-a-2", RelationshipType.USES)
+    edge("agent-0", "res-a-1", RelationshipType.USES)
+    return graph
+
+
+@pytest.fixture
+def api_store(tmp_path) -> SQLiteGraphStore:
+    backend = SQLiteGraphStore(db_path=tmp_path / "rollup-edges.db")
+    graph = _estate()
+    backend.save_graph_streaming(
+        scan_id=SCAN,
+        tenant_id=API_TENANT,
+        nodes=iter(list(graph.nodes.values())),
+        edges=iter(list(graph.edges)),
+    )
+    return backend
+
+
+@pytest.fixture
+def client(api_store):
+    from starlette.testclient import TestClient
+
+    from agent_bom.api import stores as api_stores
+    from agent_bom.api.server import app
+    from agent_bom.api.stores import set_graph_store
+
+    original = api_stores._graph_store
+    set_graph_store(api_store)
+    try:
+        yield TestClient(app)
+    finally:
+        set_graph_store(original)
+
+
+def _edge_pairs(payload: dict) -> set[tuple[str, str]]:
+    return {(edge["source"], edge["target"]) for edge in payload["edges"]}
+
+
+class TestTopLevelRollup:
+    def test_the_response_carries_the_aggregated_relationships(self, client):
+        response = client.get("/v1/graph/rollup", params={"scan_id": SCAN})
+        assert response.status_code == 200, response.text
+        payload = response.json()
+
+        assert payload["edges"], "the collapsed estate came back with no relationships to draw"
+        assert ("agent-0", "org-0") in _edge_pairs(payload)
+        assert all(edge["relationships"] == ["uses"] for edge in payload["edges"])
+
+    def test_containment_is_still_never_drawn_as_a_relationship(self, client):
+        payload = client.get("/v1/graph/rollup", params={"scan_id": SCAN}).json()
+        relationships = {name for edge in payload["edges"] for name in edge["relationships"]}
+        assert relationships.isdisjoint({"contains", "hosts", "owns"})
+
+    def test_the_answer_matches_a_full_in_memory_materialisation(self, client):
+        """The endpoint must not be a narrower view of the estate than the graph is."""
+        expected = rollup_view(_estate())
+        payload = client.get("/v1/graph/rollup", params={"scan_id": SCAN}).json()
+        assert payload["edges"] == expected["edges"]
+
+    def test_the_summary_reports_the_snapshot_edge_count_not_the_fetched_one(self, client):
+        """``total_edges`` is what the estate holds; a fetch filter must not shrink it."""
+        payload = client.get("/v1/graph/rollup", params={"scan_id": SCAN}).json()
+        assert payload["summary"]["total_edges"] == len(_estate().edges)
+
+
+class TestDrillDown:
+    def test_drilling_into_a_container_carries_its_children_relationships(self, client):
+        response = client.get("/v1/graph/rollup", params={"scan_id": SCAN, "node": "acct-a"})
+        assert response.status_code == 200, response.text
+        payload = response.json()
+
+        assert payload["edges"], "the drill-down came back with no relationships to draw"
+        assert ("app-a-1", "app-a-2") in _edge_pairs(payload)
+
+    def test_a_relationship_leaving_the_drilled_container_is_not_drawn(self, client):
+        """``res-a-1 -> res-b-1`` leaves ``acct-a``; nothing at this level stands for it."""
+        payload = client.get("/v1/graph/rollup", params={"scan_id": SCAN, "node": "acct-a"}).json()
+        assert all(target in {"app-a-1", "app-a-2"} for _source, target in _edge_pairs(payload))

--- a/tests/test_graph_rollup_scoped_drilldown.py
+++ b/tests/test_graph_rollup_scoped_drilldown.py
@@ -40,6 +40,7 @@ from agent_bom.graph.node import UnifiedNode
 from agent_bom.graph.rollup import (
     ROLLUP_CONTAINMENT_RELATIONSHIP_TYPES,
     ROLLUP_CONTAINMENT_RELATIONSHIPS,
+    ROLLUP_RELATIONSHIPS,
     RollupFilters,
     drill_down,
 )
@@ -86,6 +87,12 @@ def _estate(tenant: str = TENANT) -> UnifiedGraph:
                 )
                 graph.add_edge(UnifiedEdge(source=app, target=res, relationship=RelationshipType.CONTAINS))
             graph.add_edge(UnifiedEdge(source=app, target="orphan-0", relationship=RelationshipType.USES))
+    # A relationship between two resources under *different* applications of one
+    # account. Drilling into that account is where it must appear, aggregated
+    # onto the two application cards — so a scoped fetch that skips it, as the
+    # containment-only walk did, differs from the full load rather than passing
+    # because the fixture happened to have no sibling relationship to draw.
+    graph.add_edge(UnifiedEdge(source="res-0-0-0", target="res-0-1-0", relationship=RelationshipType.USES))
     # account -> cloud resource via OWNS: the inventory shape drill-down rolls up
     # even though the relationship is not CONTAINS.
     graph.add_node(UnifiedNode(id="owned-0", entity_type=EntityType.CLOUD_RESOURCE, label="owned-0", severity="high"))
@@ -117,8 +124,13 @@ def api_store(tmp_path) -> SQLiteGraphStore:
 
 
 def _full_materialisation(store: SQLiteGraphStore, tenant: str = TENANT) -> UnifiedGraph:
-    """The shipped fetch: every node and edge of the snapshot."""
-    return store.load_graph(tenant_id=tenant, scan_id=SCAN, relationship_types=ROLLUP_CONTAINMENT_RELATIONSHIPS)
+    """The reference fetch: every node and edge of the snapshot.
+
+    Loaded with ``ROLLUP_RELATIONSHIPS``, not the containment subset. A
+    reference narrowed to containment cannot show that a scoped read dropped
+    the relationships between the children it returns — it dropped them too.
+    """
+    return store.load_graph(tenant_id=tenant, scan_id=SCAN, relationship_types=ROLLUP_RELATIONSHIPS)
 
 
 DRILL_TARGETS = [

--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -45,6 +45,7 @@ import { FrameworkIcon } from "@/components/framework-icon";
 import {
   complianceFrameworkSummaries,
   compliancePassRate,
+  complianceScoredTotals,
   controlMatchesQuery,
   type ComplianceFrameworkSummary,
 } from "@/lib/compliance-frameworks";
@@ -112,8 +113,16 @@ function CoverageBar({
 type CategoryFilter = "all" | "ai" | "governance" | "cloud";
 
 function categoryFor(id: string): "ai" | "governance" | "cloud" {
-  if (id === "cis" || id === "cmmc") return "cloud";
-  if (id === "eu-ai-act" || id === "nist-csf" || id === "iso27001" || id === "soc2")
+  if (id === "cis" || id === "cmmc" || id === "cis-foundations") return "cloud";
+  if (
+    id === "eu-ai-act" ||
+    id === "nist-csf" ||
+    id === "iso27001" ||
+    id === "soc2" ||
+    id === "nist-800-53" ||
+    id === "pci-dss" ||
+    id === "fedramp"
+  )
     return "governance";
   return "ai";
 }
@@ -240,6 +249,33 @@ function CompliancePageContent() {
         catalog: CMMC_PRACTICES,
         emptyMessage: undefined,
       },
+      // Scored on every response and counted by the headline, previously shown
+      // in no section. The API returns each control's code and name, so these
+      // need no bundled catalog.
+      {
+        id: "nist-800-53",
+        title: "NIST SP 800-53 Rev 5",
+        subtitle: "Controls with mapped evidence",
+        controls: data.nist_800_53,
+        catalog: {},
+        emptyMessage: undefined,
+      },
+      {
+        id: "pci-dss",
+        title: "PCI DSS 4.0",
+        subtitle: "Requirements with mapped evidence",
+        controls: data.pci_dss,
+        catalog: {},
+        emptyMessage: undefined,
+      },
+      {
+        id: "fedramp",
+        title: "FedRAMP Moderate",
+        subtitle: "Baseline controls",
+        controls: data.fedramp,
+        catalog: {},
+        emptyMessage: undefined,
+      },
     ];
   }, [data, hasMcp]);
 
@@ -345,9 +381,11 @@ function CompliancePageContent() {
 
   if (!data) return null;
 
-  const totalPass = frameworks.reduce((sum, f) => sum + f.pass, 0);
-  const totalWarn = frameworks.reduce((sum, f) => sum + f.warn, 0);
-  const totalFail = frameworks.reduce((sum, f) => sum + f.fail, 0);
+  // Scored rows only, which is the same basis as `evaluated_controls`: the two
+  // reconcile by construction (ui/tests/compliance-reconciliation.test.ts).
+  // Technique catalogs have no pass/fail to add, and the independently scored
+  // NIST catalog rescores evidence these rows already counted.
+  const { pass: totalPass, warn: totalWarn, fail: totalFail } = complianceScoredTotals(frameworks);
   const evaluatedFrameworks = frameworks.filter((f) => !f.disabled).length;
   const overallNotEvaluated = isNotEvaluated(data.overall_status);
 
@@ -369,7 +407,17 @@ function CompliancePageContent() {
       value: evaluatedFrameworks,
       hint: `${frameworks.length} tracked`,
     },
-    { label: "Passing", value: totalPass, accent: "success" },
+    {
+      label: "Passing",
+      value: totalPass,
+      accent: "success",
+      // Passing + Attention + Failing is exactly `evaluated_controls` above.
+      // Say so, because the page also shows a NIST 800-53 catalog line scored
+      // independently over the same evidence — a reader who adds it to these
+      // gets a larger number than the headline and no way to tell which is
+      // wrong.
+      hint: "of the evaluated controls",
+    },
     { label: "Attention", value: totalWarn, accent: "warn", accentThreshold: 0 },
     { label: "Failing", value: totalFail, accent: "critical", accentThreshold: 0 },
   ];
@@ -397,6 +445,13 @@ function CompliancePageContent() {
           <span className="text-[11px] text-[color:var(--text-tertiary)]">
             {f.disabledReason ?? "Not evaluated"}
           </span>
+        ) : f.kind === "applicability" ? (
+          // A technique catalog reports which techniques the evidence puts in
+          // play. Rendering that as a pass/fail bar would claim the estate
+          // passed the ones nothing matched.
+          <span className="text-[11px] text-[color:var(--text-tertiary)]">
+            {f.applicable ?? 0} of {f.total} applicable
+          </span>
         ) : (
           <div className="flex items-center gap-2">
             <CoverageBar pass={f.pass} warn={f.warn} fail={f.fail} total={f.total} />
@@ -412,15 +467,18 @@ function CompliancePageContent() {
       align: "right",
       sortable: true,
       width: "4rem",
-      cell: (f) => (
-        <span
-          className={
-            f.fail > 0 ? "font-semibold text-[color:var(--status-danger)]" : "text-[color:var(--text-tertiary)]"
-          }
-        >
-          {f.fail}
-        </span>
-      ),
+      cell: (f) =>
+        f.kind === "applicability" ? (
+          <span className="text-[color:var(--text-tertiary)]">—</span>
+        ) : (
+          <span
+            className={
+              f.fail > 0 ? "font-semibold text-[color:var(--status-danger)]" : "text-[color:var(--text-tertiary)]"
+            }
+          >
+            {f.fail}
+          </span>
+        ),
     },
   ];
 
@@ -449,6 +507,11 @@ function CompliancePageContent() {
         selectedKey={selectedSection?.id}
         onRowClick={(f) => {
           if (f.disabled) return;
+          // Benchmark rows are in the table because the headline counts them,
+          // but their evidence has its own drill-down below rather than a
+          // control list here. Selecting one would show a different framework's
+          // controls under its name.
+          if (!detailSections.some((section) => section.id === f.id)) return;
           setSelectedFrameworkId(f.id);
         }}
         maxHeight="calc(100vh - 22rem)"

--- a/ui/components/compliance-nist-catalog.tsx
+++ b/ui/components/compliance-nist-catalog.tsx
@@ -182,6 +182,15 @@ export function ComplianceNistCatalog() {
               </>
             )}
           </p>
+          {/* Without this the panel reads as more evaluated controls, and adding
+              its count to the page total produces a number larger than the
+              headline with nothing to explain the gap. It is the same CVE and
+              CIS evidence, scored a second way. */}
+          <p className="mt-1 text-[11px] text-[color:var(--text-tertiary)]">
+            An alternate view of the evidence above, not additional controls — these
+            controls are rescored from the same findings, so they are excluded from
+            the page total and from the overall score.
+          </p>
         </div>
         <div className="flex items-center gap-1.5 self-start whitespace-nowrap">
           <StatusIcon status={drill.status} className="h-4 w-4" />

--- a/ui/e2e/security-graph-cockpit.spec.ts
+++ b/ui/e2e/security-graph-cockpit.spec.ts
@@ -320,6 +320,20 @@ async function routeCockpit(
             },
           },
         ],
+        // The server aggregates every non-containment edge onto the containers
+        // its endpoints roll up into, so a collapsed estate arrives as a
+        // topology. This fixture used to omit the key entirely, which made the
+        // canvas draw a grid of disconnected cards and let an "edge-free
+        // roll-up" assertion look like a deliberate decision rather than a
+        // fixture that could not have shown an edge either way.
+        edges: options.emptyRollup ? [] : [
+          {
+            source: "account:development",
+            target: "account:production",
+            count: 35,
+            relationships: ["can_access", "uses"],
+          },
+        ],
         summary: {
           total_nodes: snapshotNodeCount ?? 1241,
           total_edges: graph.edges.length,
@@ -466,6 +480,9 @@ test(`large estates lead with non-overlapping clusters in ${theme}`, async ({ pa
   // old disclaimer must NOT come back.
   await expect(page.getByText(/real relationships, aggregated/i)).toBeVisible();
   await expect(page.getByText(/not rendered relationship evidence/i)).toHaveCount(0);
+  // The banner claims aggregated relationships; the canvas has to hold one, or
+  // the claim is the disclaimer it replaced with the word "not" removed.
+  await expect(page.locator(".react-flow__edge")).toHaveCount(1);
   await expect(page.getByTestId("graph-compression-summary")).toHaveCount(0);
   await expect(page.getByText(/2 containers at this level.*1241 nodes in snapshot/)).toBeVisible();
   const cards = page.locator('[data-rollup-container="true"]');
@@ -481,7 +498,7 @@ test(`large estates lead with non-overlapping clusters in ${theme}`, async ({ pa
 });
 }
 
-test("36-node snapshots default to real topology and forced roll-up stays edge-free", async ({ page }) => {
+test("36-node snapshots default to real topology and forced roll-up still draws relationships", async ({ page }) => {
   await routeCockpit(page, 36);
 
   await page.goto(`/graph?scan=${scanId}`);
@@ -493,7 +510,10 @@ test("36-node snapshots default to real topology and forced roll-up stays edge-f
   await page.waitForLoadState("networkidle");
   await expect(page.getByText("Scope navigation", { exact: true })).toBeVisible();
   await expect(page.locator('[data-rollup-container="true"]')).toHaveCount(2);
-  await expect(page.locator(".react-flow__edge")).toHaveCount(0);
+  // Collapsing the estate changes what a relationship is drawn *between*, never
+  // whether one is drawn. A roll-up with no edges is the grid of disconnected
+  // cards this view was built to stop being.
+  await expect(page.locator(".react-flow__edge")).toHaveCount(1);
   await expect(page.getByTestId("graph-compression-summary")).toHaveCount(0);
 });
 

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2318,9 +2318,16 @@ export interface ComplianceResponse {
     owasp_mcp_pass: number;
     owasp_mcp_warn: number;
     owasp_mcp_fail: number;
-    atlas_pass: number;
-    atlas_warn: number;
-    atlas_fail: number;
+    /**
+     * ATLAS and ATT&CK are technique catalogs, so they report which techniques
+     * the evidence puts in play — never pass/fail. #4709 removed the scored
+     * form from the API; the page kept reading `atlas_pass` and rendered
+     * `NaN` across every tile until the fields here matched the response.
+     */
+    atlas_applicable?: number | undefined;
+    atlas_not_applicable?: number | undefined;
+    attack_applicable?: number | undefined;
+    attack_not_applicable?: number | undefined;
     nist_pass: number;
     nist_warn: number;
     nist_fail: number;
@@ -2364,6 +2371,12 @@ export interface ComplianceResponse {
     aisvs_fail: number;
     aisvs_error: number;
     aisvs_not_applicable: number;
+    /** Benchmark evidence, counted by `evaluated_controls` like a framework row. */
+    cis_foundations_pass?: number | undefined;
+    cis_foundations_fail?: number | undefined;
+    cis_foundations_error?: number | undefined;
+    cis_foundations_not_applicable?: number | undefined;
+    cis_foundations_evaluated?: number | undefined;
   };
 }
 

--- a/ui/lib/compliance-frameworks.ts
+++ b/ui/lib/compliance-frameworks.ts
@@ -1,15 +1,56 @@
 import type { ComplianceControl, ComplianceResponse } from "@/lib/api";
 
+/**
+ * How a framework is measured, which decides whether it can be summed.
+ *
+ * `scored` — controls carry pass / warn / fail, so the row contributes to the
+ * page's aggregate and to `evaluated_controls`.
+ *
+ * `applicability` — the catalog says which adversary techniques are in play,
+ * not whether the estate passed them. ATLAS and ATT&CK are technique catalogs;
+ * treating a technique as "passing" because nothing matched it is the claim
+ * #4709 removed from the backend. Such a row is never summed.
+ */
+export type ComplianceFrameworkKind = "scored" | "applicability";
+
 export interface ComplianceFrameworkSummary {
   id: string;
   label: string;
   shortLabel: string;
+  kind: ComplianceFrameworkKind;
   pass: number;
   warn: number;
   fail: number;
   total: number;
+  /** Applicability rows only: techniques the estate's evidence puts in play. */
+  applicable?: number;
+  notApplicable?: number;
   disabled?: boolean;
   disabledReason?: string;
+}
+
+function scored(
+  id: string,
+  label: string,
+  shortLabel: string,
+  counts: { pass?: number | undefined; warn?: number | undefined; fail?: number | undefined },
+  total: number,
+  extra: { disabled?: boolean; disabledReason?: string } = {},
+): ComplianceFrameworkSummary {
+  return {
+    id,
+    label,
+    shortLabel,
+    kind: "scored",
+    // Coalesced, not asserted: a field the API stops sending must degrade to a
+    // zero the aggregate can carry, never to the NaN that took out every tile
+    // on the page when `atlas_pass` disappeared.
+    pass: counts.pass ?? 0,
+    warn: counts.warn ?? 0,
+    fail: counts.fail ?? 0,
+    total,
+    ...extra,
+  };
 }
 
 export function complianceFrameworkSummaries(
@@ -18,42 +59,98 @@ export function complianceFrameworkSummaries(
 ): ComplianceFrameworkSummary[] {
   const s = data.summary;
   return [
-    { id: "owasp-llm", label: "OWASP LLM Top 10", shortLabel: "LLM", pass: s.owasp_pass, warn: s.owasp_warn, fail: s.owasp_fail, total: 10 },
-    {
-      id: "owasp-mcp",
-      label: "OWASP MCP Top 10",
-      shortLabel: "MCP",
-      pass: s.owasp_mcp_pass,
-      warn: s.owasp_mcp_warn,
-      fail: s.owasp_mcp_fail,
-      total: 10,
+    scored("owasp-llm", "OWASP LLM Top 10", "LLM", { pass: s.owasp_pass, warn: s.owasp_warn, fail: s.owasp_fail }, 10),
+    scored("owasp-mcp", "OWASP MCP Top 10", "MCP", { pass: s.owasp_mcp_pass, warn: s.owasp_mcp_warn, fail: s.owasp_mcp_fail }, 10, {
       disabled: !hasMcp,
       disabledReason: "Requires MCP scan context",
-    },
-    { id: "atlas", label: "MITRE ATLAS", shortLabel: "ATLAS", pass: s.atlas_pass, warn: s.atlas_warn, fail: s.atlas_fail, total: data.mitre_atlas.length },
-    { id: "nist-ai-rmf", label: "NIST AI RMF", shortLabel: "AI RMF", pass: s.nist_pass, warn: s.nist_warn, fail: s.nist_fail, total: data.nist_ai_rmf.length },
+    }),
     {
-      id: "owasp-agentic",
-      label: "OWASP Agentic Top 10",
-      shortLabel: "Agentic",
-      pass: s.owasp_agentic_pass,
-      warn: s.owasp_agentic_warn,
-      fail: s.owasp_agentic_fail,
-      total: 10,
-      disabled: !hasMcp,
-      disabledReason: "Requires agent + MCP context",
+      id: "atlas",
+      label: "MITRE ATLAS",
+      shortLabel: "ATLAS",
+      kind: "applicability",
+      pass: 0,
+      warn: 0,
+      fail: 0,
+      total: data.mitre_atlas.length,
+      applicable: s.atlas_applicable ?? 0,
+      notApplicable: s.atlas_not_applicable ?? 0,
     },
-    { id: "eu-ai-act", label: "EU AI Act", shortLabel: "EU AI", pass: s.eu_ai_act_pass, warn: s.eu_ai_act_warn, fail: s.eu_ai_act_fail, total: data.eu_ai_act.length },
-    { id: "nist-csf", label: "NIST CSF 2.0", shortLabel: "CSF", pass: s.nist_csf_pass, warn: s.nist_csf_warn, fail: s.nist_csf_fail, total: data.nist_csf.length },
-    { id: "iso27001", label: "ISO 27001", shortLabel: "ISO", pass: s.iso_27001_pass, warn: s.iso_27001_warn, fail: s.iso_27001_fail, total: data.iso_27001.length },
-    { id: "soc2", label: "SOC 2", shortLabel: "SOC 2", pass: s.soc2_pass, warn: s.soc2_warn, fail: s.soc2_fail, total: data.soc2.length },
-    { id: "cis", label: "CIS Controls v8", shortLabel: "CIS", pass: s.cis_pass, warn: s.cis_warn, fail: s.cis_fail, total: data.cis_controls.length },
-    { id: "cmmc", label: "CMMC 2.0", shortLabel: "CMMC", pass: s.cmmc_pass, warn: s.cmmc_warn, fail: s.cmmc_fail, total: data.cmmc.length },
+    scored("nist-ai-rmf", "NIST AI RMF", "AI RMF", { pass: s.nist_pass, warn: s.nist_warn, fail: s.nist_fail }, data.nist_ai_rmf.length),
+    scored(
+      "owasp-agentic",
+      "OWASP Agentic Top 10",
+      "Agentic",
+      { pass: s.owasp_agentic_pass, warn: s.owasp_agentic_warn, fail: s.owasp_agentic_fail },
+      10,
+      { disabled: !hasMcp, disabledReason: "Requires agent + MCP context" },
+    ),
+    scored("eu-ai-act", "EU AI Act", "EU AI", { pass: s.eu_ai_act_pass, warn: s.eu_ai_act_warn, fail: s.eu_ai_act_fail }, data.eu_ai_act.length),
+    scored("nist-csf", "NIST CSF 2.0", "CSF", { pass: s.nist_csf_pass, warn: s.nist_csf_warn, fail: s.nist_csf_fail }, data.nist_csf.length),
+    scored("iso27001", "ISO 27001", "ISO", { pass: s.iso_27001_pass, warn: s.iso_27001_warn, fail: s.iso_27001_fail }, data.iso_27001.length),
+    scored("soc2", "SOC 2", "SOC 2", { pass: s.soc2_pass, warn: s.soc2_warn, fail: s.soc2_fail }, data.soc2.length),
+    scored("cis", "CIS Controls v8", "CIS", { pass: s.cis_pass, warn: s.cis_warn, fail: s.cis_fail }, data.cis_controls.length),
+    scored("cmmc", "CMMC 2.0", "CMMC", { pass: s.cmmc_pass, warn: s.cmmc_warn, fail: s.cmmc_fail }, data.cmmc.length),
+    // Scored on every response and counted by `evaluated_controls`, but shown
+    // in no row until now — so the headline counted 29 controls the page did
+    // not display, and its tiles could not add up to it.
+    scored("nist-800-53", "NIST SP 800-53", "800-53", { pass: s.nist_800_53_pass, warn: s.nist_800_53_warn, fail: s.nist_800_53_fail }, data.nist_800_53.length),
+    scored("pci-dss", "PCI DSS 4.0", "PCI", { pass: s.pci_dss_pass, warn: s.pci_dss_warn, fail: s.pci_dss_fail }, data.pci_dss.length),
+    scored("fedramp", "FedRAMP Moderate", "FedRAMP", { pass: s.fedramp_pass, warn: s.fedramp_warn, fail: s.fedramp_fail }, data.fedramp.length),
+    // Benchmark evidence. It reaches `evaluated_controls` through the same
+    // aggregate as the framework rows, so it belongs in the same table rather
+    // than only in a detail panel below it.
+    scored(
+      "cis-foundations",
+      "CIS Foundations Benchmark",
+      "CIS Bench",
+      { pass: s.cis_foundations_pass, fail: (s.cis_foundations_fail ?? 0) + (s.cis_foundations_error ?? 0) },
+      (s.cis_foundations_evaluated ?? 0) + (s.cis_foundations_not_applicable ?? 0),
+    ),
+    scored(
+      "aisvs",
+      "OWASP AISVS",
+      "AISVS",
+      { pass: s.aisvs_pass, fail: (s.aisvs_fail ?? 0) + (s.aisvs_error ?? 0) },
+      (s.aisvs_pass ?? 0) + (s.aisvs_fail ?? 0) + (s.aisvs_error ?? 0) + (s.aisvs_not_applicable ?? 0),
+    ),
   ];
+}
+
+/**
+ * The page's aggregate, over scored rows only.
+ *
+ * Equal to the response's `evaluated_controls` by construction — the invariant
+ * `tests/compliance-reconciliation.test.ts` pins. Two things are deliberately
+ * absent:
+ *
+ * * applicability rows, which have nothing to sum; and
+ * * `nist_800_53_catalog`, which rescores the SAME CVE and CIS evidence these
+ *   rows already count, against the full vendored catalog. It is an alternate
+ *   view of the estate rather than more of it, and the backend keeps it out of
+ *   `overall_score` for exactly this reason. Adding its 16 evaluated controls
+ *   to this total is what made the tiles read 166 against a headline of 150.
+ */
+export function complianceScoredTotals(
+  summaries: ComplianceFrameworkSummary[],
+): { pass: number; warn: number; fail: number } {
+  return summaries
+    .filter((summary) => summary.kind === "scored")
+    .reduce(
+      (totals, summary) => ({
+        pass: totals.pass + summary.pass,
+        warn: totals.warn + summary.warn,
+        fail: totals.fail + summary.fail,
+      }),
+      { pass: 0, warn: 0, fail: 0 },
+    );
 }
 
 export function compliancePassRate(summary: ComplianceFrameworkSummary): number {
   if (summary.total <= 0) return 0;
+  if (summary.kind === "applicability") {
+    return Math.round(((summary.applicable ?? 0) / summary.total) * 100);
+  }
   return Math.round((summary.pass / summary.total) * 100);
 }
 

--- a/ui/tests/compliance-frameworks.test.ts
+++ b/ui/tests/compliance-frameworks.test.ts
@@ -37,9 +37,12 @@ function sampleCompliance(overrides: Partial<ComplianceResponse> = {}): Complian
       owasp_mcp_pass: 2,
       owasp_mcp_warn: 0,
       owasp_mcp_fail: 8,
-      atlas_pass: 25,
-      atlas_warn: 0,
-      atlas_fail: 40,
+      // ATLAS is an applicability overlay (#4709): the API reports which
+      // techniques the evidence puts in play, never pass/fail. This fixture
+      // asserted the scored form long after the server stopped sending it,
+      // which is why a page rendering NaN kept a green suite.
+      atlas_applicable: 40,
+      atlas_not_applicable: 25,
       nist_pass: 2,
       nist_warn: 0,
       nist_fail: 12,

--- a/ui/tests/compliance-reconciliation.test.ts
+++ b/ui/tests/compliance-reconciliation.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The compliance page's tiles must reconcile with its own headline.
+ *
+ * Measured against the demo estate on 2026-08-09, the page showed:
+ *
+ *   headline   "150 of 195 controls evaluated"
+ *   tiles      Passing 6 · Attention 0 · Failing 95   (= 101)
+ *   ATLAS row  NaN
+ *
+ * Three separate causes, one symptom — numbers on one screen that cannot all
+ * be true:
+ *
+ * 1. **ATLAS.** #4709 reclassified MITRE ATLAS as an applicability overlay and
+ *    the API stopped emitting `atlas_pass` / `atlas_warn` / `atlas_fail`. The
+ *    row still read those three fields, so it rendered `undefined` and poisoned
+ *    the tile sums with `NaN`. The UI suite did not catch it because its
+ *    fixture hand-writes `atlas_pass: 25`, a payload the server cannot produce.
+ *
+ * 2. **Frameworks scored but never rendered.** `nist_800_53` (20 evaluated),
+ *    `pci_dss` (9) and `fedramp` (0) come back on every response, count toward
+ *    `evaluated_controls`, and appeared in no row — 29 evaluated controls the
+ *    headline counted and the page did not show. Same for the CIS Foundations
+ *    and AISVS benchmark evidence (20 more).
+ *
+ * 3. **The catalog line.** `nist_800_53_catalog` (16 evaluated: 3 pass, 13
+ *    fail) is scored INDEPENDENTLY over the vendored catalog from the SAME
+ *    CVE/CIS evidence the framework rows already count. Adding it gives 166,
+ *    which is where the "tiles say 166, headline says 150" report came from.
+ *    It must stay out of the aggregate — folding it in double-counts evidence
+ *    into a leadership-facing score — so the relationship is pinned here
+ *    rather than left as a delta someone will eventually "fix".
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { ComplianceResponse } from "@/lib/api";
+import {
+  complianceFrameworkSummaries,
+  complianceScoredTotals,
+} from "@/lib/compliance-frameworks";
+
+/** The demo estate's actual /v1/compliance response, reduced to what the tiles read. */
+function demoEstateCompliance(): ComplianceResponse {
+  const controls = (count: number, status: string) =>
+    Array.from({ length: count }, (_unused, index) => ({
+      code: `C-${index}`,
+      name: `Control ${index}`,
+      findings: 0,
+      status,
+      severity_breakdown: {},
+      affected_packages: [],
+      affected_agents: [],
+    }));
+  return {
+    overall_score: 13.3,
+    overall_status: "fail",
+    evaluated_controls: 150,
+    total_controls: 195,
+    coverage_pct: 76.9,
+    scan_count: 1,
+    latest_scan: "2026-08-09T00:00:00Z",
+    has_mcp_context: true,
+    summary: {
+      owasp_pass: 0, owasp_warn: 0, owasp_fail: 7,
+      owasp_mcp_pass: 0, owasp_mcp_warn: 0, owasp_mcp_fail: 8,
+      // No atlas_pass / atlas_warn / atlas_fail: the server stopped sending them.
+      atlas_applicable: 40, atlas_not_applicable: 25,
+      attack_applicable: 27, attack_not_applicable: 664,
+      nist_pass: 0, nist_warn: 0, nist_fail: 12,
+      owasp_agentic_pass: 0, owasp_agentic_warn: 0, owasp_agentic_fail: 9,
+      eu_ai_act_pass: 0, eu_ai_act_warn: 0, eu_ai_act_fail: 6,
+      nist_csf_pass: 3, nist_csf_warn: 0, nist_csf_fail: 11,
+      iso_27001_pass: 0, iso_27001_warn: 0, iso_27001_fail: 9,
+      soc2_pass: 0, soc2_warn: 0, soc2_fail: 9,
+      cis_pass: 3, cis_warn: 0, cis_fail: 7,
+      cmmc_pass: 0, cmmc_warn: 0, cmmc_fail: 17,
+      nist_800_53_pass: 2, nist_800_53_warn: 0, nist_800_53_fail: 18,
+      fedramp_pass: 0, fedramp_warn: 0, fedramp_fail: 0,
+      pci_dss_pass: 0, pci_dss_warn: 0, pci_dss_fail: 9,
+      cis_foundations_pass: 12, cis_foundations_fail: 8, cis_foundations_error: 0,
+      cis_foundations_not_applicable: 0, cis_foundations_evaluated: 20,
+      aisvs_pass: 0, aisvs_fail: 0, aisvs_error: 0, aisvs_not_applicable: 0,
+      nist_800_53_catalog_pass: 3,
+      nist_800_53_catalog_fail: 13,
+      nist_800_53_catalog_warning: 0,
+      nist_800_53_catalog_error: 0,
+      nist_800_53_catalog_evaluated: 16,
+      nist_800_53_catalog_not_evaluated: 998,
+    },
+    owasp_llm_top10: controls(10, "fail"),
+    owasp_mcp_top10: controls(10, "fail"),
+    mitre_atlas: [...controls(40, "applicable"), ...controls(25, "not_applicable")],
+    nist_ai_rmf: controls(14, "fail"),
+    owasp_agentic_top10: controls(10, "fail"),
+    eu_ai_act: controls(6, "fail"),
+    nist_csf: controls(14, "fail"),
+    iso_27001: controls(9, "fail"),
+    soc2: controls(9, "fail"),
+    cis_controls: controls(10, "fail"),
+    cmmc: controls(17, "fail"),
+    nist_800_53: controls(29, "fail"),
+    fedramp: controls(25, "not_evaluated"),
+    pci_dss: controls(12, "fail"),
+  } as unknown as ComplianceResponse;
+}
+
+describe("compliance tiles reconcile with the headline", () => {
+  const data = demoEstateCompliance();
+  const rows = complianceFrameworkSummaries(data, true);
+
+  it("never renders a framework count the API does not send", () => {
+    for (const row of rows) {
+      expect(Number.isFinite(row.pass), `${row.id}.pass`).toBe(true);
+      expect(Number.isFinite(row.warn), `${row.id}.warn`).toBe(true);
+      expect(Number.isFinite(row.fail), `${row.id}.fail`).toBe(true);
+    }
+  });
+
+  it("models ATLAS as an applicability overlay, not as passing and failing controls", () => {
+    const atlas = rows.find((row) => row.id === "atlas");
+    expect(atlas).toBeDefined();
+    expect(atlas!.kind).toBe("applicability");
+    expect(atlas!.applicable).toBe(40);
+    // An overlay says which techniques are in play, never that 25 of them passed.
+    expect(atlas!.pass).toBe(0);
+    expect(atlas!.fail).toBe(0);
+  });
+
+  it("renders every framework the headline counted", () => {
+    for (const id of ["nist-800-53", "pci-dss", "fedramp", "cis-foundations"]) {
+      expect(rows.map((row) => row.id)).toContain(id);
+    }
+  });
+
+  it("sums to exactly the evaluated_controls the headline reports", () => {
+    const totals = complianceScoredTotals(rows);
+    expect(totals.pass + totals.warn + totals.fail).toBe(data.evaluated_controls);
+  });
+
+  it("leaves the independently scored catalog out of the aggregate", () => {
+    // 150 + the catalog's 16 is the 166 the tiles used to imply. The catalog
+    // rescores the same CVE and CIS evidence the rows above already counted, so
+    // adding it double-counts; it is an alternate VIEW of the estate, not more
+    // of it.
+    const totals = complianceScoredTotals(rows);
+    const catalogEvaluated = data.summary.nist_800_53_catalog_evaluated ?? 0;
+    expect(catalogEvaluated).toBeGreaterThan(0);
+    expect(totals.pass + totals.warn + totals.fail + catalogEvaluated).toBe(166);
+    expect(rows.map((row) => row.id)).not.toContain("nist-800-53-catalog");
+  });
+});


### PR DESCRIPTION
Two surfaces from the release backlog, same defect class: the evidence was
computed correctly and something between it and the screen dropped it.

## 1. The roll-up drew a grid of disconnected cards (P1, demo-critical)

`#4706` taught the roll-up to aggregate every **non-containment** edge onto the
containers its endpoints roll up into. Every test it shipped built a graph in
memory and called `rollup_view` directly, so all of them passed.

The endpoint never gave that code anything to aggregate. `/v1/graph/rollup`
loaded the snapshot with `relationship_types=ROLLUP_CONTAINMENT_RELATIONSHIPS`
— precisely the edges `cross_container_edges` is documented to discard — and
the drill-down walked the subtree under the same filter.

Measured on the demo estate: **22,959 edges in the snapshot, 6,697 fetched, 0
drawn.** The comment above the constant read *"so the set fetched can never be
narrower than the set rolled up"*, which is exactly what it was.

`ROLLUP_RELATIONSHIPS` is now what a roll-up **fetches**, distinct from
`ROLLUP_CONTAINMENT_RELATIONSHIPS`, which is what it **walks**. Drill-down keeps
its scoped walk — following `USES` would leave the subtree and stop being a
drill-down — and picks up the relationships *between* the subtree's own nodes
through `edges_for_node_ids`, so the read stays proportional to the answer
rather than to the estate.

Cost, demo estate (6,789 nodes / 22,959 edges), SQLite:
load 168ms → 284ms, roll-up 16ms → 23ms, **relationships drawn 0 → 98**.

### The e2e fixture could not have caught it

Its roll-up mock omitted the `edges` key entirely, so *"forced roll-up stays
edge-free"* asserted the fixture's own omission, and the "real relationships,
aggregated" banner was asserted against a payload containing no relationships.
The fixture now carries an aggregated edge and both tests assert it renders.

## 2. The compliance tiles did not add up to the headline above them

    headline   150 of 195 controls evaluated
    tiles      Passing 6 · Attention 0 · Failing 95
    ATLAS row  NaN

- **ATLAS.** `#4709` reclassified it as an applicability overlay and the API
  stopped sending `atlas_pass` / `atlas_warn` / `atlas_fail`; it changed no UI
  file. The row still read them, rendered `undefined`, and `NaN` propagated into
  every tile. The UI suite stayed green because its fixture hand-writes
  `atlas_pass: 25` — a payload the server cannot produce.
- **Five scored frameworks reached no surface.** `nist_800_53` (20 evaluated),
  `pci_dss` (9), `fedramp` (0) plus the CIS Foundations and AISVS benchmark
  evidence (20) all count toward `evaluated_controls` and appeared in no row.
- **The catalog line invited the wrong sum.** `nist_800_53_catalog` is scored
  independently over the vendored catalog **from the same CVE and CIS evidence
  the rows already count**. 150 + its 16 = the 166 that was reported. Folding it
  in would double-count evidence into a leadership-facing score, so the fix is
  labelling, not arithmetic — and a test pins the relationship so the delta is
  not "fixed" the wrong way later.

Rows are now typed by how they are measured: `scored` rows sum, `applicability`
rows do not. Counts are coalesced rather than asserted, so the next retired
field degrades to a zero the aggregate can carry instead of a `NaN`.

## Verified

Rendered against the demo estate at 1440px:

    OVERALL 13% · 150 of 195 controls evaluated
    PASSING 20 · ATTENTION 0 · FAILING 130     (= 150)
    ATLAS   40 of 65 applicable  ·  fail —
    catalog 16 evaluated, labelled and excluded

No `NaN` in the rendered text, no console errors.

- `tests/test_graph_rollup_edges_reach_the_endpoint.py` — new, endpoint level
  against a persisted snapshot: **4 of 6 fail** on `main`.
- `test_graph_rollup_scoped_drilldown.py` — its differential guard compared
  against a containment-only reference, so it could not see a dropped sibling
  relationship. The reference is now the full load and the fixture has a
  relationship between two children: **7 tests fail** with the drill-down half
  of the fix removed.
- `ui/tests/compliance-reconciliation.test.ts` — new: **5 of 5 fail** before.
- 115 rollup tests · 234 graph-store/demo-estate tests · UI suite 1,060 passed ·
  `tsc`, `ruff`, `mypy` clean · `make preflight` green.