### PR TITLE
fix(scan): read the rpmdb schema RHEL actually ships

### DIFF
--- a/src/agent_bom/coverage.py
+++ b/src/agent_bom/coverage.py
@@ -132,6 +132,28 @@ def _release_key(pkg: "Package") -> Optional[tuple[str, str]]:
         from agent_bom.package_utils import alpine_release_branch
 
         return ("alpine", f"alpine:{alpine_release_branch(distro_version)}")
+    if eco == "rpm":
+        # RPM distros had no branch here at all, so `detect_release_coverage_gaps`
+        # could never fire for one — an RPM parser that silently produced nothing
+        # had no backstop, which is how a RHEL false-clean went unnoticed.
+        #
+        # Keyed on the major release, which is how the advisory rows are stored.
+        # Only the families the DB actually carries are mapped; anything else
+        # returns None rather than inventing a key that would report a real feed
+        # as missing.
+        major = distro_version.split(".", 1)[0].strip()
+        if not major:
+            return None
+        rpm_families = {
+            "rhel": ("rhel", f"red hat:enterprise_linux:{major}"),
+            "redhat": ("rhel", f"red hat:enterprise_linux:{major}"),
+            "red hat enterprise linux": ("rhel", f"red hat:enterprise_linux:{major}"),
+            "almalinux": ("almalinux", f"almalinux:{major}"),
+            "alma": ("almalinux", f"almalinux:{major}"),
+            "rocky": ("rocky", f"rocky linux:{major}"),
+            "rocky linux": ("rocky", f"rocky linux:{major}"),
+        }
+        return rpm_families.get(distro_name)
     return None
 
 

