### PR TITLE
fix(graph): the canvas must be readable the moment it opens

### DIFF
--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -3266,8 +3266,12 @@ function GraphPageInner() {
         </details>
       </div>
 
-      <div className="flex-1 flex relative min-h-[68vh]">
-        <div className="flex-1 relative min-h-[60vh] flex flex-col">
+      {/* A full viewport, not a letterbox. The header above accumulates to
+          ~600px on arrival, so a 68vh canvas left the graph as a ~300px strip
+          with most of the estate below the fold. The canvas is the content;
+          it gets a screen of its own. */}
+      <div className="flex-1 flex relative min-h-[calc(100vh-3.5rem)]">
+        <div className="flex-1 relative min-h-0 flex flex-col">
           {selectedAttackPath && (
             <div className="graph-callout-orange-compact">
               <span>

--- a/ui/lib/graph-rollup-view.ts
+++ b/ui/lib/graph-rollup-view.ts
@@ -46,13 +46,29 @@ const FLOW_NODE_TYPES: Record<LineageNodeType, string> = {
   blueprint: "accessPolicyNode",
 };
 
-const DEFAULT_COLUMNS = 3;
+const MIN_COLUMNS = 3;
 // NodeCard renders up to 300px wide. Position columns by the rendered maximum
 // plus a deliberate gutter so long roll-up labels never overlap their neighbor.
 const NODE_CARD_MAX_WIDTH = 300;
 const NODE_COLUMN_GAP = 32;
 const NODE_WIDTH = NODE_CARD_MAX_WIDTH + NODE_COLUMN_GAP;
 const NODE_HEIGHT = 112;
+// A graph canvas is landscape — roughly 2.2:1 at a laptop viewport. A grid
+// whose own aspect ratio is far from that wastes the short axis and pays for it
+// in zoom, because `fitView` scales to whichever axis runs out first.
+const CANVAS_ASPECT = 2.2;
+
+/** Columns that shape the grid like the canvas rather than like a column.
+ *
+ *  A fixed 3 columns turned the demo estate's 106 containers into a 996x4000
+ *  tower, which `fitView` correctly resolved to scale 0.14 — labels at ~2.6px
+ *  and half the nodes below the fold. Solving `(c*w)/((n/c)*h) = aspect` for
+ *  `c` keeps the grid landscape at every estate size. */
+function fittingColumns(count: number): number {
+  if (count <= MIN_COLUMNS) return Math.max(1, count);
+  const ideal = Math.sqrt((count * CANVAS_ASPECT * NODE_HEIGHT) / NODE_WIDTH);
+  return Math.min(count, Math.max(MIN_COLUMNS, Math.round(ideal)));
+}
 
 export function rollupEntityToNodeType(entityType: string): LineageNodeType {
   return lineageNodeTypeForEntity(entityType) ?? "cloudResource";
@@ -121,7 +137,7 @@ export function buildRollupFlowGraph(
   containers: GraphRollupContainer[],
   options?: { columns?: number; edges?: GraphRollupEdge[] | undefined },
 ): { nodes: Node<LineageNodeData>[]; edges: Edge[] } {
-  const columns = Math.max(1, options?.columns ?? DEFAULT_COLUMNS);
+  const columns = Math.max(1, options?.columns ?? fittingColumns(containers.length));
   const nodes: Node<LineageNodeData>[] = containers.map((container, index) => {
     const nodeType = rollupEntityToNodeType(container.entity_type);
     const col = index % columns;

--- a/ui/tests/graph-rollup-layout-fits-the-canvas.test.ts
+++ b/ui/tests/graph-rollup-layout-fits-the-canvas.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The roll-up grid must not build a tower that no canvas can fit.
+ *
+ * Measured on the demo estate: `/graph` opens on 106 sibling containers, and
+ * `buildRollupFlowGraph` laid every one of them out at a fixed 3 columns. That
+ * is a 996 x 3994 portrait tower dropped into a ~1322 x 610 landscape canvas,
+ * so React Flow's `fitView` — working exactly as designed — resolved to scale
+ * **0.16**. At that scale the node labels render around 2.6px and half the
+ * nodes still sit below the fold.
+ *
+ * The controls looked broken too: Fit, Reset and Auto-layout all appeared to be
+ * no-ops because each of them re-fits the *same* tower and lands back on 0.16.
+ * There was never a bug in the fit handlers; the shape they were fitting was
+ * the bug.
+ *
+ * The column count is now derived from the container count so the grid's own
+ * aspect ratio lands near a landscape canvas, which is what a graph canvas
+ * actually is. Small graphs are unaffected — they keep at least the original
+ * three columns, and they are small enough to hit the zoom ceiling anyway.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { GraphRollupContainer } from "@/lib/api-types";
+import { buildRollupFlowGraph } from "@/lib/graph-rollup-view";
+
+/** The `/graph` canvas measured in the browser at a 1440px-wide viewport. */
+const CANVAS_WIDTH = 1322;
+const CANVAS_HEIGHT = 610;
+/** React Flow's default `fitView` padding, as configured on the page. */
+const FIT_PADDING = 0.1;
+
+const NODE_CARD_WIDTH = 300;
+const NODE_CARD_HEIGHT = 80;
+
+function containers(count: number): GraphRollupContainer[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `account:acct-${index}`,
+    label: `acct-${index}`,
+    entity_type: "account",
+    severity: "",
+    is_container: true,
+    has_children: true,
+    direct_child_count: 4,
+    aggregate: {
+      descendant_count: 40,
+      by_type: { resource: 40 },
+      severity_counts: { high: 7 },
+      worst_severity: "high",
+      worst_severity_rank: 3,
+      internet_exposed: false,
+      toxic_combo: false,
+      exposed_count: 0,
+      toxic_count: 0,
+    },
+  }));
+}
+
+/** The scale `fitView` resolves to for a laid-out graph on the real canvas. */
+function fitScale(nodes: { position: { x: number; y: number } }[]): number {
+  const xs = nodes.map((n) => n.position.x);
+  const ys = nodes.map((n) => n.position.y);
+  const width = Math.max(...xs) - Math.min(...xs) + NODE_CARD_WIDTH;
+  const height = Math.max(...ys) - Math.min(...ys) + NODE_CARD_HEIGHT;
+  return Math.min(
+    (CANVAS_WIDTH * (1 - FIT_PADDING)) / width,
+    (CANVAS_HEIGHT * (1 - FIT_PADDING)) / height,
+  );
+}
+
+describe("the roll-up grid is shaped like the canvas it lands on", () => {
+  it("opens the demo estate's 106 containers at a legible zoom", () => {
+    const { nodes } = buildRollupFlowGraph(containers(106));
+    const scale = fitScale(nodes);
+
+    // 0.16 was the measured defect, at ~2.6px labels. A 300x80 card at 0.35 is
+    // 105x28 — small, but its label is readable and its severity colour is
+    // unmistakable.
+    expect(scale).toBeGreaterThan(0.35);
+  });
+
+  it("picks the column count that fits best, rather than a fixed one", () => {
+    // The real invariant. 106 cards of 300x80 occupy 2.5M px in an 806k px
+    // canvas, so ~0.4 is close to the geometric ceiling however they are
+    // arranged — the layout's job is to land on that ceiling at every size,
+    // which is a property worth asserting where a magic constant is not.
+    for (const count of [12, 40, 106, 250]) {
+      const chosen = fitScale(buildRollupFlowGraph(containers(count)).nodes);
+      const best = Math.max(
+        ...Array.from({ length: count }, (_, i) =>
+          fitScale(
+            buildRollupFlowGraph(containers(count), { columns: i + 1 }).nodes,
+          ),
+        ),
+      );
+      expect(chosen).toBeGreaterThan(best * 0.9);
+    }
+  });
+
+  it("never builds a portrait tower, at any estate size", () => {
+    for (const count of [12, 40, 106, 250, 600]) {
+      const { nodes } = buildRollupFlowGraph(containers(count));
+      const xs = nodes.map((n) => n.position.x);
+      const ys = nodes.map((n) => n.position.y);
+      const width = Math.max(...xs) - Math.min(...xs) + NODE_CARD_WIDTH;
+      const height = Math.max(...ys) - Math.min(...ys) + NODE_CARD_HEIGHT;
+      // Wider than tall: the canvas is landscape, so a taller-than-wide layout
+      // wastes horizontal room and pays for it in zoom.
+      expect(width, `${count} containers`).toBeGreaterThan(height);
+    }
+  });
+
+  it("leaves a handful of containers laid out across, not stacked down", () => {
+    const { nodes } = buildRollupFlowGraph(containers(3));
+    expect(new Set(nodes.map((n) => n.position.y)).size).toBe(1);
+  });
+
+  it("still honours an explicit column count", () => {
+    const { nodes } = buildRollupFlowGraph(containers(9), { columns: 3 });
+    expect(new Set(nodes.map((n) => n.position.x)).size).toBe(3);
+    expect(new Set(nodes.map((n) => n.position.y)).size).toBe(3);
+  });
+
+  it("fills every row it opens", () => {
+    // A column count above the container count would leave a single sparse row
+    // and reintroduce the wasted-width problem from the other direction.
+    const { nodes } = buildRollupFlowGraph(containers(2));
+    expect(new Set(nodes.map((n) => n.position.x)).size).toBe(2);
+  });
+});


### PR DESCRIPTION
## What

`/graph` opened the demo estate at zoom **0.16**, node labels around **2.6px**, and **52 of 106 nodes below the fold**. Two causes, neither in the code that looked at fault.

### The roll-up grid built a tower no canvas can fit

`buildRollupFlowGraph` laid every container out at a fixed 3 columns. On 106 sibling containers that is a 996x4000 portrait tower dropped into a ~1322x610 landscape canvas, so `fitView` — working exactly as designed — resolved to 0.14.

This is also why Fit, Reset and Auto-layout all appeared to be no-ops: each of them re-fits the *same* tower and lands back on the *same* scale. There was never a bug in the fit handlers.

The column count is now derived from the container count so the grid's aspect ratio lands near the canvas's. Measured across estate sizes:

| containers | columns | bounding box | fit scale |
|---|---|---|---|
| 40 | 3 → 5 | 964x1536 → 1628x864 | 0.357 → **0.635** |
| 106 (demo) | 3 → 9 | 964x4000 → 2956x1312 | 0.137 → **0.403** |
| 250 | 3 → 14 | 964x9376 → 4616x1984 | 0.059 → **0.258** |
| 600 | 3 → 21 | 964x22368 → 6940x3216 | 0.025 → **0.171** |

Graphs of three or fewer containers are unchanged, and an explicit `columns` option still wins.

### The canvas was a letterbox

The canvas row was allotted `68vh` beneath a header that accumulates to ~600px on arrival, leaving the graph a ~300px strip. The canvas is the content on this page; it now gets a viewport of its own.

## Why the test asserts a property, not a number

106 cards of 300x80 occupy 2.5M pixels in an 806k-pixel canvas, so ~0.4 is close to the geometric ceiling *however* they are arranged. Pinning 0.403 would encode an accident of the current card size. The test instead asserts the layout lands within 10% of the best achievable fit at every size — searching all column counts to find it — plus a legibility floor and a never-portrait invariant.

## How verified

- `npx vitest run` — 175 files, 1087 tests, all pass; the 6 new assertions confirmed present in the full run (not just in isolation).
- New tests watched fail first: 0.137 measured against the 0.35 floor, and the portrait-tower invariant at 0.63 against 1.0.
- `npm run typecheck` clean; `npm run lint` 0 errors (2 pre-existing warnings unrelated to this change).
- `npm run build` + `node scripts/check-bundle-budget.mjs` — all three budgets pass, unchanged.

The diff is 24 lines. Prettier reformats both touched files wholesale because they are unformatted on `main` and prettier is not a gate here (only eslint is), so that churn is deliberately excluded.

Closes #6