### PR TITLE
fix(graph): composite_risk must mean one thing

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-09",
+  "generated_on": "2026-08-10",
   "version": "0.99.0",
   "metrics": [
     {
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 838,
+      "value": 839,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-09`
+- Generated on: `2026-08-10`
 - Version: `0.99.0`
 
 | Metric | Value | Source | Notes |
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 838 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 839 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1031,10 +1031,18 @@ def _node_type_value(node: UnifiedNode) -> str:
 
 
 def _node_risk_100(node: UnifiedNode) -> float:
-    risk = float(getattr(node, "risk_score", 0.0) or 0.0)
-    if risk <= 10.0:
-        risk *= 10.0
+    """A node's risk on the canonical 0-100 scale.
+
+    The normalisation itself lives in `graph.risk_scale` so this and
+    `estate_graph._chain_risk` cannot drift apart again — they did, and the
+    exposure-path queue ended up sorting two unit systems as one.
+    """
+    from agent_bom.graph.risk_scale import normalize_risk_to_100
+
+    risk = normalize_risk_to_100(getattr(node, "risk_score", 0.0))
     if risk <= 0:
+        # Unrated inventory nodes fall back to severity rank, which is already
+        # expressed on the 0-100 scale (rank 5 -> 100).
         risk = float(SEVERITY_RANK.get(str(getattr(node, "severity", "") or "").lower(), 0) * 20)
     return max(0.0, min(100.0, risk))
 

--- a/src/agent_bom/demo_estate/estate_graph.py
+++ b/src/agent_bom/demo_estate/estate_graph.py
@@ -593,13 +593,18 @@ def _chain_risk(graph: UnifiedGraph, hops: Sequence[str], risk_by_asset: dict[st
     ``node.risk_score`` alone always returned 0.0 and sorted the estate's own
     incident below every hand-built path in the exposure-path queue.
     """
+    from agent_bom.graph.risk_scale import cvss_to_risk_100
+
     worst = 0.0
     for hop in hops:
         worst = max(worst, risk_by_asset.get(hop, 0.0))
         node = graph.nodes.get(hop)
         if node is not None:
             worst = max(worst, float(node.risk_score or 0.0))
-    return worst
+    # `composite_risk` is a 0-100 field. Returning a raw CVSS here put the
+    # correlated estate on a different scale from the showcase paths it is
+    # ranked against, so it sorted 74th behind every hand-built path.
+    return cvss_to_risk_100(worst)
 
 
 __all__ = [

--- a/src/agent_bom/graph/risk_scale.py
+++ b/src/agent_bom/graph/risk_scale.py
@@ -1,0 +1,81 @@
+"""One definition of what ``composite_risk`` means.
+
+``AttackPath.composite_risk`` had two producers on two different scales:
+``routes/graph._node_risk_100`` normalised to 0–100, while
+``demo_estate/estate_graph._chain_risk`` returned a raw CVSS 0–10. Both wrote
+the same field, and ``_derived_attack_paths`` sorted the merged list by it — so
+the exposure-path ranking interleaved two unit systems.
+
+The effect was not subtle. On the demo estate every hand-built showcase path
+outranked every correlated-estate path *by construction rather than by risk*:
+
+    risk buckets: {'0-10': 2116, '10-50': 1, '50-100': 27}
+    best estate-correlated path : 8.0
+    worst showcase-derived path : 48.0
+    rank of the first estate-correlated path: 74
+
+The correlated estate is the product's central claim, and it could not reach the
+top of its own queue.
+
+``graph/webhooks.py`` inherited the same ambiguity and banded the field on 0–10
+thresholds, so a shipped alert read "Composite risk 100.0/10" and treated 9 out
+of 100 as critical.
+
+So the normalisation lives here, once, and every producer calls it. A second
+copy is how the two scales diverged in the first place.
+"""
+
+from __future__ import annotations
+
+# The canonical range for `composite_risk` and every node/path risk derived
+# from it. 0–100 rather than 0–10 because the graph blends CVSS with
+# severity-rank and exposure signals that have no CVSS equivalent.
+RISK_SCALE_MAX = 100.0
+
+# Values at or below this are read as CVSS-style (0–10) and lifted. A genuine
+# 0–100 score of 8 and a CVSS of 8.0 are indistinguishable in a bare float, so
+# the boundary is a deliberate, documented convention rather than a guess: the
+# producers that emit CVSS never exceed 10, and the ones that emit 0–100 are
+# dominated by values well above it.
+_CVSS_SCALE_MAX = 10.0
+
+
+def cvss_to_risk_100(value: float | int | None) -> float:
+    """Convert a KNOWN CVSS (0–10) score onto the canonical scale.
+
+    Prefer this wherever the caller knows its input is CVSS. It is a plain,
+    monotonic 10x with a clamp — no guessing — so it has none of the boundary
+    ambiguity that :func:`normalize_risk_to_100` cannot avoid.
+    """
+    try:
+        risk = float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(RISK_SCALE_MAX, risk * 10.0))
+
+
+def normalize_risk_to_100(value: float | int | None) -> float:
+    """Return ``value`` on the canonical 0–100 scale, inferring its input scale.
+
+    For callers reading ``risk_score`` off arbitrary nodes, where producers have
+    historically written both CVSS and 0–100 values into one field.
+
+    **This is deliberately not monotonic, and cannot be.** A bare float carries
+    no unit, so 9.9 is read as CVSS and lifted to 99.0 while 11.0 is read as
+    already-scaled and left at 11.0 — a value that is numerically larger maps
+    lower. That discontinuity at the boundary is inherent to inferring a unit
+    that was never recorded; it is documented here rather than hidden, and it is
+    why :func:`cvss_to_risk_100` exists for callers that do know.
+    """
+    try:
+        risk = float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+    if risk <= 0.0:
+        return 0.0
+    if risk <= _CVSS_SCALE_MAX:
+        risk *= 10.0
+    return max(0.0, min(RISK_SCALE_MAX, risk))
+
+
+__all__ = ["RISK_SCALE_MAX", "cvss_to_risk_100", "normalize_risk_to_100"]

--- a/src/agent_bom/graph/webhooks.py
+++ b/src/agent_bom/graph/webhooks.py
@@ -19,6 +19,7 @@ from typing import Any, Protocol
 
 from agent_bom.event_normalization import build_event_ref, build_event_relationships
 from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.risk_scale import RISK_SCALE_MAX
 from agent_bom.graph.severity import SEVERITY_RANK
 from agent_bom.graph.types import EntityType
 from agent_bom.posture_streaming import PostureEvent, WebhookDestination, WebhookOutbox, default_webhook_outbox
@@ -92,6 +93,16 @@ def _dispatch_outbound_alert(dispatcher: Any, alert: dict[str, Any], outbound_ch
 
     dispatcher.dispatch_sync(alert)
     return 0, outbound_channels
+
+
+# `composite_risk` is a 0-100 field (see `graph.risk_scale`). These thresholds
+# were 7.0 and 9.0 — values on the 0-10 scale — so a shipped alert read
+# "Composite risk 100.0/10", anything scoring 9 out of 100 was labelled
+# critical, and on the demo snapshot 1,065 of 2,144 paths cleared the emit
+# threshold. Restated on the scale the field actually uses, preserving the
+# original intent: alert on the top ~30%, escalate the top ~10%.
+_NEW_PATH_ALERT_RISK = 70.0
+_NEW_PATH_CRITICAL_RISK = 90.0
 
 
 def compute_delta_alerts(
@@ -177,7 +188,7 @@ def compute_delta_alerts(
     if old_graph:
         old_path_keys = {(p.source, p.target) for p in old_graph.attack_paths}
     for path in new_graph.attack_paths:
-        if (path.source, path.target) not in old_path_keys and path.composite_risk >= 7.0:
+        if (path.source, path.target) not in old_path_keys and path.composite_risk >= _NEW_PATH_ALERT_RISK:
             details = {
                 "node_ids": path.hops,
                 "scan_id": new_graph.scan_id,
@@ -191,10 +202,10 @@ def compute_delta_alerts(
                 {
                     "type": "new_attack_path",
                     "detector": "graph_new_attack_path",
-                    "severity": "critical" if path.composite_risk >= 9.0 else "high",
+                    "severity": "critical" if path.composite_risk >= _NEW_PATH_CRITICAL_RISK else "high",
                     "message": f"New high-risk attack path: {path.summary or f'{path.source} → {path.target}'}",
                     "title": f"New high-risk attack path: {path.summary or f'{path.source} → {path.target}'}",
-                    "description": f"Composite risk {path.composite_risk}/10, {len(path.hops)} hops",
+                    "description": f"Composite risk {path.composite_risk}/{RISK_SCALE_MAX:.0f}, {len(path.hops)} hops",
                     "node_ids": path.hops,
                     "scan_id": new_graph.scan_id,
                     "details": details,

--- a/tests/test_composite_risk_has_one_scale.py
+++ b/tests/test_composite_risk_has_one_scale.py
@@ -1,0 +1,139 @@
+"""``AttackPath.composite_risk`` must mean one thing.
+
+Two producers wrote that field on two different scales:
+
+* ``routes/graph._node_risk_100`` normalises to **0–100**
+* ``demo_estate/estate_graph._chain_risk`` returned a raw CVSS **0–10**
+
+and ``_derived_attack_paths`` sorts the merged list by it. So the ranking was
+not a ranking — it was two unit systems interleaved. Measured on the demo
+estate:
+
+    paths: 28 before estate projection -> 2,144 after
+    risk buckets: {'0-10': 2116, '10-50': 1, '50-100': 27}
+    best estate-correlated path : 8.0
+    worst showcase-derived path : 48.0
+    of the top 40 ranked paths, estate-correlated: 0
+    rank of the first estate-correlated path: 74
+
+Every hand-built showcase path outranked every correlated-estate path by
+construction rather than by risk — and the correlated estate is the product's
+whole claim. ``_chain_risk``'s own docstring says it exists to stop the estate
+"sorting below every hand-built path": it fixed the 0.0 case and not the scale,
+so the symptom survived the fix.
+
+The second consequence ships to customers. ``graph/webhooks.py`` banded that
+same field on 0–10 thresholds and formatted it "/10", so a real scan emitted:
+
+    "Composite risk 100.0/10"
+
+and every path scoring ≥ 9 *out of 100* was labelled critical — on the demo
+snapshot, 1,065 of 2,144 paths cleared the emit threshold at all.
+
+The fix is one shared normaliser, so the scale cannot diverge again.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.graph.risk_scale import RISK_SCALE_MAX, cvss_to_risk_100, normalize_risk_to_100
+
+
+class TestTheSharedNormaliser:
+    def test_a_cvss_style_value_is_lifted_onto_the_hundred_scale(self) -> None:
+        assert normalize_risk_to_100(8.0) == 80.0
+        assert normalize_risk_to_100(10.0) == 100.0
+
+    def test_a_value_already_on_the_hundred_scale_is_left_alone(self) -> None:
+        assert normalize_risk_to_100(48.0) == 48.0
+        assert normalize_risk_to_100(100.0) == 100.0
+
+    def test_it_is_clamped_and_never_negative(self) -> None:
+        assert normalize_risk_to_100(-5.0) == 0.0
+        assert normalize_risk_to_100(9999.0) == RISK_SCALE_MAX
+
+    def test_the_explicit_cvss_conversion_is_monotonic(self) -> None:
+        """`cvss_to_risk_100` is a plain 10x, so it has no boundary wart."""
+        values = [cvss_to_risk_100(v) for v in (0.0, 1.0, 5.0, 9.9, 10.0)]
+        assert values == sorted(values), values
+        assert cvss_to_risk_100(8.0) == 80.0
+
+    def test_the_inferring_helper_is_documented_as_non_monotonic(self) -> None:
+        """A bare float carries no unit, so inference cannot be monotonic.
+
+        9.9 reads as CVSS and lifts to 99.0; 11.0 reads as already-scaled and
+        stays 11.0. Pinned so the discontinuity is a known property rather than
+        a surprise — and so anyone tempted to "fix" it sees why it exists.
+        """
+        assert normalize_risk_to_100(9.9) > normalize_risk_to_100(11.0)
+
+
+class TestTheEstateRanksOnTheSameScale:
+    """The defect: correlated paths could not reach the top of the queue."""
+
+    def test_a_chain_risk_is_reported_on_the_hundred_scale(self) -> None:
+        from agent_bom.demo_estate.estate_graph import _chain_risk
+        from agent_bom.graph.container import UnifiedGraph
+
+        graph = UnifiedGraph(scan_id="s", tenant_id="t")
+        # A CVSS 8.0 asset must not be outranked by a 48.0 showcase path.
+        risk = _chain_risk(graph, ["asset-a"], {"asset-a": 8.0})
+        assert risk == 80.0, risk
+
+    def test_a_correlated_path_can_outrank_a_showcase_path(self) -> None:
+        """8.0 CVSS is worse than a 48/100 path; the old scales said otherwise."""
+        from agent_bom.demo_estate.estate_graph import _chain_risk
+        from agent_bom.graph.container import UnifiedGraph
+
+        graph = UnifiedGraph(scan_id="s", tenant_id="t")
+        correlated = _chain_risk(graph, ["asset-a"], {"asset-a": 8.0})
+        showcase = normalize_risk_to_100(48.0)
+        assert correlated > showcase, (correlated, showcase)
+
+
+class TestTheWebhookSpeaksTheSameScale:
+    def _path(self, risk: float):
+        from agent_bom.graph.container import AttackPath
+
+        return AttackPath(
+            source="agent:a",
+            target="cred:b",
+            hops=["agent:a", "cred:b"],
+            edges=[],
+            composite_risk=risk,
+            summary="a → b",
+        )
+
+    def _alerts_for(self, risk: float):
+        from agent_bom.graph.container import UnifiedGraph
+        from agent_bom.graph.webhooks import compute_delta_alerts
+
+        new_graph = UnifiedGraph(scan_id="new", tenant_id="t")
+        new_graph.attack_paths.append(self._path(risk))
+        old_graph = UnifiedGraph(scan_id="old", tenant_id="t")
+        return [a for a in compute_delta_alerts(old_graph, new_graph) if a.get("type") == "new_attack_path"]
+
+    def test_the_description_does_not_say_a_hundred_out_of_ten(self) -> None:
+        alerts = self._alerts_for(100.0)
+        assert alerts, "a maximum-risk path emitted no alert"
+        assert "/10," not in alerts[0]["description"], alerts[0]["description"]
+        assert "100.0/100" in alerts[0]["description"] or "100/100" in alerts[0]["description"]
+
+    def test_a_mid_scale_path_is_not_labelled_critical(self) -> None:
+        """`>= 9.0` meant "9 out of 100" — nearly everything was critical."""
+        alerts = self._alerts_for(12.0)
+        assert all(a["severity"] != "critical" for a in alerts), alerts
+
+    def test_a_genuinely_critical_path_is_still_critical(self) -> None:
+        alerts = self._alerts_for(95.0)
+        assert alerts and alerts[0]["severity"] == "critical", alerts
+
+    def test_a_low_risk_path_does_not_alert_at_all(self) -> None:
+        """`>= 7.0` on a 0-100 field emitted on 1,065 of 2,144 demo paths."""
+        assert self._alerts_for(12.0) == [] or all(a["severity"] != "critical" for a in self._alerts_for(12.0))
+        assert self._alerts_for(5.0) == []
+
+    @pytest.mark.parametrize("risk,expected", [(69.0, False), (71.0, True)])
+    def test_the_emit_threshold_sits_at_seventy_of_a_hundred(self, risk: float, expected: bool) -> None:
+        assert bool(self._alerts_for(risk)) is expected

--- a/tests/test_graph_delta_digest.py
+++ b/tests/test_graph_delta_digest.py
@@ -51,7 +51,7 @@ def _old_graph() -> UnifiedGraph:
     g.add_node(_agent("agent:gone", "gone-agent", severity="high", risk=7.5))
     g.add_node(_vuln("vuln:old", "critical", "CVE-OLD"))
     g.add_node(_misconfig("mis:old", "high"))
-    g.attack_paths.append(AttackPath(source="agent:keep", target="vuln:old", hops=["agent:keep", "vuln:old"], composite_risk=8.0))
+    g.attack_paths.append(AttackPath(source="agent:keep", target="vuln:old", hops=["agent:keep", "vuln:old"], composite_risk=80.0))
     g.interaction_risks.append(
         InteractionRisk(pattern="loop", agents=["keep", "gone"], risk_score=8.0, description="d", owasp_agentic_tag="AA1")
     )
@@ -68,8 +68,8 @@ def _new_graph() -> UnifiedGraph:
     # carried-over old vuln (present in old -> no new-vuln alert)
     g.add_node(_vuln("vuln:old", "critical", "CVE-OLD"))
     # new high-risk attack path + interaction risk (exercise those branches)
-    g.attack_paths.append(AttackPath(source="agent:keep", target="vuln:new", hops=["agent:keep", "vuln:new"], composite_risk=9.5))
-    g.attack_paths.append(AttackPath(source="agent:keep", target="vuln:old", hops=["agent:keep", "vuln:old"], composite_risk=8.0))
+    g.attack_paths.append(AttackPath(source="agent:keep", target="vuln:new", hops=["agent:keep", "vuln:new"], composite_risk=95.0))
+    g.attack_paths.append(AttackPath(source="agent:keep", target="vuln:old", hops=["agent:keep", "vuln:old"], composite_risk=80.0))
     g.interaction_risks.append(
         InteractionRisk(pattern="new-loop", agents=["keep"], risk_score=9.1, description="d2", owasp_agentic_tag="AA2")
     )

--- a/tests/test_graph_wave23.py
+++ b/tests/test_graph_wave23.py
@@ -245,7 +245,9 @@ class TestDeltaAlerts:
                 source="package:demo",
                 target="agent:prod",
                 hops=["package:demo", "agent:prod"],
-                composite_risk=8.0,
+                # 0-100 scale (see `graph.risk_scale`): 80 is the 8.0-CVSS
+                # risk this fixture has always meant.
+                composite_risk=80.0,
                 summary="demo-pkg -> prod-agent",
             )
         )


### PR DESCRIPTION
Two producers wrote `AttackPath.composite_risk` on **two different scales**:

- `routes/graph._node_risk_100` normalised to **0–100**
- `demo_estate/estate_graph._chain_risk` returned a raw CVSS **0–10**

and `_derived_attack_paths` sorts the merged list by that field. So the
exposure-path queue was not a ranking — it was two unit systems interleaved.

```
risk buckets: {'0-10': 2116, '10-50': 1, '50-100': 27}
best estate-correlated path : 8.0
worst showcase-derived path : 48.0
estate-correlated paths in the top 40: 0
rank of the first estate-correlated path: 74
```

Every hand-built showcase path outranked every correlated-estate path **by
construction rather than by risk** — and the correlated estate is the product's
central claim. `_chain_risk`'s own docstring says it exists to stop the estate
*"sorting below every hand-built path"*; it fixed the 0.0 case and not the
scale, so the symptom outlived the fix.

## The second consequence ships to customers

`graph/webhooks.py` banded the same field on 0–10 thresholds and formatted it
`/10`, so a real scan emitted:

> **"Composite risk 100.0/10"**

Anything scoring 9 *out of 100* was labelled critical, and on the demo snapshot
**1,065 of 2,144 paths** cleared the emit threshold. This one fires on customer
scans, not just the demo.

## One definition, in one place

`graph/risk_scale.py` now owns the scale — a second copy is how the two diverged,
so both producers call it. It exposes two functions on purpose:

- **`cvss_to_risk_100`** — a plain, monotonic 10× for callers that *know* their
  input is CVSS. `_chain_risk` uses this.
- **`normalize_risk_to_100`** — infers the input scale for callers reading
  `risk_score` off arbitrary nodes, where producers have historically written
  both.

The inferring one is **documented as non-monotonic, because it cannot be**: a
bare float carries no unit, so 9.9 reads as CVSS and lifts to 99.0 while 11.0
reads as already-scaled and stays 11.0. My own test caught that discontinuity,
so it is pinned as a known property with the reason attached rather than
smoothed over — and `cvss_to_risk_100` exists so callers that know their unit
never touch the heuristic.

Webhook thresholds are restated on the field's real scale (70 / 90), preserving
the original intent: alert on the top ~30%, escalate the top ~10%.

## Verified on the demo estate

| | before | after |
|---|---|---|
| estate-correlated in top 40 | **0** | **35** |
| rank of first estate path | **74** | **1** |
| risk buckets | `{0-10: 2116, 50-100: 27}` | `{0-10: 252, 50-100: 1646}` |

Two existing tests set `composite_risk=8.0` and `9.5` — CVSS values in a 0–100
field, meaning "high" and "critical". On the corrected scale they are low, so
the alerts they assert correctly stopped firing. **Restated at the same risk on
the real scale (80.0 / 95.0) rather than by lowering the thresholds back.**

- `tests/test_composite_risk_has_one_scale.py` — **13 tests, red before**
- **1,529 passed** across graph / webhook / attack-path / demo-estate / exposure
- `ruff`, `ruff format --check`, `mypy` clean

Found by the 7-lane pre-publish audit — it rated this the biggest graph risk.