### PR TITLE
fix: bound the framework chips, and stop fetching a whole scan to read one field

### DIFF
--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -23,7 +23,7 @@ the caller wants to explore or to invoke — not by whether it is human.
 | Area | Shipped today |
 |---|---|
 | MCP security tools | 77 tools, 6 resources, 8 workflow prompts |
-| REST API | 381 operations across 45 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
+| REST API | 382 operations across 45 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |
 | Runtime proxy | stdio/local MCP inline enforcement (7 detectors) |

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 322 |
+| `docs/openapi/v1.json` | paths | 323 |
 | `docs/openapi/v1.json` | component schemas | 137 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
-- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (322 paths / 381 operations)
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (323 paths / 382 operations)
 
 ## AI / agent developers (MCP · clients · tools)
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -47,7 +47,7 @@ docker compose -f deploy/docker-compose.pilot.yml up -d
 
 - Deployment chooser (Docker / Helm / EKS / Postgres):
   [`../site-docs/deployment/overview.md`](../site-docs/deployment/overview.md)
-- API contract (381 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
+- API contract (382 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
 - Enterprise auth, tenancy, RBAC: [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md),
   [`PERMISSIONS.md`](PERMISSIONS.md)
 - Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -83,7 +83,7 @@
 <rect x="488" y="332" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="496" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,338) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
 <text x="526" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">REST API</text>
-<text x="526" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">381 ops</text>
+<text x="526" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">382 ops</text>
 <rect x="706" y="332" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="714" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(718,338) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
 <text x="744" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Gateway</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -83,7 +83,7 @@
 <rect x="488" y="332" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="496" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,338) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
 <text x="526" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">REST API</text>
-<text x="526" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">381 ops</text>
+<text x="526" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">382 ops</text>
 <rect x="706" y="332" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="714" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(718,338) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
 <text x="744" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Gateway</text>

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -18,7 +18,7 @@
 <rect x="35" y="126" width="378" height="52" rx="8" fill="none" stroke="#fb7185" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#fb7185"/>
 <text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">381 API ops · 77 MCP tools · SARIF</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">382 API ops · 77 MCP tools · SARIF</text>
 <rect x="439" y="18" width="402" height="174" rx="12" fill="#2dd4bf"/>
 <rect x="439" y="22" width="402" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="453" y="32" width="40" height="40" rx="11" fill="#2dd4bf" opacity="0.16"/><g transform="translate(457,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#2dd4bf"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#2dd4bf"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#2dd4bf"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#2dd4bf" stroke-width="1.05"/></g></g>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -18,7 +18,7 @@
 <rect x="35" y="126" width="378" height="52" rx="8" fill="none" stroke="#e11d48" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#e11d48"/>
 <text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#18181b">Agent-native surface</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">381 API ops · 77 MCP tools · SARIF</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">382 API ops · 77 MCP tools · SARIF</text>
 <rect x="439" y="18" width="402" height="174" rx="12" fill="#0d9488"/>
 <rect x="439" y="22" width="402" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="453" y="32" width="40" height="40" rx="11" fill="#0d9488" opacity="0.10"/><g transform="translate(457,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0d9488"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0d9488"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0d9488"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#ffffff" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#0d9488" stroke-width="1.05"/></g></g>

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -31880,6 +31880,51 @@
         ]
       }
     },
