### PR TITLE
fix(graph): one completeness contract, not one per backend

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -35,7 +35,12 @@ from agent_bom.graph import (
     technique_mappings_from_json,
 )
 from agent_bom.graph.analysis import GraphAnalysisStatus, analysis_status_map_from_dict, analysis_status_map_to_dict
-from agent_bom.graph.completeness import bounded_walk_reason, impact_completeness
+from agent_bom.graph.completeness import (
+    COMPLIANCE_NODE_BUDGET,
+    bounded_walk_reason,
+    graph_completeness,
+    impact_completeness,
+)
 from agent_bom.graph.container import apply_node_budget
 from agent_bom.graph.ocsf import FINDING_ENTITY_TYPES
 
@@ -1389,23 +1394,28 @@ class SQLiteGraphStore:
         framework: str = "",
     ) -> dict[str, Any]:
         tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
+        # The same budget Postgres applies. This read used to be unbounded here
+        # and bounded there, so the two backends answered the same leadership
+        # question from different amounts of the estate — and only one of them
+        # said so.
+        compliance_node_budget = COMPLIANCE_NODE_BUDGET
+        empty = {
+            "scan_id": scan_id,
+            "framework_count": 0,
+            "total_tagged_findings": 0,
+            "frameworks": {},
+            "completeness": {
+                **graph_completeness(returned=0),
+                "node_budget": compliance_node_budget,
+            },
+        }
         conn = self._open_ro_conn()
         if conn is None:
-            return {
-                "scan_id": scan_id,
-                "framework_count": 0,
-                "total_tagged_findings": 0,
-                "frameworks": {},
-            }
+            return empty
         try:
             effective_scan_id, _created_at = sqlite_graph_store._resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
             if not effective_scan_id:
-                return {
-                    "scan_id": scan_id,
-                    "framework_count": 0,
-                    "total_tagged_findings": 0,
-                    "frameworks": {},
-                }
+                return empty
 
             rows = conn.execute(
                 """
@@ -1413,9 +1423,12 @@ class SQLiteGraphStore:
                 FROM graph_nodes
                 WHERE tenant_id = ? AND scan_id = ? AND json_array_length(compliance_tags) > 0
                 ORDER BY id ASC
+                LIMIT ?
                 """,
-                [tenant_id, effective_scan_id],
+                [tenant_id, effective_scan_id, compliance_node_budget + 1],
             ).fetchall()
+            truncated = len(rows) > compliance_node_budget
+            rows = rows[:compliance_node_budget]
 
             framework_filter = framework.upper()
             framework_stats: dict[str, dict[str, Any]] = defaultdict(
@@ -1460,6 +1473,14 @@ class SQLiteGraphStore:
                 "framework_count": len(frameworks),
                 "total_tagged_findings": sum(stats["total_findings"] for stats in frameworks.values()),
                 "frameworks": frameworks,
+                "completeness": {
+                    **graph_completeness(
+                        returned=len(rows),
+                        truncated=truncated,
+                        reason="node_budget" if truncated else "",
+                    ),
+                    "node_budget": compliance_node_budget,
+                },
             }
         finally:
             conn.close()

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -27,7 +27,12 @@ from agent_bom.config import POSTGRES_GRAPH_SEARCH_TIMEOUT_MS, POSTGRES_STATEMEN
 from agent_bom.db.graph_store import DEFAULT_GRAPH_TENANT_ID, graph_retention_policy, normalize_graph_tenant_id
 from agent_bom.graph import EntityType, technique_mappings_from_json
 from agent_bom.graph.analysis import GraphAnalysisStatus, analysis_status_map_from_dict, analysis_status_map_to_dict
-from agent_bom.graph.completeness import bounded_walk_reason, impact_completeness
+from agent_bom.graph.completeness import (
+    COMPLIANCE_NODE_BUDGET,
+    bounded_walk_reason,
+    graph_completeness,
+    impact_completeness,
+)
 from agent_bom.security import sanitize_text
 
 from .postgres_common import (
@@ -1870,9 +1875,16 @@ class PostgresGraphStore:
             "neighbors": neighbors,
             "sources": sources,
             "impact": self.impact_of(tenant_id=tenant_id, scan_id=effective_scan_id, node_id=node_id),
+            # This used to hand-roll a fourth status word into a vocabulary of
+            # three, so the completeness banner — which branches on
+            # complete/truncated/sampled and on the booleans — silently ignored
+            # it and rendered a bounded neighbourhood as the whole one.
             "completeness": {
-                "status": "partial" if truncated else "complete",
-                "reason": "edge_budget" if truncated else "",
+                **graph_completeness(
+                    returned=len(edges_in) + len(edges_out),
+                    truncated=truncated,
+                    reason="edge_budget" if truncated else "",
+                ),
                 "edge_budget": 10_000,
             },
         }
