### PR TITLE
fix(exec): the leadership grade must move when the estate improves

### DIFF
--- a/src/agent_bom/exec_score.py
+++ b/src/agent_bom/exec_score.py
@@ -41,6 +41,7 @@ normalized back into range.
 from __future__ import annotations
 
 import json
+import math
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -102,11 +103,19 @@ DEFAULT_DISPLAY_FORMAT = "percent"
 # override can neither invert the score (negative) nor overflow it.
 _MAX_WEIGHT = 100.0
 # Diminishing-returns scale for the pressure→score curve
-# ``score = 100 × scale / (scale + pressure)``. At ``scale = 70`` the historical
-# anchor holds exactly (2 critical + 1 high = 30 pressure → score 70 → grade C),
-# a clean estate scores 100, and the score decays toward — but never reaches — 0
-# so ever-larger estates keep earning distinct (still-failing) scores.
-_PENALTY_SCALE = 70.0
+# ``score = 100 × scale / (scale + scale × ln(1 + pressure/scale))``.
+#
+# Re-derived from the historical anchor when pressure became log-compressed.
+# The anchor is unchanged and still exact: 2 critical + 1 high = 30 pressure →
+# score 70.0 → grade C, the value ``scale = 70`` produced under the old linear
+# curve. Solving ``1 / (1 + ln(1 + 30/s)) = 0.70`` gives s ≈ 56.07, so 56 keeps
+# that calibration point where it has always been while the compression fixes
+# the far end.
+#
+# The low end is preserved too, not just the anchor: 3 criticals still grades D
+# and 5 still grades F, exactly as before. What changes is only the region the
+# old curve had collapsed — see the note on the curve in ``compute_exec_score``.
+_PENALTY_SCALE = 56.0
 
 
 @dataclass(frozen=True)
@@ -341,10 +350,30 @@ def compute_exec_score(
             }
         )
 
-    # Diminishing-returns curve: unbounded pressure maps to a (0, 100] score that
-    # never floors at 0, so a 20-critical and a 2000-critical estate stay
-    # distinguishable instead of both saturating to F/0. score(0) == 100.
-    count_score = max(0.0, round(100.0 * _PENALTY_SCALE / (_PENALTY_SCALE + pressure), 1))
+    # Diminishing-returns curve over LOG-COMPRESSED pressure.
+    #
+    # The curve alone was not enough. `100 * scale / (scale + pressure)` with a
+    # constant scale, against a pressure that grows linearly with estate size,
+    # collapses on any real estate: the measured demo estate (pressure ~15,292)
+    # scored 0.46% and displayed "0%", and eliminating HALF of everything moved
+    # it to 0.91% — still "0%". The scores were distinct in the arithmetic and
+    # identical to a reader, which is the only place the grade exists.
+    #
+    # Compressing pressure logarithmically first makes the grade respond to
+    # ORDERS OF MAGNITUDE of risk rather than to raw counts, which is the shape
+    # a leadership metric needs: halving an estate should be visible, and the
+    # difference between 20 and 2,000 criticals should survive rendering.
+    #
+    # Everything the model promised is preserved: score(0) == 100, the mapping
+    # is still strictly monotonic (log is strictly increasing, so more findings
+    # only ever lower the score), and the documented anchor (2 critical + 1
+    # high) still grades C. Adopters still steepen or soften by scaling the
+    # weights.
+    #
+    # This does NOT make a large failing estate score well — thousands of open
+    # criticals remain an F. They simply stop being an unreadable F.
+    compressed = _PENALTY_SCALE * math.log1p(pressure / _PENALTY_SCALE)
+    count_score = max(0.0, round(100.0 * _PENALTY_SCALE / (_PENALTY_SCALE + compressed), 1))
     # Effective points removed to reach the count score (score + penalty == 100).
     penalty = round(100.0 - count_score, 1)
 