+    "/v1/scan/{job_id}/remediation": {
+      "get": {
+        "description": "Get the remediation plan for a completed scan, and nothing else.\n\n``GET /v1/scan/{job_id}`` returns the canonical AI-BOM document \u2014 every\nfinding, blast radius, asset and exposure path. The remediation surface read\none field off it, so the transfer tracked the size of the estate rather than\nthe size of the plan. Measured on the demo estate (2,068 assets / 2,716\nfindings): an 8.7 MB job payload for a 41 KB plan, 99.5% of it discarded by\nthe caller and all of it parsed by the browser first.\n\nThe plan is inherently bounded \u2014 one entry per upgradable package, not per\nasset \u2014 so it is returned whole, with ``total`` stated rather than left for\nthe client to infer.",
+        "operationId": "get_remediation_plan_v1_scan__job_id__remediation_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Remediation Plan V1 Scan  Job Id  Remediation Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Remediation Plan",
+        "tags": [
+          "scan"
+        ]
+      }
+    },
     "/v1/scan/{job_id}/skill-audit": {
       "get": {
         "description": "Get the skill security audit results for a completed scan.\n\nReturns findings from the skill file security audit including\ntyposquat detection, unverified servers, shell access, and more.\nEmpty results if no skill files were scanned.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -21022,6 +21022,45 @@ paths:
       summary: Get Licenses
       tags:
       - scan
+  /v1/scan/{job_id}/remediation:
+    get:
+      description: "Get the remediation plan for a completed scan, and nothing else.\n\
+        \n``GET /v1/scan/{job_id}`` returns the canonical AI-BOM document \u2014 every\n\
+        finding, blast radius, asset and exposure path. The remediation surface read\n\
+        one field off it, so the transfer tracked the size of the estate rather than\n\
+        the size of the plan. Measured on the demo estate (2,068 assets / 2,716\n\
+        findings): an 8.7 MB job payload for a 41 KB plan, 99.5% of it discarded by\n\
+        the caller and all of it parsed by the browser first.\n\nThe plan is inherently\
+        \ bounded \u2014 one entry per upgradable package, not per\nasset \u2014 so\
+        \ it is returned whole, with ``total`` stated rather than left for\nthe client\
+        \ to infer."
+      operationId: get_remediation_plan_v1_scan__job_id__remediation_get
+      parameters:
+      - in: path
+        name: job_id
+        required: true
+        schema:
+          title: Job Id
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Remediation Plan V1 Scan  Job Id  Remediation
+                  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Remediation Plan
+      tags:
+      - scan
   /v1/scan/{job_id}/skill-audit:
     get:
       description: 'Get the skill security audit results for a completed scan.

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1503,6 +1503,28 @@ async def get_graph_export(
     )
 
 
+@router.get("/scan/{job_id}/remediation", tags=["scan"])
+async def get_remediation_plan(request: Request, job_id: str) -> dict:
+    """Get the remediation plan for a completed scan, and nothing else.
+
+    ``GET /v1/scan/{job_id}`` returns the canonical AI-BOM document — every
+    finding, blast radius, asset and exposure path. The remediation surface read
+    one field off it, so the transfer tracked the size of the estate rather than
+    the size of the plan. Measured on the demo estate (2,068 assets / 2,716
+    findings): an 8.7 MB job payload for a 41 KB plan, 99.5% of it discarded by
+    the caller and all of it parsed by the browser first.
+
+    The plan is inherently bounded — one entry per upgradable package, not per
+    asset — so it is returned whole, with ``total`` stated rather than left for
+    the client to infer.
+    """
+    job = _job_for_request(request, job_id)
+    if job.status != JobStatus.DONE or not job.result:
+        raise HTTPException(status_code=409, detail="Scan not completed yet")
+    plan = job.result.get("remediation_plan") or [] if isinstance(job.result, dict) else []
+    return {"job_id": job_id, "remediation_plan": plan, "total": len(plan)}
+
+
 @router.get("/scan/{job_id}/licenses", tags=["scan"])
 async def get_licenses(request: Request, job_id: str) -> dict:
     """Get the license compliance report for a completed scan.

--- a/tests/test_remediation_endpoint_is_not_the_whole_scan.py
+++ b/tests/test_remediation_endpoint_is_not_the_whole_scan.py
@@ -1,0 +1,188 @@
+"""The remediation plan must be fetchable without downloading the whole scan.
+
+The remediation page already had pagination, severity and framework filters, a
+fixable-only toggle, sort and search. None of that was the reason it fell over
+on the demo estate. It fetched the plan like this:
+
+    getRemediation: async (jobId) => {
+      const job = await get<ScanJob>(`/v1/scan/${jobId}`);
+      return job.result?.remediation_plan ?? [];
+    }
+
+``GET /v1/scan/{job_id}`` returns the canonical AI-BOM document -- every
+finding, every blast radius, every asset, every exposure path. Measured on the
+demo estate (2,068 assets / 2,716 findings):
+
+    whole job payload        8.7 MB
+      blast_radius           4.5 MB
+      findings               2.7 MB
+      assets                 1.0 MB
+      exposure_paths         1.0 MB
+      remediation_plan      41.2 KB   <- the only field read
+
+**99.5% of the transfer was discarded by the caller**, and the browser parsed
+all of it before rendering 27 rows. The cost of the answer tracked the size of
+the estate rather than the size of the plan -- the same shape as the roll-up
+drill-down fix, one layer up.
+
+So the endpoint serves the plan, and the guard is differential: the narrow read
+must return exactly what the wide one carried, and must not carry the rest.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+from agent_bom.api.server import app
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import set_job_store
+
+TENANT = "default"
+
+# A plan item carries what the page renders: the upgrade, its blast-radius
+# rollup, and the framework tags the chips are drawn from.
+PLAN = [
+    {
+        "package": "langchain",
+        "current_version": "0.0.150",
+        "fixed_version": "0.1.0",
+        "ecosystem": "PyPI",
+        "severity": "critical",
+        "impact_score": 9.4,
+        "vulnerabilities": ["CVE-2025-0001", "CVE-2025-0002"],
+        "affected_agents": ["cursor"],
+        "exposed_credentials": ["AWS_SECRET_ACCESS_KEY"],
+        "reachable_tools": ["run_shell"],
+        "agents_pct": 100.0,
+        "credentials_pct": 50.0,
+        "tools_pct": 25.0,
+        "owasp_tags": ["LLM05"],
+        "atlas_tags": ["AML.T0010", "AML.T0012"],
+        "is_kev": True,
+        "risk_narrative": "Reachable from an agent with a live credential.",
+    },
+    {
+        "package": "requests",
+        "current_version": "2.20.0",
+        "fixed_version": "",
+        "ecosystem": "PyPI",
+        "severity": "medium",
+        "impact_score": 4.1,
+        "vulnerabilities": ["CVE-2025-0003"],
+        "affected_agents": [],
+        "exposed_credentials": [],
+        "reachable_tools": [],
+        "agents_pct": 0.0,
+        "credentials_pct": 0.0,
+        "tools_pct": 0.0,
+        "owasp_tags": [],
+        "atlas_tags": [],
+        "is_kev": False,
+        "risk_narrative": "No fix published.",
+    },
+]
+
+# The bulk the page never read. Sized so a payload carrying it is unmistakable.
+BULK = {
+    "findings": [{"id": f"CVE-2025-{i:04d}", "severity": "high", "blob": "x" * 512} for i in range(200)],
+    "blast_radius": [{"vulnerability": {"id": f"CVE-2025-{i:04d}"}, "blob": "y" * 512} for i in range(200)],
+    "assets": [{"asset_id": f"asset-{i}", "blob": "z" * 512} for i in range(200)],
+}
+
+
+@pytest.fixture
+def client_and_job():
+    store = InMemoryJobStore()
+    job_id = str(uuid.uuid4())
+    store.put(
+        ScanJob(
+            job_id=job_id,
+            tenant_id=TENANT,
+            status=JobStatus.DONE,
+            created_at="2026-08-10T00:00:00Z",
+            completed_at="2026-08-10T00:01:00Z",
+            request=ScanRequest(agent_projects=["/tmp/proj"], offline=True),
+            result={"remediation_plan": PLAN, **BULK},
+        )
+    )
+    set_job_store(store)
+    try:
+        yield TestClient(app), job_id, store
+    finally:
+        set_job_store(InMemoryJobStore())
+
+
+def test_the_plan_is_exactly_what_the_whole_job_carried(client_and_job):
+    """Differential: a narrower read is only correct if the answer is identical."""
+    client, job_id, _store = client_and_job
+    wide = client.get(f"/v1/scan/{job_id}")
+    narrow = client.get(f"/v1/scan/{job_id}/remediation")
+    assert narrow.status_code == 200, narrow.text
+    assert narrow.json()["remediation_plan"] == wide.json()["result"]["remediation_plan"]
+
+
+def test_the_response_does_not_carry_the_rest_of_the_scan(client_and_job):
+    """The point of the endpoint: what it leaves out."""
+    client, job_id, _store = client_and_job
+    payload = client.get(f"/v1/scan/{job_id}/remediation").json()
+    for absent in ("findings", "blast_radius", "assets", "exposure_paths"):
+        assert absent not in payload, f"{absent} came back on the remediation read"
+
+
+def test_it_is_dramatically_smaller_than_the_whole_job(client_and_job):
+    """Structural, not timing: the transfer must not track estate size."""
+    client, job_id, _store = client_and_job
+    wide = len(client.get(f"/v1/scan/{job_id}").content)
+    narrow = len(client.get(f"/v1/scan/{job_id}/remediation").content)
+    assert narrow * 10 < wide, f"narrow read {narrow}B is not materially smaller than {wide}B"
+
+
+def test_it_reports_the_plan_size_so_a_client_never_infers_it(client_and_job):
+    client, job_id, _store = client_and_job
+    payload = client.get(f"/v1/scan/{job_id}/remediation").json()
+    assert payload["total"] == len(PLAN)
+
+
+def test_an_unfinished_scan_says_so_rather_than_returning_an_empty_plan(client_and_job):
+    """An empty plan and a scan that has not produced one are different answers."""
+    client, _job_id, store = client_and_job
+    pending = str(uuid.uuid4())
+    store.put(
+        ScanJob(
+            job_id=pending,
+            tenant_id=TENANT,
+            status=JobStatus.RUNNING,
+            created_at="2026-08-10T00:00:00Z",
+            request=ScanRequest(agent_projects=["/tmp/proj"], offline=True),
+        )
+    )
+    response = client.get(f"/v1/scan/{pending}/remediation")
+    assert response.status_code == 409, response.text
+
+
+def test_a_completed_scan_with_no_plan_returns_an_empty_one(client_and_job):
+    client, _job_id, store = client_and_job
+    empty = str(uuid.uuid4())
+    store.put(
+        ScanJob(
+            job_id=empty,
+            tenant_id=TENANT,
+            status=JobStatus.DONE,
+            created_at="2026-08-10T00:00:00Z",
+            completed_at="2026-08-10T00:01:00Z",
+            request=ScanRequest(agent_projects=["/tmp/proj"], offline=True),
+            result={"findings": []},
+        )
+    )
+    payload = client.get(f"/v1/scan/{empty}/remediation").json()
+    assert payload["remediation_plan"] == []
+    assert payload["total"] == 0
+
+
+def test_an_unknown_job_is_not_found(client_and_job):
+    client, _job_id, store = client_and_job
+    assert client.get(f"/v1/scan/{uuid.uuid4()}/remediation").status_code == 404

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -16,6 +16,7 @@ import {
   OWASP_LLM_TOP10,
   MITRE_ATLAS,
 } from "@/lib/api";
+import { FrameworkTagChips } from "@/components/framework-tag-chips";
 import { SeverityBadge } from "@/components/severity-badge";
 import {
   ReactFlow,
@@ -1232,17 +1233,9 @@ function AgentDetail({ agentName }: { agentName: string }) {
                     )}
                   </div>
                   {/* Framework tags */}
-                  <div className="flex flex-wrap gap-1 mt-2">
-                    {(br.owasp_tags ?? []).map((t) => (
-                      <span key={t} className="bg-indigo-950 border border-indigo-800 text-indigo-300 px-1.5 py-0.5 rounded text-[10px]">
-                        {t} {OWASP_LLM_TOP10[t] ?? ""}
-                      </span>
-                    ))}
-                    {(br.atlas_tags ?? []).map((t) => (
-                      <span key={t} className="bg-rose-950 border border-rose-800 text-rose-300 px-1.5 py-0.5 rounded text-[10px]">
-                        {t} {MITRE_ATLAS[t] ?? ""}
-                      </span>
-                    ))}
+                  <div className="flex flex-wrap items-center gap-1 mt-2">
+                    <FrameworkTagChips tags={br.owasp_tags} catalog={OWASP_LLM_TOP10} tone="owasp" />
+                    <FrameworkTagChips tags={br.atlas_tags} catalog={MITRE_ATLAS} tone="atlas" />
                   </div>
                 </div>
               ))}

