### PR TITLE
fix(ui): an asset-type page must ask for its own asset type

### DIFF
--- a/ui/app/inventory/[kind]/InventoryKindClient.tsx
+++ b/ui/app/inventory/[kind]/InventoryKindClient.tsx
@@ -3,6 +3,7 @@
 import { useParams } from "next/navigation";
 
 import { AssetInventoryView } from "@/components/inventory/asset-inventory-view";
+import { InventoryProvider } from "@/lib/inventory-context";
 import { PageEmptyState } from "@/components/states/page-state";
 import { ASSET_KIND_BY_ID, type AssetKindId } from "@/lib/inventory";
 
@@ -20,5 +21,12 @@ export default function InventoryKindClient() {
     );
   }
 
-  return <AssetInventoryView kind={raw as AssetKindId} />;
+  const kind = raw as AssetKindId;
+  // Scoped to this kind's entity types so the rows are of the type the page is
+  // about, rather than whatever survived a ranked cut of the whole estate.
+  return (
+    <InventoryProvider entityTypes={ASSET_KIND_BY_ID[kind].entityTypes}>
+      <AssetInventoryView kind={kind} />
+    </InventoryProvider>
+  );
 }

--- a/ui/app/inventory/layout.tsx
+++ b/ui/app/inventory/layout.tsx
@@ -1,9 +1,14 @@
 import type { ReactNode } from "react";
 
-import { InventoryProvider } from "@/lib/inventory-context";
-
-// One graph read for the whole Inventory section — shared with every asset-type
-// page so navigating between them is instant and never refetches.
+// The Inventory section no longer shares one graph read across every page.
+//
+// The index takes its card counts from `stats.node_types` over the whole
+// snapshot, but each asset-type page needs ROWS of its own type — and a ranked
+// page of the estate is not that. Agents, MCP servers and container images all
+// rank below a misconfiguration-dominated cut, so those pages rendered "nothing
+// discovered yet" while their own card advertised hundreds.
+//
+// Each route now provides its own `InventoryProvider` with the right scope.
 export default function InventoryLayout({ children }: { children: ReactNode }) {
-  return <InventoryProvider>{children}</InventoryProvider>;
+  return <>{children}</>;
 }

--- a/ui/app/inventory/page.tsx
+++ b/ui/app/inventory/page.tsx
@@ -1,8 +1,13 @@
 import { InventoryIndex } from "@/components/inventory/inventory-index";
+import { InventoryProvider } from "@/lib/inventory-context";
 
 // Unified Asset Inventory landing — one card per asset type, correlated back to
-// findings and the security graph. Supersedes the former /inventory → /manifest
-// redirect (the AI BOM now lives under this section as "AI agents").
+// findings and the security graph. Unscoped on purpose: the index needs every
+// kind at once, and its counts come from `stats.node_types` rather than rows.
 export default function InventoryPage() {
-  return <InventoryIndex />;
+  return (
+    <InventoryProvider>
+      <InventoryIndex />
+    </InventoryProvider>
+  );
 }

--- a/ui/lib/inventory-context.tsx
+++ b/ui/lib/inventory-context.tsx
@@ -55,7 +55,22 @@ function classifyError(err: unknown): { message: string; kind: InventoryErrorKin
   };
 }
 
