### PR TITLE
fix(ui): raise the client-JS budget for the TanStack Table v9 runtime

### DIFF
--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -81,7 +81,15 @@ const BUDGETS = {
   // both the largest-chunk and shared-runtime budgets still pass with margin.
   // Restore ~18 KiB of headroom on the same terms as every raise above —
   // bounded room for routine bundler variance, other budgets unchanged.
-  totalClientJsBytes: 3_784_704,
+  // @tanstack/react-table 8.21.3 -> 9.1.2 measures 3739.0 KiB, 43 KiB over the
+  // 3696 KiB line. v9 splits its state out into @tanstack/react-store +
+  // @tanstack/store, so the growth is the LIBRARY's rather than a route of
+  // ours: no page was added, and both the largest-chunk and shared-runtime
+  // budgets still pass with margin (379.8/927.7 and 434.6/439.5 KiB).
+  // Code-splitting the one consumer was tried first and does not help — this
+  // budget totals every chunk, so moving bytes between them changes nothing.
+  // Restore ~21 KiB of headroom on the same terms as every raise above.
+  totalClientJsBytes: 3_850_240,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };


### PR DESCRIPTION
**`main` is red on `UI Validate`** and has been since #4738 merged, so every
open PR inherits the failure:

    FAIL total client JS: 3739.0 KiB / budget 3696.0 KiB

v9 splits its state handling out into `@tanstack/react-store` and
`@tanstack/store`, so the +43 KiB (1.2%) is the **library's** growth rather than
a route of ours: no page was added, and both other ceilings still pass with
margin — largest chunk 379.8 / 927.7 KiB, shared runtime 434.7 / 439.5 KiB.

## Code-splitting was tried first and does not fix it

`ComplianceMatrix` is the only component built on TanStack Table and it sits
behind the "Matrix" view toggle, so lazy-loading it via `next/dynamic` is a
genuine first-load improvement. It does **not** fix this check: the budget
totals *every emitted chunk*, so moving bytes between chunks changes the number
not at all (measured 3742.4 KiB either way).

So the split was reverted rather than carried along as an unrelated change that
appeared to fix something it did not. It is worth doing on its own merits, as
its own PR.

## The raise

3760 KiB, keeping ~21 KiB of headroom for routine bundler variance — the same
terms as every raise recorded in the comment block above it (dagre 3.1.0, Next
16.3.0, and the rest).

Verified locally on a clean `npm ci` + `npm run build`:

    PASS total client JS: 3742.4 KiB / budget 3760.0 KiB
    PASS largest chunk:    379.8 KiB / budget  927.7 KiB
    PASS shared app runtime: 434.7 KiB / budget 439.5 KiB