--- a/tests/test_exec_score.py
+++ b/tests/test_exec_score.py
@@ -108,7 +108,15 @@ def test_large_estate_grades_f_without_flooring_at_zero() -> None:
     no room to distinguish a bad estate from a catastrophic one)."""
     result = compute_exec_score(severity=_sev(critical=50))
     assert result["grade"] == "F"
-    assert 0.0 < result["score"] < 15.0
+    assert 0.0 < result["score"] < 60.0
+    # Distinguishable from a catastrophic estate, which is the whole point of
+    # not flooring: the bound used to be `< 15.0`, a number calibrated to the
+    # old linear curve. Pressure is log-compressed now, so the same estate
+    # scores higher while staying an unambiguous F — and the ordering, which is
+    # what this test is actually about, still holds by a wide margin.
+    catastrophic = compute_exec_score(severity=_sev(critical=5000))
+    assert catastrophic["score"] < result["score"]
+    assert round(result["score"]) != round(catastrophic["score"])
     # score + penalty_total reconcile to a full 100 points.
     assert round(result["score"] + result["penalty_total"], 1) == 100.0
 

--- a/tests/test_exec_score_discriminates_at_estate_scale.py
+++ b/tests/test_exec_score_discriminates_at_estate_scale.py
@@ -1,0 +1,146 @@
+"""The exec grade must move when the estate improves.
+
+`exec_score.py` documents its diminishing-returns curve as existing
+
+    "so the grade discriminates across the full estate size instead of
+     saturating"
+
+and claims it "keeps assigning *distinct* failing scores to a 20-critical vs a
+2000-critical estate (both F, but distinguishable)".
+
+It saturates. `score = 100 x scale / (scale + pressure)` with a **constant**
+`scale = 70`, against a `pressure` that grows linearly with estate size:
+
+    demo estate pressure ~= 15,292  ->  0.46%  -> displays "0%"
+    the same estate halved          ->  0.91%  -> displays "0%"
+    a 90% reduction                 ->  4.38%  -> displays "4%"
+
+So the first number on the first screen of the leadership view is pinned at
+zero on any real estate, and eliminating **half** of everything moves it by
+under one point. The scores are distinct in the arithmetic and identical to a
+reader, which is the only place it matters. `scale = 70` is calibrated to the
+3-finding anchor in the docstring, not to an estate of thousands.
+
+The curve now compresses pressure logarithmically before the same
+diminishing-returns mapping, so the grade responds to *orders of magnitude* of
+risk rather than to raw counts. Three invariants the module guarantees are
+preserved deliberately, and asserted here:
+
+* a genuinely clean estate is still exactly 100 / grade A;
+* the score is still monotonic — more findings never raise it;
+* the documented anchor (2 critical + 1 high) still grades C.
+
+What this does **not** do is let a large failing estate score well. Thousands of
+open criticals remain an F; they simply stop being an *unreadable* F.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.exec_score import compute_exec_score
+
+
+def score_for(**severity: int) -> float:
+    return float(compute_exec_score(severity=severity)["score"])
+
+
+def demo_estate_score(divisor: int = 1) -> float:
+    """The measured demo estate, optionally reduced by ``divisor``."""
+    return score_for(
+        critical=440 // divisor,
+        high=1337 // divisor,
+        medium=628 // divisor,
+        low=257 // divisor,
+        unrated=69 // divisor,
+    )
+
+
+def test_a_clean_scanned_estate_is_still_a_perfect_hundred() -> None:
+    """Zero findings WITH evidence. Zero findings and no evidence is `N/A`
+    ("awaiting evidence"), which is a deliberate separate state — a grade must
+    not be invented for an estate nobody has looked at."""
+    result = compute_exec_score(
+        severity={"critical": 0, "high": 0, "medium": 0, "low": 0, "unrated": 0},
+        floor_score=100.0,
+    )
+    assert result["score"] == 100
+    assert result["grade"] == "A"
+
+
+def test_an_ungraded_estate_still_reports_no_evidence() -> None:
+    result = compute_exec_score(severity={"critical": 0, "high": 0})
+    assert result["grade"] == "N/A"
+
+
+def test_the_documented_anchor_still_grades_c() -> None:
+    """The docstring's own calibration point: 2 critical + 1 high."""
+    result = compute_exec_score(severity={"critical": 2, "high": 1})
+    assert result["grade"] == "C", result
+
+
+def test_the_score_is_still_monotonic() -> None:
+    """More findings may only ever lower the grade."""
+    # From 1: zero findings is the separate `N/A` state, not a score.
+    scores = [score_for(critical=n) for n in (1, 5, 50, 500, 5000)]
+    assert scores == sorted(scores, reverse=True), scores
+    assert len(set(scores)) == len(scores), f"two different estates scored identically: {scores}"
+
+
+def test_a_real_estate_does_not_display_as_zero() -> None:
+    """The defect: the leadership headline pinned at 0% on any real estate."""
+    score = demo_estate_score()
+    assert round(score) > 0, f"the demo estate still displays as {round(score)}%"
+
+
+def test_halving_the_estate_visibly_moves_the_grade() -> None:
+    """Eliminating half of everything used to move the dial from 0% to 1%."""
+    full = demo_estate_score()
+    halved = demo_estate_score(divisor=2)
+    assert halved > full
+    assert round(halved) - round(full) >= 1, f"halving the estate moved {full:.2f}% -> {halved:.2f}%"
+
+
+def test_a_large_reduction_is_clearly_visible() -> None:
+    full = demo_estate_score()
+    reduced = demo_estate_score(divisor=10)
+    assert reduced - full >= 5, f"a 90% reduction moved only {full:.2f}% -> {reduced:.2f}%"
+
+
+def test_a_large_failing_estate_is_still_failing() -> None:
+    """Legibility must not become leniency."""
+    result = compute_exec_score(severity={"critical": 440, "high": 1337, "medium": 628, "low": 257})
+    assert result["grade"] == "F", result
+    assert result["score"] < 60
+
+
+def test_two_failing_estates_of_different_size_are_distinguishable_to_a_reader() -> None:
+    """Distinct in the arithmetic was never the point — distinct on screen is."""
+    small = score_for(critical=20)
+    large = score_for(critical=2000)
+    assert round(small) != round(large), f"{small:.2f}% vs {large:.2f}% both render the same"
+
+
+def test_the_floor_still_wins_when_it_is_worse() -> None:
+    """A failing scan scorecard can never be laundered upward."""
+    result = compute_exec_score(severity={"critical": 0, "high": 0}, floor_score=12.0)
+    assert result["score"] <= 12.0, result
+
+
+@pytest.mark.parametrize("weight_scale", [0.5, 2.0])
+def test_adopters_can_still_steepen_or_soften_the_curve(weight_scale: float) -> None:
+    """The documented tuning path must survive the change."""
+    from agent_bom.exec_score import DEFAULT_EXEC_SCORE_WEIGHTS, ExecScoreConfig, load_exec_score_config
+
+    base = load_exec_score_config()
+    tuned = ExecScoreConfig(
+        weights={k: v * weight_scale for k, v in DEFAULT_EXEC_SCORE_WEIGHTS.items()},
+        grade_thresholds=base.grade_thresholds,
+        display_format=base.display_format,
+    )
+    heavier = compute_exec_score(severity={"critical": 50}, config=tuned)["score"]
+    default = compute_exec_score(severity={"critical": 50})["score"]
+    if weight_scale > 1:
+        assert heavier < default
+    else:
+        assert heavier > default


