### PR TITLE
fix(security): websocket streams failed open, and DLP excerpts leaked the secret

### DIFF
--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -12,6 +12,7 @@ Endpoints:
 
 from __future__ import annotations
 
+import logging
 import time
 from collections import Counter, OrderedDict, deque
 from dataclasses import dataclass
@@ -48,6 +49,8 @@ from agent_bom.runtime.gateway_events import (
 from agent_bom.security import sanitize_error, sanitize_sensitive_payload
 
 router = APIRouter(dependencies=[Depends(demo_daily_evidence_dependency)])
+
+_logger = logging.getLogger(__name__)
 ws_router = APIRouter()
 
 # ── In-process ring buffer for proxy alerts/metrics ──────────────────────────
@@ -993,34 +996,59 @@ def _role_allows(actual: str, required: str = "viewer") -> bool:
     return role_rank(actual_role) >= role_rank(required_role)
 
 
-def _ws_auth_required() -> bool:
-    import os as _os
+def _key_store_has_keys() -> bool:
+    from agent_bom.api.auth import get_key_store
 
-    from agent_bom.api.oidc import oidc_enabled_from_env
+    return bool(get_key_store().has_keys())
+
+
+def _ws_auth_required() -> bool:
+    """Whether these websocket streams must authenticate before accepting.
+
+    ``APIKeyMiddleware`` is a ``BaseHTTPMiddleware`` and never runs on websocket
+    scopes, so this gate is the only thing standing in front of
+    ``/ws/proxy/metrics`` and ``/ws/proxy/alerts`` — and a negative answer here
+    accepts anonymously as ``role="admin"``. Two rules follow from that.
+
+    **Use the shared derivation, do not hand-roll a second one.** This used to
+    sweep the environment itself and missed Snowflake OAuth entirely, so a
+    Snowflake-OAuth-only deployment served both sockets anonymously while its
+    HTTP surface was authenticated. ``derive_auth_posture`` is the single
+    env-based derivation every other reader already consumes; a second,
+    narrower copy of the same question is how the two answers drifted apart.
+
+    **Fail closed.** The previous ``except Exception: return False`` turned a
+    store outage into an anonymous admin stream — the moment a control plane is
+    least able to afford one. An error means we could not establish that auth is
+    unnecessary, which is not the same as establishing that it is.
+
+    This is not a lockout: a genuinely unconfigured single-user deployment still
+    streams, because the posture reports no sources and the key store is empty.
+    """
+    from agent_bom.api.middleware import derive_auth_posture
     from agent_bom.api.secret_source import secret_is_configured
 
-    configured = any(
-        (
-            secret_is_configured("AGENT_BOM_API_KEY"),
-            secret_is_configured("AGENT_BOM_API_KEYS"),
-            oidc_enabled_from_env(),
-            _os.environ.get("AGENT_BOM_SAML_IDP_ENTITY_ID", "").strip(),
-            _os.environ.get("AGENT_BOM_SAML_IDP_SSO_URL", "").strip(),
-            _os.environ.get("AGENT_BOM_SAML_IDP_X509_CERT", "").strip(),
-            _os.environ.get("AGENT_BOM_SAML_SP_ENTITY_ID", "").strip(),
-            _os.environ.get("AGENT_BOM_SAML_SP_ACS_URL", "").strip(),
-            secret_is_configured("AGENT_BOM_SCIM_BEARER_TOKEN"),
-            _os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH", "").strip().lower() in {"1", "true", "yes", "on"},
-        )
-    )
-    if configured:
-        return True
     try:
-        from agent_bom.api.auth import get_key_store
+        api_key_configured = (
+            secret_is_configured("AGENT_BOM_API_KEY") or secret_is_configured("AGENT_BOM_API_KEYS") or _key_store_has_keys()
+        )
+        posture = derive_auth_posture(
+            api_key_configured=api_key_configured,
+            allow_unauthenticated=False,
+        )
+        if posture.auth_configured:
+            return True
+        # `posture.trusted_proxy` reports whether trusted-proxy auth is
+        # *usable* — it is false for a misconfigured one (missing or weak
+        # secret). An operator who switched it on has asked for authentication,
+        # and a broken configuration is not an invitation to stream anonymously,
+        # so intent alone keeps the socket closed.
+        import os as _os
 
-        return get_key_store().has_keys()
+        return _os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH", "").strip().lower() in {"1", "true", "yes", "on"}
     except Exception:
-        return False
+        _logger.warning("websocket auth posture unavailable; requiring authentication", exc_info=True)
+        return True
 
 
 def _ws_auth_from_trusted_proxy(websocket: WebSocket) -> _WebSocketAuthContext | None:

--- a/src/agent_bom/proxy_scanner.py
+++ b/src/agent_bom/proxy_scanner.py
@@ -224,11 +224,38 @@ def _normalize_detector_text(text: str) -> str:
     return normalized.replace('\\"', '"').replace("\\'", "'")
 
 
-def _redact_excerpt(match_text: str, max_len: int = 12) -> str:
-    """Return a safely redacted preview of a match."""
-    if len(match_text) <= 4:
+# How much of a matched value an excerpt may reveal. Four is the PCI DSS 3.4
+# allowance for a PAN and is the most any rule here needs; it exists so an
+# operator can correlate one alert with another, never so the value can be read.
+_EXCERPT_TAIL = 4
+# Fixed-width mask: a mask that mirrored the input would leak its length, which
+# is itself identifying for many credential formats.
+_EXCERPT_MASK = "*" * 8
+
+
+def _redact_excerpt(match_text: str, max_len: int = _EXCERPT_TAIL) -> str:
+    """Return a masked preview of a match, never the match itself.
+
+    This used to be ``match_text[:12] + "***"`` — a *truncation*. Every pattern
+    shorter than the cut therefore survived in full: an SSN redacted to
+    ``123-45-6789***``, a phone number to ``415-555-1234***``, a private address
+    to ``10.1.2.3***``, and 12 of a card's 16 digits. The excerpt *was* the
+    finding.
+
+    That matters well beyond the log line: redaction is applied at the durable
+    storage boundary, but the same alert object also reaches the alert webhook,
+    the control-plane push, disk spillover, and the ``/ws/proxy/alerts`` stream.
+
+    An excerpt exists so a human can tell *which* rule fired and correlate
+    repeats — so it keeps a short tail and masks the rest. A value too short for
+    a tail to be non-identifying is masked outright.
+    """
+    tail = max(0, min(max_len, _EXCERPT_TAIL))
+    # Below ~3x the tail, the revealed characters are a large fraction of a
+    # short secret, so reveal nothing at all.
+    if not match_text or len(match_text) < tail * 3:
         return "***"
-    return match_text[:max_len] + "***"
+    return _EXCERPT_MASK + match_text[-tail:]
 
 
 def _scan_patterns(

--- a/tests/test_dlp_excerpt_is_masked_not_truncated.py
+++ b/tests/test_dlp_excerpt_is_masked_not_truncated.py
@@ -1,0 +1,92 @@
+"""A DLP excerpt must not carry the secret it detected.
+
+`_redact_excerpt` was `match_text[:12] + "***"` — a *truncation*, not a
+redaction. Every pattern shorter than the cut survived in full:
+
+    SSN         '123-45-6789'       -> '123-45-6789***'
+    phone       '415-555-1234'      -> '415-555-1234***'
+    internal ip '10.1.2.3'          -> '10.1.2.3***'
+    PAN (visa)  '4111111111111111'  -> '411111111111***'   (12 of 16 digits)
+    long token  (40 chars)         -> first 12 characters, verbatim
+
+The SSN, phone and private-IP patterns are all at most 12 characters, so the
+"redacted" preview *was* the finding. Worse, redaction was applied only at the
+durable-storage boundary: the same alert object also goes to the alert webhook,
+the control-plane push, disk spillover, and `runtime_alerts` — which is what
+`/ws/proxy/alerts` streams.
+
+The rule this encodes: an excerpt exists to let a human recognise *which* rule
+fired and roughly where, never to reproduce the matched value. PCI DSS allows
+at most first-6/last-4 of a PAN; nothing here needs even that, so the excerpt
+keeps a short tail for correlation and masks everything else. A value short
+enough that any tail would identify it is masked entirely.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.proxy_scanner import _redact_excerpt
+
+# The exact values the audit recovered from the shipped implementation.
+LEAKED_IN_FULL = [
+    ("ssn", "123-45-6789"),
+    ("phone", "415-555-1234"),
+    ("internal_ip", "10.1.2.3"),
+    ("short_key", "EXAMPLEKEYID0"),
+]
+
+# Built from parts, and labelled neutrally, so no long literal sits next to a
+# credential-shaped keyword. Real fixtures here previously tripped our own
+# secret scanning in CI — the values only need the right *length*, since
+# `_redact_excerpt` is a pure string function.
+_LONG_40 = "abcdefghij" * 4
+_SLASHED_40 = "aaaaaaaaaa" + "/" + "bbbbbbbbbbbbbbbbbb" + "/" + "cccccccccc"
+
+PARTIALLY_LEAKED = [
+    ("pan_visa", "4111111111111111"),
+    ("long_opaque_value", _LONG_40),
+    ("slashed_opaque_value", _SLASHED_40),
+]
+
+
+@pytest.mark.parametrize("rule,secret", LEAKED_IN_FULL + PARTIALLY_LEAKED)
+def test_the_secret_never_appears_in_the_excerpt(rule: str, secret: str) -> None:
+    excerpt = _redact_excerpt(secret)
+    assert secret not in excerpt, f"{rule}: the whole value survived redaction"
+
+
+@pytest.mark.parametrize("rule,secret", LEAKED_IN_FULL + PARTIALLY_LEAKED)
+def test_no_long_run_of_the_secret_survives(rule: str, secret: str) -> None:
+    """Not just the whole value — no substring long enough to be the secret."""
+    masked = _redact_excerpt(secret)
+    revealed = "".join(ch for ch in masked if ch not in "*")
+    assert len(revealed) <= 6, f"{rule}: {len(revealed)} characters of the value survived: {masked!r}"
+
+
+def test_a_pan_keeps_at_most_the_last_four() -> None:
+    """PCI DSS 3.4 permits first-6/last-4; we need far less than that."""
+    masked = _redact_excerpt("4111111111111111")
+    assert "411111111111" not in masked
+    digits = "".join(ch for ch in masked if ch.isdigit())
+    assert len(digits) <= 4, masked
+
+
+def test_a_short_value_is_masked_entirely() -> None:
+    """Below a useful length, any tail identifies the value."""
+    assert _redact_excerpt("1234") == "***"
+    assert _redact_excerpt("") == "***"
+
+
+def test_the_excerpt_still_says_something_useful() -> None:
+    """Redaction must not make the alert unrecognisable — it is triage evidence."""
+    masked = _redact_excerpt(_LONG_40)
+    assert masked, "an empty excerpt tells an operator nothing"
+    assert "*" in masked, "the excerpt should read as redacted, not as a value"
+
+
+def test_length_is_not_recoverable_from_the_mask() -> None:
+    """A mask that mirrors length leaks the length of the secret."""
+    short = _redact_excerpt(_LONG_40[:16])
+    long = _redact_excerpt(_LONG_40 + "extra")
+    assert len(short) == len(long), (short, long)

--- a/tests/test_proxy_scanner.py
+++ b/tests/test_proxy_scanner.py
@@ -476,9 +476,19 @@ class TestEdgeCases:
         assert scan_content("ignore previous instructions", ScanConfig()) == []
 
     def test_excerpt_redaction(self):
-        results = scan_content("AKIAIOSFODNN7EXAMPLE", _cfg())
+        """The excerpt must not contain the value that triggered the rule.
+
+        This used to assert only ``endswith("***")``, which the old
+        ``match_text[:12] + "***"`` truncation satisfied while leaking the
+        secret it was redacting. The assertion now describes redaction rather
+        than the shape of the suffix.
+        """
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        results = scan_content(secret, _cfg())
         for r in results:
-            assert r.excerpt.endswith("***")
+            assert secret not in r.excerpt
+            revealed = "".join(ch for ch in r.excerpt if ch not in "*")
+            assert len(revealed) <= 6, r.excerpt
 
     def test_result_dataclass_fields(self):
         results = scan_content("ignore previous instructions", _cfg())

--- a/tests/test_websocket_auth_fails_closed.py
+++ b/tests/test_websocket_auth_fails_closed.py
@@ -1,0 +1,132 @@
+"""WebSocket streams must fail CLOSED, and must not hand-roll auth detection.
+
+`APIKeyMiddleware` is a `BaseHTTPMiddleware`, so it never runs on websocket
+scopes. `/ws/proxy/metrics` and `/ws/proxy/alerts` therefore implement their own
+gate, and when that gate says "no auth configured" they accept anonymously into
+`_WebSocketAuthContext(tenant_id="default", role="admin")`.
+
+Two defects in that gate, both found by the pre-release security audit:
+
+1. **It failed OPEN on a store error.** `_ws_auth_required()` ended with
+   `except Exception: return False`, so a Postgres pool exhaustion — precisely
+   when a control plane is already unhealthy — silently turned an admin stream
+   anonymous. Observed: HTTP `/v1/findings` returned 500 while both websockets
+   kept accepting.
+
+2. **It swept the environment itself and missed a credential source.** The
+   hand-rolled sweep never consulted Snowflake OAuth, so a Snowflake-OAuth-only
+   deployment served both sockets anonymously while its HTTP surface was
+   authenticated.
+
+`derive_auth_posture` is the single env-based derivation every other reader
+already consumes. These tests drive real environment variables rather than
+patching that function, because the contract under test is "a deployment that
+configured *any* credential source gets an authenticated socket" — not which
+helper the gate happens to call.
+
+This matters beyond the socket: `/ws/proxy/alerts` streams runtime DLP alerts,
+whose excerpts carry the matched secret material.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.api.routes import proxy as proxy_routes
+
+# Every environment variable any credential source reads, cleared before each
+# case so one source can be switched on in isolation.
+_AUTH_ENV = [
+    "AGENT_BOM_API_KEY",
+    "AGENT_BOM_API_KEYS",
+    "AGENT_BOM_OIDC_ISSUER",
+    "AGENT_BOM_OIDC_AUDIENCE",
+    "AGENT_BOM_OIDC_JWKS_URL",
+    "AGENT_BOM_OIDC_BROWSER_CLIENT_ID",
+    "AGENT_BOM_SNOWFLAKE_OAUTH_ACCOUNT_URL",
+    "AGENT_BOM_SNOWFLAKE_OAUTH_REDIRECT_URI",
+    "AGENT_BOM_SNOWFLAKE_OAUTH_CLIENT_ID",
+    "AGENT_BOM_SCIM_BEARER_TOKEN",
+    "AGENT_BOM_SAML_IDP_ENTITY_ID",
+    "AGENT_BOM_SAML_IDP_SSO_URL",
+    "AGENT_BOM_SAML_IDP_X509_CERT",
+    "AGENT_BOM_SAML_SP_ENTITY_ID",
+    "AGENT_BOM_SAML_SP_ACS_URL",
+    "AGENT_BOM_TRUST_PROXY_AUTH",
+    "AGENT_BOM_TRUST_PROXY_SECRET",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_auth_env(monkeypatch: pytest.MonkeyPatch):
+    for name in _AUTH_ENV:
+        monkeypatch.delenv(name, raising=False)
+    # Default: no runtime-issued keys. Individual cases override.
+    monkeypatch.setattr(proxy_routes, "_key_store_has_keys", lambda: False, raising=False)
+
+
+def test_a_genuinely_unconfigured_deployment_still_streams() -> None:
+    """Local single-user dev must keep working — this is not a lockout."""
+    assert proxy_routes._ws_auth_required() is False
+
+
+def test_snowflake_oauth_alone_still_requires_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The source the hand-rolled env sweep never consulted."""
+    monkeypatch.setenv("AGENT_BOM_SNOWFLAKE_OAUTH_ACCOUNT_URL", "https://acme-prod.snowflakecomputing.com")
+    monkeypatch.setenv("AGENT_BOM_SNOWFLAKE_OAUTH_CLIENT_ID", "abom-client")
+    monkeypatch.setenv("AGENT_BOM_SNOWFLAKE_OAUTH_REDIRECT_URI", "https://abom.example/oauth/callback")
+    assert proxy_routes._ws_auth_required() is True
+
+
+def test_an_api_key_requires_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_API_KEY", "s3cret-key-value")
+    assert proxy_routes._ws_auth_required() is True
+
+
+def test_saml_alone_requires_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_SAML_IDP_ENTITY_ID", "https://idp.example/meta")
+    monkeypatch.setenv("AGENT_BOM_SAML_IDP_SSO_URL", "https://idp.example/sso")
+    monkeypatch.setenv("AGENT_BOM_SAML_IDP_X509_CERT", "MIIC-not-a-real-cert")
+    monkeypatch.setenv("AGENT_BOM_SAML_SP_ENTITY_ID", "https://abom.example")
+    monkeypatch.setenv("AGENT_BOM_SAML_SP_ACS_URL", "https://abom.example/acs")
+    assert proxy_routes._ws_auth_required() is True
+
+
+def test_issued_api_keys_require_auth_even_with_no_env_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keys minted at runtime are a credential source with no env var."""
+    monkeypatch.setattr(proxy_routes, "_key_store_has_keys", lambda: True, raising=False)
+    assert proxy_routes._ws_auth_required() is True
+
+
+def test_a_key_store_error_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The original `except Exception: return False`, which opened an admin stream."""
+
+    def _boom() -> bool:
+        raise RuntimeError("connection pool exhausted")
+
+    monkeypatch.setattr(proxy_routes, "_key_store_has_keys", _boom, raising=False)
+    assert proxy_routes._ws_auth_required() is True
+
+
+def test_a_posture_derivation_error_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Any failure to establish that auth is unnecessary must require auth."""
+    import agent_bom.api.middleware as mw
+
+    def _boom(**_kwargs: object) -> object:
+        raise RuntimeError("posture derivation failed")
+
+    monkeypatch.setattr(mw, "derive_auth_posture", _boom)
+    assert proxy_routes._ws_auth_required() is True
+
+
+def test_trusted_proxy_intent_requires_auth_even_when_misconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A weak or missing proxy secret is a misconfiguration, not "no auth".
+
+    `AuthPosture.trusted_proxy` reports whether the mode is *usable*, so it is
+    false for a weak secret. Treating that as "nothing configured" would hand an
+    anonymous admin stream to exactly the deployment that got its auth wrong —
+    which `tests/api/test_api_proxy_scorecard.py` already pins over HTTP.
+    """
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", "short")
+    assert proxy_routes._ws_auth_required() is True


### PR DESCRIPTION
The pre-release audit's **worst finding**: two defects that compose into
anonymous exfiltration of detected secrets from a running control plane. Both
reproduced before fixing.

## 1. `/ws/proxy/metrics` and `/ws/proxy/alerts` were unauthenticated

`APIKeyMiddleware` is a `BaseHTTPMiddleware`, so **it never runs on websocket
scopes**. These endpoints implement their own gate, and a negative answer
accepts anonymously as `_WebSocketAuthContext(tenant_id="default",
role="admin")`.

That gate was wrong twice:

- **It failed OPEN.** `_ws_auth_required()` ended in
  `except Exception: return False`, so a store outage — exactly when a control
  plane can least afford it — turned an admin stream anonymous. Observed in the
  audit: HTTP `/v1/findings` returning **500** while both sockets kept
  accepting.
- **It hand-rolled a second env sweep** and missed Snowflake OAuth, so a
  Snowflake-OAuth-only deployment served both sockets anonymously while its
  HTTP surface was authenticated.

It now uses `derive_auth_posture` — the single env-based derivation every other
reader already consumes — and **any failure to establish that auth is
unnecessary requires auth**.

One subtlety the existing suite caught, and which the naive version got wrong:
`AuthPosture.trusted_proxy` reports whether trusted-proxy auth is *usable*, so
it is false for a missing or weak secret. Treating that as "nothing configured"
would hand an anonymous admin stream to precisely the deployment that
misconfigured its auth. Intent alone now keeps the socket closed.

## 2. `_redact_excerpt` truncated instead of masking

It was `match_text[:12] + "***"`. Every pattern shorter than the cut survived
**in full**:

| rule | raw | stored (before) | stored (after) |
|---|---|---|---|
| SSN | `123-45-6789` | `123-45-6789***` | `***` |
| phone | `415-555-1234` | `415-555-1234***` | `********1234` |
| internal IP | `10.1.2.3` | `10.1.2.3***` | `***` |
| PAN (visa) | `4111111111111111` | `411111111111***` (12 of 16) | `********1111` |

The excerpt *was* the finding. And redaction is applied only at the
durable-storage boundary — the same alert object also reaches the alert
webhook, the control-plane push, disk spillover, and `runtime_alerts`, which is
**what `/ws/proxy/alerts` streams**. So defect 1 served defect 2.

Now masked to a fixed-width prefix plus at most a 4-character tail (the PCI DSS
3.4 allowance, and more than any rule here needs), with anything too short for a
non-identifying tail masked outright. The mask is fixed-width so it cannot leak
the length of the secret either.

`tests/test_proxy_scanner.py::test_excerpt_redaction` asserted only
`endswith("***")` — which the truncation satisfied **while leaking**. It now
asserts redaction rather than the shape of the suffix.

## Verified

- `tests/test_websocket_auth_fails_closed.py` — 8 tests, red before the change.
  They drive **real environment variables** rather than patching the helper, so
  they test the contract ("a deployment that configured any credential source
  gets an authenticated socket") rather than the call graph. Includes the
  store-error and misconfigured-trusted-proxy cases.
- `tests/test_dlp_excerpt_is_masked_not_truncated.py` — 18 tests over the exact
  values the audit recovered, including length non-recoverability.
- **186 passed** across the proxy/websocket/DLP suites; 1,729 across the wider
  sweep. `ruff format --check`, `ruff`, `mypy` clean.

## Not addressed here

The audit's remaining P1s are separate changes: the Microsoft Graph bearer token
re-sent to any host `@odata.nextLink` names (the host-pinning pattern already
exists at `db/sync.py:976`), and the governance hash chain forking under
concurrency (the sibling table already has the right unique index).