### PR TITLE
fix(e2e): mock the remediation endpoint the page now reads

### DIFF
--- a/ui/e2e/workspace-actions.spec.ts
+++ b/ui/e2e/workspace-actions.spec.ts
@@ -67,20 +67,7 @@ const campaign = {
   membership_provisional: false,
 };
 
-async function routeRemediation(page: Page) {
-  await routeShell(page);
-  await page.route("**/v1/jobs**", (route) => route.fulfill({ json: {
-    jobs: [{ job_id: "job-remediation", status: "done", created_at: CREATED_AT, completed_at: CREATED_AT, request: {}, summary: {} }],
-    count: 1, total: 1, limit: 25, offset: 0, status_counts: { done: 1 },
-  } }));
-  await page.route("**/v1/scan/job-remediation", (route) => route.fulfill({ json: {
-    job_id: "job-remediation",
-    status: "done",
-    created_at: CREATED_AT,
-    completed_at: CREATED_AT,
-    request: {},
-    progress: [],
-    result: { remediation_plan: [{
+const REMEDIATION_PLAN = [{
       package: "openssl",
       ecosystem: "generic",
       current_version: "3.0.13",
@@ -103,7 +90,33 @@ async function routeRemediation(page: Page) {
       atlas_tags: [],
       references: [],
       risk_narrative: "Patch the package, then regenerate evidence.",
-    }] },
+    }];
+
+async function routeRemediation(page: Page) {
+  await routeShell(page);
+  await page.route("**/v1/jobs**", (route) => route.fulfill({ json: {
+    jobs: [{ job_id: "job-remediation", status: "done", created_at: CREATED_AT, completed_at: CREATED_AT, request: {}, summary: {} }],
+    count: 1, total: 1, limit: 25, offset: 0, status_counts: { done: 1 },
+  } }));
+  // The page reads the plan from `/v1/scan/{id}/remediation`, which serves the
+  // plan alone rather than the whole 8.7 MB scan document. Playwright's
+  // `**/v1/scan/job-remediation` glob does NOT match that sub-path, so this
+  // route has to be declared separately -- and it is declared FIRST, because
+  // the broader pattern would otherwise claim the request and answer it with a
+  // whole-job payload the caller no longer reads.
+  await page.route("**/v1/scan/job-remediation/remediation", (route) => route.fulfill({ json: {
+    job_id: "job-remediation",
+    remediation_plan: REMEDIATION_PLAN,
+    total: REMEDIATION_PLAN.length,
+  } }));
+  await page.route("**/v1/scan/job-remediation", (route) => route.fulfill({ json: {
+    job_id: "job-remediation",
+    status: "done",
+    created_at: CREATED_AT,
+    completed_at: CREATED_AT,
+    request: {},
+    progress: [],
+    result: { remediation_plan: REMEDIATION_PLAN },
   } }));
   await page.route("**/v1/ticketing/tickets", (route) => route.fulfill({ json: {
     schema_version: "ticketing.tickets.v1", tenant_id: "default", tickets: [], count: 0,


### PR DESCRIPTION
**`main` is red on `UI Validate`.** #4736 auto-merged with this check
failing, so every PR cut from `main` now inherits it.

## What broke

#4736 pointed the remediation page at `/v1/scan/{id}/remediation` — the
endpoint that serves the plan alone instead of the 8.75 MB scan document.
The e2e fixture mocks only:

```ts
page.route("**/v1/scan/job-remediation", ...)
```

Playwright's glob does **not** match the `/remediation` sub-path, so the
request went unmocked, the page rendered `0 packages · 500 Internal Server
Error`, and the `Details` button the test clicks never existed.

Changing the fetch without updating the fixture was the miss. The unit tests
and the live demo both exercised the new endpoint; the e2e mock was the one
remaining caller still describing the old one.

## The fix

The new route is declared **before** the whole-job route, because the broader
pattern would otherwise claim the request and answer it with a payload the
caller no longer reads. Both routes now serve the same `REMEDIATION_PLAN`
constant, so the narrow read and the wide one cannot drift apart in the
fixture the way they did in the code.

## Verified

Full e2e suite on a **fresh production build**: **35 passed**.

Worth noting for anyone reproducing: running `npx playwright test` directly
serves whatever is already in `.next`, and a stale build reports the *old*
code's failures. `npm run test:e2e` gates on `assert-build-is-current.mjs`
and refuses to run — use it.