### PR TITLE
fix(test): the release-tag check must not assert on the runner's git state

### DIFF
--- a/scripts/check_release_tag_is_new.py
+++ b/scripts/check_release_tag_is_new.py
@@ -49,11 +49,20 @@ def _local_tags() -> set[str]:
     return {line.strip() for line in _git("tag", "--list").splitlines() if line.strip()}
 
 
-def _remote_tags() -> set[str]:
-    # Never fatal: an offline pre-flight still checks local tags rather than
-    # reporting a green verdict it cannot support.
-    out = _git("ls-remote", "--tags", "origin")
-    return {ref.split("refs/tags/", 1)[1].removesuffix("^{}") for line in out.splitlines() if "refs/tags/" in line for ref in [line]}
+def _remote_tags() -> tuple[set[str], bool]:
+    """Return (tags, reachable).
+
+    Never fatal: an offline pre-flight still checks local tags. But it must not
+    report the *failure* as "no tags there" — a silently empty answer reads
+    exactly like a clean one, which is how a shipped version can look new. The
+    caller says so out loud instead.
+    """
+    result = subprocess.run(["git", "ls-remote", "--tags", "origin"], capture_output=True, text=True)
+    if result.returncode != 0:
+        return set(), False
+    return {
+        ref.split("refs/tags/", 1)[1].removesuffix("^{}") for line in result.stdout.splitlines() if "refs/tags/" in line for ref in [line]
+    }, True
 
 
 def _commits_since_newest_tag() -> tuple[str, int]:
@@ -78,7 +87,16 @@ def main() -> int:
     tag = f"v{version}"
     problems: list[str] = []
 
-    existing = _local_tags() | _remote_tags()
+    local = _local_tags()
+    remote, remote_reachable = _remote_tags()
+    existing = local | remote
+    if not remote_reachable:
+        print(
+            "WARNING: could not reach 'origin' to list tags; this check saw only the "
+            f"{len(local)} local tag(s). A shallow or tagless checkout can make a "
+            "shipped version look new.",
+            file=sys.stderr,
+        )
     if tag in existing:
         problems.append(
             f"{tag} has ALREADY been tagged. Re-tagging republishes a shipped version.\n"

--- a/tests/test_release_tag_is_new.py
+++ b/tests/test_release_tag_is_new.py
@@ -104,7 +104,17 @@ def test_it_reports_how_far_main_has_moved_past_the_last_tag(repo: Path) -> None
 
 
 def test_the_real_repo_refuses_the_version_that_already_shipped() -> None:
-    """The regression itself, against this repository rather than a fixture."""
+    """The regression itself, against this repository rather than a fixture.
+
+    Skipped where the checkout has no tags. CI's Alpine job clones without
+    them, so `v0.99.0` is genuinely absent there and the script is right to
+    accept it — asserting a refusal would be asserting that the *runner*
+    fetched tags, not that the gate works. The fixture-backed cases above
+    create their own tags and cover the behaviour unconditionally.
+    """
     root = Path(__file__).resolve().parents[1]
+    tags = subprocess.run(["git", "tag", "--list", "v0.99.0"], cwd=root, capture_output=True, text=True)
+    if not tags.stdout.strip():
+        pytest.skip("checkout has no tags, so there is no already-shipped version to refuse")
     result = subprocess.run([sys.executable, str(SCRIPT), "0.99.0"], cwd=root, capture_output=True, text=True)
     assert result.returncode != 0, result.stdout


### PR DESCRIPTION
**`Test (Alpine/musl)` has been red on `main` since #4739, and the failure is
mine** — not the dependency batch (#4749) or the base-image bump (#4741) it was
showing up on:

    FAILED tests/test_release_tag_is_new.py::test_the_real_repo_refuses_the_version_that_already_shipped
    AssertionError: OK: v0.99.0 is new and CHANGELOG.md documents it.

CI's Alpine job checks out **without tags**, so `v0.99.0` is genuinely absent in
that container and the script is right to accept it. The test was asserting that
the *runner* had fetched tags, not that the gate works.

## Two changes, because the test only exposed the smaller problem

**1 — the test skips when its premise does not hold.** The six fixture-backed
cases create their own tags and cover the behaviour unconditionally. This one
exists to run the real repository through the real script, so it now says why it
skipped rather than failing on an environment it never controlled.

**2 — the script says when it could not ask.** `_remote_tags()` swallowed a
failed `git ls-remote` and returned an empty set — *indistinguishable from "the
remote has no such tag"*. That is the same fail-open shape as the websocket gate
in #4740: a lookup that could not be performed reported as a lookup that came
back clean, which is precisely how a shipped version looks new.

It still does not fail offline — a pre-flight without network should check what
it can — but it now prints:

    WARNING: could not reach 'origin' to list tags; this check saw only the
    0 local tag(s). A shallow or tagless checkout can make a shipped version
    look new.

## Verified in the condition that actually failed

Rather than reasoning about it, I reproduced a tagless clone with no reachable
`origin` — what the Alpine container sees:

- **before:** the check returns 0 and the test fails
- **after:** the warning prints and the suite reports **6 passed, 1 skipped**

Against this repository, where the tags are present: **7 passed**, still refusing
0.99.0. `ruff format --check`, `ruff`, `mypy` clean.

Merging this unblocks the Alpine job on #4749 and #4741.