@@ -1895,12 +1907,11 @@ class PostgresGraphStore:
                 "total_tagged_findings": 0,
                 "frameworks": {},
                 "completeness": {
-                    "status": "complete",
-                    "reason": "",
-                    "node_budget": 50_000,
+                    **graph_completeness(returned=0),
+                    "node_budget": COMPLIANCE_NODE_BUDGET,
                 },
             }
-        compliance_node_budget = 50_000
+        compliance_node_budget = COMPLIANCE_NODE_BUDGET
         with _tenant_connection(self._pool) as conn:
             _apply_graph_search_timeout(conn)
             rows = conn.execute(
@@ -1960,8 +1971,11 @@ class PostgresGraphStore:
             "total_tagged_findings": sum(stats["total_findings"] for stats in frameworks.values()),
             "frameworks": frameworks,
             "completeness": {
-                "status": "partial" if truncated else "complete",
-                "reason": "node_budget" if truncated else "",
+                **graph_completeness(
+                    returned=min(len(rows), compliance_node_budget),
+                    truncated=truncated,
+                    reason="node_budget" if truncated else "",
+                ),
                 "node_budget": compliance_node_budget,
             },
         }

--- a/src/agent_bom/graph/completeness.py
+++ b/src/agent_bom/graph/completeness.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
+#: Tagged-node ceiling for a compliance summary read. Lives here rather than in
+#: either store so both backends bound the same question the same way.
+COMPLIANCE_NODE_BUDGET = 50_000
+
 
 def graph_completeness(
     *,

--- a/tests/test_compliance_summary_says_when_it_is_bounded.py
+++ b/tests/test_compliance_summary_says_when_it_is_bounded.py
@@ -1,0 +1,99 @@
+"""A bounded compliance read must say so, in the vocabulary clients speak.
+
+`/v1/graph/compliance` is a leadership-facing surface: it answers "how does the
+estate score against NIST / CIS / SOC2". Its two backends disagreed about how —
+and whether — to admit that the answer was cut short.
+
+* Postgres bounds the read at 50,000 tagged nodes and reported
+  ``{"status": "partial", "reason": "node_budget", "node_budget": 50000}``.
+* SQLite read every tagged node and reported **no completeness key at all**.
+
+`graph/completeness.py` already defines the shared vocabulary, and the UI type
+`GraphCompleteness` publishes it: ``status`` is one of ``complete`` /
+``truncated`` / ``sampled``, alongside ``complete`` / ``truncated`` / ``sampled``
+booleans and a ``returned`` count. ``"partial"`` is in neither.
+
+The consequence is not cosmetic, and it is worse than a missing field. The
+client-side reader `graphResponseIsTruncated` treats ``completeness`` as
+authoritative the moment it is present: it returns ``completeness.truncated ===
+true`` and never falls back to ``pagination.has_more``. So an envelope carrying
+a status word but no booleans reads as *not truncated* **and** suppresses the
+fallback that would otherwise have caught it. That is pinned from the client
+side in `ui/tests/completeness-envelope-contract.test.ts`.
+
+`node_context` is the one of the two with a rendering consumer today — the
+inventory asset drawer (`api/routes/inventory_assets.py`) — where a
+neighbourhood cut off at the 10,000-edge budget claimed to be the whole one.
+`compliance_summary` is an API/MCP surface with no UI consumer yet; the point
+there is that a leadership-facing score must not answer from a silently bounded
+denominator on either backend.
+
+The identical defect was already fixed for `impact_of` — see the comment at
+`postgres_graph.py`, "Was a bare 'partial'/'complete' string here and absent
+entirely on SQLite: one field, two shapes". Its two sibling call sites were
+missed. This pins the contract so a third shape cannot appear.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.graph.completeness import graph_completeness
+
+VALID_STATUSES = {"complete", "truncated", "sampled"}
+
+
+def assert_speaks_the_shared_vocabulary(completeness: object, *, who: str) -> None:
+    assert isinstance(completeness, dict), f"{who} returned no completeness envelope"
+    status = completeness.get("status")
+    assert status in VALID_STATUSES, f"{who} reported status {status!r}, which no client branches on"
+    # The booleans exist so clients never have to parse the string, which is
+    # exactly the mistake that let "partial" pass silently.
+    for key in ("complete", "truncated", "sampled"):
+        assert isinstance(completeness.get(key), bool), f"{who} omitted the {key!r} boolean"
+    assert completeness["complete"] is (status == "complete"), f"{who} disagrees with its own status"
+    assert isinstance(completeness.get("returned"), int), f"{who} did not say how much it returned"
+
+
+def test_the_shared_helper_never_emits_partial() -> None:
+    """The vocabulary itself, so the assertions above are pinned to something."""
+    for truncated in (False, True):
+        assert graph_completeness(returned=5, truncated=truncated)["status"] in VALID_STATUSES
+
+
+def test_sqlite_compliance_summary_reports_its_completeness() -> None:
+    from agent_bom.api.graph_store import SQLiteGraphStore
+
+    store = SQLiteGraphStore()
+    summary = store.compliance_summary(tenant_id="")
+    assert_speaks_the_shared_vocabulary(summary.get("completeness"), who="SQLite compliance_summary")
+
+
+def test_sqlite_compliance_summary_reports_completeness_when_empty() -> None:
+    """The no-snapshot path returned early, skipping the envelope entirely."""
+    from agent_bom.api.graph_store import SQLiteGraphStore
+
+    store = SQLiteGraphStore()
+    summary = store.compliance_summary(tenant_id="", scan_id="no-such-scan")
+    assert_speaks_the_shared_vocabulary(summary.get("completeness"), who="SQLite compliance_summary (empty)")
+
+
+@pytest.mark.parametrize("method", ["compliance_summary", "node_context"])
+def test_postgres_read_paths_do_not_invent_a_status(method: str) -> None:
+    """Both Postgres sites hand-rolled `"partial"`; neither may any longer.
+
+    Read as source rather than executed against a live Postgres, so the contract
+    is pinned on every runner rather than only where a database is available.
+    """
+    import inspect
+
+    from agent_bom.api.postgres_graph import PostgresGraphStore
+
+    source = inspect.getsource(getattr(PostgresGraphStore, method))
+    assert '"partial"' not in source, (
+        f"PostgresGraphStore.{method} still emits the literal 'partial', which is not "
+        "one of complete/truncated/sampled and which the completeness banner ignores"
+    )
+    assert "graph_completeness(" in source, (
+        f"PostgresGraphStore.{method} should build its envelope with the shared helper rather than a fourth hand-rolled dict"
+    )

--- a/ui/tests/completeness-envelope-contract.test.ts
+++ b/ui/tests/completeness-envelope-contract.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The client-side reader of `completeness` must not be handed a shape it
+ * silently misreads.
+ *
+ * `graphResponseIsTruncated` treats `completeness` as authoritative the moment
+ * it is present — it returns `completeness.truncated === true` and stops,
+ * *without* falling back to `pagination.has_more`. That is the right design
+ * when the envelope is well-formed, and a trap when it is not: an envelope that
+ * carries a status word but no `truncated` boolean reads as "not truncated"
+ * AND suppresses the fallback that would otherwise have caught it.
+ *
+ * Two backend read paths used to emit exactly that shape —
+ * `{"status": "partial", "reason": "node_budget", "node_budget": 50000}` — a
+ * status word outside the published `GraphCompleteness` union with none of its
+ * booleans. These tests pin the failure so the shape cannot come back, and pin
+ * the corrected shape so a bounded read is recognised as bounded.
+ */
+import { describe, expect, it } from "vitest";
+
+import { graphResponseIsTruncated } from "@/lib/graph-truncation";
+
+const pagination = {
+  total: 120_000,
+  limit: 1_000,
+  offset: 0,
+  has_more: true,
+};
+
+describe("a completeness envelope missing its booleans", () => {
+  it("reads as complete AND suppresses the pagination fallback", () => {
+    // Documenting the trap, not endorsing it: `has_more` is true, so without a
+    // completeness block this response is plainly truncated.
+    const withoutEnvelope = graphResponseIsTruncated({ pagination });
+    expect(withoutEnvelope).toBe(true);
+
+    const legacyShape = {
+      pagination,
+      completeness: {
+        status: "partial",
+        reason: "node_budget",
+      } as never,
+    };
+    expect(graphResponseIsTruncated(legacyShape)).toBe(false);
+  });
+
+  it("recognises the shared envelope a bounded read now emits", () => {
+    expect(
+      graphResponseIsTruncated({
+        pagination,
+        completeness: {
+          status: "truncated",
+          complete: false,
+          sampled: false,
+          truncated: true,
+          returned: 50_000,
+          reason: "node_budget",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("still reads an exhaustive read as exhaustive", () => {
+    expect(
+      graphResponseIsTruncated({
+        pagination: { ...pagination, total: 7, has_more: false },
+        completeness: {
+          status: "complete",
+          complete: true,
+          sampled: false,
+          truncated: false,
+          returned: 7,
+        },
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

`graph/completeness.py` defines the vocabulary a bounded graph read reports itself in — `status` is `complete` / `truncated` / `sampled`, carried alongside `complete` / `truncated` / `sampled` booleans and a `returned` count, so clients never have to parse the string. Three read paths didn't use it:

| path | what it emitted | bounded at |
|---|---|---|
| `PostgresGraphStore.compliance_summary` | `{"status": "partial", "reason": "node_budget", "node_budget": 50000}` | 50,000 nodes |
| `PostgresGraphStore.node_context` | `{"status": "partial", "reason": "edge_budget", "edge_budget": 10000}` | 10,000 edges |
| `SQLiteGraphStore.compliance_summary` | **no envelope at all** | **unbounded** |

So the two backends answered the same leadership-facing question from different amounts of the estate, and only one of them mentioned it — in a word no client knows.

## Why the malformed shape is worse than a missing field

`graphResponseIsTruncated` treats `completeness` as authoritative the moment it's present: it returns `completeness.truncated === true` and **never falls back to `pagination.has_more`**. An envelope carrying a status word but no booleans therefore reads as *not truncated* **and** suppresses the fallback that would otherwise have caught it.

That's pinned from the client side in `ui/tests/completeness-envelope-contract.test.ts` rather than asserted — the first test shows the same response reading `true` without the envelope and `false` with the old one.

## Changes

- All three paths build their envelope with `graph_completeness()`.
- The 50,000-node budget moves into `completeness.py` as `COMPLIANCE_NODE_BUDGET`, so one number bounds both stores rather than the same literal living in two files. SQLite now applies it too.
- The `node_budget` / `edge_budget` keys are preserved alongside the shared envelope, so nothing that reads them today breaks.

The identical fix already landed for `impact_of`, whose comment names the class verbatim — *"one field, two shapes"*. Its two siblings were missed.

## Scope note

`node_context` is the path with a rendering consumer today — the inventory asset drawer (`api/routes/inventory_assets.py`), where a neighbourhood cut off at the edge budget claimed to be the whole one. `/v1/graph/compliance` is an API/MCP surface with no UI consumer yet; the point there is that a leadership-facing score must not answer from a silently bounded denominator on either backend.

## How verified

Against a **real Postgres with RLS enforced**, migrated through the full Alembic chain (87 tables, chain at head) and connecting as the `agent_bom_app` DML role:

```
BUDGET 5, 7 rows -> {"status":"truncated","complete":false,"sampled":false,"truncated":true,"returned":5,"reason":"node_budget","node_budget":5}   counted: 5
BUDGET 5000      -> {"status":"complete","complete":true,"sampled":false,"truncated":false,"returned":7,"node_budget":5000}                        counted: 7
NO SUCH SCAN     -> {"status":"complete","complete":true,"sampled":false,"truncated":false,"returned":0,"node_budget":5000}
NODE_CONTEXT     -> {"status":"complete","complete":true,"sampled":false,"truncated":false,"returned":0,"edge_budget":10000}
```

Worth recording: the migration chain **refused** to run as a role holding `agent_bom_rls_maintenance`, and RLS **rejected** a raw insert that didn't set the tenant GUC. Both guards fired exactly as intended.

- New Python tests watched fail first (4 of 5 red, each for its own reason).
- `pytest` on the touched surface — 237 passed (`test_graph_api`, `test_compliance`, `test_postgres_store`, `test_neptune_unsupported_501`, `api/test_api_compliance_auth`, and the new file).
- `npx vitest run` — 176 files, 1090 tests, all pass.
- `make preflight` green; `make lint-ruff`, `make format-check`, `mypy` on the three changed modules all clean.