--- a/ui/components/attack-flow.tsx
+++ b/ui/components/attack-flow.tsx
@@ -18,6 +18,7 @@ import {
   OWASP_LLM_TOP10, OWASP_MCP_TOP10, MITRE_ATLAS,
 } from "@/lib/api";
 import type { AttackFlowNodeData, AttackFlowResponse } from "@/lib/api";
+import { FrameworkTagChips } from "@/components/framework-tag-chips";
 import { SeverityBadge } from "@/components/severity-badge";
 import { CONTROLS_CLASS, MINIMAP_CLASS, BACKGROUND_COLOR, BACKGROUND_GAP, ATTACK_FLOW_MINIMAP_COLORS, graphNodeDisplayLabels, readableGraphEdges } from "@/lib/graph-utils";
 import { getOsvVulnerabilityUrl } from "@/lib/vulnerabilities";
@@ -127,9 +128,9 @@ function DetailPanel({ data, onClose }: { data: AttackFlowNodeData; onClose: () 
             </div>
             {data.is_kev && <div className="attack-flow-kev-banner"><AlertTriangle className="w-3 h-3" />CISA Known Exploited Vulnerability</div>}
             {data.fixed_version && <div className="text-xs text-[var(--text-secondary)]">Fix available: <span className="text-emerald-400 font-mono font-semibold">{data.fixed_version}</span></div>}
-            {data.owasp_tags && data.owasp_tags.length > 0 && <FrameworkTags title="OWASP LLM Top 10" tags={data.owasp_tags} catalog={OWASP_LLM_TOP10} color="purple" />}
-            {data.owasp_mcp_tags && data.owasp_mcp_tags.length > 0 && <FrameworkTags title="OWASP MCP Top 10" tags={data.owasp_mcp_tags} catalog={OWASP_MCP_TOP10} color="amber" />}
-            {data.atlas_tags && data.atlas_tags.length > 0 && <FrameworkTags title="MITRE ATLAS" tags={data.atlas_tags} catalog={MITRE_ATLAS} color="cyan" />}
+            {data.owasp_tags && data.owasp_tags.length > 0 && <FrameworkTags title="OWASP LLM Top 10" tags={data.owasp_tags} catalog={OWASP_LLM_TOP10} tone="owasp" />}
+            {data.owasp_mcp_tags && data.owasp_mcp_tags.length > 0 && <FrameworkTags title="OWASP MCP Top 10" tags={data.owasp_mcp_tags} catalog={OWASP_MCP_TOP10} tone="mcp" />}
+            {data.atlas_tags && data.atlas_tags.length > 0 && <FrameworkTags title="MITRE ATLAS" tags={data.atlas_tags} catalog={MITRE_ATLAS} tone="atlas" />}
             {data.risk_score != null && <div className="text-xs text-[var(--text-secondary)]">Risk score: <span className="text-red-400 font-mono font-bold">{data.risk_score}</span></div>}
             {osvUrl && (
               <a href={osvUrl} target="_blank" rel="noopener noreferrer" className="attack-flow-external-link">
@@ -148,16 +149,14 @@ function DetailPanel({ data, onClose }: { data: AttackFlowNodeData; onClose: () 
   );
 }
 
-function FrameworkTags({ title, tags, catalog, color }: { title: string; tags: string[]; catalog: Record<string, string>; color: string }) {
+function FrameworkTags({ title, tags, catalog, tone }: { title: string; tags: string[]; catalog: Record<string, string>; tone: "owasp" | "mcp" | "atlas" }) {
   return (
     <div>
       <div className="attack-flow-filter-label">{title}</div>
-      <div className="space-y-1">
-        {tags?.map((tag) => (
-          <div key={tag} className={`text-xs font-mono bg-${color}-950/40 border border-${color}-800/50 text-${color}-400 rounded px-2 py-1`}>
-            {tag} <span className={`text-${color}-600 font-sans`}>{catalog[tag]}</span>
-          </div>
-        ))}
+      {/* One row per technique put 36 rows in a node panel for a single CVE.
+          Wrapped chips behind a disclosure keep the panel a panel. */}
+      <div className="flex flex-wrap items-center gap-1">
+        <FrameworkTagChips tags={tags} catalog={catalog} tone={tone} showNames visible={4} />
       </div>
     </div>
   );

--- a/ui/components/framework-tag-chips.tsx
+++ b/ui/components/framework-tag-chips.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * A finding's framework tags, bounded.
+ *
+ * `tag_blast_radius` returns **36** ATLAS techniques for a critical CVE on an
+ * agent path with exposed credentials and an execute-capable tool, and can emit
+ * 45. Every surface rendered the list unbounded with each technique's full name
+ * inline, so one finding buried the evidence under it.
+ *
+ * The breadth is not the defect — an applicability overlay (#4709) genuinely
+ * does put that many techniques in play — so this shows the first few, states
+ * how many are hidden, and lets the reader open the rest. The count is never
+ * silently cut: a reader can always tell the difference between "six
+ * techniques" and "six of thirty-six".
+ */
+
+const DEFAULT_VISIBLE = 6;
+
+/**
+ * Tones are spelled out as whole class strings on purpose. The previous
+ * `bg-${color}-950` form in `attack-flow.tsx` cannot be seen by Tailwind's
+ * static extractor, so those classes were never generated and the chips
+ * rendered with no background or border at all.
+ */
+type Tone = "owasp" | "mcp" | "atlas";
+
+const TONE_CLASS: Record<Tone, string> = {
+  owasp: "bg-purple-950 border-purple-800 text-purple-400",
+  mcp: "bg-amber-950 border-amber-800 text-amber-400",
+  atlas: "bg-cyan-950 border-cyan-800 text-cyan-400",
+};
+
+const TONE_NAME_CLASS: Record<Tone, string> = {
+  owasp: "text-purple-600",
+  mcp: "text-amber-600",
+  atlas: "text-cyan-600",
+};
+
+export function FrameworkTagChips({
+  tags,
+  catalog,
+  tone,
+  showNames = false,
+  visible = DEFAULT_VISIBLE,
+}: {
+  tags: string[] | undefined;
+  catalog: Record<string, string>;
+  tone: Tone;
+  /** Render the technique name beside its id. Off in dense rows. */
+  showNames?: boolean;
+  visible?: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const all = tags ?? [];
+  if (all.length === 0) return null;
+
+  const shown = expanded ? all : all.slice(0, visible);
+  const hidden = all.length - shown.length;
+
+  return (
+    <>
+      {shown.map((tag) => (
+        <span
+          key={tag}
+          data-testid="framework-tag-chip"
+          title={catalog[tag] ?? tag}
+          className={`text-xs font-mono ${TONE_CLASS[tone]} border rounded px-1.5 py-0.5 cursor-help`}
+        >
+          {tag}
+          {showNames && catalog[tag] ? (
+            <span className={`ml-1 ${TONE_NAME_CLASS[tone]} font-sans`}>{catalog[tag]}</span>
+          ) : null}
+        </span>
+      ))}
+      {hidden > 0 || expanded ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((open) => !open)}
+          className="text-xs text-[color:var(--text-tertiary)] underline decoration-dotted underline-offset-2 hover:text-[color:var(--text-secondary)]"
+        >
+          {expanded ? "show fewer" : `+${hidden} more`}
+        </button>
+      ) : null}
+    </>
+  );
+}
+
+export default FrameworkTagChips;

--- a/ui/components/scan-result.tsx
+++ b/ui/components/scan-result.tsx
@@ -8,6 +8,7 @@ import { mergePipelineSteps, parsePipelineStepsFromProgress } from "@/lib/scan-p
 import { domainFindingsForScan } from "@/lib/scan-domain-findings";
 import { ScanPipeline } from "@/components/scan-pipeline";
 import { RepoScanOverviewPanel } from "@/components/repo-scan-overview-panel";
+import { FrameworkTagChips } from "@/components/framework-tag-chips";
 import { SeverityBadge } from "@/components/severity-badge";
 import { StatCard } from "@/components/stat-card";
 import {
@@ -613,17 +614,9 @@ function BlastRadiusCard({ blast }: { blast: BlastRadius }) {
         <ImpactPill icon={Wrench} label="Tools reachable" items={blast.reachable_tools ?? blast.exposed_tools ?? []} />
       </div>
       {((blast.owasp_tags && blast.owasp_tags.length > 0) || (blast.atlas_tags && blast.atlas_tags.length > 0)) && (
-        <div className="mt-3 flex flex-wrap gap-1.5">
-          {blast.owasp_tags?.map((tag) => (
-            <span key={tag} title={OWASP_LLM_TOP10[tag] ?? tag} className="text-xs font-mono bg-purple-950 border border-purple-800 text-purple-400 rounded px-1.5 py-0.5 cursor-help">
-              {tag}<span className="ml-1 text-purple-600 font-sans">{OWASP_LLM_TOP10[tag]}</span>
-            </span>
-          ))}
-          {blast.atlas_tags?.map((tag) => (
-            <span key={tag} title={MITRE_ATLAS[tag] ?? tag} className="text-xs font-mono bg-cyan-950 border border-cyan-800 text-cyan-400 rounded px-1.5 py-0.5 cursor-help">
-              {tag}<span className="ml-1 text-cyan-600 font-sans">{MITRE_ATLAS[tag]}</span>
-            </span>
-          ))}
+        <div className="mt-3 flex flex-wrap items-center gap-1.5">
+          <FrameworkTagChips tags={blast.owasp_tags} catalog={OWASP_LLM_TOP10} tone="owasp" showNames />
+          <FrameworkTagChips tags={blast.atlas_tags} catalog={MITRE_ATLAS} tone="atlas" showNames />
         </div>
       )}
     </div>
@@ -684,14 +677,10 @@ function RemediationPlan({ items }: { items: RemediationItem[] }) {
             <ImpactBox label="Tools secured" items={item.reachable_tools} pct={item.tools_pct} color="blue" />
           </div>
           {(item.owasp_tags.length > 0 || item.atlas_tags.length > 0) && (
-            <div className="flex flex-wrap gap-1.5 mb-3">
+            <div className="flex flex-wrap items-center gap-1.5 mb-3">
               <span className="text-xs text-[color:var(--text-tertiary)] mr-1">mitigates:</span>
-              {item.owasp_tags?.map((tag) => (
-                <span key={tag} title={OWASP_LLM_TOP10[tag] ?? tag} className="text-xs font-mono bg-purple-950 border border-purple-800 text-purple-400 rounded px-1.5 py-0.5 cursor-help">{tag}</span>
-              ))}
-              {item.atlas_tags?.map((tag) => (
-                <span key={tag} title={MITRE_ATLAS[tag] ?? tag} className="text-xs font-mono bg-cyan-950 border border-cyan-800 text-cyan-400 rounded px-1.5 py-0.5 cursor-help">{tag}</span>
-              ))}
+              <FrameworkTagChips tags={item.owasp_tags} catalog={OWASP_LLM_TOP10} tone="owasp" />
+              <FrameworkTagChips tags={item.atlas_tags} catalog={MITRE_ATLAS} tone="atlas" />
             </div>
           )}
           <div className="flex items-start gap-2 bg-red-950/20 border border-red-900/30 rounded-lg px-3 py-2">

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -1584,10 +1584,17 @@ export const api = {
   exportFindingTriageVex: () => get<FindingTriageVexResponse>("/v1/findings/triage/vex"),
 
   // ── Remediation ──
-  /** Extract remediation plan from the latest completed scan */
+  /** Remediation plan for a completed scan.
+   *
+   * Reads the dedicated endpoint rather than `/v1/scan/{id}`. The whole-job
+   * read carried every finding, blast radius, asset and exposure path so the
+   * page could use one field: 8.7 MB fetched and parsed for a 41 KB plan on the
+   * demo estate. */
   getRemediation: async (jobId: string): Promise<RemediationItem[]> => {
-    const job = await get<ScanJob>(`/v1/scan/${jobId}`);
-    return job.result?.remediation_plan ?? [];
+    const response = await get<{ remediation_plan?: RemediationItem[] }>(
+      `/v1/scan/${jobId}/remediation`,
+    );
+    return response.remediation_plan ?? [];
   },
 
   // ── Audit Log ──

--- a/ui/tests/framework-tag-chips.test.tsx
+++ b/ui/tests/framework-tag-chips.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * A CVE's framework tags must stay readable at the count the tagger produces.
+ *
+ * `agent_bom.atlas.tag_blast_radius` maps a blast radius onto ATLAS techniques
+ * from observable signals — tool capabilities, credential exposure, AI package
+ * context, severity, vulnerability type. On a critical CVE that sits on an
+ * agent path with exposed credentials and an execute-capable tool it returns
+ * **36 techniques** (reproduced 2026-08-09; the function can emit 45).
+ *
+ * Every surface rendered `tags.map(...)` unbounded, and each chip carries the
+ * technique's full name, so one finding produced a wall of chips that pushed
+ * the evidence below it off screen. The breadth is not wrong — #4709
+ * established ATLAS as an applicability overlay, and a critical CVE on an agent
+ * path genuinely does put that many techniques in play — so the fix is
+ * disclosure, not a narrower mapping: show the first few, keep the count
+ * honest, let the reader open the rest.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { FrameworkTagChips } from "@/components/framework-tag-chips";
+
+// The 36 techniques the worst-case blast radius actually produced.
+const ATLAS_36 = [
+  "AML.T0010", "AML.T0010.001", "AML.T0012", "AML.T0013", "AML.T0014",
+  "AML.T0018", "AML.T0018.000", "AML.T0018.002", "AML.T0024", "AML.T0025",
+  "AML.T0035", "AML.T0036", "AML.T0037", "AML.T0040", "AML.T0043",
+  "AML.T0043.004", "AML.T0048", "AML.T0050", "AML.T0051", "AML.T0051.001",
+  "AML.T0052", "AML.T0052.000", "AML.T0053", "AML.T0054", "AML.T0055",
+  "AML.T0056", "AML.T0057", "AML.T0063", "AML.T0064", "AML.T0065",
+  "AML.T0066", "AML.T0067", "AML.T0068", "AML.T0069", "AML.T0070",
+  "AML.T0071",
+];
+
+const CATALOG = Object.fromEntries(ATLAS_36.map((id) => [id, `Technique ${id}`]));
+
+function chips() {
+  return screen.getAllByTestId("framework-tag-chip");
+}
+
+describe("FrameworkTagChips", () => {
+  it("does not render 36 chips for one finding", () => {
+    render(<FrameworkTagChips tags={ATLAS_36} catalog={CATALOG} tone="atlas" />);
+    expect(chips().length).toBeLessThan(ATLAS_36.length);
+  });
+
+  it("keeps the hidden count honest rather than silently truncating", () => {
+    render(<FrameworkTagChips tags={ATLAS_36} catalog={CATALOG} tone="atlas" />);
+    const shown = chips().length;
+    expect(screen.getByRole("button", { name: new RegExp(`${ATLAS_36.length - shown} more`) })).toBeVisible();
+  });
+
+  it("reveals every tag when the reader opens the rest, and collapses again", () => {
+    render(<FrameworkTagChips tags={ATLAS_36} catalog={CATALOG} tone="atlas" />);
+    const collapsed = chips().length;
+
+    fireEvent.click(screen.getByRole("button", { name: /more/ }));
+    expect(chips()).toHaveLength(ATLAS_36.length);
+
+    fireEvent.click(screen.getByRole("button", { name: /show fewer/i }));
+    expect(chips()).toHaveLength(collapsed);
+  });
+
+  it("renders a short tag list whole, with no disclosure control", () => {
+    render(<FrameworkTagChips tags={["AML.T0010", "AML.T0012"]} catalog={CATALOG} tone="atlas" />);
+    expect(chips()).toHaveLength(2);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("renders nothing at all for a finding with no tags", () => {
+    const { container } = render(<FrameworkTagChips tags={[]} catalog={CATALOG} tone="atlas" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("names the technique, so a chip is readable without the catalog open", () => {
+    render(<FrameworkTagChips tags={["AML.T0010"]} catalog={CATALOG} tone="atlas" />);
+    expect(screen.getByTestId("framework-tag-chip")).toHaveAttribute("title", "Technique AML.T0010");
+  });
+});


### PR DESCRIPTION
Two surfaces that stopped being usable as the estate grew. Both were
measured on the demo estate before and after.

## 36 ATLAS chips on a single CVE

`agent_bom.atlas.tag_blast_radius` maps a blast radius onto ATLAS techniques
from observable signals — tool capabilities, credential exposure, AI package
context, severity, vulnerability type. On a critical CVE sitting on an agent
path with exposed credentials and an execute-capable tool it returns **36
techniques**, and it can emit 45.

Every surface rendered `tags.map(...)` unbounded, several with the technique's
full name inline, so one finding produced a wall of chips that pushed its own
evidence off screen.

**The breadth is not the defect.** #4709 established ATLAS as an applicability
overlay, and a critical CVE on an agent path genuinely does put that many
techniques in play — so the fix is disclosure, not a narrower mapping.
`FrameworkTagChips` shows the first few, states how many are hidden, and opens
on demand. The count is never silently cut: a reader can always tell "six
techniques" from "six of thirty-six".

Applied to the blast-radius card, the remediation plan, the agents page, and
the attack-flow node panel — the last of which listed one row per technique
inside a 320px drawer.

It also fixes chips that were **never styled at all**: `attack-flow.tsx` built
its classes as `bg-${color}-950/40`, which Tailwind's static extractor cannot
see, so those classes were never generated.

## 8.75 MB fetched to render a 41 KB plan

The remediation page already had pagination, severity and framework filters, a
fixable-only toggle, sort and search. **None of that was why it fell over.** It
fetched the plan as:

```ts
const job = await get<ScanJob>(`/v1/scan/${jobId}`);
return job.result?.remediation_plan ?? [];
```

`GET /v1/scan/{job_id}` returns the canonical AI-BOM document. On the demo
estate (2,068 assets / 2,716 findings):

| field | size |
|---|---|
| whole job payload | **8.75 MB** |
| `blast_radius` | 4.5 MB |
| `findings` | 2.7 MB |
| `assets` | 1.0 MB |
| `exposure_paths` | 1.0 MB |
| `remediation_plan` | **41.2 KB** ← the only field read |

**99.5% of the transfer was discarded by the caller**, and the browser parsed
all of it before rendering 27 rows. The cost of the answer tracked the size of
the estate rather than the size of the plan — the same shape as the roll-up
drill-down, one layer up.

`GET /v1/scan/{job_id}/remediation` serves the plan and nothing else. The plan
is bounded by upgradable packages rather than by assets, so it is returned
whole with `total` stated rather than inferred. An incomplete scan still 409s
rather than returning an empty plan, because "no plan yet" and "nothing to fix"
are different answers.

Verified live: **8.75 MB → 38.6 KB, a 99.57% reduction.**

## Verified

- `tests/test_remediation_endpoint_is_not_the_whole_scan.py` — 7 tests, **4 fail
  before the route exists**. The guard is differential: the narrow read must
  return exactly what the wide one carried, and must not carry the rest.
- `ui/tests/framework-tag-chips.test.tsx` — 6 tests over the real 36-technique
  list, red before the component existed.
- Remediation page rendered against the live demo: no console errors,
  `/v1/scan/{id}/remediation` 38.6 KB.
- 164 scan/remediation API tests · UI suite **1,061 passed** · `tsc`, `ruff`,
  `mypy` clean · `make preflight` green (OpenAPI, doc counts, data-model atlas
  and architecture SVGs regenerated).

## Known, not addressed here

`/v1/campaigns` returns every campaign unbounded — **1.6 MB of the same page's
load**, and now the dominant cost on it. Separate contract, separate change.