### PR TITLE
fix(security): give the governance audit chain the fork guard its sibling has

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260810_01_governance_audit_fork_guard.py
+++ b/deploy/supabase/postgres/alembic/versions/20260810_01_governance_audit_fork_guard.py
@@ -41,27 +41,55 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute("ALTER TABLE governance_audit_log ADD COLUMN IF NOT EXISTS prev_hash TEXT NOT NULL DEFAULT ''")
-    # Backfill from the sealed payload, which has always carried prev_hash —
-    # it simply had no column of its own. Guarded so a malformed row cannot
-    # abort the migration.
+    # `governance_audit_log` is created by runtime-schema.sql and by the store's
+    # own _init_tables() — no migration creates it. A database upgraded from an
+    # older revision (the legacy contract starts at 20260728_02 with only the
+    # scan tables) therefore may not have it yet, and an unguarded ALTER would
+    # abort the whole chain. Fresh deployments already take the column and the
+    # index from runtime-schema.sql, so this block is the catch-up path only.
     op.execute(
         """
-        UPDATE governance_audit_log
-           SET prev_hash = COALESCE(data::jsonb ->> 'prev_hash', '')
-         WHERE prev_hash = ''
-           AND data IS NOT NULL
-           AND jsonb_typeof(data::jsonb) = 'object'
+        DO $$
+        BEGIN
+            IF to_regclass('public.governance_audit_log') IS NULL THEN
+                RETURN;
+            END IF;
+
+            ALTER TABLE governance_audit_log ADD COLUMN IF NOT EXISTS prev_hash TEXT NOT NULL DEFAULT '';
+
+            -- Backfill from the sealed payload, which has always carried
+            -- prev_hash — it simply had no column of its own. Guarded so a
+            -- malformed row cannot abort the migration.
+            UPDATE governance_audit_log
+               SET prev_hash = COALESCE(data::jsonb ->> 'prev_hash', '')
+             WHERE prev_hash = ''
+               AND data IS NOT NULL
+               AND jsonb_typeof(data::jsonb) = 'object';
+
+            -- IF NOT EXISTS keeps this idempotent and a no-op where
+            -- runtime-schema.sql already created it. Pre-existing forks in older
+            -- data would make creation fail; that mirrors 20260719_01's posture —
+            -- the store's append retries, so a deployment carrying historical
+            -- forks is not left unable to migrate.
+            CREATE UNIQUE INDEX IF NOT EXISTS governance_audit_log_tenant_prevhash_uniq
+                ON governance_audit_log (tenant_id, prev_hash);
+        END
+        $$;
         """
     )
-    # IF NOT EXISTS keeps this idempotent and a no-op on deployments that
-    # already took the index from runtime-schema.sql. Pre-existing forks in
-    # older data would make creation fail; that mirrors 20260719_01's posture —
-    # the store's append retries, so a deployment carrying historical forks is
-    # not left unable to migrate.
-    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS governance_audit_log_tenant_prevhash_uniq ON governance_audit_log (tenant_id, prev_hash)")
 
 
 def downgrade() -> None:
-    op.execute("DROP INDEX IF EXISTS governance_audit_log_tenant_prevhash_uniq")
-    op.execute("ALTER TABLE governance_audit_log DROP COLUMN IF EXISTS prev_hash")
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF to_regclass('public.governance_audit_log') IS NULL THEN
+                RETURN;
+            END IF;
+            DROP INDEX IF EXISTS governance_audit_log_tenant_prevhash_uniq;
+            ALTER TABLE governance_audit_log DROP COLUMN IF EXISTS prev_hash;
+        END
+        $$;
+        """
+    )

--- a/deploy/supabase/postgres/alembic/versions/20260810_01_governance_audit_fork_guard.py
+++ b/deploy/supabase/postgres/alembic/versions/20260810_01_governance_audit_fork_guard.py
@@ -1,0 +1,67 @@
+"""Give the governance audit chain the fork guard its sibling already has.
+
+``PostgresGovernanceAuditLog.append`` reads the tenant's chain head, seals the
+record against it, and inserts. Two writers that read the same head both seal
+against it, so both rows claim the same predecessor and the chain forks. The
+existing ``UNIQUE (tenant_id, action_id)`` prevents duplicate *actions*; it says
+nothing about two different actions claiming one parent.
+
+Measured on live Postgres before this migration: 6 processes x 8 appends
+produced 48 rows over 15 distinct predecessors, and ``verify_chain`` reported
+33 of 48 tampered. 16 threads in one process produced 16 rows over 5
+predecessors. The module docstring claimed a single process "never forks a
+chain" and framed the risk as cross-replica only; both halves were wrong.
+
+The user-visible effect is a false alarm rather than data loss:
+``GET /v1/self-posture`` reports ``governance.audit_chain_integrity`` as FAIL
+("broken or forked") on healthy data for any multi-replica deployment, and the
+NHI cleanup loop runs per-replica on a timer, so it fires in normal operation.
+
+``audit_log`` — the table one file over — has carried
+``audit_log_team_prevsig_uniq (team_id, prev_signature)`` plus a re-sign/retry
+loop since 20260719_01. This is the same judgement applied to the second chain,
+not a new one.
+
+``prev_hash`` is promoted from the ``data`` JSON to its own column so the index
+is a plain column index like its sibling, rather than an expression over a cast
+of a TEXT column.
+
+Revision ID: 20260810_01
+Revises: 20260801_01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260810_01"
+down_revision = "20260801_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE governance_audit_log ADD COLUMN IF NOT EXISTS prev_hash TEXT NOT NULL DEFAULT ''")
+    # Backfill from the sealed payload, which has always carried prev_hash —
+    # it simply had no column of its own. Guarded so a malformed row cannot
+    # abort the migration.
+    op.execute(
+        """
+        UPDATE governance_audit_log
+           SET prev_hash = COALESCE(data::jsonb ->> 'prev_hash', '')
+         WHERE prev_hash = ''
+           AND data IS NOT NULL
+           AND jsonb_typeof(data::jsonb) = 'object'
+        """
+    )
+    # IF NOT EXISTS keeps this idempotent and a no-op on deployments that
+    # already took the index from runtime-schema.sql. Pre-existing forks in
+    # older data would make creation fail; that mirrors 20260719_01's posture —
+    # the store's append retries, so a deployment carrying historical forks is
+    # not left unable to migrate.
+    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS governance_audit_log_tenant_prevhash_uniq ON governance_audit_log (tenant_id, prev_hash)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS governance_audit_log_tenant_prevhash_uniq")
+    op.execute("ALTER TABLE governance_audit_log DROP COLUMN IF EXISTS prev_hash")

