### PR TITLE
feat(findings): make KEV filterable, not just displayed

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -17165,6 +17165,24 @@
             }
           },
           {
+            "description": "Only known-exploited (KEV) findings, or only non-KEV when false",
+            "in": "query",
+            "name": "kev",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only known-exploited (KEV) findings, or only non-KEV when false",
+              "title": "Kev"
+            }
+          },
+          {
             "in": "query",
             "name": "include_facets",
             "required": false,

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -11544,6 +11544,16 @@ paths:
             type: string
           - type: 'null'
           title: Finding Class
+      - description: Only known-exploited (KEV) findings, or only non-KEV when false
+        in: query
+        name: kev
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: Only known-exploited (KEV) findings, or only non-KEV when false
+          title: Kev
       - in: query
         name: include_facets
         required: false

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -2128,6 +2128,7 @@ def _canonical_scope_filters(
     domain: str | None,
     finding_class: str | None = None,
     q: str | None = None,
+    kev: bool | None = None,
 ) -> dict[str, str]:
     """Normalize the optional scope/domain filters into an active-filter map.
 
@@ -2152,6 +2153,8 @@ def _canonical_scope_filters(
         filters["domain"] = _LEGACY_DOMAIN_ALIASES.get(key, key)
     if finding_class:
         filters["finding_class"] = finding_class
+    if kev is not None:
+        filters["kev"] = "true" if kev else "false"
     if q and q.strip():
         filters["q"] = q.strip()
     return filters
@@ -2408,6 +2411,7 @@ async def list_findings(
     window_days: Annotated[int | None, Query(ge=0, le=3650)] = None,
     status: Annotated[str, Query(max_length=16)] = _DEFAULT_FINDING_STATUS,
     finding_class: FindingClass | None = None,
+    kev: Annotated[bool | None, Query(description="Only known-exploited (KEV) findings, or only non-KEV when false")] = None,
     include_facets: bool = False,
 ) -> dict:
     """List unified findings aggregated from completed scan results.
@@ -2452,6 +2456,7 @@ async def list_findings(
                 window_days,
                 status,
                 finding_class,
+                kev,
                 include_facets,
             )
     except BackpressureRejectedError as exc:
@@ -2479,6 +2484,7 @@ def _list_findings_impl(
     window_days: int | None = None,
     status: str = _DEFAULT_FINDING_STATUS,
     finding_class: str | None = None,
+    kev: bool | None = None,
     include_facets: bool = False,
 ) -> dict:
     """Synchronous body of :func:`list_findings` (runs in a worker thread).
@@ -2605,7 +2611,7 @@ def _list_findings_impl(
     # returns that scan's rows verbatim.
     from agent_bom.api.findings_current import current_scan_findings
 
-    scope_filters = _canonical_scope_filters(provider, account, environment, domain, finding_class, q)
+    scope_filters = _canonical_scope_filters(provider, account, environment, domain, finding_class, q, kev=kev)
 
     store = get_compliance_hub_store()
     bulk_list = getattr(store, "list_current_page", None) or getattr(store, "list_page", None)

--- a/src/agent_bom/finding_scope.py
+++ b/src/agent_bom/finding_scope.py
@@ -765,6 +765,13 @@ def row_matches_scope(row: dict, filters: Mapping[str, str]) -> bool:
     wanted_class = filters.get("finding_class")
     if wanted_class is not None and finding_class_for_row(row) != wanted_class:
         return False
+    # KEV leads the executive headline — "actively exploited, fix these first" —
+    # so the list has to be able to answer it. An absent verdict is not a match:
+    # a row nobody checked must never be presented as known-exploited.
+    wanted_kev = filters.get("kev")
+    if wanted_kev is not None:
+        if (row.get("is_kev") is True) is not (str(wanted_kev).strip().lower() in {"true", "1", "yes"}):
+            return False
     if not row_matches_search(row, filters.get("q")):
         return False
     return True

--- a/tests/test_findings_are_filterable_by_kev.py
+++ b/tests/test_findings_are_filterable_by_kev.py
@@ -1,0 +1,77 @@
+"""KEV is on the executive headline; it must be reachable from the list.
+
+The exec view leads with a KEV count — "actively exploited, fix these first" is
+the single strongest prioritisation signal a security tool has. `is_kev` is
+carried on every finding row and rendered per finding. `/v1/findings` had no
+parameter to filter on it, so the headline was a dead end: a reader could see
+that N findings are known-exploited and had no way to ask for those N.
+
+The predicate goes into `row_matches_scope`, the single source of truth shared
+by the route's in-memory scan findings and the hub store's bulk-ingested rows,
+so the two paths cannot diverge on what "KEV" selects.
+
+``kev=true`` narrows to known-exploited findings. ``kev=false`` is the useful
+inverse (everything not known-exploited) rather than a no-op, and omitting the
+parameter changes nothing — a filter that cannot be turned off is not a filter.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.finding_scope import row_matches_scope
+
+
+def row(**overrides: object) -> dict:
+    base: dict = {
+        "id": "f1",
+        "title": "CVE-2026-0001 in left-pad",
+        "severity": "critical",
+        "finding_type": "CVE",
+        "source": "OSV",
+        "cve_id": "CVE-2026-0001",
+        "is_kev": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_kev_true_keeps_a_known_exploited_finding() -> None:
+    assert row_matches_scope(row(), {"kev": "true"}) is True
+
+
+def test_kev_true_drops_a_finding_that_is_not_known_exploited() -> None:
+    assert row_matches_scope(row(is_kev=False), {"kev": "true"}) is False
+
+
+def test_kev_true_drops_a_finding_with_no_kev_verdict() -> None:
+    """Absent is not the same as true. A row we never checked must not be
+    presented as actively exploited."""
+    assert row_matches_scope(row(is_kev=None), {"kev": "true"}) is False
+    unknown = row()
+    del unknown["is_kev"]
+    assert row_matches_scope(unknown, {"kev": "true"}) is False
+
+
+def test_kev_false_is_the_inverse_not_a_no_op() -> None:
+    assert row_matches_scope(row(is_kev=False), {"kev": "false"}) is True
+    assert row_matches_scope(row(), {"kev": "false"}) is False
+
+
+def test_no_kev_filter_changes_nothing() -> None:
+    for value in (True, False, None):
+        assert row_matches_scope(row(is_kev=value), {}) is True
+
+
+def test_kev_composes_with_the_other_scope_filters() -> None:
+    """Filters intersect; KEV must not widen a scoped read."""
+    scoped = row(provider="aws", environment="prod")
+    assert row_matches_scope(scoped, {"kev": "true", "provider": "aws"}) is True
+    assert row_matches_scope(scoped, {"kev": "true", "provider": "gcp"}) is False
+
+
+@pytest.mark.parametrize("truthy", ["true", "True", "1", "yes"])
+def test_common_truthy_spellings_are_accepted(truthy: str) -> None:
+    """The value is canonicalised by the route, but the predicate is shared and
+    reached directly by the store, so it must not be brittle about spelling."""
+    assert row_matches_scope(row(), {"kev": truthy}) is True

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -1438,6 +1438,9 @@ export const api = {
     domain?: string;
     findingClass?: "vulnerability" | "misconfiguration" | "secret" | "identity" | "unclassified";
     status?: "open" | "resolved" | "all";
+    // Known-exploited only, or explicitly everything else. Omit for no filter —
+    // `false` is the inverse, not the default.
+    kev?: boolean;
     includeFacets?: boolean;
     // Default read-window in days (#4009). Omit for the server default (~90d);
     // pass 0 to widen to all retained history.
@@ -1457,6 +1460,7 @@ export const api = {
     if (filters?.environment) params.set("environment", filters.environment);
     if (filters?.domain) params.set("domain", filters.domain);
     if (filters?.findingClass) params.set("finding_class", filters.findingClass);
+    if (filters?.kev != null) params.set("kev", String(filters.kev));
     if (filters?.status) params.set("status", filters.status);
     if (filters?.includeFacets) params.set("include_facets", "true");
     if (filters?.windowDays != null) params.set("window_days", String(filters.windowDays));


### PR DESCRIPTION
Closes the last open finding from the pre-publish audit.

## What

The executive view leads with a KEV count — *actively exploited, fix these first* is the strongest prioritisation signal the product has. `is_kev` is carried on every finding row and rendered per finding, but `/v1/findings` had **no parameter to filter on it**. The headline was a dead end: a reader could see that N findings are known-exploited and had no way to ask for those N.

## Where the predicate lives

In `row_matches_scope` — the single source of truth shared by the route's in-memory scan findings **and** the hub store's bulk-ingested keyset path. Putting it anywhere else would have created a second implementation of one judgement, which is the defect class this release has been burning down.

## Two deliberate choices

- **An absent `is_kev` is not a match.** A row nobody checked must never be presented as actively exploited — the same fail-closed rule the reachability (#4763) and completeness (#4760) work landed on.
- **`kev=false` is the real inverse**, not a no-op, and omitting the parameter changes nothing. A filter you can't turn off isn't a filter.

## Full-stack

Route parameter → worker-thread call → shared predicate → regenerated OpenAPI artifacts → `ui/lib/api.ts`. No half-wiring.

`make preflight` caught the OpenAPI drift on the first run; regenerated, and the diff is only the `kev` parameter.

## How verified

- 10 tests, watched fail first (3 red for product reasons — the absent-verdict and inverse cases).
- **End-to-end on the demo estate**: 63 KEV findings, every returned row `is_kev: true`, inverse excludes all 63.
- `pytest -k "kev or finding_scope or findings"` — exit 0.
- `make preflight`, `make lint-ruff`, `make format-check`, `mypy` clean; `npm run typecheck` clean.

One note on process: an earlier run of that suite reported 83 failures. It had been launched **mid-edit**, while `kev` was still undefined at a call site (ruff flagged it as F821 moments later). I re-ran it against the finished code rather than reason the number away — it passes.