### PR TITLE
chore(ui): upgrade TanStack Table to v9

### DIFF
--- a/ui/components/compliance-matrix.tsx
+++ b/ui/components/compliance-matrix.tsx
@@ -1,16 +1,21 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { flexRender } from "@tanstack/react-table";
+// v9 removed `useReactTable` and `createColumnHelper` from the package root and
+// moved the row-model factories behind `/legacy`. This component keeps the v8
+// table shape through that compat layer; porting it to v9's `useTable` is a
+// separate change, and doing both at once would leave nothing to bisect if the
+// matrix regressed.
 import {
-  useReactTable,
+  useLegacyTable,
   getCoreRowModel,
   getSortedRowModel,
   getFilteredRowModel,
-  flexRender,
-  createColumnHelper,
-  SortingState,
-  ColumnFiltersState,
-} from "@tanstack/react-table";
+  legacyCreateColumnHelper,
+  type LegacyColumnDef,
+} from "@tanstack/react-table/legacy";
+import type { SortingState, ColumnFiltersState } from "@tanstack/table-core";
 import {
   ComplianceResponse,
   ComplianceControl,
@@ -86,7 +91,7 @@ function flattenControls(data: ComplianceResponse): MatrixRow[] {
 
 // ─── Column definitions ──────────────────────────────────────────────────────
 
-const col = createColumnHelper<MatrixRow>();
+const col = legacyCreateColumnHelper<MatrixRow>();
 
 const columns = [
   col.accessor("framework", {
@@ -239,9 +244,14 @@ export function ComplianceMatrix({ data }: { data: ComplianceResponse }) {
 
   const rows = useMemo(() => flattenControls(data), [data]);
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: rows,
-    columns,
+    // `ColumnDef` is invariant in its value type, so an array mixing string,
+    // number and string[] columns has no common annotation; the table erases
+    // that type to `unknown` at runtime. v8 tolerated the mismatch, v9 under
+    // `exactOptionalPropertyTypes` does not, so the erasure is stated here
+    // rather than hidden behind `any`.
+    columns: columns as unknown as LegacyColumnDef<MatrixRow>[],
     state: { sorting, columnFilters, globalFilter },
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.99.0",
       "dependencies": {
         "@dagrejs/dagre": "^3.1.0",
-        "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-table": "9.1.2",
         "@tanstack/react-virtual": "^3.14.9",
         "@xyflow/react": "^12.11.2",
         "graphology": "^0.26.0",
@@ -3871,24 +3871,42 @@
         "tailwindcss": "4.3.3"
       }
     },
-    "node_modules/@tanstack/react-table": {
-      "version": "8.21.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
-      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+    "node_modules/@tanstack/react-store": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.11.1.tgz",
+      "integrity": "sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/table-core": "8.21.3"
-      },
-      "engines": {
-        "node": ">=12"
+        "@tanstack/store": "0.11.1",
+        "use-sync-external-store": "^1.6.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-9.1.2.tgz",
+      "integrity": "sha512-YQPZFJ1nIi/bjjwsPZVouABgahDcl7Gdm33CdTStUJBn0DjEVJ2uhSTVmIoWt9MVKdQziXGAsXipSzy949Hygg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/react-store": "^0.11.0",
+        "@tanstack/table-core": "9.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=18"
       }
     },
     "node_modules/@tanstack/react-virtual": {
@@ -3908,13 +3926,26 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@tanstack/table-core": {
-      "version": "8.21.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
-      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+    "node_modules/@tanstack/store": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.11.1.tgz",
+      "integrity": "sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA==",
       "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-9.1.2.tgz",
+      "integrity": "sha512-ONpWQeass1sfg80CWF1NSwQ8r3GiqxA2lT/EdqIcrDEPZ0Z+0mM94eQoFYLPN0Kztzj8TQVb2+PrSZSItqA61g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "^0.11.0"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       },
       "funding": {
         "type": "github",

--- a/ui/package.json
+++ b/ui/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@dagrejs/dagre": "^3.1.0",
-    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-table": "9.1.2",
     "@tanstack/react-virtual": "^3.14.9",
     "@xyflow/react": "^12.11.2",
     "graphology": "^0.26.0",

--- a/ui/tests/compliance-matrix.test.tsx
+++ b/ui/tests/compliance-matrix.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Behaviour guard for the one component built on TanStack Table.
+ *
+ * `ComplianceMatrix` is the only consumer of `@tanstack/react-table` in the
+ * app, and it had no test. That made the v8 -> v9 upgrade unverifiable: v9
+ * removes `useReactTable` and `createColumnHelper` from the package root and
+ * moves the row-model factories behind a `/legacy` entry point, so the
+ * migration is a real API change, not a version bump. Without a test, "it
+ * compiles" would have been the only evidence that sorting, per-column
+ * filtering and global search still worked.
+ *
+ * So these assert the table's *behaviour* — not its wiring — and are written
+ * to pass identically on either major. They were run green against v8 before
+ * the upgrade, and again after.
+ */
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ComplianceMatrix } from "@/components/compliance-matrix";
+import type { ComplianceResponse } from "@/lib/api";
+
+function control(code: string, name: string, status: string, findings = 0) {
+  return {
+    code,
+    name,
+    status,
+    findings,
+    severity_breakdown: {},
+    affected_packages: [],
+    affected_agents: [],
+  };
+}
+
+/** Two frameworks so the framework filter has something to exclude. */
+function matrixData(): ComplianceResponse {
+  return {
+    overall_score: 40,
+    overall_status: "fail",
+    evaluated_controls: 4,
+    total_controls: 4,
+    coverage_pct: 100,
+    scan_count: 1,
+    latest_scan: "2026-08-10T00:00:00Z",
+    has_mcp_context: true,
+    summary: {},
+    owasp_llm_top10: [
+      control("LLM01", "Prompt Injection", "fail", 3),
+      control("LLM02", "Insecure Output Handling", "pass"),
+    ],
+    owasp_mcp_top10: [
+      control("MCP01", "Tool Poisoning", "warning", 1),
+      control("MCP02", "Server Impersonation", "pass"),
+    ],
+    mitre_atlas: [],
+    nist_ai_rmf: [],
+    owasp_agentic_top10: [],
+    eu_ai_act: [],
+    nist_csf: [],
+    iso_27001: [],
+    soc2: [],
+    cis_controls: [],
+    cmmc: [],
+    nist_800_53: [],
+    fedramp: [],
+    pci_dss: [],
+  } as unknown as ComplianceResponse;
+}
+
+function bodyRowText(): string[] {
+  const table = screen.getByRole("table");
+  const body = table.querySelectorAll("tbody tr");
+  return Array.from(body).map((row) => row.textContent ?? "");
+}
+
+describe("ComplianceMatrix", () => {
+  it("renders one row per mapped control across every framework", () => {
+    render(<ComplianceMatrix data={matrixData()} />);
+    const rows = bodyRowText();
+    expect(rows).toHaveLength(4);
+    expect(rows.join(" ")).toContain("LLM01");
+    expect(rows.join(" ")).toContain("MCP01");
+  });
+
+  it("narrows to matching controls as the reader searches", () => {
+    render(<ComplianceMatrix data={matrixData()} />);
+    fireEvent.change(screen.getByPlaceholderText(/search controls/i), {
+      target: { value: "Prompt Injection" },
+    });
+    const rows = bodyRowText();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toContain("LLM01");
+  });
+
+  it("reorders rows when a sortable header is clicked", () => {
+    render(<ComplianceMatrix data={matrixData()} />);
+    const header = screen.getByRole("table").querySelector("thead");
+    const controlHeader = within(header as HTMLElement).getByText("Control");
+
+    const before = bodyRowText();
+    fireEvent.click(controlHeader);
+    const ascending = bodyRowText();
+    fireEvent.click(controlHeader);
+    const descending = bodyRowText();
+
+    expect(ascending).toHaveLength(before.length);
+    // Sorting is only proven by the order actually changing between directions.
+    expect(descending).not.toEqual(ascending);
+    expect([...descending].reverse()).toEqual(ascending);
+  });
+
+  it("reports how many of the total rows survive the current filter", () => {
+    render(<ComplianceMatrix data={matrixData()} />);
+    expect(screen.getByText(/4 of 4 controls/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/search controls/i), {
+      target: { value: "MCP" },
+    });
+    expect(screen.getByText(/2 of 4 controls/)).toBeInTheDocument();
+  });
+
+  it("keeps the evidence-triage disclaimer visible", () => {
+    render(<ComplianceMatrix data={matrixData()} />);
+    expect(screen.getByTestId("compliance-matrix-helper-disclaimer")).toBeVisible();
+  });
+});


### PR DESCRIPTION
`@tanstack/react-table` **8.21.3 → 9.1.2**. Pinned exactly, and deliberately
alone on its own branch: v9 is a breaking major, so this must be revertible
without taking anything else with it.

## The one consumer had no test

`ComplianceMatrix` is the only component in the app built on TanStack Table,
and it was untested. That made the upgrade unverifiable — v9 removes
`useReactTable` and `createColumnHelper` from the package root and moves the
row-model factories behind a `/legacy` entry point, so "it compiles" would
have been the only evidence that sorting, per-column filtering and global
search still worked.

`ui/tests/compliance-matrix.test.tsx` asserts the table's **behaviour** rather
than its wiring: row count across frameworks, search narrowing, sort direction
actually reversing the order, and the filtered/total count.

It was run green against **v8 first**, then again against v9 unchanged — which
is what makes it a parity proof rather than a rewritten expectation.

## What v9 actually changed

Verified against the published package, not from memory:

| v8 | v9 |
|---|---|
| `useReactTable` | `useLegacyTable` (`/legacy`) |
| `createColumnHelper` | `legacyCreateColumnHelper` (`/legacy`) |
| `getCoreRowModel` / `getSortedRowModel` / `getFilteredRowModel` | same names, moved to `/legacy` |
| `flexRender` | unchanged, package root |
| `SortingState` / `ColumnFiltersState` | now from `@tanstack/table-core` |

The component keeps the v8 table shape through the compat layer. Porting it to
v9's native `useTable` is a separate change; doing both at once would leave
nothing to bisect if the matrix regressed.

`ColumnDef` is invariant in its value type, so an array mixing string, number
and `string[]` columns has no common annotation. The table erases that type to
`unknown` at runtime; v8 tolerated the mismatch and v9 under
`exactOptionalPropertyTypes` does not, so the erasure is stated at the table
boundary rather than hidden behind `any`.

## Supply chain

v9 pulls two new transitive dependencies (`@tanstack/react-store`,
`@tanstack/store`) alongside `@tanstack/table-core`. All three resolve to
`registry.npmjs.org`, to the real `TanStack/store` and `TanStack/table`
repositories, under TanStack's own maintainer — checked rather than assumed,
since we ship a typosquat scanner.

## Verified

`tsc` clean · `npm run build` green (every route still prerenders) · UI suite
**1,071 passed**, including the 5 new matrix tests green on **both** majors.

**E2E depends on #4737.** This branch merges current `main`, which is red on
`workspace-actions.spec.ts` — unrelated to this upgrade (34 pass, 1 fails on
the remediation route mock). #4737 fixes it; once that lands, a `main` merge
here goes green.