--- a/deploy/supabase/postgres/runtime-schema.sql
+++ b/deploy/supabase/postgres/runtime-schema.sql
@@ -161,9 +161,10 @@ CREATE INDEX IF NOT EXISTS idx_model_virtual_keys_hash ON model_virtual_keys(tok
 -- Simple JSON-record stores.
 CREATE TABLE IF NOT EXISTS risk_campaign_workflows (tenant_id TEXT NOT NULL,campaign_id TEXT NOT NULL,owner TEXT,sla_due_at TEXT,state TEXT NOT NULL,verification_status TEXT NOT NULL,title TEXT NOT NULL DEFAULT '',member_ids TEXT NOT NULL DEFAULT '[]',membership_fingerprint TEXT NOT NULL DEFAULT '',generation INTEGER NOT NULL DEFAULT 1,active BOOLEAN NOT NULL DEFAULT TRUE,version INTEGER NOT NULL DEFAULT 1,updated_at TEXT NOT NULL,PRIMARY KEY(tenant_id,campaign_id));
 CREATE INDEX IF NOT EXISTS idx_risk_campaign_workflows_tenant_state ON risk_campaign_workflows(tenant_id,state,updated_at DESC);
-CREATE TABLE IF NOT EXISTS governance_audit_log (seq BIGSERIAL PRIMARY KEY,action_id TEXT NOT NULL,tenant_id TEXT NOT NULL,action TEXT NOT NULL,observed_at TEXT NOT NULL,record_hash TEXT NOT NULL,data TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS governance_audit_log (seq BIGSERIAL PRIMARY KEY,action_id TEXT NOT NULL,tenant_id TEXT NOT NULL,action TEXT NOT NULL,observed_at TEXT NOT NULL,record_hash TEXT NOT NULL,prev_hash TEXT NOT NULL DEFAULT '',data TEXT NOT NULL);
 CREATE INDEX IF NOT EXISTS idx_governance_audit_tenant ON governance_audit_log(tenant_id,seq);
 CREATE UNIQUE INDEX IF NOT EXISTS uq_governance_audit_tenant_action ON governance_audit_log(tenant_id,action_id);
+CREATE UNIQUE INDEX IF NOT EXISTS governance_audit_log_tenant_prevhash_uniq ON governance_audit_log(tenant_id,prev_hash);
 CREATE TABLE IF NOT EXISTS scan_dispatch_queue (job_id TEXT PRIMARY KEY REFERENCES scan_jobs(job_id) ON DELETE CASCADE,tenant_id TEXT NOT NULL,created_at TEXT NOT NULL,status TEXT NOT NULL DEFAULT 'pending',claimed_by TEXT,lease_expires_at TEXT);
 CREATE INDEX IF NOT EXISTS idx_dispatch_pending ON scan_dispatch_queue(status,created_at);
 ALTER TABLE scan_dispatch_queue ENABLE ROW LEVEL SECURITY;

--- a/src/agent_bom/api/postgres_governance_audit.py
+++ b/src/agent_bom/api/postgres_governance_audit.py
@@ -50,6 +50,28 @@ from agent_bom.api.postgres_common import (
 )
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
+# The fork-guard index this store relies on. Named so a unique violation can be
+# attributed to a chain race rather than to the (tenant_id, action_id) dedupe.
+_GOVERNANCE_FORK_GUARD_INDEX = "governance_audit_log_tenant_prevhash_uniq"
+# Bounded: a genuine fork race resolves in one or two rounds. An unbounded loop
+# would turn a persistent constraint problem into a hang on the request path.
+_MAX_APPEND_RETRIES = 5
+
+
+def _is_chain_fork_conflict(exc: Exception) -> bool:
+    """True when ``exc`` is a unique violation on the chain fork-guard index.
+
+    Deliberately narrow: the same INSERT also carries
+    ``ON CONFLICT (tenant_id, action_id) DO NOTHING``, so a dedupe collision
+    never raises. Anything that is not this index is a real error and must not
+    be retried into a loop.
+    """
+    if getattr(exc, "sqlstate", None) != "23505":
+        return False
+    diag = getattr(exc, "diag", None)
+    constraint = getattr(diag, "constraint_name", None) if diag else None
+    return constraint in (None, "", _GOVERNANCE_FORK_GUARD_INDEX)
+
 
 class PostgresGovernanceAuditLog:
     """Shared, tenant-scoped, append-only governance audit chain on Postgres."""
@@ -100,6 +122,19 @@ class PostgresGovernanceAuditLog:
         return GovernanceAuditRecord(**json.loads(row[0])) if row else None
 
     def append(self, record: GovernanceAuditRecord) -> GovernanceAuditRecord:
+        """Append one record to this tenant's chain, re-sealing on a fork race.
+
+        Reading the head and inserting against it is not atomic: two writers
+        that read the same head both seal against it, and the chain forks. An
+        in-process lock cannot help, because the writers are separate uvicorn
+        workers or replicas. Measured before the guard: 6 processes x 8 appends
+        produced 48 rows over 15 distinct predecessors.
+
+        ``UNIQUE (tenant_id, prev_hash)`` makes the database reject the loser,
+        which is then re-sealed against the winner's hash and retried — the same
+        shape ``PostgresAuditLog.append`` has used since 20260719_01. Retrying
+        is what keeps the guard from turning a race into a dropped audit record.
+        """
         # Bind the record's own tenant so the head lookup and RLS WITH CHECK
         # resolve to that tenant's chain — never the ambient request tenant.
         token = _current_tenant.set(record.tenant_id)
@@ -108,27 +143,40 @@ class PostgresGovernanceAuditLog:
                 existing = self._get_within_tenant(conn, record.action_id)
                 if existing is not None:
                     return existing
-                head_row = conn.execute(
-                    "SELECT record_hash FROM governance_audit_log WHERE tenant_id = %s ORDER BY seq DESC LIMIT 1",
-                    (record.tenant_id,),
-                ).fetchone()
-                head = str(head_row[0]) if head_row else ""
-                sealed = _seal_record(record, head)
-                conn.execute(
-                    "INSERT INTO governance_audit_log "
-                    "(action_id, tenant_id, action, observed_at, record_hash, data) "
-                    "VALUES (%s, %s, %s, %s, %s, %s) "
-                    "ON CONFLICT (tenant_id, action_id) DO NOTHING",
-                    (
-                        sealed.action_id,
-                        sealed.tenant_id,
-                        sealed.action,
-                        sealed.observed_at,
-                        sealed.record_hash,
-                        json.dumps(asdict(sealed), sort_keys=True),
-                    ),
-                )
-                conn.commit()
+                attempts = 0
+                while True:
+                    attempts += 1
+                    head_row = conn.execute(
+                        "SELECT record_hash FROM governance_audit_log WHERE tenant_id = %s ORDER BY seq DESC LIMIT 1",
+                        (record.tenant_id,),
+                    ).fetchone()
+                    head = str(head_row[0]) if head_row else ""
+                    sealed = _seal_record(record, head)
+                    try:
+                        conn.execute(
+                            "INSERT INTO governance_audit_log "
+                            "(action_id, tenant_id, action, observed_at, record_hash, prev_hash, data) "
+                            "VALUES (%s, %s, %s, %s, %s, %s, %s) "
+                            "ON CONFLICT (tenant_id, action_id) DO NOTHING",
+                            (
+                                sealed.action_id,
+                                sealed.tenant_id,
+                                sealed.action,
+                                sealed.observed_at,
+                                sealed.record_hash,
+                                sealed.prev_hash,
+                                json.dumps(asdict(sealed), sort_keys=True),
+                            ),
+                        )
+                        conn.commit()
+                        break
+                    except Exception as exc:  # noqa: BLE001 - narrowed by _is_chain_fork_conflict
+                        conn.rollback()
+                        if _is_chain_fork_conflict(exc) and attempts <= _MAX_APPEND_RETRIES:
+                            # Another writer took our predecessor. Re-read the
+                            # head and seal against theirs instead of ours.
+                            continue
+                        raise
                 # A concurrent replica may have won the UNIQUE race between our
                 # existence check and insert; re-read so the canonical row wins.
                 stored = self._get_within_tenant(conn, sealed.action_id)

--- a/tests/test_governance_audit_chain_fork_guard.py
+++ b/tests/test_governance_audit_chain_fork_guard.py
@@ -1,0 +1,113 @@
+"""The governance audit chain must reject a fork, like its sibling already does.
+
+``PostgresGovernanceAuditLog.append`` reads the tenant's chain head, seals the
+record against it, and inserts. Two writers that read the same head both seal
+against it, so both rows claim the same predecessor and the chain forks.
+``UNIQUE (tenant_id, action_id)`` prevents duplicate *actions*; it says nothing
+about two different actions claiming one parent.
+
+Measured on live Postgres before the guard:
+
+    6 processes x 8 appends -> 48 rows, 15 distinct prev_hash
+                               verify_chain: 33 of 48 tampered
+    16 threads, one process -> 16 rows,  5 distinct prev_hash
+
+The module docstring claimed a single process "never forks a chain" and framed
+the risk as cross-replica only. Both halves were wrong.
+
+The user-visible effect is a false alarm rather than data loss:
+``GET /v1/self-posture`` reports ``governance.audit_chain_integrity`` as FAIL
+("broken or forked") on healthy data for any multi-replica deployment.
+
+``audit_log`` — one file over — has carried a fork-guard unique index plus a
+re-sign/retry loop since 20260719_01. These tests pin the same judgement onto
+the second chain: the DDL exists in both authoritative places, and the store
+re-seals rather than dropping the record when the database rejects a race.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = ROOT / "deploy/supabase/postgres/alembic/versions/20260810_01_governance_audit_fork_guard.py"
+RUNTIME_SCHEMA = ROOT / "deploy/supabase/postgres/runtime-schema.sql"
+
+_INDEX = "governance_audit_log_tenant_prevhash_uniq"
+
+
+def _canonical_sql(text: str) -> str:
+    return re.sub(r"[\s\"]+", "", text).lower()
+
+
+def test_the_migration_creates_the_fork_guard_index() -> None:
+    sql = MIGRATION.read_text()
+    assert re.search(r'revision\s*=\s*"20260810_01"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260801_01"', sql), "must chain from the current head"
+    canon = _canonical_sql(sql)
+    assert f"createuniqueindexifnotexists{_INDEX}ongovernance_audit_log(tenant_id,prev_hash)" in canon
+    assert f"DROP INDEX IF EXISTS {_INDEX}" in sql, "must be reversible"
+
+
+def test_the_migration_backfills_prev_hash_before_indexing() -> None:
+    """The column is new; existing rows carry prev_hash inside `data`.
+
+    Creating the unique index over an all-empty column would collide on the
+    first two rows of every tenant.
+    """
+    sql = MIGRATION.read_text()
+    add = sql.index("ADD COLUMN IF NOT EXISTS prev_hash")
+    backfill = sql.index("UPDATE governance_audit_log")
+    create = sql.index("CREATE UNIQUE INDEX")
+    assert add < backfill < create, "order must be add column, backfill, then index"
+
+
+def test_the_runtime_schema_authority_carries_the_same_ddl() -> None:
+    """Fresh deployments take the schema from here, not from the migration."""
+    schema = _canonical_sql(RUNTIME_SCHEMA.read_text())
+    assert f"createuniqueindexifnotexists{_INDEX}ongovernance_audit_log(tenant_id,prev_hash)" in schema
+    assert "prev_hashtextnotnulldefault''" in schema
+
+
+def test_the_store_retries_a_fork_race_instead_of_dropping_the_record() -> None:
+    """A guard that turned a race into a lost audit record would be worse."""
+    source = (ROOT / "src/agent_bom/api/postgres_governance_audit.py").read_text()
+    assert "_MAX_APPEND_RETRIES" in source, "the append path must bound its retries"
+    assert "_is_chain_fork_conflict" in source, "a fork race must be told apart from a real error"
+    assert "prev_hash" in source, "the sealed prev_hash must be written to its own column"
+
+
+class TestForkConflictDetection:
+    """Only a unique violation on the fork-guard index may be retried."""
+
+    def _exc(self, sqlstate: str, constraint: str | None):
+        class _Diag:
+            constraint_name = constraint
+
+        class _FakeDbError(Exception):
+            pass
+
+        exc = _FakeDbError("boom")
+        exc.sqlstate = sqlstate  # type: ignore[attr-defined]
+        exc.diag = _Diag()  # type: ignore[attr-defined]
+        return exc
+
+    @pytest.mark.parametrize("constraint", [_INDEX, None, ""])
+    def test_a_unique_violation_on_the_guard_is_a_fork(self, constraint) -> None:
+        from agent_bom.api.postgres_governance_audit import _is_chain_fork_conflict
+
+        assert _is_chain_fork_conflict(self._exc("23505", constraint)) is True
+
+    def test_an_unrelated_error_is_not_retried(self) -> None:
+        """Retrying a real error would spin instead of surfacing it."""
+        from agent_bom.api.postgres_governance_audit import _is_chain_fork_conflict
+
+        assert _is_chain_fork_conflict(self._exc("42P01", None)) is False
+
+    def test_a_different_unique_index_is_not_treated_as_a_fork(self) -> None:
+        from agent_bom.api.postgres_governance_audit import _is_chain_fork_conflict
+
+        assert _is_chain_fork_conflict(self._exc("23505", "uq_governance_audit_tenant_action")) is False

--- a/tests/test_postgres_governance_audit.py
+++ b/tests/test_postgres_governance_audit.py
@@ -16,6 +16,8 @@ properties that matter for a multi-replica control plane:
 
 from __future__ import annotations
 
+import pytest
+
 import json
 from typing import Any
 
@@ -40,6 +42,19 @@ class _FakeCursor:
 
     def fetchall(self):
         return self.rows
+
+
+class _FakeUniqueViolation(Exception):
+    """Shaped like psycopg's UniqueViolation: sqlstate 23505 + a named constraint."""
+
+    def __init__(self, constraint: str) -> None:
+        super().__init__(f'duplicate key value violates unique constraint "{constraint}"')
+        self.sqlstate = "23505"
+
+        class _Diag:
+            constraint_name = constraint
+
+        self.diag = _Diag()
 
 
 class _FakeConnection:
@@ -76,11 +91,16 @@ class _FakeConnection:
             return _FakeCursor()
 
         if s.startswith("insert into governance_audit_log"):
-            action_id, tenant_id, action, observed_at, record_hash, data = params
+            action_id, tenant_id, action, observed_at, record_hash, prev_hash, data = params
             rows = self._state["rows"]
             # ON CONFLICT (tenant_id, action_id) DO NOTHING — composite arbiter.
             if any(r["action_id"] == action_id and r["tenant_id"] == tenant_id for r in rows):
                 return _FakeCursor()
+            # UNIQUE (tenant_id, prev_hash) — the fork guard. Two records may
+            # never claim the same predecessor within one tenant. Modelled here
+            # because it is the constraint the store's retry loop exists for.
+            if any(r["tenant_id"] == tenant_id and r["prev_hash"] == prev_hash for r in rows):
+                raise _FakeUniqueViolation("governance_audit_log_tenant_prevhash_uniq")
             self._state["seq"] += 1
             rows.append(
                 {
@@ -90,6 +110,7 @@ class _FakeConnection:
                     "action": action,
                     "observed_at": observed_at,
                     "record_hash": record_hash,
+                    "prev_hash": prev_hash,
                     "data": data,
                 }
             )
@@ -135,6 +156,12 @@ class _FakeConnection:
         return _FakeCursor()
 
     def commit(self):
+        pass
+
+    def rollback(self):
+        # The store rolls back before re-sealing on a fork race. Nothing to undo
+        # here (the failed INSERT never mutated state), but the method must
+        # exist or the retry path raises AttributeError instead of retrying.
         pass
 
     def __enter__(self):
@@ -353,3 +380,65 @@ def test_backend_selection_memory_and_sqlite(monkeypatch, tmp_path):
         assert isinstance(mod.get_governance_audit_log(), SQLiteGovernanceAuditLog)
     finally:
         set_governance_audit_log(None)
+
+
+# ─── Chain fork guard under concurrency ──────────────────────────────────────
+
+
+def test_a_stale_head_read_is_re_sealed_instead_of_forking() -> None:
+    """The race, made deterministic.
+
+    Threads alone do not reproduce this: the fake is fast enough that the GIL
+    serialises them and each writer happens to read a fresh head, so a threaded
+    test passes even with the guard removed — it proves nothing.
+
+    So the race is injected instead. The second append is served ONE stale head
+    (the value the first writer saw), which is exactly what a concurrent replica
+    observes. The insert then collides on ``UNIQUE (tenant_id, prev_hash)`` and
+    the store must re-read, re-seal against the real head, and land a linear
+    chain rather than a fork or a dropped record.
+    """
+    state = {"rows": [], "seq": 0}
+    pool = _FakePool(state=state)
+    store = _postgres_store(pool)
+
+    first = store.append(_rec("acme", "identity-a", "w1"))
+
+    stale_head = {"served": False}
+    real_execute = _FakeConnection.execute
+
+    def stale_head_once(self, sql, params=None):
+        s_norm = " ".join(sql.lower().split())
+        if "select record_hash from governance_audit_log" in s_norm and not stale_head["served"]:
+            stale_head["served"] = True
+            # What the first writer saw before it committed: an empty chain.
+            return _FakeCursor([])
+        return real_execute(self, sql, params)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(_FakeConnection, "execute", stale_head_once)
+        second = store.append(_rec("acme", "identity-b", "w2"))
+
+    assert stale_head["served"], "the stale head was never served — the race was not exercised"
+
+    rows = [r for r in state["rows"] if r["tenant_id"] == "acme"]
+    assert len(rows) == 2, f"both records must persist, got {len(rows)}"
+    predecessors = [r["prev_hash"] for r in rows]
+    assert len(set(predecessors)) == 2, f"the chain forked: two records claim {predecessors}"
+    assert second.prev_hash == first.record_hash, "the loser must be re-sealed onto the winner"
+
+
+def test_a_fork_race_never_drops_the_record() -> None:
+    """The guard must reject the row, not the write.
+
+    A constraint without the retry would turn a race into a silently missing
+    audit record — worse than the fork it prevents.
+    """
+    state = {"rows": [], "seq": 0}
+    store = _postgres_store(_FakePool(state=state))
+
+    first = store.append(_rec("acme", "identity-a", "w1"))
+    second = store.append(_rec("acme", "identity-b", "w2"))
+
+    assert second.prev_hash == first.record_hash, "the second record must chain onto the first"
+    assert len([r for r in state["rows"] if r["tenant_id"] == "acme"]) == 2

--- a/tests/test_postgres_governance_audit.py
+++ b/tests/test_postgres_governance_audit.py
@@ -16,10 +16,10 @@ properties that matter for a multi-replica control plane:
 
 from __future__ import annotations
 
-import pytest
-
 import json
 from typing import Any
+
+import pytest
 
 from agent_bom.api.governance_audit_log import (
     ACTION_IDENTITY_DORMANT_REVOKE,
@@ -44,7 +44,7 @@ class _FakeCursor:
         return self.rows
 
 
-class _FakeUniqueViolation(Exception):
+class _FakeUniqueViolationError(Exception):
     """Shaped like psycopg's UniqueViolation: sqlstate 23505 + a named constraint."""
 
     def __init__(self, constraint: str) -> None:
@@ -100,7 +100,7 @@ class _FakeConnection:
             # never claim the same predecessor within one tenant. Modelled here
             # because it is the constraint the store's retry loop exists for.
             if any(r["tenant_id"] == tenant_id and r["prev_hash"] == prev_hash for r in rows):
-                raise _FakeUniqueViolation("governance_audit_log_tenant_prevhash_uniq")
+                raise _FakeUniqueViolationError("governance_audit_log_tenant_prevhash_uniq")
             self._state["seq"] += 1
             rows.append(
                 {

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -44,6 +44,11 @@ RUNTIME_SCHEMA_SQL = POSTGRES_DIR / "runtime-schema.sql"
 _FORK_GUARD_INDEX_CANON = "createuniqueindexifnotexistsaudit_log_team_prevsig_uniqonaudit_log(team_id,prev_signature)"
 
 
+# The newest migration. One place to update when a revision lands, so the
+# single-head property and the head's identity do not drift apart.
+ALEMBIC_HEAD = "20260810_01"
+
+
 def _canonical_sql(text: str) -> str:
     return re.sub(r"[\s\"]+", "", text).lower()
 
@@ -436,22 +441,27 @@ def test_teams_tenant_rls_is_chained_idempotent_and_irreversible() -> None:
     assert "NO FORCE ROW LEVEL SECURITY" not in sql
 
 
-def test_fleet_agents_tenant_scoped_key_is_the_alembic_head() -> None:
-    """Nothing may chain past the new revision without being noticed."""
+def test_there_is_exactly_one_alembic_head() -> None:
+    """Nothing may chain past the newest revision without being noticed.
+
+    Named by property rather than by revision id: this test previously pinned
+    `20260801_01` literally, so every new migration edited the assertion and the
+    *reason* for it — one head, no forks — drifted out of the name. The current
+    head is asserted separately below, in one place.
+    """
     revisions = {
         path.name: re.search(r'down_revision\s*=\s*"([^"]+)"', path.read_text())
         for path in VERSIONS_DIR.glob("*.py")
         if path.name != "__init__.py"
     }
     parents = {match.group(1) for match in revisions.values() if match}
-    assert "20260801_01" not in parents
-    # And exactly one head: every other revision is some revision's parent.
     all_revisions = {
         match.group(1)
         for match in (re.search(r'^revision\s*=\s*"([^"]+)"', path.read_text(), re.M) for path in VERSIONS_DIR.glob("*.py"))
         if match
     }
-    assert all_revisions - parents == {"20260801_01"}
+    heads = all_revisions - parents
+    assert heads == {ALEMBIC_HEAD}, f"expected a single head {ALEMBIC_HEAD!r}, found {sorted(heads)}"
 
 
 def test_fleet_agents_tenant_key_is_chained_concurrent_and_irreversible() -> None:


### PR DESCRIPTION
`PostgresGovernanceAuditLog.append` reads the tenant's chain head, seals the
record against it, and inserts. Two writers that read the same head both seal
against it, so **both rows claim the same predecessor and the chain forks**. The
existing `UNIQUE (tenant_id, action_id)` prevents duplicate *actions*; it says
nothing about two different actions claiming one parent.

Measured on live Postgres by the pre-release audit:

```
6 processes x 8 appends -> 48 rows, 15 distinct prev_hash
                           verify_chain: 33 of 48 tampered
16 threads, one process -> 16 rows,  5 distinct prev_hash
```

The module docstring claimed a single process *"never forks a chain"* and framed
the risk as cross-replica only. **Both halves were wrong** — an in-process lock
cannot serialize uvicorn workers, and there was no lock either.

**User-visible effect is a false alarm rather than data loss:**
`GET /v1/self-posture` reports `governance.audit_chain_integrity` as **FAIL
("broken or forked") on healthy data** for any multi-replica deployment. The NHI
cleanup loop runs per-replica on a timer, so this fires in normal operation.

## One judgement, applied to the second chain

`audit_log` — the table one file over — has carried
`audit_log_team_prevsig_uniq (team_id, prev_signature)` plus a re-sign/retry
loop since 20260719_01. This is that same judgement, not a new one.

`UNIQUE (tenant_id, prev_hash)` lets the database reject the loser, which is
re-sealed against the winner's hash and retried. **Retrying is what keeps the
guard from turning a race into a dropped audit record** — worse than the fork it
prevents. `prev_hash` is promoted from the `data` JSON to its own column so the
index is a plain column index like its sibling, rather than an expression over a
cast of a TEXT column.

## The threaded test was a false green — worth reading

My first concurrency test **passed with the guard removed**. The in-memory fake
is fast enough that the GIL serializes the writers, so each happens to read a
fresh head and no fork ever occurs. A test that cannot fail proves nothing.

So the race is now injected deterministically: the second append is served **one
stale head** — precisely what a concurrent replica observes. With the guard
removed it fails with `the chain forked: two records claim ['', '']`; with it,
the loser is re-sealed onto the winner.

## Verified

- `tests/test_postgres_governance_audit.py` — **12 passed**, including the
  deterministic race. The fake now models the fork-guard constraint and
  `rollback()`, because that is the interface the store actually uses.
- `tests/test_governance_audit_chain_fork_guard.py` — **9 tests** over the
  migration, the runtime-schema authority, backfill ordering, and the narrow
  conflict detection (an unrelated error must not be retried into a loop).
- `test_postgres_migrations.py` pinned `20260801_01` as the head **literally**,
  so every new migration edited the assertion and its *reason* — one head, no
  forks — drifted out of the name. It now asserts the property, with the head in
  one named constant.
- **296 passed** across governance / audit-chain / self-posture / migration
  suites · `ruff`, `ruff format --check`, `mypy` clean.

## Note on live verification

The concurrency property is proven through the functional fake, which models the
constraint. A live-Postgres run under real cross-process contention (as the audit
did to find this) would be the strongest confirmation and is worth doing on a
runner with the PG service available.