-export function InventoryProvider({ children }: { children: ReactNode }) {
+export function InventoryProvider({
+  children,
+  entityTypes,
+}: {
+  children: ReactNode;
+  /** Scope the read to one asset kind's graph entity types.
+   *
+   * Omitted on the index page, which needs every kind at once and takes its
+   * card counts from `stats.node_types` rather than from the rows.
+   *
+   * Supplied on an asset-type page, because a ranked page of the estate is not
+   * a page of THAT type: agents, MCP servers and container images all rank
+   * below a misconfiguration-dominated cut, so those pages rendered "nothing
+   * discovered yet" while their own card advertised hundreds. */
+  entityTypes?: readonly string[] | undefined;
+}) {
   const [graph, setGraph] = useState<UnifiedGraphResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -64,6 +79,9 @@ export function InventoryProvider({ children }: { children: ReactNode }) {
   const [nonce, setNonce] = useState(0);
 
   const reload = useCallback(() => setNonce((value) => value + 1), []);
+  // Stable dependency: the array identity changes on every render, the
+  // membership does not.
+  const entityTypesKey = (entityTypes ?? []).join(",");
 
   useEffect(() => {
     let cancelled = false;
@@ -72,7 +90,11 @@ export function InventoryProvider({ children }: { children: ReactNode }) {
     setError("");
     setGraph(null);
     api
-      .getGraph({ limit: GRAPH_NODE_PAGE, offset: 0 })
+      .getGraph({
+        limit: GRAPH_NODE_PAGE,
+        offset: 0,
+        ...(entityTypes && entityTypes.length > 0 ? { entityTypes: [...entityTypes] } : {}),
+      })
       .then((page) => {
         if (cancelled) return;
         setGraph(page);
@@ -90,7 +112,7 @@ export function InventoryProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, [nonce]);
+  }, [nonce, entityTypesKey]);
 
   const hasMore = Boolean(graph?.pagination?.has_more);
   const model = useMemo(() => (graph ? buildInventory(graph) : null), [graph]);
@@ -100,11 +122,16 @@ export function InventoryProvider({ children }: { children: ReactNode }) {
     setLoadingMore(true);
     try {
       const nextCursor = graph.pagination.next_cursor?.trim();
+      // The scope has to travel with the page. Without it the second page
+      // widens back to a ranked read of the whole estate, so a kind page would
+      // start correct and then fill with other people's rows.
+      const scope = entityTypes && entityTypes.length > 0 ? { entityTypes: [...entityTypes] } : {};
       const nextPage = nextCursor
-        ? await api.getGraph({ limit: GRAPH_NODE_PAGE, cursor: nextCursor })
+        ? await api.getGraph({ limit: GRAPH_NODE_PAGE, cursor: nextCursor, ...scope })
         : await api.getGraph({
             limit: GRAPH_NODE_PAGE,
             offset: (graph.pagination.offset ?? 0) + (graph.pagination.limit ?? GRAPH_NODE_PAGE),
+            ...scope,
           });
       setGraph((current) => (current ? mergeGraphPages(current, nextPage) : nextPage));
     } catch (err: unknown) {
@@ -114,7 +141,7 @@ export function InventoryProvider({ children }: { children: ReactNode }) {
     } finally {
       setLoadingMore(false);
     }
-  }, [graph, loadingMore]);
+  }, [graph, loadingMore, entityTypesKey]);
 
   const value = useMemo<InventoryState>(
     () => ({

--- a/ui/tests/inventory-kind-fetches-its-own-type.test.tsx
+++ b/ui/tests/inventory-kind-fetches-its-own-type.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * An asset-type page must ask for its own asset type.
+ *
+ * `/inventory` advertises 93 AI agents, 211 MCP servers and 258 container
+ * images. Clicking any of those three cards landed on:
+ *
+ *     "No ai agents discovered yet — Run a scan or connect an account"
+ *
+ * with every request returning 200 on a healthy API and the estate fully
+ * populated. **562 advertised assets were unreachable**, and the empty state
+ * told the user to run a scan they had already run.
+ *
+ * The mechanism is the same split this release has been closing everywhere: the
+ * card COUNT comes from `stats.node_types`, computed over the whole snapshot,
+ * while the ROWS come from `api.getGraph({ limit, offset: 0 })` — a *ranked*
+ * page of 1,073 nodes out of 6,802, dominated by misconfigurations. Agents,
+ * servers and containers rank below the cut, so the page had genuinely zero of
+ * them to show.
+ *
+ * `/v1/graph` has accepted an `entity_types` filter the whole time, and
+ * `api.getGraph` has accepted `entityTypes` the whole time. Neither was wired
+ * up. So the fix is not a new capability — it is asking the question the page
+ * actually means: *give me this kind*, not *give me the top of the estate and
+ * hope my kind is in it*.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "@/lib/api";
+import { InventoryProvider } from "@/lib/inventory-context";
+import { ASSET_KIND_BY_ID } from "@/lib/inventory";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, api: { ...actual.api, getGraph: vi.fn() } };
+});
+
+/** A ranked page shaped like the real one: misconfigurations only. */
+function rankedPageWithoutAgents() {
+  const nodes = Array.from({ length: 40 }, (_unused, index) => ({
+    id: `misconfig:${index}`,
+    entity_type: "misconfiguration",
+    label: `CIS finding ${index}`,
+    severity: "high",
+    attributes: {},
+    compliance_tags: [],
+    data_sources: ["scan"],
+  }));
+  return {
+    scan_id: "s1",
+    tenant_id: "default",
+    created_at: "2026-08-10T00:00:00Z",
+    nodes,
+    edges: [],
+    attack_paths: [],
+    interaction_risks: [],
+    // The counts the cards render — the estate genuinely holds 93 agents.
+    stats: { total_nodes: 6802, total_edges: 22993, node_types: { misconfiguration: 1581, agent: 93 } },
+    pagination: { total: 6802, offset: 0, limit: 40, has_more: true },
+  };
+}
+
+/** The same estate, asked the right question: only agent nodes. */
+function agentOnlyPage() {
+  const nodes = Array.from({ length: 5 }, (_unused, index) => ({
+    id: `agent:${index}`,
+    entity_type: "agent",
+    label: `agent-${index}`,
+    severity: "none",
+    attributes: {},
+    compliance_tags: [],
+    data_sources: ["scan"],
+  }));
+  return { ...rankedPageWithoutAgents(), nodes, pagination: { total: 93, offset: 0, limit: 40, has_more: true } };
+}
+
+beforeEach(() => {
+  vi.mocked(api.getGraph).mockReset();
+});
+
+describe("an asset-type page asks for its own type", () => {
+  it("requests the kind's entity types rather than a global ranked page", async () => {
+    vi.mocked(api.getGraph).mockResolvedValue(agentOnlyPage() as never);
+
+    render(
+      <InventoryProvider entityTypes={ASSET_KIND_BY_ID.agents.entityTypes}>
+        <div />
+      </InventoryProvider>,
+    );
+
+    await waitFor(() => expect(api.getGraph).toHaveBeenCalled());
+    const call = vi.mocked(api.getGraph).mock.calls[0]?.[0];
+    expect(call?.entityTypes).toEqual(ASSET_KIND_BY_ID.agents.entityTypes);
+  });
+
+  it("still fetches unfiltered when no kind is scoped (the index page)", async () => {
+    vi.mocked(api.getGraph).mockResolvedValue(rankedPageWithoutAgents() as never);
+
+    render(
+      <InventoryProvider>
+        <div />
+      </InventoryProvider>,
+    );
+
+    await waitFor(() => expect(api.getGraph).toHaveBeenCalled());
+    expect(vi.mocked(api.getGraph).mock.calls[0]?.[0]?.entityTypes).toBeUndefined();
+  });
+
+  it("renders the kind's rows instead of an empty state", async () => {
+    vi.mocked(api.getGraph).mockResolvedValue(agentOnlyPage() as never);
+    const { AssetInventoryView } = await import("@/components/inventory/asset-inventory-view");
+
+    render(
+      <InventoryProvider entityTypes={ASSET_KIND_BY_ID.agents.entityTypes}>
+        <AssetInventoryView kind="agents" />
+      </InventoryProvider>,
+    );
+
+    await waitFor(() => expect(screen.queryByText(/discovered yet/i)).toBeNull());
+    expect(screen.getByText("agent-0")).toBeInTheDocument();
+  });
+
+  it("refetches when the scoped kind changes", async () => {
+    vi.mocked(api.getGraph).mockResolvedValue(agentOnlyPage() as never);
+
+    const { rerender } = render(
+      <InventoryProvider entityTypes={ASSET_KIND_BY_ID.agents.entityTypes}>
+        <div />
+      </InventoryProvider>,
+    );
+    await waitFor(() => expect(api.getGraph).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <InventoryProvider entityTypes={ASSET_KIND_BY_ID.containers.entityTypes}>
+        <div />
+      </InventoryProvider>,
+    );
+    await waitFor(() => expect(api.getGraph).toHaveBeenCalledTimes(2));
+    expect(vi.mocked(api.getGraph).mock.calls[1]?.[0]?.entityTypes).toEqual(
+      ASSET_KIND_BY_ID.containers.entityTypes,
+    );
+  });
+});


### PR DESCRIPTION
`/inventory` advertised **93 AI agents, 211 MCP servers and 258 container
images**. Clicking any of those three cards landed on:

> "No ai agents discovered yet — Run a scan or connect an account"

Every request returned 200, the estate was fully populated, and the empty state
told the user to run a scan they had **already run**. 562 advertised assets were
unreachable — and the card a demo visitor is most likely to click, **AI agents,
the product's core claim**, reported an empty estate.

## The same split this release keeps closing

The card **count** comes from `stats.node_types`, computed over the whole
snapshot. The **rows** came from `api.getGraph({ limit, offset: 0 })` — a
*ranked* page of 1,073 nodes out of 6,802, dominated by misconfigurations.
Agents, MCP servers and container images all rank below that cut, so those pages
genuinely had zero rows to show.

One number from the estate, another from a page of it.

## The capability was already there

`/v1/graph` has accepted `entity_types` all along, and `api.getGraph` has
accepted `entityTypes` all along. **Neither was wired up.** So this is not a new
capability — it is asking the question the page actually means: *give me this
kind*, rather than *give me the top of the estate and hope my kind is in it*.

`InventoryProvider` now takes an optional `entityTypes` scope:

- the **index** stays unscoped — it needs every kind at once, and its counts come
  from `stats.node_types` rather than from rows;
- each **asset-type route** supplies its own kind's entity types.

The scope travels with `loadMore` too. Without that, the second page widens back
to a ranked read, so a kind page would start correct and then fill with other
kinds' rows — a subtler version of the same bug.

## Verified against the live demo estate

Rendered at 1440px, **zero console errors**. Row counts now match the advertised
card counts *exactly*:

```
/inventory/agents      empty-state: false   rows: 93
/inventory/servers     empty-state: false   rows: 211
/inventory/containers  empty-state: false   rows: 258
```

- `ui/tests/inventory-kind-fetches-its-own-type.test.tsx` — 4 tests, **2 red
  before the change**: the scoped request, the unscoped index, rows rendering
  instead of an empty state, and a refetch when the kind changes.
- UI suite **1,075 passed** · `tsc` clean · bundle budget PASS on all three
  ceilings · e2e **35 passed**.

Found by the 7-lane pre-publish audit — it was the worst UI defect.