--- a/src/agent_bom/filesystem.py
+++ b/src/agent_bom/filesystem.py
@@ -313,45 +313,50 @@ def _parse_rpm_sqlite(db_path: Path) -> list[Package]:
     """
     import sqlite3
 
+    from agent_bom.oci_parser import _parse_rpm_header_blob
+
     if not db_path.exists():
         return []
 
+    # RHEL 9+ stores `Packages(hnum INTEGER PRIMARY KEY, blob BLOB)` — one binary
+    # RPM header per row. This used to select `name, version, release, epoch,
+    # arch`, columns that exist in no rpmdb; the query raised, the except
+    # swallowed it, and every RHEL/UBI/Fedora/Amazon filesystem scanned clean.
+    #
+    # `oci_parser._parse_rpm_header_blob` already decodes this format correctly
+    # (#4684 fixed the same defect there). Reusing it means one decoder, so the
+    # two paths cannot disagree about the same bytes again.
     packages: list[Package] = []
     try:
         con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
         try:
-            cur = con.execute("SELECT name, version, release, epoch, arch FROM Packages")
-            rows = cur.fetchall()
+            rows = con.execute("SELECT blob FROM Packages").fetchall()
         finally:
             con.close()
     except Exception as exc:  # noqa: BLE001
         logger.debug("RPM SQLite parse failed for %s: %s", db_path, exc)
         return []
 
-    for row in rows:
-        name, version, release, epoch, arch = row
-        if not name or not version:
+    seen: set[tuple[str, str]] = set()
+    for (blob,) in rows:
+        if not isinstance(blob, bytes):
             continue
-
-        # Build version string: epoch:version-release (omit epoch when 0)
-        epoch_str = str(epoch).strip() if epoch is not None else "0"
-        ver_release = f"{version}-{release}" if release else version
-        if epoch_str and epoch_str != "0":
-            full_version = f"{epoch_str}:{ver_release}"
-        else:
-            full_version = ver_release
-
-        # PURL: pkg:rpm/rhel/name@epoch:version-release?arch=x86_64
-        purl = f"pkg:rpm/rhel/{name}@{full_version}"
-        if arch:
-            purl += f"?arch={arch}"
-
+        parsed = _parse_rpm_header_blob(blob)
+        if not parsed:
+            continue
+        name, full_version = parsed
+        # A signing key in the rpmdb, not installed software.
+        if name == "gpg-pubkey":
+            continue
+        if (name, full_version) in seen:
+            continue
+        seen.add((name, full_version))
         packages.append(
             Package(
                 name=name,
                 version=full_version,
                 ecosystem="rpm",
-                purl=purl,
+                purl=f"pkg:rpm/rhel/{name}@{full_version}",
                 is_direct=True,
             )
         )

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,8 +1,9 @@
 """Tests for filesystem/disk snapshot scanning via Syft."""
 
 import json
-import sqlite3
+import shutil
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -277,55 +278,57 @@ def test_run_syft_captures_stderr(monkeypatch):
 # ─── RPM SQLite parser ────────────────────────────────────────────────────────
 
 
-def _make_rpm_sqlite(db_path, rows):
-    """Helper: create a minimal SQLite RPM DB with given rows."""
-    con = sqlite3.connect(str(db_path))
-    con.execute("CREATE TABLE Packages (name TEXT, version TEXT, release TEXT, epoch INTEGER, arch TEXT)")
-    con.executemany("INSERT INTO Packages VALUES (?,?,?,?,?)", rows)
-    con.commit()
-    con.close()
+REAL_RPMDB = Path(__file__).parent / "fixtures" / "rpmdb_sqlite_min.sqlite"
+
+
+def _make_rpm_sqlite(db_path, _rows=None):
+    """Place a REAL rpmdb.sqlite at ``db_path``.
+
+    This used to fabricate the schema::
+
+        CREATE TABLE Packages (name TEXT, version TEXT, release TEXT, epoch INTEGER, arch TEXT)
+
+    Those columns exist in no rpmdb. RHEL 9+ ships
+    ``Packages(hnum INTEGER PRIMARY KEY, blob BLOB)``, one binary RPM header per
+    row. So every test below validated the parser against an invented format,
+    and all of them stayed green while `agent-bom fs` returned zero packages for
+    every RHEL / UBI / Fedora / Amazon Linux filesystem.
+
+    The fixture is the one the OCI path already scans, so both code paths are
+    now tested against the same real bytes.
+    """
+    shutil.copy(REAL_RPMDB, db_path)
 
 
 def test_parse_rpm_sqlite_db(tmp_path):
-    """_parse_rpm_sqlite reads Packages table and returns Package objects."""
+    """_parse_rpm_sqlite reads the real Packages table and returns Packages."""
     db = tmp_path / "rpmdb.sqlite"
-    _make_rpm_sqlite(db, [("bash", "5.1.8", "6.el9", 0, "x86_64")])
+    _make_rpm_sqlite(db)
 
     pkgs = _parse_rpm_sqlite(db)
-    assert len(pkgs) == 1
-    assert pkgs[0].name == "bash"
-    assert pkgs[0].ecosystem == "rpm"
-    assert "5.1.8" in pkgs[0].version
+    assert pkgs, "a genuine rpmdb.sqlite produced no packages"
+    by_name = {p.name: p for p in pkgs}
+    assert "bash" in by_name
+    assert by_name["bash"].ecosystem == "rpm"
+    assert "5.1.8" in by_name["bash"].version
 
 
-def test_parse_rpm_sqlite_epoch_in_version(tmp_path):
-    """Packages with non-zero epoch include it in the version string."""
+def test_parse_rpm_sqlite_version_includes_release(tmp_path):
+    """The RPM version carries its release suffix, as the advisory feeds key on."""
     db = tmp_path / "rpmdb.sqlite"
-    _make_rpm_sqlite(db, [("openssl", "1.1.1", "34.el9_0", 1, "x86_64")])
+    _make_rpm_sqlite(db)
 
-    pkgs = _parse_rpm_sqlite(db)
-    assert len(pkgs) == 1
-    assert pkgs[0].version.startswith("1:")
+    by_name = {p.name: p.version for p in _parse_rpm_sqlite(db)}
+    assert by_name["bash"] == "5.1.8-9.el9", by_name
+    assert by_name["openssl-libs"] == "3.0.7-27.el9", by_name
 
 
-def test_rpm_purl_with_epoch(tmp_path):
-    """PURL includes epoch when non-zero."""
+def test_rpm_purl_is_well_formed(tmp_path):
     db = tmp_path / "rpmdb.sqlite"
-    _make_rpm_sqlite(db, [("curl", "7.76.1", "14.el9_0.2", 1, "x86_64")])
+    _make_rpm_sqlite(db)
 
-    pkgs = _parse_rpm_sqlite(db)
-    assert len(pkgs) == 1
-    assert "1:7.76.1-14.el9_0.2" in pkgs[0].purl
-
-
-def test_rpm_purl_without_epoch(tmp_path):
-    """PURL omits epoch when epoch is 0."""
-    db = tmp_path / "rpmdb.sqlite"
-    _make_rpm_sqlite(db, [("gzip", "1.10", "1.el9", 0, "x86_64")])
-
-    pkgs = _parse_rpm_sqlite(db)
-    assert len(pkgs) == 1
-    assert "pkg:rpm/rhel/gzip@1.10-1.el9" in pkgs[0].purl
+    by_name = {p.name: p.purl for p in _parse_rpm_sqlite(db)}
+    assert by_name["bash"] == "pkg:rpm/rhel/bash@5.1.8-9.el9", by_name
 
 
 def test_parse_rpm_sqlite_missing_file(tmp_path):
@@ -335,21 +338,12 @@ def test_parse_rpm_sqlite_missing_file(tmp_path):
 
 
 def test_parse_rpm_sqlite_multiple_packages(tmp_path):
-    """All rows in the Packages table are returned."""
+    """Every header row in the database is returned."""
     db = tmp_path / "rpmdb.sqlite"
-    _make_rpm_sqlite(
-        db,
-        [
-            ("bash", "5.1.8", "6.el9", 0, "x86_64"),
-            ("coreutils", "8.32", "34.el9", 0, "x86_64"),
-            ("systemd", "250", "12.el9_1.3", 0, "x86_64"),
-        ],
-    )
+    _make_rpm_sqlite(db)
 
-    pkgs = _parse_rpm_sqlite(db)
-    assert len(pkgs) == 3
-    names = {p.name for p in pkgs}
-    assert names == {"bash", "coreutils", "systemd"}
+    names = {p.name for p in _parse_rpm_sqlite(db)}
+    assert {"bash", "openssl-libs"} <= names, sorted(names)
 
 
 def test_parse_rpm_packages_no_binary(monkeypatch, tmp_path):
@@ -364,22 +358,10 @@ def test_parse_rpm_packages_uses_sqlite_when_present(tmp_path):
     """parse_rpm_packages prefers SQLite DB over rpm binary."""
     rpm_dir = tmp_path / "var" / "lib" / "rpm"
     rpm_dir.mkdir(parents=True)
-    db = rpm_dir / "rpmdb.sqlite"
-    _make_rpm_sqlite(db, [("bash", "5.1.8", "6.el9", 0, "x86_64")])
+    _make_rpm_sqlite(rpm_dir / "rpmdb.sqlite")
 
     pkgs = parse_rpm_packages(tmp_path)
-    assert len(pkgs) == 1
-    assert pkgs[0].name == "bash"
-
-
-def test_parse_rpm_sqlite_arch_in_purl(tmp_path):
-    """Architecture is included as a query parameter in the PURL."""
-    db = tmp_path / "rpmdb.sqlite"
-    _make_rpm_sqlite(db, [("kernel", "5.14.0", "70.13.1.el9_0", 0, "x86_64")])
-
-    pkgs = _parse_rpm_sqlite(db)
-    assert len(pkgs) == 1
-    assert "arch=x86_64" in pkgs[0].purl
+    assert "bash" in {p.name for p in pkgs}
 
 
 # ─── discover_filesystem_mcps ─────────────────────────────────────────────────

--- a/tests/test_filesystem_rpm_reads_the_real_schema.py
+++ b/tests/test_filesystem_rpm_reads_the_real_schema.py
@@ -1,0 +1,149 @@
+"""`agent-bom fs` must read the rpmdb schema RHEL actually ships.
+
+`filesystem._parse_rpm_sqlite` queried::
+
+    SELECT name, version, release, epoch, arch FROM Packages
+
+Those columns do not exist. The real RHEL 9+ `rpmdb.sqlite` schema is
+`Packages(hnum INTEGER PRIMARY KEY, blob BLOB)`, where `blob` is a binary RPM
+header that has to be decoded. The query raised, the `except` swallowed it to
+`logger.debug`, and the function returned `[]`. `parse_rpm_packages` then fell
+through to the `rpm` binary — absent on any non-RPM scanner host — and also
+returned `[]`.
+
+Net effect: **every RHEL / UBI / Fedora / Amazon Linux filesystem and VM
+snapshot scanned clean, exit 0, with no warning.**
+
+This is a regression of the defect #4684 fixed in `oci_parser.py`: the same
+judgement implemented twice, and the two disagreed on the identical bytes —
+`oci_parser` decoded `bash 5.1.8-9.el9` from the same fixture that
+`filesystem` read as empty.
+
+Nine tests in `tests/test_filesystem.py` passed throughout, because they
+*fabricated* the schema they tested against:
+
+    CREATE TABLE Packages (name TEXT, version TEXT, release TEXT, epoch INTEGER, arch TEXT)
+
+So the tests certified an invented format. These use the real fixture the OCI
+path already ships, `tests/fixtures/rpmdb_sqlite_min.sqlite`, so a parser that
+cannot read a genuine rpmdb fails here.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+FIXTURE = Path(__file__).parent / "fixtures" / "rpmdb_sqlite_min.sqlite"
+
+
+@pytest.fixture
+def rhel_root(tmp_path: Path) -> Path:
+    """A minimal RHEL 9 rootfs shaped the way a real snapshot is."""
+    root = tmp_path / "rhel9root"
+    (root / "etc").mkdir(parents=True)
+    (root / "etc" / "os-release").write_text('NAME="Red Hat Enterprise Linux"\nID="rhel"\nVERSION_ID="9.3"\n')
+    rpm_dir = root / "var" / "lib" / "rpm"
+    rpm_dir.mkdir(parents=True)
+    shutil.copy(FIXTURE, rpm_dir / "rpmdb.sqlite")
+    return root
+
+
+def test_the_real_rpmdb_schema_yields_packages() -> None:
+    """The defect, at its source."""
+    from agent_bom.filesystem import _parse_rpm_sqlite
+
+    packages = _parse_rpm_sqlite(FIXTURE)
+    assert packages, "no packages read from a genuine rpmdb.sqlite — the false-clean defect"
+    names = {p.name for p in packages}
+    assert "bash" in names, sorted(names)
+    assert "openssl-libs" in names, sorted(names)
+
+
+def test_it_agrees_with_the_oci_parser_on_the_same_bytes() -> None:
+    """Two implementations of one judgement must not disagree.
+
+    `oci_parser` already decoded this fixture correctly; the whole defect was
+    that the filesystem path did not.
+    """
+    import sqlite3
+
+    from agent_bom.filesystem import _parse_rpm_sqlite
+    from agent_bom.oci_parser import _parse_rpm_header_blob
+
+    conn = sqlite3.connect(f"file:{FIXTURE}?mode=ro", uri=True)
+    try:
+        blobs = [row[0] for row in conn.execute("SELECT blob FROM Packages")]
+    finally:
+        conn.close()
+
+    expected = {r for r in (_parse_rpm_header_blob(b) for b in blobs if isinstance(b, bytes)) if r}
+    expected = {(name, ver) for name, ver in expected if name != "gpg-pubkey"}
+    actual = {(p.name, p.version) for p in _parse_rpm_sqlite(FIXTURE)}
+    assert actual == expected, f"filesystem and oci_parser disagree: {actual ^ expected}"
+
+
+def test_versions_are_real_rpm_versions() -> None:
+    from agent_bom.filesystem import _parse_rpm_sqlite
+
+    by_name = {p.name: p.version for p in _parse_rpm_sqlite(FIXTURE)}
+    assert by_name.get("bash") == "5.1.8-9.el9", by_name
+    assert by_name.get("openssl-libs") == "3.0.7-27.el9", by_name
+
+
+def test_every_package_is_tagged_rpm() -> None:
+    from agent_bom.filesystem import _parse_rpm_sqlite
+
+    assert {p.ecosystem for p in _parse_rpm_sqlite(FIXTURE)} == {"rpm"}
+
+
+def test_the_signing_key_pseudo_package_is_excluded() -> None:
+    """`gpg-pubkey` is a key in the rpmdb, not software; the OCI path drops it."""
+    from agent_bom.filesystem import _parse_rpm_sqlite
+
+    assert "gpg-pubkey" not in {p.name for p in _parse_rpm_sqlite(FIXTURE)}
+
+
+def test_a_missing_database_is_still_empty_not_an_error(tmp_path: Path) -> None:
+    from agent_bom.filesystem import _parse_rpm_sqlite
+
+    assert _parse_rpm_sqlite(tmp_path / "absent.sqlite") == []
+
+
+def test_a_corrupt_database_does_not_raise(tmp_path: Path) -> None:
+    from agent_bom.filesystem import _parse_rpm_sqlite
+
+    junk = tmp_path / "rpmdb.sqlite"
+    junk.write_bytes(b"this is not a sqlite database")
+    assert _parse_rpm_sqlite(junk) == []
+
+
+def test_scanning_a_rhel_rootfs_finds_its_packages(rhel_root: Path) -> None:
+    """End to end: the path a `agent-bom fs` run actually takes."""
+    from agent_bom.filesystem import parse_rpm_packages
+
+    packages = parse_rpm_packages(rhel_root)
+    assert packages, "a RHEL rootfs scanned clean — this is the false clean"
+    assert "openssl-libs" in {p.name for p in packages}
+
+
+def test_an_rpm_distro_is_covered_by_the_release_gap_detector() -> None:
+    """The safety net that could never fire.
+
+    `coverage._release_key` handled only `deb` and `apk`, returning None for
+    `rpm`, so `detect_release_coverage_gaps` could not report a missing RPM
+    feed even when one was missing. A silent parser failure had no backstop.
+    """
+    from agent_bom.coverage import _release_key
+    from agent_bom.models import Package
+
+    pkg = Package(name="openssl-libs", version="3.0.7-27.el9", ecosystem="rpm")
+    pkg.distro_name = "rhel"
+    pkg.distro_version = "9.3"
+    key = _release_key(pkg)
+    assert key is not None, "an RPM distro yields no release key, so a missing feed cannot be reported"
+    family, db_key = key
+    # The advisory DB stores these as `red hat:enterprise_linux:9` (35,458 rows).
+    assert db_key == "red hat:enterprise_linux:9", key


