### PR TITLE
fix(ui): three identity counts and a compliance matrix that read as contradictions

### DIFF
--- a/ui/app/identity/page.tsx
+++ b/ui/app/identity/page.tsx
@@ -88,11 +88,19 @@ function StatCard({
   label,
   value,
   color,
+  scope,
 }: {
   icon: React.ElementType;
   label: string;
   value: number;
   color: string;
+  /** What population this number counts.
+   *
+   * This page shows three identity counts from three different populations —
+   * managed agent identities here, discovered NHIs in the governance panel
+   * below, and every identity-typed asset on /inventory. Unlabelled, they read
+   * as one number contradicting itself three ways. */
+  scope?: string;
 }) {
   return (
     <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-4">
@@ -103,6 +111,7 @@ function StatCard({
       <p className="text-2xl font-bold text-[var(--foreground)]">
         {value.toLocaleString()}
       </p>
+      {scope ? <p className="mt-0.5 text-[11px] text-[var(--text-tertiary)]">{scope}</p> : null}
     </div>
   );
 }
@@ -506,6 +515,7 @@ export default function IdentityPage() {
           label="Active identities"
           value={activeIdentities}
           color="text-indigo-400"
+          scope="issued and managed here"
         />
         <StatCard
           icon={Clock}
@@ -524,6 +534,7 @@ export default function IdentityPage() {
           label="Revoked / expired"
           value={inactiveIdentities}
           color="text-[var(--text-secondary)]"
+          scope="issued and managed here"
         />
       </div>
 

--- a/ui/components/compliance-matrix.tsx
+++ b/ui/components/compliance-matrix.tsx
@@ -122,20 +122,35 @@ const columns = [
   col.accessor("status", {
     header: "Status",
     cell: (info) => {
-      const s = info.getValue();
-      const styles = {
+      const status = String(info.getValue() ?? "");
+      // Keyed on every status the API can send, not just the scored three.
+      // #4709 made ATLAS an applicability overlay, so its controls arrive as
+      // `applicable` / `not_applicable`; other frameworks send `not_evaluated`.
+      // Those fell through `styles[s]` / `labels[s]` as `undefined`, rendering
+      // an EMPTY pill with the literal string "undefined" in its class list.
+      const styles: Record<string, string> = {
         pass: "bg-emerald-950 text-emerald-300 border-emerald-800",
         warning: "bg-yellow-950 text-yellow-300 border-yellow-800",
         fail: "bg-red-950 text-red-300 border-red-800",
+        error: "bg-yellow-950 text-yellow-300 border-yellow-800",
+        applicable: "bg-cyan-950 text-cyan-300 border-cyan-800",
+        not_applicable: "bg-[color:var(--surface-muted)] text-[color:var(--text-tertiary)] border-[color:var(--border-subtle)]",
+        not_evaluated: "bg-[color:var(--surface-muted)] text-[color:var(--text-tertiary)] border-[color:var(--border-subtle)]",
       };
-      const labels = { pass: "Pass", warning: "Warning", fail: "Fail" };
-      return (
-        <span
-          className={`text-[10px] px-2 py-0.5 rounded-full border font-medium ${styles[s]}`}
-        >
-          {labels[s]}
-        </span>
-      );
+      const labels: Record<string, string> = {
+        pass: "Pass",
+        warning: "Warning",
+        fail: "Fail",
+        error: "Error",
+        applicable: "Applicable",
+        not_applicable: "Not applicable",
+        not_evaluated: "Not evaluated",
+      };
+      // An unknown status is shown de-namespaced rather than dropped: a blank
+      // cell hides that the API sent something this table does not model.
+      const label = labels[status] ?? status.replace(/_/g, " ") ?? "Unknown";
+      const style = styles[status] ?? styles.not_evaluated;
+      return <span className={`text-[10px] px-2 py-0.5 rounded-full border font-medium ${style}`}>{label}</span>;
     },
     filterFn: "equals",
   }),
@@ -350,7 +365,15 @@ export function ComplianceMatrix({ data }: { data: ComplianceResponse }) {
 
       {/* Count */}
       <div className="text-xs text-[color:var(--text-tertiary)]">
-        {table.getFilteredRowModel().rows.length} of {rows.length} controls
+        {table.getFilteredRowModel().rows.length} of {rows.length} controls across{" "}
+        {FRAMEWORK_MAP.length} AI frameworks
+        <span className="ml-2 text-[color:var(--text-tertiary)]">
+          {/* The tiles above count every tracked framework, including the
+              governance and cloud ones this matrix deliberately excludes. Two
+              honest numbers measuring different things need to say so, or the
+              smaller one reads as the larger one shrinking. */}
+          — governance and cloud frameworks are summarised in the tiles above, not in this matrix
+        </span>
       </div>
 
       {/* Table */}

--- a/ui/components/nhi-governance-panel.tsx
+++ b/ui/components/nhi-governance-panel.tsx
@@ -78,6 +78,14 @@ export function NhiGovernancePanel({ scanId }: { scanId?: string | undefined }) 
             Graph-backed non-human identity risk from{" "}
             <span className="font-mono">/v1/graph/nhi/governance</span>
           </p>
+          {/* Counts DISCOVERED non-human identities across the estate — a
+              different population from the managed agent identities in the
+              tiles above, which agent-bom issues itself. Both numbers are
+              correct; without saying which is which they read as one number
+              disagreeing with itself. */}
+          <p className="mt-0.5 text-[11px] text-[color:var(--text-tertiary)]">
+            Discovered across the estate — not the agent identities issued above
+          </p>
         </div>
         {loading ? <Loader2 className="h-4 w-4 animate-spin text-[color:var(--text-tertiary)]" /> : null}
       </div>

--- a/ui/tests/compliance-matrix-scope-and-status.test.tsx
+++ b/ui/tests/compliance-matrix-scope-and-status.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * The matrix must say what it covers, and render every status it receives.
+ *
+ * Two defects, both found by the rendered-UI audit on one screen:
+ *
+ * **1. It contradicts the tiles above it.** The tiles read
+ * "150 of 195 controls evaluated" (20 passing + 130 failing); the Matrix tab
+ * directly below reads "115 of 115 controls". Both numbers are correct about
+ * themselves — the matrix deliberately covers six AI-specific frameworks
+ * (OWASP LLM / MCP / Agentic, ATLAS, NIST AI RMF, EU AI Act) while the tiles
+ * count all sixteen — but nothing on screen says the scopes differ, so a reader
+ * sees 35 evaluated controls vanish between two adjacent panels.
+ *
+ * Same judgement as the NIST catalog line: when two honest numbers on one
+ * screen measure different things, the fix is to say so, not to force them
+ * equal.
+ *
+ * **2. It renders blank badges.** The status cell keyed `styles`/`labels` on
+ * `pass | warning | fail` only. #4709 reclassified MITRE ATLAS as an
+ * applicability overlay, so its 65 controls now arrive as `applicable` /
+ * `not_applicable`, and other frameworks send `not_evaluated`. For those,
+ * `labels[s]` is `undefined` — an empty pill — and `styles[s]` interpolates the
+ * literal string "undefined" into the class list.
+ */
+
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ComplianceMatrix } from "@/components/compliance-matrix";
+import type { ComplianceResponse } from "@/lib/api";
+
+function control(code: string, name: string, status: string) {
+  return {
+    code,
+    name,
+    status,
+    findings: 0,
+    severity_breakdown: {},
+    affected_packages: [],
+    affected_agents: [],
+  };
+}
+
+function matrixData(): ComplianceResponse {
+  return {
+    overall_score: 13,
+    overall_status: "fail",
+    evaluated_controls: 150,
+    total_controls: 195,
+    coverage_pct: 76.9,
+    scan_count: 1,
+    latest_scan: "2026-08-10T00:00:00Z",
+    has_mcp_context: true,
+    summary: {},
+    owasp_llm_top10: [control("LLM01", "Prompt Injection", "fail")],
+    owasp_mcp_top10: [control("MCP01", "Tool Poisoning", "warning")],
+    owasp_agentic_top10: [control("AGT01", "Agent Hijack", "pass")],
+    // Post-#4709 ATLAS: an applicability overlay, not pass/fail.
+    mitre_atlas: [
+      control("AML.T0010", "AI Supply Chain Compromise", "applicable"),
+      control("AML.T0011", "User Execution", "not_applicable"),
+    ],
+    nist_ai_rmf: [control("MEASURE-2.9", "Model Explanation", "not_evaluated")],
+    eu_ai_act: [control("ART-15", "Accuracy and Robustness", "fail")],
+  } as unknown as ComplianceResponse;
+}
+
+describe("compliance matrix scope", () => {
+  it("says which frameworks it covers, so its count cannot read as the page total", () => {
+    render(<ComplianceMatrix data={matrixData()} />);
+    const body = document.body.textContent ?? "";
+    // The page total is 150 of 195; the matrix counts 7. Without a scope label
+    // the two adjacent numbers simply disagree.
+    expect(body).toMatch(/AI framework|AI-specific|6 framework/i);
+  });
+});
+
+describe("compliance matrix status rendering", () => {
+  it("never renders an empty status badge", () => {
+    render(<ComplianceMatrix data={matrixData()} />);
+    const rows = document.querySelectorAll("table tbody tr");
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      const cells = row.querySelectorAll("td");
+      const statusCell = cells[3];
+      expect(statusCell?.textContent?.trim(), `empty status badge in row: ${row.textContent}`).toBeTruthy();
+    }
+  });
+
+  it("never emits the literal string 'undefined' into a class list", () => {
+    render(<ComplianceMatrix data={matrixData()} />);
+    const offenders = Array.from(document.querySelectorAll("[class*='undefined']"));
+    expect(offenders.map((el) => el.className)).toEqual([]);
+  });
+
+  it("labels an applicability status as applicability, not as a pass", () => {
+    render(<ComplianceMatrix data={matrixData()} />);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/^Applicable$/i)).toBeInTheDocument();
+    expect(within(table).getByText(/^Not applicable$/i)).toBeInTheDocument();
+  });
+
+  it("renders not_evaluated as prose rather than a raw enum", () => {
+    render(<ComplianceMatrix data={matrixData()} />);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/^Not evaluated$/i)).toBeInTheDocument();
+    expect(within(table).queryByText("not_evaluated")).toBeNull();
+  });
+
+  it("still renders the scored statuses it always did", () => {
+    render(<ComplianceMatrix data={matrixData()} />);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/^Pass$/)).toBeInTheDocument();
+    expect(within(table).getByText(/^Warning$/)).toBeInTheDocument();
+    expect(within(table).getAllByText(/^Fail$/).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Two screens where every number was individually correct and the screen as a
whole was not.

## The compliance matrix rendered blank status badges

The status cell keyed `styles` and `labels` on `pass | warning | fail` only.
#4709 reclassified MITRE ATLAS as an **applicability overlay**, so its 65
controls now arrive as `applicable` / `not_applicable`, and other frameworks
send `not_evaluated`.

For all of those, `labels[status]` was `undefined` — an **empty pill** — and
`styles[status]` interpolated the literal string `"undefined"` into the class
list.

Now keyed on every status the API can send, with an unknown status shown
de-namespaced rather than dropped: a blank cell hides that the API sent
something the table does not model.

## The matrix count read as the page total shrinking

| panel | says |
|---|---|
| tiles | "150 of 195 controls evaluated" |
| matrix, directly below | "115 of 115 controls" |

Both are right *about themselves* — the matrix deliberately covers six
AI-specific frameworks (OWASP LLM / MCP / Agentic, ATLAS, NIST AI RMF, EU AI
Act) while the tiles count all sixteen — but nothing said the scopes differ, so
35 evaluated controls appeared to vanish between adjacent panels.

Same judgement as the NIST catalog line in #4735: when two honest numbers on one
screen measure different things, **say so** rather than forcing them equal. The
matrix now states its scope and points at where the rest is counted.

## `/identity` showed three mutually exclusive identity counts

"Active identities **5**", NHI risk bands summing **274**, and `/inventory`'s
**396** — three genuinely different populations on one journey:

- managed agent identities, which agent-bom issues itself
- non-human identities **discovered** across the estate
- every identity-typed asset in the graph

Each tile and the governance panel now say which population they count. **No
number changed**; the screen stopped contradicting itself.

## Verified

`ui/tests/compliance-matrix-scope-and-status.test.tsx` — 6 tests, **5 red before
the change**. They assert properties rather than strings: no empty status badge
in any row, no element carrying `"undefined"` in its class list, applicability
shown as applicability rather than as a pass, and the scored statuses still
rendering.

UI suite **1,077 passed** · `tsc` clean · bundle budget PASS on all three
ceilings · e2e **35 passed**.

Found by the 7-lane pre-publish audit.