### PR DESCRIPTION
`exec_score.py` documents its diminishing-returns curve as existing

> "so the grade discriminates across the full estate size instead of saturating"

**It saturates.** `score = 100 × scale / (scale + pressure)` used a *constant*
`scale = 70` against a `pressure` that grows linearly with estate size:

| estate | score | displays |
|---|---|---|
| demo estate (pressure ~15,292) | 0.46% | **0%** |
| the same estate **halved** | 0.91% | **0%** |
| a 90% reduction | 4.38% | 4% |

So the first number on the first screen of the leadership view was pinned at
zero on any real estate, and eliminating **half of everything** moved it by
under one point. The scores were distinct in the arithmetic and identical to a
reader — which is the only place a grade exists. `scale = 70` was calibrated to
the 3-finding anchor in the docstring, not to an estate of thousands.

## The change

Pressure is log-compressed before the same curve, so the grade responds to
**orders of magnitude** of risk rather than to raw counts:

```
score = 100 × scale / (scale + scale × ln(1 + pressure/scale))
```

`scale` is **re-derived rather than kept**: solving `1 / (1 + ln(1 + 30/s)) = 0.70`
gives `s ≈ 56.07`, so **56** puts the documented anchor (2 critical + 1 high)
back on *exactly* 70.0 / grade C — the value the old linear curve produced.

The low end is preserved too, not just the anchor: **3 criticals still grades D,
5 still grades F.** Only the region the old curve had collapsed changes.

```
demo estate today : 15.1%  F
after halving it  : 16.9%  F
after a 90% cut   : 23.1%  F
```

## What this deliberately does NOT do

It does not let a large failing estate score well. Thousands of open criticals
remain an unambiguous **F** — they simply stop being an *unreadable* F.
Legibility is not leniency.

## Two existing tests encoded the old curve

- `test_score_derives_from_honest_counts` **passes unchanged**, because the
  anchor was re-derived specifically to preserve it: score 70.0, penalty 30.0,
  contributions 24 + 6.
- `test_large_estate_grades_f_without_flooring_at_zero` asserted `score < 15.0`
  — a bound calibrated to the old curve rather than to the property its own
  docstring describes. It now asserts what it is actually about: still F, still
  non-zero, and still distinguishable from a catastrophic estate.

## Verified

`tests/test_exec_score_discriminates_at_estate_scale.py` — **12 tests, 2 red
before the change**, pinning all three invariants the module guarantees (clean
estate 100/A, strict monotonicity, the documented anchor) alongside the new
legibility properties.

**410 passed** across the exec-score, overview and posture suites · `ruff`,
`ruff format --check`, `mypy` clean.

Found by the 7-lane pre-publish audit — it rated exec value 4/10 largely on this.

**Reviewer note:** this changes a leadership-facing number. Grades for small
estates are unchanged by construction; large estates move from an unreadable
~0% to a legible failing score. Worth a conscious sign-off on the curve rather
than a rubber stamp.