### PR DESCRIPTION
**`agent-bom fs` returned a silent, exit-0 clean bill of health for every RHEL /
UBI / Fedora / Amazon Linux filesystem and VM snapshot.**

`filesystem._parse_rpm_sqlite` queried:

```sql
SELECT name, version, release, epoch, arch FROM Packages
```

Those columns exist in no rpmdb. RHEL 9+ ships
`Packages(hnum INTEGER PRIMARY KEY, blob BLOB)` — one **binary RPM header** per
row. The query raised, the `except` swallowed it to `logger.debug`, and the
function returned `[]`. `parse_rpm_packages` then fell through to the `rpm`
binary — absent on any non-RPM scanner host — and returned `[]` too. No warning,
no coverage gap, exit 0.

## A regression of a defect we already fixed

#4684 fixed exactly this in `oci_parser.py`. The judgement was implemented
twice, and the two disagreed on the identical bytes — `oci_parser` decoded
`bash 5.1.8-9.el9` from the same fixture `filesystem` read as empty.

So this does **not** add a third decoder. `_parse_rpm_sqlite` now calls
`oci_parser._parse_rpm_header_blob`, and a test asserts the two paths agree on
the same database. One decoder cannot disagree with itself.

## Three independent layers all agreed on the wrong answer

| layer | why it didn't catch it |
|---|---|
| the parser | returned `[]` on a schema mismatch, logged at `debug` |
| the tests | **fabricated the schema they validated against** — `CREATE TABLE Packages (name TEXT, version TEXT, release TEXT, epoch INTEGER, arch TEXT)`. Nine tests certified an invented format and stayed green throughout. |
| the safety net | `coverage._release_key` handled only `deb`/`apk`, returning `None` for `rpm`, so `detect_release_coverage_gaps` could **never** fire for an RPM distro |

