### PR TITLE
fix(demo): the deploy gate asserted an estate that no longer exists

### DIFF
--- a/.github/workflows/demo-deploy-cloudrun.yml
+++ b/.github/workflows/demo-deploy-cloudrun.yml
@@ -204,15 +204,31 @@ jobs:
           payload = json.loads(Path(os.environ["STORY_PATH"]).read_text())
           assert payload["synthetic"] is True and payload["fictional"] is True
           summary = payload["summary"]
-          assert summary == {
-              "assets": 20,
-              "observations": 15,
-              "evidence_sources": 9,
-              "complete_sources": 8,
-              "partial_sources": 1,
-              "correlations": 4,
-              "snapshots": 3,
+          # Exact-equality on the counts asserted a 20-asset estate that has
+          # since grown to thousands, so this gate described a demo that no
+          # longer existed. Counts are seeded data and will keep moving; what
+          # must hold is the SHAPE and a non-trivial floor, so the gate catches
+          # an empty or collapsed estate without rotting on every reseed.
+          expected_keys = {
+              "assets",
+              "observations",
+              "evidence_sources",
+              "complete_sources",
+              "partial_sources",
+              "correlations",
+              "snapshots",
           }
+          missing = expected_keys - set(summary)
+          assert not missing, f"demo story summary lost keys: {sorted(missing)}"
+          # The source split is a fixed fixture, not seeded volume — pin it.
+          assert summary["evidence_sources"] == 9, summary
+          assert summary["complete_sources"] == 8, summary
+          assert summary["partial_sources"] == 1, summary
+          assert summary["snapshots"] == 3, summary
+          # Volume floors: an estate that collapses to a handful of rows is the
+          # failure this gate exists to catch.
+          for key, floor in (("assets", 100), ("observations", 100), ("correlations", 10)):
+              assert int(summary[key]) >= floor, f"demo {key}={summary[key]} below floor {floor}: {summary}"
           assert payload["primary_correlation"]["outcome"] == "blocked"
           assert payload["primary_correlation"]["sources"] == [
               "github_actions",

--- a/src/agent_bom/cli/_demo.py
+++ b/src/agent_bom/cli/_demo.py
@@ -54,7 +54,7 @@ def _render_story(story: EnterpriseDemoStory) -> str:
             "",
             *_render_chain(story),
             "Next: agent-bom serve --demo-estate --allow-insecure-no-auth",
-            "Then open: http://127.0.0.1:8000/demo-estate",
+            "Then open: http://127.0.0.1:8422/demo-estate",
         ]
     )
 


### PR DESCRIPTION
First of the six pre-tag items from the Codex audit. Both findings independently reproduced before changing anything.

## The gate

`demo-deploy-cloudrun.yml` asserted **exact dict equality** on the demo story summary:

```python
assert summary == {"assets": 20, "observations": 15, ..., "correlations": 4, ...}
```

Measured actual, via `build_enterprise_demo_story()`:

| field | asserted | actual |
|---|---|---|
| assets | 20 | **3,860** |
| observations | 15 | **12,171** |
| correlations | 4 | **2,322** |

**This runs *after* Release.** Tagging would have shipped the release and then failed the demo deploy on the way out — which is why it's a genuine tag blocker rather than cosmetic.

## Why not just re-pin the numbers

That resets the same trap for the next reseed. Counts are seeded data; they will move again. The gate now asserts what must actually hold:

- **all seven keys present** — catches a renamed or dropped field
- **source split exact** (`evidence_sources` 9, `complete_sources` 8, `partial_sources` 1, `snapshots` 3) — that's fixture *structure*, not volume, so pinning it is correct
- **floors** on assets/observations/correlations — catches the failure this gate exists for: an estate collapsed to a handful of rows

Structure stays strict, volume stops rotting.

## The port

`_demo.py:57` printed `http://127.0.0.1:8000/demo-estate` directly below `Next: agent-bom serve --demo-estate`, whose default port is **8422**. The first thing a new user was told to open could not answer.

## How verified

- Ran the new assertions against the real `build_enterprise_demo_story()` output: **pass** on 3,860/12,171/2,322, and they would have failed the old hardcoded set.
- Confirmed 8422 is the documented default (`_entry_points.py:855`).
- Demo story tests pass; `make lint-ruff` and `make format-check` clean.

Remaining pre-tag items (2–6) are unaffected by this change.