### PR TITLE
fix: the release gate could not detect a re-release, and opening the vuln DB read all of it

### DIFF
--- a/scripts/check_release_tag_is_new.py
+++ b/scripts/check_release_tag_is_new.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Refuse a release version that has already shipped.
+
+On 2026-08-10 ``scripts/preflight_release.sh 0.99.0`` printed
+**"Pre-flight OK — safe to tag"**. ``v0.99.0`` had been tagged five days
+earlier and was already live on PyPI, Docker Hub and Glama, with 24 further
+commits sitting on ``main``.
+
+Every gate the pre-flight runs was green, and every one of them answers the
+same shape of question: *are the managed files consistent with the version
+string I was handed?* None of them asked the question that separates a release
+from a re-release — *does this tag already exist?* — so the one script
+positioned as the release go/no-go could not detect the most consequential
+release error there is.
+
+Two checks, both cheap, both otherwise discovered too late:
+
+* **The tag must not exist**, locally or on the remote. Annotated or
+  lightweight is irrelevant; a tag is a tag.
+* **The CHANGELOG must already carry the heading.** ``release.yml``'s
+  version-guard requires ``## [<version>]``, so a tag pushed without one fails
+  in CI *after the tag exists*, which is the expensive place to find out.
+
+It also prints how far ``main`` has moved past the newest tag. That number is
+what made the 0.99.0 situation obvious once someone looked, so the pre-flight
+should say it out loud rather than leave it to be discovered.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _git(*args: str) -> str:
+    result = subprocess.run(["git", *args], capture_output=True, text=True)
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _normalize(version: str) -> str:
+    """``0.99.0`` and ``v0.99.0`` name the same release."""
+    return version[1:] if version.startswith("v") else version
+
+
+def _local_tags() -> set[str]:
+    return {line.strip() for line in _git("tag", "--list").splitlines() if line.strip()}
+
+
+def _remote_tags() -> set[str]:
+    # Never fatal: an offline pre-flight still checks local tags rather than
+    # reporting a green verdict it cannot support.
+    out = _git("ls-remote", "--tags", "origin")
+    return {
+        ref.split("refs/tags/", 1)[1].removesuffix("^{}")
+        for line in out.splitlines()
+        if "refs/tags/" in line
+        for ref in [line]
+    }
+
+
+def _commits_since_newest_tag() -> tuple[str, int]:
+    newest = _git("describe", "--tags", "--abbrev=0")
+    if not newest:
+        return "", 0
+    count = _git("rev-list", "--count", f"{newest}..HEAD")
+    return newest, int(count) if count.isdigit() else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="the version you intend to tag, e.g. 0.99.1")
+    parser.add_argument(
+        "--changelog",
+        default="CHANGELOG.md",
+        help="path to the changelog that must already carry the heading",
+    )
+    args = parser.parse_args()
+
+    version = _normalize(args.version)
+    tag = f"v{version}"
+    problems: list[str] = []
+
+    existing = _local_tags() | _remote_tags()
+    if tag in existing:
+        problems.append(
+            f"{tag} has ALREADY been tagged. Re-tagging republishes a shipped version.\n"
+            f"    Pick the next version instead, and check what has landed since:\n"
+            f"      git log --oneline {tag}..HEAD"
+        )
+
+    changelog = Path(args.changelog)
+    if not changelog.exists():
+        problems.append(f"{changelog} not found, so the release notes cannot be checked.")
+    elif not re.search(rf"^## \[{re.escape(version)}\]", changelog.read_text(), re.MULTILINE):
+        problems.append(
+            f"{changelog} has no '## [{version}]' heading.\n"
+            f"    release.yml's version-guard requires it, so the tag would fail in CI\n"
+            f"    after it already exists. Move the [Unreleased] entries under it."
+        )
+
+    newest, ahead = _commits_since_newest_tag()
+    if newest:
+        print(f"newest tag: {newest} · main is {ahead} commit{'' if ahead == 1 else 's'} ahead")
+
+    if problems:
+        print("\nRELEASE TAG CHECK FAILED:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {tag} is new and {changelog} documents it.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release_tag_is_new.py
+++ b/scripts/check_release_tag_is_new.py
@@ -53,12 +53,7 @@ def _remote_tags() -> set[str]:
     # Never fatal: an offline pre-flight still checks local tags rather than
     # reporting a green verdict it cannot support.
     out = _git("ls-remote", "--tags", "origin")
-    return {
-        ref.split("refs/tags/", 1)[1].removesuffix("^{}")
-        for line in out.splitlines()
-        if "refs/tags/" in line
-        for ref in [line]
-    }
+    return {ref.split("refs/tags/", 1)[1].removesuffix("^{}") for line in out.splitlines() if "refs/tags/" in line for ref in [line]}
 
 
 def _commits_since_newest_tag() -> tuple[str, int]:

--- a/scripts/check_surface_freshness.py
+++ b/scripts/check_surface_freshness.py
@@ -338,6 +338,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--attempts", type=int, default=DEFAULT_ATTEMPTS)
     parser.add_argument("--backoff-seconds", type=float, default=DEFAULT_BACKOFF)
     parser.add_argument("--out", default=None, help="Write the consolidated JSON report to this path.")
+    parser.add_argument(
+        "--fail-on-stale",
+        action="store_true",
+        help=(
+            "Exit non-zero when any surface has drifted. Without it this script always "
+            "exits 0, so a stale surface is reported and no gate can act on it — which "
+            "is how Smithery sat at 36 of 77 tools through a release."
+        ),
+    )
     args = parser.parse_args(argv)
 
     expected = (args.expected or _expected_version()).lstrip("v").strip()
@@ -366,6 +375,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.out:
         Path(args.out).write_text(out + "\n")
     print(out)
+    if drift and args.fail_on_stale:
+        names = ", ".join(f"{s['surface']} ({s['status']})" for s in drift)
+        print(f"\nSurface drift: {names}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/scripts/preflight_release.sh
+++ b/scripts/preflight_release.sh
@@ -36,6 +36,13 @@ if [ -z "$VERSION" ]; then
   exit 2
 fi
 python scripts/bump-version.py "$VERSION" --check || fail=1
+
+step "tag is new + changelog documents it"
+# Every check above answers "are the managed files consistent with the version
+# string I was handed?" — none of them asks whether that version already
+# shipped. This script printed "safe to tag" for 0.99.0 five days after
+# v0.99.0 was tagged and published, with 24 commits since.
+python scripts/check_release_tag_is_new.py "$VERSION" || fail=1
 python scripts/check_release_consistency.py || fail=1
 python scripts/check_product_surface_contract.py || fail=1
 python scripts/export_openapi.py --check || fail=1

--- a/src/agent_bom/db/schema.py
+++ b/src/agent_bom/db/schema.py
@@ -197,11 +197,16 @@ def _set_db_permissions(db_path: Path) -> None:
 
 
 def _check_integrity(conn: sqlite3.Connection, db_path: Path) -> None:
-    """Run SQLite quick_check (fast header-only validation).
+    """Run SQLite ``quick_check`` over the database.
 
-    Full ``integrity_check`` scans every page (~4s on 700K records) —
-    too expensive for every scan.  Use ``quick_check`` which validates
-    the B-tree structure without reading every row.
+    **This is not cheap.** The previous docstring claimed ``quick_check``
+    "validates the B-tree structure without reading every row"; that is wrong.
+    ``quick_check`` walks every page of every btree — what it omits, relative to
+    ``integrity_check``, is the index-vs-table cross-check. Measured on a fully
+    synced 1.95 GB ``vulns.db``: **191 s cold, 10-21 s warm.**
+
+    So it belongs on maintenance paths that already touch the whole file (a DB
+    update), never on an open. See :func:`init_db`.
     """
     result = conn.execute("PRAGMA quick_check").fetchone()
     if result and result[0] != "ok":
@@ -212,12 +217,22 @@ def _check_integrity(conn: sqlite3.Connection, db_path: Path) -> None:
         )
 
 
-def init_db(path: Path | None = None) -> sqlite3.Connection:
+def init_db(path: Path | None = None, *, verify_integrity: bool = False) -> sqlite3.Connection:
     """Open (and initialise if needed) the local vuln DB.
 
-    Creates the DB file and parent directories if they don't exist.
-    Applies 0600 file permissions and runs an integrity check on open.
-    Returns an open connection with WAL mode and foreign keys enabled.
+    Creates the DB file and parent directories if they don't exist, applies 0600
+    permissions, and returns an open connection with WAL mode and foreign keys
+    enabled.
+
+    ``verify_integrity`` runs :func:`_check_integrity`, which reads the entire
+    file. It used to run on **every** open, and ``intel_lookup`` opens the DB
+    once per request in four places — so on a fully synced 1.95 GB database
+    every ``/v1/intel/*`` call re-validated the whole thing (measured: 22-58 s
+    per request, on a UI panel whose client cache is explicitly disabled).
+
+    Invisible in dev and CI because the cost scales with the size of
+    ``vulns.db``, not with the estate. Callers that already rewrite the database
+    — the sync/update path and the ``db`` CLI — opt in; readers do not.
     """
     db_path = path or DB_PATH
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -229,8 +244,10 @@ def init_db(path: Path | None = None) -> sqlite3.Connection:
     # Lock down file permissions after first creation
     _set_db_permissions(db_path)
 
-    # Integrity check — warn on corrupt DB, don't crash (read-only callers are safe)
-    _check_integrity(conn, db_path)
+    # Integrity check — warn on corrupt DB, don't crash (read-only callers are safe).
+    # Opt-in: it reads the whole file, so it must never sit on an open.
+    if verify_integrity:
+        _check_integrity(conn, db_path)
 
     # Seed schema_version on first creation
     row = conn.execute("SELECT version FROM schema_version LIMIT 1").fetchone()

--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -1993,7 +1993,9 @@ def sync_db(
     from agent_bom.db.schema import DB_PATH, init_db
 
     db_path = path or DB_PATH
-    conn = init_db(db_path)
+    # The update rewrites the database, so it is the right place to pay for a
+    # full integrity check — and the only place that still does.
+    conn = init_db(db_path, verify_integrity=True)
     enabled = set(sources or ["osv", "alpine", "debian", "epss", "kev"])
     results: dict[str, int] = {}
 

--- a/tests/test_intel_db_open_is_not_a_full_scan.py
+++ b/tests/test_intel_db_open_is_not_a_full_scan.py
@@ -1,0 +1,104 @@
+"""Opening the vuln DB must not read the whole file.
+
+`init_db()` ran `PRAGMA quick_check` on **every** open
+(`src/agent_bom/db/schema.py`), and `intel_lookup` opens the DB once per
+request in four places. On a fully synced `vulns.db` (1.95 GB) that made every
+`/v1/intel/*` call re-validate the entire database:
+
+    GET /v1/intel/advisories/CVE-2024-3094   2,218 bytes in 58.27 s
+    GET /v1/intel/sources                    9,450 bytes in 22.24 s
+    POST /v1/intel/match                    20,861 bytes in 14.94 s
+
+    PRAGMA quick_check on that file: 191 s cold, 10-21 s warm
+
+It reaches a shipped surface: the Integrations → Intel panel calls
+`getIntelSources()` with `{ ttlMs: 0 }`, so the client cache is explicitly
+disabled and every visit pays it again.
+
+The docstring justified the cost by claiming `quick_check` "validates the
+B-tree structure without reading every row". That premise is wrong —
+`quick_check` walks every page of every btree; what it skips is the
+index-vs-table cross-check that `integrity_check` adds. So the check was never
+cheap, and it was never free to put on an open.
+
+It is invisible in dev and CI because the cost scales with the size of
+`vulns.db`, not with the estate — the one axis fixtures never exercise. These
+tests therefore assert the *structure* (who runs the check) rather than timing,
+which would pass on any small fixture DB.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from agent_bom.db import schema
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "vulns.db"
+
+
+def _spy_on_integrity(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    checked: list[Path] = []
+
+    def _record(conn: sqlite3.Connection, path: Path) -> None:
+        checked.append(path)
+
+    monkeypatch.setattr(schema, "_check_integrity", _record)
+    return checked
+
+
+def test_a_plain_open_does_not_validate_the_database(db_path, monkeypatch) -> None:
+    """The read path: four intel endpoints open the DB per request."""
+    checked = _spy_on_integrity(monkeypatch)
+    conn = schema.init_db(db_path)
+    conn.close()
+    assert checked == [], "opening the vuln DB still runs a full-file integrity check"
+
+
+def test_the_check_is_still_available_when_asked_for(db_path, monkeypatch) -> None:
+    """Removing the cost must not remove the capability."""
+    checked = _spy_on_integrity(monkeypatch)
+    conn = schema.init_db(db_path, verify_integrity=True)
+    conn.close()
+    assert checked == [db_path]
+
+
+def test_a_plain_open_still_produces_a_usable_database(db_path) -> None:
+    """The whole point is that everything else about the open is unchanged."""
+    conn = schema.init_db(db_path)
+    try:
+        version = conn.execute("SELECT version FROM schema_version LIMIT 1").fetchone()
+        assert version is not None and version[0] >= 1
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+    finally:
+        conn.close()
+
+
+def test_verification_still_reports_a_corrupt_database(db_path, caplog) -> None:
+    """A real corrupt file must still be caught on the path that opts in."""
+    schema.init_db(db_path).close()
+    # Truncating mid-file leaves a header SQLite accepts and pages it cannot.
+    with open(db_path, "r+b") as handle:
+        handle.truncate(max(1024, db_path.stat().st_size // 2))
+
+    with caplog.at_level("WARNING"):
+        try:
+            schema.init_db(db_path, verify_integrity=True).close()
+        except sqlite3.DatabaseError:
+            return  # refusing outright is also an acceptable answer
+    assert any("integrity" in record.message.lower() for record in caplog.records), caplog.text
+
+
+def test_the_intel_read_path_opens_without_verifying(monkeypatch, db_path) -> None:
+    """The four per-request opens are the reason this matters."""
+    import agent_bom.intel_lookup as intel
+
+    checked = _spy_on_integrity(monkeypatch)
+    monkeypatch.setattr(intel, "resolve_intel_db_path", lambda: db_path)
+    intel.list_intel_sources()
+    assert checked == [], "an intel request still triggers a full-file integrity check"

--- a/tests/test_local_vuln_db.py
+++ b/tests/test_local_vuln_db.py
@@ -547,8 +547,10 @@ def test_sync_db_runs_wal_checkpoint(tmp_path, monkeypatch):
     proxies: list[_ConnProxy] = []
     real_init = schema_mod.init_db
 
-    def fake_init(path=None):
-        proxy = _ConnProxy(real_init(path))
+    def fake_init(path=None, **kwargs):
+        # `verify_integrity` is passed by the sync path (it rewrites the DB, so
+        # it is the one caller that still pays for a full integrity check).
+        proxy = _ConnProxy(real_init(path, **kwargs))
         proxies.append(proxy)
         return proxy
 

--- a/tests/test_release_tag_is_new.py
+++ b/tests/test_release_tag_is_new.py
@@ -38,9 +38,7 @@ def repo(tmp_path: Path) -> Path:
     _git(tmp_path, "init", "-q", "-b", "main")
     _git(tmp_path, "config", "user.email", "test@example.com")
     _git(tmp_path, "config", "user.name", "Test")
-    (tmp_path / "CHANGELOG.md").write_text(
-        "# Changelog\n\n## [Unreleased]\n\n## [0.99.0] - 2026-08-05\n\nShipped.\n"
-    )
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n\n## [Unreleased]\n\n## [0.99.0] - 2026-08-05\n\nShipped.\n")
     _git(tmp_path, "add", "-A")
     _git(tmp_path, "commit", "-qm", "initial")
     return tmp_path
@@ -64,9 +62,7 @@ def test_an_already_tagged_version_is_refused(repo: Path) -> None:
 
 
 def test_a_new_version_is_allowed(repo: Path) -> None:
-    (repo / "CHANGELOG.md").write_text(
-        "# Changelog\n\n## [0.99.1] - 2026-08-10\n\nFixes.\n\n## [0.99.0] - 2026-08-05\n"
-    )
+    (repo / "CHANGELOG.md").write_text("# Changelog\n\n## [0.99.1] - 2026-08-10\n\nFixes.\n\n## [0.99.0] - 2026-08-05\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-qm", "changelog")
     _git(repo, "tag", "-a", "v0.99.0", "-m", "release")
@@ -99,9 +95,7 @@ def test_a_v_prefixed_argument_is_accepted(repo: Path) -> None:
 def test_it_reports_how_far_main_has_moved_past_the_last_tag(repo: Path) -> None:
     """A reviewer needs the drift, not just a verdict: 24 commits was the signal."""
     _git(repo, "tag", "-a", "v0.99.0", "-m", "release")
-    (repo / "CHANGELOG.md").write_text(
-        "# Changelog\n\n## [0.99.1] - 2026-08-10\n\nFixes.\n\n## [0.99.0] - 2026-08-05\n"
-    )
+    (repo / "CHANGELOG.md").write_text("# Changelog\n\n## [0.99.1] - 2026-08-10\n\nFixes.\n\n## [0.99.0] - 2026-08-05\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-qm", "later work")
     result = run(repo, "0.99.1")
@@ -112,7 +106,5 @@ def test_it_reports_how_far_main_has_moved_past_the_last_tag(repo: Path) -> None
 def test_the_real_repo_refuses_the_version_that_already_shipped() -> None:
     """The regression itself, against this repository rather than a fixture."""
     root = Path(__file__).resolve().parents[1]
-    result = subprocess.run(
-        [sys.executable, str(SCRIPT), "0.99.0"], cwd=root, capture_output=True, text=True
-    )
+    result = subprocess.run([sys.executable, str(SCRIPT), "0.99.0"], cwd=root, capture_output=True, text=True)
     assert result.returncode != 0, result.stdout

--- a/tests/test_release_tag_is_new.py
+++ b/tests/test_release_tag_is_new.py
@@ -1,0 +1,118 @@
+"""The release pre-flight must refuse a version that has already shipped.
+
+`scripts/preflight_release.sh 0.99.0` printed **"Pre-flight OK — safe to tag"**
+on 2026-08-10, when `v0.99.0` had been tagged on 2026-08-05 and was already
+live on PyPI, Docker Hub and Glama, with 24 further commits on `main`.
+
+Every gate it runs was green and every one of them answers a different
+question: *are the managed files consistent with the version string I was
+handed?* Nothing asked the only question that distinguishes a release from a
+re-release — *does this tag already exist?* The script's own header comment
+records the previous instance of this class (a missing VERSION used to skip the
+bump check and still print a green verdict), which is why the check belongs in
+the script positioned as the go/no-go rather than in a reviewer's memory.
+
+The CHANGELOG assertion is here for the same reason: `release.yml`'s
+version-guard requires a `## [<version>]` heading, so a tag pushed without one
+fails *in CI, after the tag exists* — the expensive place to find out.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_release_tag_is_new.py"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A throwaway repo with one commit and a CHANGELOG."""
+    _git(tmp_path, "init", "-q", "-b", "main")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "Test")
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [Unreleased]\n\n## [0.99.0] - 2026-08-05\n\nShipped.\n"
+    )
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "initial")
+    return tmp_path
+
+
+def run(repo: Path, version: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), version],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_an_already_tagged_version_is_refused(repo: Path) -> None:
+    """The defect: 0.99.0 was tagged, published, and still called safe to tag."""
+    _git(repo, "tag", "-a", "v0.99.0", "-m", "release")
+    result = run(repo, "0.99.0")
+    assert result.returncode != 0, result.stdout
+    assert "already" in (result.stdout + result.stderr).lower()
+
+
+def test_a_new_version_is_allowed(repo: Path) -> None:
+    (repo / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [0.99.1] - 2026-08-10\n\nFixes.\n\n## [0.99.0] - 2026-08-05\n"
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "changelog")
+    _git(repo, "tag", "-a", "v0.99.0", "-m", "release")
+    result = run(repo, "0.99.1")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_a_version_with_no_changelog_entry_is_refused(repo: Path) -> None:
+    """`release.yml`'s version-guard requires the heading; fail before the tag."""
+    _git(repo, "tag", "-a", "v0.99.0", "-m", "release")
+    result = run(repo, "0.99.1")
+    assert result.returncode != 0, result.stdout
+    assert "changelog" in (result.stdout + result.stderr).lower()
+
+
+def test_the_lightweight_tag_form_is_caught_too(repo: Path) -> None:
+    """A tag is a tag; the annotated/lightweight distinction must not matter."""
+    _git(repo, "tag", "v0.99.0")
+    result = run(repo, "0.99.0")
+    assert result.returncode != 0, result.stdout
+
+
+def test_a_v_prefixed_argument_is_accepted(repo: Path) -> None:
+    """`0.99.0` and `v0.99.0` name the same release; both must be refused."""
+    _git(repo, "tag", "-a", "v0.99.0", "-m", "release")
+    result = run(repo, "v0.99.0")
+    assert result.returncode != 0, result.stdout
+
+
+def test_it_reports_how_far_main_has_moved_past_the_last_tag(repo: Path) -> None:
+    """A reviewer needs the drift, not just a verdict: 24 commits was the signal."""
+    _git(repo, "tag", "-a", "v0.99.0", "-m", "release")
+    (repo / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [0.99.1] - 2026-08-10\n\nFixes.\n\n## [0.99.0] - 2026-08-05\n"
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "later work")
+    result = run(repo, "0.99.1")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "1 commit" in result.stdout, result.stdout
+
+
+def test_the_real_repo_refuses_the_version_that_already_shipped() -> None:
+    """The regression itself, against this repository rather than a fixture."""
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "0.99.0"], cwd=root, capture_output=True, text=True
+    )
+    assert result.returncode != 0, result.stdout


### PR DESCRIPTION
Two release blockers found by the pre-release audit. Both are cases where a
check existed and could not see the thing it was for.

## 1. The go/no-go gate green-lit an already-shipped version

`scripts/preflight_release.sh 0.99.0` printed **"Pre-flight OK — safe to
tag"**. `v0.99.0` had been tagged five days earlier and was already live on
PyPI, Docker Hub and Glama, with **24 commits since**.

Every gate it runs was green, and every one answers the same shape of question:
*are the managed files consistent with the version string I was handed?* None
asked the question that separates a release from a re-release — **does this tag
already exist?** The script's own header comment records the previous instance
of this class (a missing VERSION used to skip the bump check and still print
green). Same shape, one layer out.

`check_release_tag_is_new.py` adds two cheap checks that were otherwise found
too late:
- the tag must not exist, locally or on the remote (annotated or lightweight);
- the CHANGELOG must already carry `## [<version>]`, because `release.yml`'s
  version-guard requires it and would otherwise fail **after** the tag exists.

It also prints the drift that makes a stale release obvious:

    newest tag: v0.99.0 · main is 25 commits ahead

**`check_surface_freshness.py --fail-on-stale`**: the monitor reported Smithery
as stale (advertising **36 of 77 tools**) and exited `0`, so no gate could act
on it. Opt-in, so existing report-only callers are unchanged.

## 2. Opening the vuln DB read the entire file

`init_db()` ran `PRAGMA quick_check` on **every** open, and `intel_lookup`
opens the DB once per request in four places:

    GET  /v1/intel/advisories/CVE-2024-3094   2,218 bytes in 58.27 s
    GET  /v1/intel/sources                    9,450 bytes in 22.24 s
    POST /v1/intel/match                     20,861 bytes in 14.94 s

Measured against the real 1.8 GB local database:

| call | time |
|---|---|
| `init_db(path)` | **0.7 ms** |
| `init_db(path, verify_integrity=True)` | **22,405.7 ms** ← what every request paid |

**The justification was factually wrong.** The docstring claimed `quick_check`
"validates the B-tree structure without reading every row". It walks every page
of every btree; what it omits versus `integrity_check` is the index-vs-table
cross-check. It was never cheap, so it was never free to put on an open.

It reaches a shipped surface: the Integrations → Intel panel calls
`getIntelSources()` with `{ ttlMs: 0 }` — client cache explicitly disabled, so
every visit pays it again.

**Why nobody saw it:** the cost scales with the size of `vulns.db`, not the
estate — the one axis fixtures and the demo estate never exercise. Dev and CI
have a small database and pay nothing.

`verify_integrity` is now opt-in, defaulting off. The capability moves to the
caller that already rewrites the whole file: `sync_db()` verifies, readers do
not.

## Verified

    $ bash scripts/preflight_release.sh 0.99.0; echo $?
    RELEASE TAG CHECK FAILED:
      - v0.99.0 has ALREADY been tagged. Re-tagging republishes a shipped version.
    PRE-FLIGHT FAILED — do NOT push a release tag.
    1

    $ python scripts/check_surface_freshness.py --fail-on-stale; echo $?
    Surface drift: Smithery (stale)
    1

- `tests/test_release_tag_is_new.py` — 7 tests, **4 red** before the script
  existed; covers annotated and lightweight tags, the `v`-prefixed form, the
  missing-changelog case, and this repository refusing 0.99.0.
- `tests/test_intel_db_open_is_not_a_full_scan.py` — 5 tests, **4 red** before
  the change. They assert **structure** (which caller runs the check) rather
  than timing, which would pass on any small fixture DB and reproduce exactly
  the blind spot that let this ship.
- 91 passed across the vuln-DB suites · `ruff` + `mypy` clean.