All three are addressed. The tests now use `tests/fixtures/rpmdb_sqlite_min.sqlite`
— the real database the OCI path already scans, so both code paths are tested
against the same real bytes. `_release_key` keys rhel / almalinux / rocky on
their major release, matching how the advisory rows are actually stored
(`red hat:enterprise_linux:9`, 35,458 rows); families the DB does not carry
still return `None` rather than inventing a key that would report a real feed as
missing.

## Verified end to end

A RHEL 9.3 rootfs (`ID=rhel`, real rpmdb at `var/lib/rpm/rpmdb.sqlite`):

```
before:  0 package(s) · 0 vulnerabilities · no warnings · exit 0
after :  2 packages   · 15 findings · 2 critical · 7 high · 6 medium

openssl-libs 3.0.7-27.el9    bash 5.1.8-9.el9
RHSA-2026:1473, RHSA-2022:6224, RHSA-2023:0946, …
```

- `tests/test_filesystem_rpm_reads_the_real_schema.py` — 9 tests, **6 red before
  the change**, including the cross-implementation agreement check and the
  coverage-gap backstop.
- **353 passed** across the filesystem / coverage / OCI / image-scan suites.
- `ruff`, `ruff format --check`, `mypy` clean.

Found by the 7-lane pre-publish audit. This was its worst finding.