### PR TITLE
ci: gate the drift classes that shipped stale claims by hand

### DIFF
--- a/.github/workflows/cflite-pr.yml
+++ b/.github/workflows/cflite-pr.yml
@@ -43,15 +43,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          # `mode: code-change` selects targets by diffing `<base_ref>...HEAD`
-          # (oss-fuzz infra/cifuzz/continuous_integration.py), which needs a
-          # merge base. ClusterFuzzLite fetches the base branch itself, but that
-          # fetch leaves a depth-1 clone shallow, so no common ancestor exists
-          # and the changed-file set comes back empty — the job then fuzzes
-          # nothing and still exits 0. Same silent-skip shape as the MCP config
-          # scanner above. Batch-Fuzzing needs no history: it fuzzes everything.
-          fetch-depth: 0
 
       - name: Build fuzzers
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1

--- a/.github/workflows/cflite-pr.yml
+++ b/.github/workflows/cflite-pr.yml
@@ -43,6 +43,15 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # `mode: code-change` selects targets by diffing `<base_ref>...HEAD`
+          # (oss-fuzz infra/cifuzz/continuous_integration.py), which needs a
+          # merge base. ClusterFuzzLite fetches the base branch itself, but that
+          # fetch leaves a depth-1 clone shallow, so no common ancestor exists
+          # and the changed-file set comes back empty — the job then fuzzes
+          # nothing and still exits 0. Same silent-skip shape as the MCP config
+          # scanner above. Batch-Fuzzing needs no history: it fuzzes everything.
+          fetch-depth: 0
 
       - name: Build fuzzers
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       action: ${{ steps.classify.outputs.action }}
       alpine: ${{ steps.classify.outputs.alpine }}
       alpine_full: ${{ steps.classify.outputs.alpine_full }}
+      compose: ${{ steps.classify.outputs.compose }}
       docs: ${{ steps.classify.outputs.docs }}
       docs_only: ${{ steps.classify.outputs.docs_only }}
       endpoint: ${{ steps.classify.outputs.endpoint }}
@@ -81,6 +82,7 @@ jobs:
           action=false
           alpine=false
           alpine_full=false
+          compose=false
           docs=false
           endpoint=false
           helm=false
@@ -94,6 +96,11 @@ jobs:
           ui=false
           if printf '%s\n' "$changed" | grep -Eq '^(action\.yml|\.github/actions/|tests/fixtures/test-(sbom|policy)\.json$)'; then
             action=true
+          fi
+          # Compose contract: every shipped compose file, the bootstrap SQL and
+          # secrets they mount, the Dockerfiles they build, and the gate itself.
+          if printf '%s\n' "$changed" | grep -Eq '^(deploy/docker-compose|deploy/[^/]+/[^/]*/?docker-compose|deploy/supabase/|deploy/docker/|deploy/secrets/|examples/docker-compose|Dockerfile$|ui/Dockerfile$|scripts/check_compose_contract\.py$|tests/test_compose_)'; then
+            compose=true
           fi
           # Changes to this workflow must exercise the Alpine job itself;
           # otherwise checkout/bootstrap fixes can merge without ever running
@@ -121,7 +128,7 @@ jobs:
           # are deliberately excluded: no integration test drives the ASGI app
           # against real Postgres, so the job could not observe a regression
           # there and gating those hot files would cost time for no signal.
-          if printf '%s\n' "$changed" | grep -Eq '^(src/agent_bom/api/(postgres_|storage_schema\.py|connection_store\.py|connection_scheduler\.py|proxy_replay_store\.py)|src/agent_bom/cloud/([a-z_]*event_ingest|runtime_workload_evidence_store)\.py|src/agent_bom/ticketing/postgres_store\.py|tests/test_postgres_|deploy/supabase/postgres/)'; then
+          if printf '%s\n' "$changed" | grep -Eq '^(src/agent_bom/api/(postgres_|storage_schema\.py|connection_store\.py|connection_scheduler\.py|proxy_replay_store\.py)|src/agent_bom/api/hub_observations_partition\.py|src/agent_bom/cloud/([a-z_]*event_ingest|runtime_workload_evidence_store)\.py|src/agent_bom/ticketing/postgres_store\.py|tests/test_postgres_|deploy/supabase/postgres/|scripts/check_postgres_schema_parity\.py$)'; then
             postgres=true
           fi
           # Python test suite: skip only when a PR clearly cannot affect it
@@ -148,6 +155,7 @@ jobs:
             echo "action=${action}"
             echo "alpine=${alpine}"
             echo "alpine_full=${alpine_full}"
+            echo "compose=${compose}"
             echo "docs=${docs}"
             echo "endpoint=${endpoint}"
             echo "helm=${helm}"
@@ -161,6 +169,7 @@ jobs:
             echo "- GitHub Action dogfood required: \`${action}\`"
             echo "- Alpine/musl compatibility required: \`${alpine}\`"
             echo "- Alpine/musl full-suite required: \`${alpine_full}\`"
+            echo "- Compose contract validation required: \`${compose}\`"
             echo "- Docs strict build required: \`${docs}\`"
             echo "- Documentation-only fast path: \`${docs_only}\`"
             echo "- Endpoint packaging required: \`${endpoint}\`"
@@ -191,6 +200,15 @@ jobs:
 
       - name: Block Finder duplicate artifacts
         run: python scripts/check_duplicate_artifacts.py
+
+      # Deliberately NOT gated on docs_only. A stale advertised count IS a
+      # docs-only change, and a masked pipeline can be introduced by a workflow
+      # edit that touches nothing else. Both checks run in ~2s combined.
+      - name: CI pipefail policy — no shell pipeline may mask a failure
+        run: python scripts/check_ci_pipefail.py
+
+      - name: Published counts match the shipped build
+        run: python scripts/check_published_counts.py
 
       - name: Docker base-image policy
         if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
@@ -287,6 +305,12 @@ jobs:
 
       - name: OSV Scanner (all lockfiles)
         if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
+        # `shell: bash` runs `bash --noprofile --norc -eo pipefail {0}`. Without
+        # pipefail every `osv-scanner ... | tee` below exited with tee's status,
+        # so the `|| { ... }` fixable-CVE branch was unreachable and this gate
+        # passed unconditionally on all three lockfiles. See
+        # scripts/check_ci_pipefail.py, which now blocks the whole class.
+        shell: bash
         run: |
           OSV_SCANNER_VERSION="v2.3.3"
           OSV_SCANNER_SHA256="777b4bb7ddd10bdcc8a1aa398d37d05e91e866e7586f9cff3fca2f72b8153033"
@@ -294,39 +318,32 @@ jobs:
             "https://github.com/google/osv-scanner/releases/download/${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
           echo "${OSV_SCANNER_SHA256}  /tmp/osv-scanner" | sha256sum -c -
           install -m 0755 /tmp/osv-scanner /usr/local/bin/osv-scanner
-          # Scan main lockfile (all pinned deps for every extra, including transitive)
-          # osv-scanner v2 syntax: scan --lockfile=<path>
-          # Scan main lockfile — pass if only unfixable CVEs remain (FIXED VERSION = --)
-          osv-scanner scan --config osv-scanner.toml --lockfile=uv.lock 2>&1 | tee /tmp/osv-uv.txt || {
-            FIXABLE=$(grep -E "^\|" /tmp/osv-uv.txt | grep -v "| -- " | grep -v "OSV URL" | grep -v "+--" | head -5)
-            if [ -n "$FIXABLE" ]; then
-              echo "::error::osv-scanner found vulnerabilities with available fixes:"
-              echo "$FIXABLE"
-              exit 1
+
+          # Pass only when every remaining CVE is unfixable (FIXED VERSION = --).
+          # Status is captured explicitly rather than inferred from a pipeline so
+          # the branch cannot silently stop being taken again.
+          osv_gate() {
+            lockfile="$1"; label="$2"; report="$3"
+            status=0
+            osv-scanner scan --config osv-scanner.toml --lockfile="$lockfile" 2>&1 | tee "$report" || status=$?
+            if [ "$status" -eq 0 ]; then
+              return 0
             fi
-            echo "::warning::osv-scanner found only unfixable CVEs (no upstream fix) — passing"
+            fixable=$(grep -E "^\|" "$report" | grep -v "| -- " | grep -v "OSV URL" | grep -v "+--" | head -5 || true)
+            if [ -n "$fixable" ]; then
+              echo "::error::osv-scanner found ${label} vulnerabilities with available fixes:"
+              echo "$fixable"
+              return 1
+            fi
+            echo "::warning::osv-scanner found only unfixable ${label} CVEs (no upstream fix) — passing"
+            return 0
           }
-          # Scan dashboard deps
+
+          osv_gate uv.lock "uv.lock" /tmp/osv-uv.txt
+          osv_gate ui/package-lock.json "UI lockfile" /tmp/osv-ui.txt
+          osv_gate sdks/typescript/package-lock.json "TypeScript SDK lockfile" /tmp/osv-sdk.txt
+          # Scan dashboard deps — no unfixable-CVE carve-out, any finding fails.
           osv-scanner scan --config osv-scanner.toml --lockfile=dashboard/requirements.txt
-          # Scan UI and SDK npm lockfiles with the same OSV gate as uv.lock
-          osv-scanner scan --config osv-scanner.toml --lockfile=ui/package-lock.json 2>&1 | tee /tmp/osv-ui.txt || {
-            FIXABLE=$(grep -E "^\|" /tmp/osv-ui.txt | grep -v "| -- " | grep -v "OSV URL" | grep -v "+--" | head -5)
-            if [ -n "$FIXABLE" ]; then
-              echo "::error::osv-scanner found UI lockfile vulnerabilities with available fixes:"
-              echo "$FIXABLE"
-              exit 1
-            fi
-            echo "::warning::osv-scanner found only unfixable UI lockfile CVEs (no upstream fix) — passing"
-          }
-          osv-scanner scan --config osv-scanner.toml --lockfile=sdks/typescript/package-lock.json 2>&1 | tee /tmp/osv-sdk.txt || {
-            FIXABLE=$(grep -E "^\|" /tmp/osv-sdk.txt | grep -v "| -- " | grep -v "OSV URL" | grep -v "+--" | head -5)
-            if [ -n "$FIXABLE" ]; then
-              echo "::error::osv-scanner found TypeScript SDK lockfile vulnerabilities with available fixes:"
-              echo "$FIXABLE"
-              exit 1
-            fi
-            echo "::warning::osv-scanner found only unfixable TypeScript SDK lockfile CVEs (no upstream fix) — passing"
-          }
 
       - name: Filesystem vulnerability scan (agent-bom — dogfood)
         if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
@@ -375,15 +392,26 @@ jobs:
 
       - name: JavaScript supply-chain guard
         if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
+        shell: bash
         run: |
           python scripts/check_js_supply_chain.py
           cd sdks/typescript
           # The preceding SDK audit step installed this exact lockfile. Reuse
           # that tree instead of paying for a second npm ci on every run.
           npm run build
-          if find dist -name '*.map' -print -quit | grep -q .; then
+          # `find dist ... | grep -q .` reported "clean" whenever `dist` was
+          # missing, because grep's exit 1 was indistinguishable from find's
+          # failure. Assert the build output exists before concluding it is
+          # source-map free — a guard that cannot observe its subject is not a
+          # guard.
+          if [ ! -d dist ]; then
+            echo "::error::TypeScript SDK build produced no dist/ directory"
+            exit 1
+          fi
+          maps=$(find dist -name '*.map' -print)
+          if [ -n "$maps" ]; then
             echo "::error::TypeScript SDK build emitted source maps"
-            find dist -name '*.map' -print
+            echo "$maps"
             exit 1
           fi
 
@@ -660,6 +688,42 @@ jobs:
             echo "::error::NEXT_EXPORT=1 build did not produce ui/out/index.html"
             exit 1
           }
+
+  compose-contract:
+    name: Compose Contract Validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: changes
+    # Path-filtered: this only has something to say when a compose file, the
+    # SQL/secrets it mounts, or a Dockerfile it builds actually changes.
+    if: >-
+      !cancelled() && (
+        (github.event_name != 'pull_request' && github.event_name != 'push') ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.compose == 'true'
+      )
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      # Nothing in CI has ever run `docker compose config` against these files,
+      # while docs/DEPLOY_PLATFORM.md told operators the stack passes it. The
+      # gate also asserts the RENDERED graph, because "exited 0" is not a test.
+      - name: Validate every shipped compose file and overlay combination
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python scripts/check_compose_contract.py
 
   helm-profiles:
     name: Helm Profile Validate
@@ -1144,6 +1208,15 @@ jobs:
           SQL
           PGPASSWORD=psqlpass psql -h 127.0.0.1 -U agentbom_psql_owner -d agent_bom \
             -v ON_ERROR_STOP=1 -f deploy/supabase/postgres/init.sql
+          # The Docker entrypoint mounts BOTH 01-init.sql and 02-runtime-schema.sql
+          # (deploy/docker-compose.platform.yml). Replaying only the first was not
+          # the bootstrap any deployment performs, and it left this path without
+          # hub_findings_current_observations — so the partition migration found
+          # nothing to convert and the two paths ended at the same Alembic head
+          # with materially different schemas. Only the new schema-parity check
+          # below could see that; the head comparison could not.
+          PGPASSWORD=psqlpass psql -h 127.0.0.1 -U agentbom_psql_owner -d agent_bom \
+            -v ON_ERROR_STOP=1 -f deploy/supabase/postgres/runtime-schema.sql
           export ALEMBIC_DATABASE_URL='postgresql+psycopg://agentbom_psql_owner:psqlpass@127.0.0.1:5432/agent_bom'
           uv run alembic -c deploy/supabase/postgres/alembic.ini stamp 20260416_01
           uv run alembic -c deploy/supabase/postgres/alembic.ini upgrade head
@@ -1151,6 +1224,22 @@ jobs:
           test "$actual_head" = "$expected_head"
           test -z "$(PGPASSWORD=psqlpass psql -h 127.0.0.1 -U agentbom_psql_owner -d agent_bom -Atc "SELECT current_setting('init.app_password', true)")"
           test "$(PGPASSWORD=psqlpass psql -h 127.0.0.1 -U agentbom_psql_owner -d agent_bom -Atc "SELECT rolsuper OR rolbypassrls FROM pg_roles WHERE rolname = current_user")" = "f"
+
+      - name: Postgres schema parity — both bootstrap paths must render one schema
+        # Matching `alembic_version` proves the two paths RAN the same revisions,
+        # not that they PRODUCED the same schema. The convention here is that a
+        # new column lands in a migration and is back-added to init.sql; miss the
+        # second edit and fresh installs ship a different database under an
+        # identical head. Every other guard against that is a regex over SQL text
+        # — this diffs the two live databases the job already built.
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python scripts/check_postgres_schema_parity.py \
+            --migration-url 'postgresql://agentbom_migration_owner:migrationpass@127.0.0.1:5432/agentbom_migration' \
+            --bootstrap-url 'postgresql://agentbom_psql_owner:psqlpass@127.0.0.1:5432/agent_bom' \
+            --require-extension pg_trgm \
+            --require-extension pgcrypto
 
       - name: Provision non-superuser application role
         run: |

--- a/.github/workflows/deploy-mcp-sse.yml
+++ b/.github/workflows/deploy-mcp-sse.yml
@@ -25,6 +25,7 @@ jobs:
       }}
     steps:
       - name: Resolve trusted release tag
+        shell: bash
         id: tag
         env:
           REF_NAME: ${{ github.ref_name }}
@@ -89,6 +90,7 @@ jobs:
           fi
 
       - name: Post-deploy version check
+        shell: bash
         env:
           RAILWAY_MCP_URL: ${{ vars.RAILWAY_MCP_URL }}
           RAILWAY_MCP_BEARER_TOKEN: ${{ secrets.RAILWAY_MCP_BEARER_TOKEN }}

--- a/.github/workflows/deployment-freshness.yml
+++ b/.github/workflows/deployment-freshness.yml
@@ -43,6 +43,7 @@ jobs:
           echo "Expected version: $VERSION"
 
       - name: Check Railway deployment
+        shell: bash
         id: railway
         continue-on-error: true
         env:
@@ -76,6 +77,7 @@ jobs:
           fi
 
       - name: Check Smithery catalog listing
+        shell: bash
         id: public
         continue-on-error: true
         env:
@@ -144,6 +146,7 @@ jobs:
           fi
 
       - name: Open issue if deployment surfaces drift or public endpoint is misconfigured
+        shell: bash
         if: steps.railway.outputs.stale == 'true' || steps.public.outputs.stale == 'true' || steps.public.outputs.auth_gate == 'true' || steps.public.outputs.probe_failed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -34,14 +34,23 @@ jobs:
         run: uv tool install .  # PR checkout — a PyPI pin equal to the repo version breaks between bump and publish
 
       - name: Scan changed MCP configs
+        shell: bash
         id: scan
         env:
           PR_NUMBER: "${{ github.event.pull_request.number }}"
         run: |
           set +e
 
-          # Find which MCP config files changed in this PR
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '(\.mcp\.json|mcp\.json|docker-compose\.ya?ml|compose\.ya?ml)$' || true)
+          # Resolve the changed-file list BEFORE filtering it. Folding the two
+          # into one `|| true` pipeline made "git diff failed" (missing base ref
+          # after a shallow fetch) indistinguishable from "nothing matched", so a
+          # PR that did change MCP configs skipped this security scan silently.
+          if ! DIFF=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD"); then
+            echo "::error::could not diff against origin/${{ github.base_ref }} — refusing to report 'no MCP config changes' from a failed diff"
+            exit 1
+          fi
+          # Only the filter may legitimately match nothing.
+          CHANGED=$(printf '%s\n' "$DIFF" | grep -E '(\.mcp\.json|mcp\.json|docker-compose\.ya?ml|compose\.ya?ml)$' || true)
 
           if [ -z "$CHANGED" ]; then
             echo "No MCP config files changed"

--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -82,12 +82,8 @@ jobs:
           echo "### Security Scan Results" >> scan-report.md
           echo "" >> scan-report.md
 
-          # Run agent-bom check on each config. A scanner that crashes must not
-          # look like a scanner that found nothing: the old `|| true` wrote the
-          # traceback into the report and reported success. Failures are counted
-          # and surfaced at the end.
-          SCANNED=0
-          FAILED=0
+          # Run agent-bom check on each config
+          VULN_COUNT=0
           for f in $CHANGED; do
             if [ -f "$f" ]; then
               echo "Scanning $f..."
@@ -95,39 +91,19 @@ jobs:
               echo "<summary><code>$f</code></summary>" >> scan-report.md
               echo "" >> scan-report.md
               echo '```' >> scan-report.md
-              scan_output="$(uv run agent-bom agents --project "$(dirname "$f")" --format json 2>&1)"
-              scan_status=$?
-              printf '%s\n' "$scan_output" | head -100 >> scan-report.md
+              uv run agent-bom agents --project "$(dirname "$f")" --format json 2>&1 | head -100 >> scan-report.md || true
               echo '```' >> scan-report.md
-              if [ "$scan_status" -ne 0 ]; then
-                FAILED=$((FAILED + 1))
-                echo "::error::agent-bom agents failed on ${f} (exit ${scan_status})"
-                echo "" >> scan-report.md
-                echo "> **Scan failed for \`$f\` (exit ${scan_status})** — results above are incomplete." >> scan-report.md
-              else
-                SCANNED=$((SCANNED + 1))
-              fi
               echo "</details>" >> scan-report.md
               echo "" >> scan-report.md
             fi
           done
-          echo "Scanned ${SCANNED} config(s); ${FAILED} failed."
 
           echo "" >> scan-report.md
           echo "---" >> scan-report.md
           echo "*Scanned by [agent-bom](https://github.com/msaad00/agent-bom) — AI supply chain and infrastructure security scanner*" >> scan-report.md
 
-          # Fail AFTER the report is complete so the PR comment still explains
-          # what happened. A security scan that could not run is not a pass.
-          if [ "$FAILED" -ne 0 ]; then
-            echo "::error::${FAILED} MCP config scan(s) failed — not reporting this PR as scanned"
-            exit 1
-          fi
-
-      # `always()` so a failed scan still posts the report explaining itself;
-      # the job stays red either way.
       - name: Comment on PR
-        if: always() && steps.scan.outputs.has_changes == 'true'
+        if: steps.scan.outputs.has_changes == 'true'
         env:
           GH_TOKEN: "${{ github.token }}"
           PR_NUMBER: "${{ github.event.pull_request.number }}"

--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -25,6 +25,12 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The default shallow clone fetches one commit and no base ref, so the
+          # diff below could never resolve. Every other workflow that diffs
+          # against a base already sets this; this one was the outlier, and the
+          # old `git diff … || true` shape hid the failure as "nothing changed".
+          fetch-depth: 0
 
       - uses: ./.github/actions/setup-python
         with:
@@ -38,6 +44,8 @@ jobs:
         id: scan
         env:
           PR_NUMBER: "${{ github.event.pull_request.number }}"
+          BASE_SHA: "${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
         run: |
           set +e
 
@@ -45,8 +53,10 @@ jobs:
           # into one `|| true` pipeline made "git diff failed" (missing base ref
           # after a shallow fetch) indistinguishable from "nothing matched", so a
           # PR that did change MCP configs skipped this security scan silently.
-          if ! DIFF=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD"); then
-            echo "::error::could not diff against origin/${{ github.base_ref }} — refusing to report 'no MCP config changes' from a failed diff"
+          # Diffing the two PR SHAs — the same pattern ci.yml's path classifier
+          # uses — avoids depending on a remote branch ref being present.
+          if ! DIFF=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA"); then
+            echo "::error::could not diff $BASE_SHA..$HEAD_SHA — refusing to report 'no MCP config changes' from a failed diff"
             exit 1
           fi
           # Only the filter may legitimately match nothing.
@@ -72,8 +82,12 @@ jobs:
           echo "### Security Scan Results" >> scan-report.md
           echo "" >> scan-report.md
 
-          # Run agent-bom check on each config
-          VULN_COUNT=0
+          # Run agent-bom check on each config. A scanner that crashes must not
+          # look like a scanner that found nothing: the old `|| true` wrote the
+          # traceback into the report and reported success. Failures are counted
+          # and surfaced at the end.
+          SCANNED=0
+          FAILED=0
           for f in $CHANGED; do
             if [ -f "$f" ]; then
               echo "Scanning $f..."
@@ -81,19 +95,39 @@ jobs:
               echo "<summary><code>$f</code></summary>" >> scan-report.md
               echo "" >> scan-report.md
               echo '```' >> scan-report.md
-              uv run agent-bom agents --project "$(dirname "$f")" --format json 2>&1 | head -100 >> scan-report.md || true
+              scan_output="$(uv run agent-bom agents --project "$(dirname "$f")" --format json 2>&1)"
+              scan_status=$?
+              printf '%s\n' "$scan_output" | head -100 >> scan-report.md
               echo '```' >> scan-report.md
+              if [ "$scan_status" -ne 0 ]; then
+                FAILED=$((FAILED + 1))
+                echo "::error::agent-bom agents failed on ${f} (exit ${scan_status})"
+                echo "" >> scan-report.md
+                echo "> **Scan failed for \`$f\` (exit ${scan_status})** — results above are incomplete." >> scan-report.md
+              else
+                SCANNED=$((SCANNED + 1))
+              fi
               echo "</details>" >> scan-report.md
               echo "" >> scan-report.md
             fi
           done
+          echo "Scanned ${SCANNED} config(s); ${FAILED} failed."
 
           echo "" >> scan-report.md
           echo "---" >> scan-report.md
           echo "*Scanned by [agent-bom](https://github.com/msaad00/agent-bom) — AI supply chain and infrastructure security scanner*" >> scan-report.md
 
+          # Fail AFTER the report is complete so the PR comment still explains
+          # what happened. A security scan that could not run is not a pass.
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::${FAILED} MCP config scan(s) failed — not reporting this PR as scanned"
+            exit 1
+          fi
+
+      # `always()` so a failed scan still posts the report explaining itself;
+      # the job stays red either way.
       - name: Comment on PR
-        if: steps.scan.outputs.has_changes == 'true'
+        if: always() && steps.scan.outputs.has_changes == 'true'
         env:
           GH_TOKEN: "${{ github.token }}"
           PR_NUMBER: "${{ github.event.pull_request.number }}"

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -70,6 +70,7 @@ jobs:
           echo "After the repository is registered with the official MCP Registry, set repository variable MCP_REGISTRY_PUBLISH_ENABLED=true or run this workflow manually with publish=true."
 
       - name: Get GitHub OIDC token
+        shell: bash
         id: oidc
         if: steps.mode.outputs.publish == 'true'
         run: |

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -503,6 +503,7 @@ jobs:
           clawhub --help > /dev/null
 
       - name: Publish to ClawHub
+        shell: bash
         if: steps.clawhub_config.outputs.enabled == 'true'
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}

--- a/.github/workflows/release-snowflake.yml
+++ b/.github/workflows/release-snowflake.yml
@@ -68,6 +68,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Build reproducible Native App artifact
+        shell: bash
         run: |
           mkdir -p dist
           python scripts/release/snowflake_native_app.py package \
@@ -111,6 +112,7 @@ jobs:
           docker image inspect "$LOCAL_IMAGE" --format '{{.Id}}'
 
       - name: Export image for the protected publish job
+        shell: bash
         env:
           LOCAL_IMAGE: agent-bom-spcs/${{ matrix.image.name }}:${{ matrix.image.tag }}
         run: |
@@ -199,6 +201,7 @@ jobs:
             --private-key-file "$key" --role "$SNOWFLAKE_ROLE"
 
       - name: Push all version-pinned SPCS images
+        shell: bash
         env:
           PACKAGE_VERSION: ${{ needs.package.outputs.package_version }}
           SNOWFLAKE_IMAGE_REPOSITORY_URL: ${{ vars.SNOWFLAKE_IMAGE_REPOSITORY_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -813,6 +813,7 @@ jobs:
           helm package /tmp/agent-bom-chart --destination dist/helm
 
       - name: Login to GHCR OCI registry
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: echo "${GH_TOKEN}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
@@ -953,6 +954,10 @@ jobs:
           npm audit --audit-level=high
 
       - name: OSV scanner (ui lockfile) — block release on fixable CVEs
+        # Without pipefail the `| tee` below swallowed osv-scanner's exit code,
+        # so this release blocker could never block anything. Same defect as the
+        # CI twin in ci.yml; both are now covered by scripts/check_ci_pipefail.py.
+        shell: bash
         run: |
           OSV_SCANNER_VERSION="v2.3.3"
           OSV_SCANNER_SHA256="777b4bb7ddd10bdcc8a1aa398d37d05e91e866e7586f9cff3fca2f72b8153033"
@@ -960,15 +965,17 @@ jobs:
             "https://github.com/google/osv-scanner/releases/download/${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
           echo "${OSV_SCANNER_SHA256}  /tmp/osv-scanner" | sha256sum -c -
           install -m 0755 /tmp/osv-scanner /usr/local/bin/osv-scanner
-          osv-scanner scan --config osv-scanner.toml --lockfile=ui/package-lock.json 2>&1 | tee /tmp/osv-ui-release.txt || {
-            FIXABLE=$(grep -E "^\|" /tmp/osv-ui-release.txt | grep -v "| -- " | grep -v "OSV URL" | grep -v "+--" | head -5)
+          status=0
+          osv-scanner scan --config osv-scanner.toml --lockfile=ui/package-lock.json 2>&1 | tee /tmp/osv-ui-release.txt || status=$?
+          if [ "$status" -ne 0 ]; then
+            FIXABLE=$(grep -E "^\|" /tmp/osv-ui-release.txt | grep -v "| -- " | grep -v "OSV URL" | grep -v "+--" | head -5 || true)
             if [ -n "$FIXABLE" ]; then
               echo "::error::osv-scanner found UI lockfile vulnerabilities with available fixes:"
               echo "$FIXABLE"
               exit 1
             fi
             echo "::warning::osv-scanner found only unfixable UI lockfile CVEs (no upstream fix) — passing"
-          }
+          fi
 
       - name: pip-audit (shipping Python deps) — block release on high/critical or fixable CVEs
         run: |
@@ -1310,6 +1317,7 @@ jobs:
           fi
 
       - name: Update floating major tag (v0)
+        shell: bash
         if: ${{ vars.AGENT_BOM_UPDATE_FLOATING_MAJOR_TAGS == '1' }}
         run: |
           MAJOR=$(echo "${{ github.ref_name }}" | grep -oP '^v\d+')

--- a/.github/workflows/uv-lock-upgrade.yml
+++ b/.github/workflows/uv-lock-upgrade.yml
@@ -31,6 +31,7 @@ jobs:
         run: uv lock --upgrade
 
       - name: Check for changes
+        shell: bash
         id: diff
         run: |
           if git diff --quiet uv.lock; then

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ preflight:  ## Run the drift gates that CI's "Version Alignment" job runs — do
 	@echo "→ graph proof fixtures";                 python scripts/check_graph_epic_proof.py
 	@echo "→ enterprise demo surfaces";             python scripts/check_enterprise_demo_surfaces.py
 	@echo "→ release/README consistency";           python scripts/check_release_consistency.py
+	@echo "→ published counts vs shipped build";    python scripts/check_published_counts.py
+	@echo "→ CI pipefail policy";                   python scripts/check_ci_pipefail.py
 	@echo "→ product metrics snapshot";             python scripts/product_metrics_snapshot.py --check
 	@echo "→ CVE matching accuracy";                python scripts/cve_matching_accuracy.py --check
 	@echo "→ env-var reference";                    python scripts/generate_env_var_reference.py --check

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -56,8 +56,11 @@ services:
       - ~/.agent-bom:/home/abom/.agent-bom
       # Mount current directory for output
       - ./reports:/workspace/reports
-      # Mount test configs
-      - ./tests:/workspace/tests:ro
+      # Mount test configs. Relative paths resolve against this file's directory,
+      # so `./tests` pointed at `deploy/tests` — a directory that does not exist.
+      # Docker creates a missing read-only bind source as an empty directory
+      # instead of failing, so the container silently scanned nothing.
+      - ../tests:/workspace/tests:ro
     command: scan --enrich --format json --output /workspace/reports/ai-bom.json
     networks:
       - backend

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -245,7 +245,7 @@ compliance reports without leaving the chat:
 ```
 scan                — full discovery + scan, returns JSON report
 check               — CVE check for a single package
-registry_lookup     — search 1013 MCP servers by name/tag
+registry_lookup     — search 1081 MCP servers by name/tag
 compliance          — generate framework-mapped compliance report
 blast_radius        — blast radius for a specific CVE
 should_i_deploy     — allow/warn/block guidance from ExposurePath risk

--- a/docs/images/scan-pipeline-light.svg
+++ b/docs/images/scan-pipeline-light.svg
@@ -98,7 +98,7 @@
   <rect x="226" y="216" width="140" height="1" fill="#e4e4e7"/>
 
   <text x="232" y="234" class="item-label" fill="#d97706">MCP Registry</text>
-  <text x="366" y="234" text-anchor="end" class="step-desc">1013 servers</text>
+  <text x="366" y="234" text-anchor="end" class="step-desc">1081 servers</text>
   <rect x="226" y="240" width="140" height="1" fill="#e4e4e7"/>
 
   <text x="232" y="254" class="step-desc">Queries run in parallel</text>

--- a/docs/skills/mcp-server-review.md
+++ b/docs/skills/mcp-server-review.md
@@ -26,7 +26,7 @@ pip install agent-bom
 
 ### 1. Registry Lookup
 
-Check if the server is in agent-bom's curated registry (1013 servers, 940 verified):
+Check if the server is in agent-bom's curated registry (1081 servers, 60 verified):
 
 ```bash
 # Via CLI

--- a/integrations/cortex-code/README.md
+++ b/integrations/cortex-code/README.md
@@ -57,7 +57,7 @@ All agent-bom MCP tools become available in Cortex Code:
 | `check` | Pre-install CVE check for a package |
 | `blast_radius` | Map CVE impact across agents and credentials |
 | `policy_check` | Evaluate security policy against findings |
-| `registry_lookup` | Query 1013 MCP server security metadata records |
+| `registry_lookup` | Query 1081 MCP server security metadata records |
 | `generate_sbom` | Generate CycloneDX or SPDX SBOM |
 | `compliance` | Map findings to OWASP, NIST, MITRE, EU AI Act, and related frameworks |
 | `remediate` | Prioritized remediation plan |

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -57,6 +57,12 @@ VERSION_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
         r"\g<1>{v}\g<2>",
     ),
     ("uv.lock", re.compile(r'(\[\[package\]\]\nname = "agent-bom"\nversion = ")[^"]+(")', re.M), r"\g<1>{v}\g<2>"),
+    # `agent-bom-sdk` is a thin alias that re-exports the packaged control-plane
+    # client, so it ships the platform's version. It was bumped by hand once and
+    # then forgotten, drifting to 0.92.0 while the platform reached 0.100.0.
+    # scripts/check_release_consistency.py now sweeps for this structurally; this
+    # entry is the writer half, so the sweep has nothing to catch.
+    ("sdks/python/pyproject.toml", re.compile(r'^(version\s*=\s*")[^"]+(")', re.M), r"\g<1>{v}\g<2>"),
 ]
 
 OPENCLAW_SKILL_PATTERNS: list[tuple[str, re.Pattern, str]] = [

--- a/scripts/check_ci_pipefail.py
+++ b/scripts/check_ci_pipefail.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Fail closed on CI shell pipelines that cannot report a failure.
+
+GitHub Actions runs an unqualified ``run:`` step as ``bash -e {0}`` — ``-e`` but
+NOT ``-o pipefail``. A pipeline therefore exits with the status of its LAST
+command, so ``some-scanner | tee log`` exits 0 no matter how badly
+``some-scanner`` failed. Declaring ``shell: bash`` instead runs
+``bash --noprofile --norc -eo pipefail {0}``, which does propagate the failure.
+Both invocations are documented under "workflow syntax → jobs.<job_id>.steps[*].shell".
+
+This gate exists because the class bit us twice in one day: ``npm install --silent``
+returned 0 while ERESOLVE-failing, and a capture script piped to ``tail`` hid a
+non-zero exit. Worse, the repo's own OSV CVE gate piped ``osv-scanner`` into
+``tee`` and then branched on ``|| { ... }`` — a branch that could never be taken,
+so the "block on fixable CVEs" logic was dead code that always reported success.
+
+A gate that cannot fail is not a gate. Every ``run:`` step containing a shell
+pipeline must run under a pipefail shell, either by declaring ``shell: bash``
+(or a job/workflow ``defaults.run.shell``) or by calling ``set -o pipefail``
+before the first pipeline in the script body.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS = ROOT / ".github" / "workflows"
+ACTIONS = ROOT / ".github" / "actions"
+ROOT_ACTION = ROOT / "action.yml"
+
+# Shells whose GitHub-Actions invocation already includes ``-o pipefail``, plus
+# the non-POSIX shells where bash pipeline semantics simply do not apply.
+_PIPEFAIL_SHELLS = {"bash", "pwsh", "powershell", "python"}
+# ``sh -e {0}`` and the implicit ``bash -e {0}`` are the unsafe ones.
+_UNSAFE_EXPLICIT_SHELLS = {"sh"}
+
+_SET_PIPEFAIL = re.compile(r"^\s*set\s+[-+]\S*o?\s*.*\bpipefail\b|^\s*set\s+-\S*o\s+pipefail\b", re.M)
+_HEREDOC_START = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+_CASE_IN = re.compile(r"\bcase\b.*\bin\b\s*$")
+_ESAC = re.compile(r"^\s*esac\b")
+# A `case` alternation arm such as `  *.md|*.txt)` — a pattern list, not a pipeline.
+_CASE_ARM = re.compile(r"^\s*\(?[^;&()]*\)(?:\s*(?:#.*)?)$")
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    step: str
+    line: int
+    pipeline: str
+
+    def render(self) -> str:
+        rel = self.path.relative_to(ROOT)
+        return f"{rel}:{self.line}: step {self.step!r} pipes without pipefail:\n      {self.pipeline.strip()}"
+
+
+def _strip_quotes_and_comments(line: str) -> str:
+    """Blank out quoted spans and trailing comments so only shell operators remain.
+
+    Pipes inside strings are data, not operators: a ``--jq '.a|.b'`` filter, a
+    markdown table echoed into the step summary, and a Python regex in a heredoc
+    all contain ``|`` and none of them is a pipeline.
+    """
+    out: list[str] = []
+    quote: str | None = None
+    index = 0
+    while index < len(line):
+        char = line[index]
+        if quote is None and char == "\\":
+            index += 2
+            continue
+        if quote is None and char in "'\"":
+            quote = char
+            out.append(" ")
+        elif quote is not None and char == quote:
+            quote = None
+            out.append(" ")
+        elif quote is None and char == "#" and (not out or out[-1].isspace()):
+            break
+        else:
+            out.append(" " if quote is not None else char)
+        index += 1
+    return "".join(out)
+
+
+def _script_lines(script: str) -> Iterator[tuple[int, str, str]]:
+    """Yield ``(1-based line number, raw line, operator-only line)``.
+
+    Heredoc bodies are skipped entirely — an embedded Python/SQL program is not
+    shell, and its pipes are not shell pipelines.
+    """
+    heredoc: str | None = None
+    for number, raw in enumerate(script.splitlines(), start=1):
+        if heredoc is not None:
+            if raw.strip() == heredoc:
+                heredoc = None
+            continue
+        stripped = _strip_quotes_and_comments(raw)
+        match = _HEREDOC_START.search(raw)
+        if match:
+            heredoc = match.group(2)
+            # The line that opens the heredoc is still shell and may itself pipe.
+            yield number, raw, stripped
+            continue
+        yield number, raw, stripped
+
+
+def _pipelines(script: str) -> list[tuple[int, str]]:
+    """Return ``(line number, raw line)`` for every real shell pipeline."""
+    found: list[tuple[int, str]] = []
+    case_depth = 0
+    for number, raw, stripped in _script_lines(script):
+        if _CASE_IN.search(stripped):
+            case_depth += 1
+            continue
+        if _ESAC.match(stripped):
+            case_depth = max(0, case_depth - 1)
+            continue
+        # Inside a `case`, a bare `a|b)` arm is a pattern list, not a pipeline.
+        if case_depth and _CASE_ARM.match(stripped):
+            continue
+        # Collapse `||` so only single-pipe operators remain.
+        operators = stripped.replace("||", "  ")
+        if "|" in operators.replace("|&", "  "):
+            found.append((number, raw))
+    return found
+
+
+def _mapping(node: yaml.Node | None) -> dict[str, yaml.Node]:
+    if not isinstance(node, yaml.MappingNode):
+        return {}
+    return {str(key.value): value for key, value in node.value if isinstance(key, yaml.ScalarNode)}
+
+
+def _sequence(node: yaml.Node | None) -> list[yaml.Node]:
+    return list(node.value) if isinstance(node, yaml.SequenceNode) else []
+
+
+def _scalar(node: yaml.Node | None) -> str | None:
+    return str(node.value) if isinstance(node, yaml.ScalarNode) else None
+
+
+def _default_shell(scope: dict[str, yaml.Node]) -> str | None:
+    return _scalar(_mapping(_mapping(scope.get("defaults")).get("run")).get("shell"))
+
+
+def _effective_shell(step: dict[str, yaml.Node], job_default: str | None, workflow_default: str | None) -> str | None:
+    explicit = _scalar(step.get("shell"))
+    for candidate in (explicit, job_default, workflow_default):
+        if candidate and candidate.strip():
+            return candidate.strip()
+    return None
+
+
+def _shell_is_pipefail(shell: str | None) -> bool:
+    if shell is None:
+        return False  # implicit `bash -e {0}` — no pipefail
+    head = shell.split()[0]
+    if head in _UNSAFE_EXPLICIT_SHELLS:
+        return False
+    if head in _PIPEFAIL_SHELLS:
+        return True
+    return "pipefail" in shell
+
+
+def _steps(root: yaml.Node) -> Iterator[tuple[dict[str, yaml.Node], str | None, str | None]]:
+    """Yield ``(step, job default shell, workflow default shell)``.
+
+    Walks the composed node tree rather than ``safe_load`` output so every
+    ``run:`` body keeps the source line it came from — a finding the reader
+    cannot jump to is a finding they will not fix.
+    """
+    document = _mapping(root)
+    workflow_default = _default_shell(document)
+    jobs = _mapping(document.get("jobs"))
+    if jobs:
+        for job_node in jobs.values():
+            job = _mapping(job_node)
+            job_default = _default_shell(job) or workflow_default
+            for step_node in _sequence(job.get("steps")):
+                yield _mapping(step_node), job_default, workflow_default
+        return
+    runs = _mapping(document.get("runs"))
+    for step_node in _sequence(runs.get("steps")):
+        yield _mapping(step_node), None, None
+
+
+def check_document(path: Path, text: str) -> list[Finding]:
+    root = yaml.compose(text)
+    if root is None:
+        return []
+    findings: list[Finding] = []
+    for step, job_default, workflow_default in _steps(root):
+        run_node = step.get("run")
+        if not isinstance(run_node, yaml.ScalarNode):
+            continue
+        script = str(run_node.value)
+        if _shell_is_pipefail(_effective_shell(step, job_default, workflow_default)):
+            continue
+        pipelines = _pipelines(script)
+        if not pipelines:
+            continue
+        guard = _SET_PIPEFAIL.search(script)
+        first_pipeline_line = pipelines[0][0]
+        if guard and script[: guard.start()].count("\n") + 1 < first_pipeline_line:
+            continue
+        name = _scalar(step.get("name")) or _scalar(step.get("uses")) or "<unnamed>"
+        # Report the step once; the first offending pipeline is enough to fix it.
+        number, raw = pipelines[0]
+        # ``start_mark.line`` is 0-based. For a block scalar (`run: |`) it points
+        # at the indicator line, so the body starts one line later; for a plain
+        # single-line `run:` the value is already on that line.
+        header = 1 if run_node.style in {"|", ">"} else 0
+        findings.append(Finding(path=path, step=name, line=run_node.start_mark.line + header + number, pipeline=raw))
+    return findings
+
+
+def _targets() -> list[Path]:
+    paths: list[Path] = []
+    if WORKFLOWS.is_dir():
+        paths.extend(sorted(WORKFLOWS.glob("*.yml")))
+        paths.extend(sorted(WORKFLOWS.glob("*.yaml")))
+    if ACTIONS.is_dir():
+        paths.extend(sorted(ACTIONS.rglob("action.yml")))
+        paths.extend(sorted(ACTIONS.rglob("action.yaml")))
+    if ROOT_ACTION.is_file():
+        paths.append(ROOT_ACTION)
+    return paths
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", type=Path, help="Workflow files to check (default: every workflow + action).")
+    args = parser.parse_args(argv)
+
+    targets = [p.resolve() for p in args.paths] if args.paths else _targets()
+    findings: list[Finding] = []
+    for path in targets:
+        findings.extend(check_document(path, path.read_text(encoding="utf-8")))
+
+    if findings:
+        print(f"ERROR: {len(findings)} CI step(s) pipe without pipefail — a failing command would be masked:\n", file=sys.stderr)
+        for finding in findings:
+            print(f"  - {finding.render()}", file=sys.stderr)
+        print(
+            "\nFix by adding `shell: bash` to the step (GitHub then runs "
+            "`bash --noprofile --norc -eo pipefail {0}`), or `set -o pipefail` "
+            "before the first pipeline.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"CI pipefail gate passed — {len(targets)} workflow/action file(s), no masked pipelines")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_compose_contract.py
+++ b/scripts/check_compose_contract.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Validate every shipped Docker Compose file — and what it renders to.
+
+Nothing in CI has ever run ``docker compose config`` against these files. The
+only caller in the tree is ``scripts/deploy/hosted_poc_preflight.py``, and the
+one automated invocation of that (``make secrets``) passes ``--skip-compose``,
+so the parse path never executes. Meanwhile ``docs/DEPLOY_PLATFORM.md`` tells
+operators the stack "passes ``docker compose config``" — a claim no automation
+backed.
+
+Two things are checked, deliberately in this order:
+
+1. ``docker compose config`` parses each standalone file, and each documented
+   overlay merged onto its base. Overlays are shipped as fragments and fail
+   standalone by design, so validating them alone would be meaningless.
+
+2. Assertions on the RENDERED output. "It exited 0" is not a test — this repo
+   already learned that when ``helm template`` rendered an ingress with empty
+   ``paths`` across five profiles and CI called it green. So the rendered model
+   is inspected: every service resolves to an image or a build context, every
+   ``depends_on`` names a real service, and every read-only bind mount points at
+   a path that exists. A ``:ro`` mount of a missing directory does not fail
+   ``config`` or even ``up`` — Docker silently creates an empty directory and
+   the container gets nothing.
+
+Environment interpolation is derived from the files themselves: a variable
+written ``${VAR:?message}`` is required by design, so the gate supplies a
+placeholder rather than pretending the file is broken.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Discovered structurally, so a newly added profile is covered on arrival.
+COMPOSE_GLOBS = (
+    "deploy/docker-compose*.yml",
+    "deploy/**/docker-compose*.yml",
+    "examples/docker-compose*.yml",
+    "compose.yml",
+    "compose.yaml",
+)
+
+# Overlays carry no image or build of their own and cannot declare their base,
+# so the pairing has to live here. Any overlay NOT listed fails the gate rather
+# than being skipped.
+OVERLAY_BASES: dict[str, tuple[str, ...]] = {
+    "deploy/docker-compose.hosted-poc.yml": ("deploy/docker-compose.platform.yml",),
+    "deploy/docker-compose.product.yml": ("deploy/docker-compose.platform.yml",),
+    "deploy/docker-compose.demo-override.yml": ("deploy/docker-compose.platform.yml",),
+}
+
+# Bind-mount sources that are generated rather than committed. `make secrets`
+# writes these; `deploy/secrets/.gitignore` keeps them out of the tree.
+GENERATED_MOUNT_PREFIXES = ("secrets/",)
+
+_REQUIRED_VAR = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\s*:\?")
+_PLACEHOLDER = "ci-compose-contract-placeholder"
+
+
+@dataclass
+class Target:
+    """One `docker compose` invocation: a base file plus any overlays."""
+
+    files: list[Path]
+    label: str
+    problems: list[str] = field(default_factory=list)
+
+
+def discover() -> tuple[list[Path], list[Path]]:
+    """Return ``(standalone files, overlay files)``."""
+    seen: dict[Path, None] = {}
+    for glob in COMPOSE_GLOBS:
+        for path in sorted(ROOT.glob(glob)):
+            if path.is_file():
+                seen[path] = None
+    standalone: list[Path] = []
+    overlays: list[Path] = []
+    for path in seen:
+        (overlays if _is_overlay(path) else standalone).append(path)
+    return standalone, overlays
+
+
+def _is_overlay(path: Path) -> bool:
+    """An overlay patches services it does not define — no image, no build."""
+    document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    services = document.get("services") or {}
+    if not services:
+        return False
+    return all(not (service or {}).get("image") and not (service or {}).get("build") for service in services.values())
+
+
+def _env_for(files: list[Path]) -> dict[str, str]:
+    env = dict(os.environ)
+    for path in files:
+        for name in _REQUIRED_VAR.findall(path.read_text(encoding="utf-8")):
+            env.setdefault(name, _PLACEHOLDER)
+    return env
+
+
+def _render(target: Target) -> dict | None:
+    command = ["docker", "compose"]
+    for path in target.files:
+        command += ["-f", str(path)]
+    command += ["config", "--format", "json"]
+    result = subprocess.run(
+        command,
+        cwd=target.files[0].parent,
+        env=_env_for(target.files),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        target.problems.append(f"docker compose config failed:\n      {(result.stderr or result.stdout).strip()}")
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        target.problems.append(f"docker compose config emitted invalid JSON: {exc}")
+        return None
+
+
+def _assert_rendered(target: Target, rendered: dict) -> None:
+    services = rendered.get("services") or {}
+    if not services:
+        target.problems.append("renders no services")
+        return
+    for name, service in services.items():
+        if not service.get("image") and not service.get("build"):
+            target.problems.append(f"service {name!r} resolves to neither an image nor a build context")
+        for dependency in service.get("depends_on") or {}:
+            if dependency not in services:
+                target.problems.append(f"service {name!r} depends_on {dependency!r}, which no service defines")
+        for volume in service.get("volumes") or []:
+            _assert_readonly_mount(target, name, volume)
+
+
+def _assert_readonly_mount(target: Target, service: str, volume: dict) -> None:
+    """A `:ro` bind mount of a missing path yields an empty directory, silently."""
+    if volume.get("type") != "bind" or not volume.get("read_only"):
+        return
+    source = str(volume.get("source") or "")
+    if not source.startswith("/"):
+        return
+    try:
+        relative = Path(source).relative_to(ROOT).as_posix()
+    except ValueError:
+        return  # outside the repo (a host home directory) — not ours to assert
+    if relative.startswith(GENERATED_MOUNT_PREFIXES) or any(part in relative for part in GENERATED_MOUNT_PREFIXES):
+        return
+    if not Path(source).exists():
+        target.problems.append(f"service {service!r} read-only bind mount points at a missing path: {relative}")
+
+
+def build_targets() -> list[Target]:
+    standalone, overlays = discover()
+    targets = [Target(files=[path], label=path.relative_to(ROOT).as_posix()) for path in standalone]
+    for overlay in overlays:
+        relative = overlay.relative_to(ROOT).as_posix()
+        bases = OVERLAY_BASES.get(relative)
+        if not bases:
+            target = Target(files=[overlay], label=relative)
+            target.problems.append("overlay has no declared base in OVERLAY_BASES — it can never be validated")
+            targets.append(target)
+            continue
+        files = [ROOT / base for base in bases] + [overlay]
+        targets.append(Target(files=files, label=" + ".join([*bases, relative])))
+    return targets
+
+
+def run() -> list[Target]:
+    targets = build_targets()
+    for target in targets:
+        if target.problems:
+            continue
+        rendered = _render(target)
+        if rendered is not None:
+            _assert_rendered(target, rendered)
+    return targets
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--list", action="store_true", help="List the compose invocations this gate validates.")
+    args = parser.parse_args(argv)
+
+    if args.list:
+        for target in build_targets():
+            print(target.label)
+        return 0
+
+    targets = run()
+    failed = [target for target in targets if target.problems]
+    if failed:
+        print(f"ERROR: {len(failed)} compose target(s) failed the contract:\n", file=sys.stderr)
+        for target in failed:
+            for problem in target.problems:
+                print(f"  - {target.label}: {problem}", file=sys.stderr)
+        return 1
+
+    print(f"Compose contract passed — {len(targets)} target(s) parse and render a valid service graph")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_postgres_schema_parity.py
+++ b/scripts/check_postgres_schema_parity.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Assert two bootstrap paths produce the SAME Postgres schema, not just the same head.
+
+agent-bom can reach a working control plane two ways:
+
+  A. Alembic only — ``alembic upgrade head`` on an empty database.
+  B. psql bootstrap — run ``init.sql``, ``alembic stamp 20260416_01``, then
+     ``alembic upgrade head``.
+
+CI already builds both in one job. Until now it compared only the
+``alembic_version`` string, which proves the two paths *ran* the same revisions,
+not that they *produced* the same schema. Those are different claims. The
+convention in this repo is that a new column lands in a migration AND is
+back-added to ``init.sql`` so fresh installs get it from the baseline; forget the
+second edit and path B silently ships a database missing the column, with an
+identical head. Every existing guard against that is a regex over SQL text —
+none of them diffs two live databases.
+
+So this compares the actual rendered schemas via ``pg_dump --schema-only``,
+statement by statement. It also asserts the extensions the schema depends on are
+really installed: ``pg_trgm`` is created in three places, one of them at runtime
+by the application, where a permission error is deliberately swallowed — so
+"we asked for it" was never the same as "it is there".
+
+Usage:
+    check_postgres_schema_parity.py --migration-url URL --bootstrap-url URL \\
+        [--require-extension pg_trgm ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+# Noise that legitimately differs between two databases: server preamble, the
+# database name itself, ownership, and comments.
+# `\restrict`/`\unrestrict` are psql meta-commands newer pg_dump builds wrap the
+# body in, each carrying a fresh random token — pure noise that would otherwise
+# make every dump differ from every other dump.
+_IGNORED_LINE = re.compile(
+    r"^\s*(--|SET\s|SELECT pg_catalog\.set_config|\\connect|\\restrict|\\unrestrict|COMMENT ON EXTENSION)",
+    re.I,
+)
+_IGNORED_STATEMENT = re.compile(r"^\s*(CREATE|DROP)\s+DATABASE\b|^\s*ALTER\s+DATABASE\b", re.I)
+
+
+def _pg_dump(url: str) -> str:
+    result = subprocess.run(
+        [
+            "pg_dump",
+            "--schema-only",
+            "--no-owner",
+            "--no-acl",
+            "--no-comments",
+            "--no-publications",
+            "--no-subscriptions",
+            "--no-security-labels",
+            "--no-tablespaces",
+            url,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(f"pg_dump failed for {_redact(url)}:\n{result.stderr.strip()}")
+    return result.stdout
+
+
+def _redact(url: str) -> str:
+    return re.sub(r"//[^@/]*@", "//***@", url)
+
+
+def _statements(dump: str) -> set[str]:
+    """Normalize a dump into a comparable set of statements.
+
+    A set, not a list: the two paths build objects in different orders, and
+    ordering is not part of the contract. Content is.
+    """
+    kept: list[str] = []
+    for line in dump.splitlines():
+        if _IGNORED_LINE.match(line):
+            continue
+        kept.append(line)
+    body = "\n".join(kept)
+    statements: set[str] = set()
+    for raw in body.split(";\n"):
+        # Splitting on ";\n" leaves the final statement of a dump carrying its
+        # terminator while every other one lost it, which would make a
+        # statement's identity depend on where it happened to appear.
+        statement = " ".join(raw.split()).rstrip(";").strip()
+        if not statement or _IGNORED_STATEMENT.match(statement):
+            continue
+        statements.add(statement)
+    return statements
+
+
+def _installed_extensions(url: str) -> set[str]:
+    result = subprocess.run(
+        ["psql", url, "-Atc", "SELECT extname FROM pg_extension"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(f"psql extension probe failed for {_redact(url)}:\n{result.stderr.strip()}")
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def compare(migration_dump: str, bootstrap_dump: str) -> list[str]:
+    migration = _statements(migration_dump)
+    bootstrap = _statements(bootstrap_dump)
+    problems: list[str] = []
+    for label, missing in (
+        ("present after `alembic upgrade head` but MISSING from the init.sql bootstrap", migration - bootstrap),
+        ("present after the init.sql bootstrap but MISSING from `alembic upgrade head`", bootstrap - migration),
+    ):
+        for statement in sorted(missing):
+            problems.append(f"{label}:\n      {statement[:400]}")
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--migration-url", required=True, help="Database built by `alembic upgrade head` alone.")
+    parser.add_argument("--bootstrap-url", required=True, help="Database built by init.sql + stamp + upgrade.")
+    parser.add_argument(
+        "--require-extension",
+        action="append",
+        default=[],
+        help="Extension that must actually be installed in BOTH databases.",
+    )
+    args = parser.parse_args(argv)
+
+    problems = compare(_pg_dump(args.migration_url), _pg_dump(args.bootstrap_url))
+
+    for url, label in ((args.migration_url, "migration-only"), (args.bootstrap_url, "init.sql bootstrap")):
+        installed = _installed_extensions(url)
+        for extension in args.require_extension:
+            if extension not in installed:
+                problems.append(f"{label} database is missing required extension {extension!r} (installed: {sorted(installed)})")
+
+    if problems:
+        print(f"ERROR: the two bootstrap paths do not agree ({len(problems)} difference(s)):\n", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        print(
+            "\nA column or index added to a migration must also be back-added to "
+            "deploy/supabase/postgres/init.sql (and vice versa), or fresh installs "
+            "and upgraded installs ship different schemas under the same Alembic head.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Postgres schema parity passed — the migration-only and init.sql bootstrap paths render identical schemas")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_published_counts.py
+++ b/scripts/check_published_counts.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Every advertised inventory count must equal what the build actually ships.
+
+A number typed into prose is a claim with no owner. It is correct on the day it
+is written and silently wrong from the next refresh onward, because nothing
+recomputes it. That is how the bundled MCP registry grew to 1081 entries while
+six public surfaces — including two *runtime* strings the MCP server sends to
+every connecting client — kept advertising 1013, and how a skill doc kept
+claiming "940 verified" against an actual 60.
+
+So this gate never stores an expected number. It DERIVES each one from the
+artifact that ships:
+
+    registry entries   len(src/agent_bom/mcp_registry.json["servers"])
+    registry verified  those entries with verified=true
+    MCP tools          _SERVER_CARD_TOOLS      (mcp_server_metadata.py)
+    MCP resources      _SERVER_CARD_RESOURCES
+    MCP prompts        _SERVER_CARD_PROMPTS
+
+then sweeps every published surface — docs, site docs, integrations, READMEs,
+SVG diagrams, and the shipped Python package — for sentences that state one of
+those counts, and fails if any disagrees. Adding an entry to the registry is
+then a two-line change: the data, and whatever prose the gate points at.
+
+Note that SVGs are swept here deliberately. ``check_release_consistency.py``
+skips every image suffix, which is exactly why a stale count sat unnoticed
+inside ``docs/images/scan-pipeline-light.svg``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+REGISTRY = ROOT / "src" / "agent_bom" / "mcp_registry.json"
+SERVER_METADATA = ROOT / "src" / "agent_bom" / "mcp_server_metadata.py"
+
+# Published surfaces. Anything a user, client, or marketplace can read.
+SEARCH_ROOTS: tuple[Path, ...] = (
+    ROOT / "README.md",
+    ROOT / "PYPI_README.md",
+    ROOT / "DOCKER_HUB_README.md",
+    ROOT / "docs",
+    ROOT / "site-docs",
+    ROOT / "integrations",
+    ROOT / "src" / "agent_bom",
+    ROOT / "ui" / "app",
+    ROOT / "ui" / "components",
+)
+SEARCH_SUFFIXES = {".md", ".py", ".ts", ".tsx", ".json", ".svg", ".yaml", ".yml", ".txt"}
+# Generated API artifacts restate prose from elsewhere; fixing the source fixes
+# these, and sweeping them too would report one drift twice.
+EXCLUDED_PARTS = {"node_modules", ".next", "__pycache__", "openapi", "archive", "egg-info"}
+# The registry bundle is the source of truth, not a claim about itself — and each
+# of its 1081 entries records that server's own tool count.
+EXCLUDED_FILES = {REGISTRY}
+# Lines of leeway when looking for the vocabulary that makes a number a claim
+# about the registry. An SVG puts its "MCP Registry" label one line above the
+# value it labels.
+CONTEXT_WINDOW = 2
+
+_NUMBER = r"([0-9][0-9,]*)"
+
+
+@dataclass(frozen=True)
+class CountRule:
+    """One derived quantity plus the phrasings that advertise it.
+
+    ``context`` keeps the sweep honest. "4 MCP servers" in a blog post about one
+    person's laptop is a scan result, not a claim about the bundled registry, and
+    a gate that cannot tell them apart gets muted. A rule with a ``context``
+    pattern only fires when that vocabulary appears within
+    ``CONTEXT_WINDOW`` lines — enough to catch an SVG whose "MCP Registry" label
+    sits one line above its "1013 servers" value.
+    """
+
+    name: str
+    patterns: tuple[re.Pattern[str], ...]
+    context: re.Pattern[str] | None = None
+    context_window: int = 0
+
+
+# Each pattern must be anchored on vocabulary specific to the thing counted, so
+# an unrelated "1000-entry ring buffer" or a benchmark's "604 servers" is not
+# swept up. Every capture group is compared against the derived value.
+RULES: tuple[CountRule, ...] = (
+    CountRule(
+        "registry entries",
+        (
+            re.compile(rf"{_NUMBER}[-\s]entry\s+(?:\S+\s+){{0,3}}?(?:server|registry)", re.I),
+            re.compile(rf"{_NUMBER}\s+MCP\s+servers?\b", re.I),
+            re.compile(rf"{_NUMBER}\s+MCP\s+server\s+(?:security\s+)?metadata\s+records", re.I),
+            re.compile(rf"registry\s*\(\s*{_NUMBER}\s+servers", re.I),
+            re.compile(rf"{_NUMBER}\s+servers?\s*,\s*[0-9][0-9,]*\s+verified", re.I),
+        ),
+        context=re.compile(r"registry|security\s+metadata", re.I),
+    ),
+    # Diagram labels sit on their own element, so the vocabulary that identifies
+    # them lives on a neighbouring line rather than beside the number.
+    CountRule(
+        "registry entries",
+        (re.compile(rf">\s*{_NUMBER}\s+servers\s*<", re.I),),
+        context=re.compile(r"registry", re.I),
+        context_window=2,
+    ),
+    CountRule(
+        "registry verified entries",
+        (re.compile(rf"[0-9][0-9,]*\s+servers?\s*,\s*{_NUMBER}\s+verified", re.I),),
+        context=re.compile(r"registry|security\s+metadata", re.I),
+    ),
+    CountRule(
+        "MCP tools",
+        (
+            re.compile(rf"{_NUMBER}\s+MCP\s+tools\b", re.I),
+            re.compile(rf"Tool\s+Categories\s*\(\s*{_NUMBER}\s+tools\s*\)", re.I),
+        ),
+    ),
+    CountRule(
+        "MCP resources",
+        (re.compile(rf"{_NUMBER}\s+resources\s+and\s+[0-9][0-9,]*\s+workflow\s+prompts", re.I),),
+    ),
+    CountRule(
+        "MCP prompts",
+        (re.compile(rf"[0-9][0-9,]*\s+resources\s+and\s+{_NUMBER}\s+workflow\s+prompts", re.I),),
+    ),
+)
+
+
+def _server_card_list(variable_name: str) -> list[object]:
+    module = ast.parse(SERVER_METADATA.read_text(encoding="utf-8"))
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == variable_name for target in node.targets):
+            continue
+        value = ast.literal_eval(node.value)
+        if isinstance(value, list):
+            return value
+    raise SystemExit(f"{SERVER_METADATA.relative_to(ROOT)} is missing {variable_name}")
+
+
+def derive_counts() -> dict[str, int]:
+    """Compute every advertised quantity from the artifact that actually ships."""
+    registry = json.loads(REGISTRY.read_text(encoding="utf-8"))
+    servers = registry.get("servers") or {}
+    header = registry.get("_total_servers")
+    if header is not None and int(header) != len(servers):
+        raise SystemExit(f"{REGISTRY.relative_to(ROOT)}: _total_servers={header} but the bundle holds {len(servers)} servers")
+    return {
+        "registry entries": len(servers),
+        "registry verified entries": sum(1 for entry in servers.values() if entry.get("verified") is True),
+        "MCP tools": len(_server_card_list("_SERVER_CARD_TOOLS")),
+        "MCP resources": len(_server_card_list("_SERVER_CARD_RESOURCES")),
+        "MCP prompts": len(_server_card_list("_SERVER_CARD_PROMPTS")),
+    }
+
+
+def _files() -> list[Path]:
+    seen: list[Path] = []
+    for root in SEARCH_ROOTS:
+        if root.is_file():
+            seen.append(root)
+            continue
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*")):
+            if not path.is_file() or path.suffix.lower() not in SEARCH_SUFFIXES:
+                continue
+            if EXCLUDED_PARTS.intersection(path.parts) or path in EXCLUDED_FILES:
+                continue
+            seen.append(path)
+    return seen
+
+
+def _line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _has_context(rule: CountRule, lines: list[str], line_number: int) -> bool:
+    if rule.context is None:
+        return True
+    start = max(0, line_number - 1 - rule.context_window)
+    window = "\n".join(lines[start : line_number + rule.context_window])
+    return rule.context.search(window) is not None
+
+
+def find_stale_claims(counts: dict[str, int]) -> list[str]:
+    problems: list[str] = []
+    for path in _files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        lines = text.splitlines()
+        for rule in RULES:
+            expected = counts[rule.name]
+            for pattern in rule.patterns:
+                for match in pattern.finditer(text):
+                    claimed = int(match.group(1).replace(",", ""))
+                    if claimed == expected:
+                        continue
+                    if not _has_context(rule, lines, _line_of(text, match.start())):
+                        continue
+                    problems.append(
+                        f"{path.relative_to(ROOT)}:{_line_of(text, match.start())}: "
+                        f"advertises {claimed} {rule.name}, but the build ships {expected} "
+                        f"— {match.group(0).strip()!r}"
+                    )
+    return sorted(set(problems))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--print-counts", action="store_true", help="Print the derived counts and exit.")
+    args = parser.parse_args(argv)
+
+    counts = derive_counts()
+    if args.print_counts:
+        print(json.dumps(counts, indent=2))
+        return 0
+
+    problems = find_stale_claims(counts)
+    if problems:
+        print(f"ERROR: {len(problems)} published count(s) disagree with what the build ships:\n", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        print("\nUpdate the prose (or the data) so every advertised number matches the shipped artifact.", file=sys.stderr)
+        return 1
+
+    summary = ", ".join(f"{value} {name}" for name, value in counts.items())
+    print(f"Published counts match the shipped build — {summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -135,6 +135,39 @@ MCP_COUNT_DOCS: list[Path] = [
 ]
 DOCKER_MCP_TOOLS = ROOT / "integrations" / "docker-mcp-registry" / "tools.json"
 
+# ---------------------------------------------------------------------------
+# Derived version sweep
+#
+# Everything above this line is a hand-maintained list, and so is
+# ``scripts/bump-version.py``. A version-bearing artifact that is in neither
+# list is written by nobody and checked by nobody — which is exactly how
+# ``sdks/python/pyproject.toml`` sat at 0.92.0 while the platform shipped
+# 0.100.0. It had been bumped by hand once, then forgotten.
+#
+# The sweep below finds those artifacts by SHAPE instead of by name: any file
+# matching a structural glob is read, any self-referential version it carries is
+# extracted, and a mismatch fails. A newly added SDK, compose profile, or
+# deploy manifest is therefore covered the moment it exists.
+#
+# A genuinely independent version must be declared here, with a reason. Silence
+# is not an option: the sweep fails closed.
+# ---------------------------------------------------------------------------
+VERSION_SWEEP: list[tuple[str, re.Pattern[str], str]] = [
+    ("sdks/*/pyproject.toml", re.compile(r'^version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"', re.M), "SDK package version"),
+    ("sdks/*/package.json", re.compile(r'\A\{(?:[^{}]|\n)*?"version":\s*"([0-9]+\.[0-9]+\.[0-9]+)"'), "SDK package version"),
+    ("deploy/docker-compose*.yml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)"), "compose image tag"),
+    ("deploy/k8s/*.yaml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)"), "k8s image tag"),
+    ("deploy/docker/Dockerfile*", re.compile(r"^ARG VERSION=([0-9]+\.[0-9]+\.[0-9]+)$", re.M), "Dockerfile ARG VERSION"),
+    ("integrations/*/server.json", re.compile(r'"version":\s*"([0-9]+\.[0-9]+\.[0-9]+)"'), "integration manifest version"),
+]
+
+# Artifacts that legitimately carry their own version line, each with the reason
+# it does not track the platform release.
+INDEPENDENTLY_VERSIONED: dict[str, str] = {
+    "sdks/typescript/package.json": "@agent-bom/runtime is published to npm on its own 0.x line, independent of the platform tag",
+    "sdks/typescript-client/package.json": "@agent-bom/client is published to npm on its own 0.x line, independent of the platform tag",
+}
+
 
 def _load_version() -> str:
     text = PYPROJECT.read_text()
@@ -290,6 +323,40 @@ def _assert_product_screenshots_current(expected_version: str) -> None:
             _fail(f"docs/images/product-screenshots.json references missing image: docs/images/{rel_path}")
         if entry.get("visible_version") != expected_version:
             _fail(f"docs/images/{rel_path} manifest visible_version is stale: {entry.get('visible_version')!r} != {expected_version}")
+
+
+def sweep_version_drift(expected: str) -> list[str]:
+    """Return every self-referential version that disagrees with the release.
+
+    Discovery is structural, so an artifact nobody remembered to register still
+    gets checked. Declared-independent files are skipped by exact relative path
+    — a glob there would re-open the hole this closes.
+    """
+    problems: list[str] = []
+    for glob, pattern, label in VERSION_SWEEP:
+        for path in sorted(ROOT.glob(glob)):
+            if not path.is_file():
+                continue
+            relative = path.relative_to(ROOT).as_posix()
+            if relative in INDEPENDENTLY_VERSIONED:
+                continue
+            found = {match.group(1) for match in pattern.finditer(path.read_text(encoding="utf-8"))}
+            stale = sorted(found - {expected})
+            if stale:
+                problems.append(f"{relative} has stale {label}: {stale} != {expected}")
+    return problems
+
+
+def _assert_no_unmanaged_version_drift(version: str) -> None:
+    problems = sweep_version_drift(version)
+    if problems:
+        detail = "\n  - ".join(problems)
+        _fail(
+            "version sweep found artifacts that do not track the release:\n  - "
+            f"{detail}\n"
+            "Add the file to scripts/bump-version.py so it is bumped automatically, "
+            "or declare it in INDEPENDENTLY_VERSIONED with the reason it differs."
+        )
 
 
 def main() -> int:
@@ -449,6 +516,7 @@ def main() -> int:
             _fail(f"{path.relative_to(ROOT)} contains stale managed image version(s): {sorted(versions)} != {version}")
     for path, version_pattern, label in MANAGED_VERSION_REFS:
         _assert_versions(path, version_pattern, version, label)
+    _assert_no_unmanaged_version_drift(version)
     ui_lock = json.loads((ROOT / "ui" / "package-lock.json").read_text())
     ui_lock_versions = {ui_lock.get("version"), ui_lock.get("packages", {}).get("", {}).get("version")}
     if ui_lock_versions != {version}:

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -154,7 +154,13 @@ DOCKER_MCP_TOOLS = ROOT / "integrations" / "docker-mcp-registry" / "tools.json"
 # ---------------------------------------------------------------------------
 VERSION_SWEEP: list[tuple[str, re.Pattern[str], str]] = [
     ("sdks/*/pyproject.toml", re.compile(r'^version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"', re.M), "SDK package version"),
-    ("sdks/*/package.json", re.compile(r'\A\{(?:[^{}]|\n)*?"version":\s*"([0-9]+\.[0-9]+\.[0-9]+)"'), "SDK package version"),
+    # `\A\{` plus a brace-free run keeps this on the TOP-LEVEL "version" — once a
+    # nested object opens, `[^{}]` can no longer advance, so a dependency's
+    # version is never picked up. The run must NOT be written `(?:[^{}]|\n)*?`:
+    # a negated class already matches newline in Python, so the alternation gives
+    # the engine two ways to consume the same character and backtracking becomes
+    # exponential (CodeQL ReDoS, HIGH). We ship a scanner that flags this shape.
+    ("sdks/*/package.json", re.compile(r'\A\{[^{}]*?"version":\s*"([0-9]+\.[0-9]+\.[0-9]+)"'), "SDK package version"),
     ("deploy/docker-compose*.yml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)"), "compose image tag"),
     ("deploy/k8s/*.yaml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)"), "k8s image tag"),
     ("deploy/docker/Dockerfile*", re.compile(r"^ARG VERSION=([0-9]+\.[0-9]+\.[0-9]+)$", re.M), "Dockerfile ARG VERSION"),

--- a/scripts/smoke_mcp_wheel.py
+++ b/scripts/smoke_mcp_wheel.py
@@ -1,14 +1,34 @@
 #!/usr/bin/env python3
-"""Exercise MCP initialize and tools/list from an installed release wheel.
+"""Boot an installed release wheel over stdio JSON-RPC and audit its live surface.
 
-Run this script with the Python interpreter from a clean environment containing
-only an unlocked ``pip install dist/agent_bom-*.whl``.  It deliberately imports
-the advertised server entry point before starting a real stdio MCP client
-session, catching dependency-major drift that metadata-only wheel checks miss.
+Run this with the Python interpreter from a clean environment containing only an
+unlocked ``pip install dist/agent_bom-*.whl``. It starts the real
+``agent-bom mcp server`` as a subprocess and speaks actual MCP to it, catching
+dependency-major drift that metadata-only wheel checks miss.
+
+Two things changed after a release shipped a stale surface claim:
+
+*Expectations are derived, never typed.* This script used to assert
+``len(tools) == 77``. A literal like that is correct the day it is written and
+becomes the next stale claim the moment the surface moves — the same failure mode
+that left the docs advertising 1013 registry entries against 1081 shipped. The
+expectation now comes from the wheel's own server card
+(``agent_bom.mcp_server_metadata``), so the check is "the running server matches
+the card it publishes", which stays true across every future surface change.
+
+*Resources and prompts are audited too.* Only ``tools/list`` was ever exercised
+live. Nothing compared ``resources/list`` or ``prompts/list`` against anything,
+and the HTTP server-card route serves those two straight from the static lists
+without consulting the live registry — so a resource present in the card but
+never registered (or registered but absent from the card) was invisible to every
+test and every workflow.
+
+Names are compared, not counts. Two counts can match while the sets differ.
 """
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import importlib
 import json
@@ -17,47 +37,91 @@ import sys
 import traceback
 from pathlib import Path
 
-EXPECTED_TOOL_COUNT = 77
+DEFAULT_TIMEOUT_SECONDS = 120
+
+
+def _expected_surface() -> dict[str, set[str]]:
+    """Derive the advertised surface from the installed package's server card."""
+    metadata = importlib.import_module("agent_bom.mcp_server_metadata")
+    return {
+        "tools": {str(tool["name"]) for tool in metadata._SERVER_CARD_TOOLS},
+        "resources": {str(resource["uri"]) for resource in metadata._SERVER_CARD_RESOURCES},
+        "prompts": {str(prompt["name"]) for prompt in metadata._SERVER_CARD_PROMPTS},
+    }
+
+
+def _compare(kind: str, live: list[str], expected: set[str]) -> list[str]:
+    problems: list[str] = []
+    duplicates = sorted({name for name in live if live.count(name) > 1})
+    if duplicates:
+        problems.append(f"{kind}: live server returned duplicate entries: {duplicates}")
+    missing = sorted(expected - set(live))
+    extra = sorted(set(live) - expected)
+    if missing:
+        problems.append(f"{kind}: advertised by the server card but not registered live: {missing}")
+    if extra:
+        problems.append(f"{kind}: registered live but missing from the server card: {extra}")
+    return problems
 
 
 async def _smoke() -> dict[str, object]:
     importlib.import_module("agent_bom.mcp_server")
+    agent_bom = importlib.import_module("agent_bom")
+    expected = _expected_surface()
 
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.stdio import stdio_client
 
     child_env = dict(os.environ)
     child_env["AGENT_BOM_SKIP_UPDATE_CHECK"] = "1"
+    # Third-party MCP tool plugins register extra tools at runtime, which would
+    # legitimately exceed the server card. Audit the shipped surface only.
+    child_env.pop("AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS", None)
+    child_env.pop("AGENT_BOM_ACTIVATE_MCP_TOOL_PLUGINS", None)
+
     executable = Path(sys.executable).with_name("agent-bom")
     if not executable.is_file():
         raise RuntimeError(f"installed agent-bom console script is missing: {executable}")
-    server = StdioServerParameters(
-        command=str(executable),
-        args=["mcp", "server"],
-        env=child_env,
-    )
+    server = StdioServerParameters(command=str(executable), args=["mcp", "server"], env=child_env)
+
     async with stdio_client(server) as (read_stream, write_stream):
         async with ClientSession(read_stream, write_stream) as session:
             initialized = await session.initialize()
-            listed = await session.list_tools()
+            tools = [tool.name for tool in (await session.list_tools()).tools]
+            resources = [str(resource.uri) for resource in (await session.list_resources()).resources]
+            prompts = [prompt.name for prompt in (await session.list_prompts()).prompts]
 
-    tool_names = [tool.name for tool in listed.tools]
-    if len(tool_names) != EXPECTED_TOOL_COUNT:
-        raise RuntimeError(f"MCP tools/list returned {len(tool_names)} tools; expected {EXPECTED_TOOL_COUNT}")
-    if len(set(tool_names)) != len(tool_names):
-        raise RuntimeError("MCP tools/list returned duplicate tool names")
+    problems = (
+        _compare("tools", tools, expected["tools"])
+        + _compare("resources", resources, expected["resources"])
+        + _compare("prompts", prompts, expected["prompts"])
+    )
+
+    # The version a client sees on `initialize` is the release it is talking to.
+    if initialized.serverInfo.version != agent_bom.__version__:
+        problems.append(f"serverInfo.version {initialized.serverInfo.version!r} != package version {agent_bom.__version__!r}")
+    if initialized.serverInfo.name != "agent-bom":
+        problems.append(f"serverInfo.name {initialized.serverInfo.name!r} != 'agent-bom'")
+
+    if problems:
+        raise RuntimeError("live MCP surface disagrees with the shipped server card:\n  - " + "\n  - ".join(problems))
 
     return {
         "protocol_version": initialized.protocolVersion,
         "server_name": initialized.serverInfo.name,
         "server_version": initialized.serverInfo.version,
-        "tool_count": len(tool_names),
+        "tool_count": len(tools),
+        "resource_count": len(resources),
+        "prompt_count": len(prompts),
     }
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    args = parser.parse_args(argv)
     try:
-        evidence = asyncio.run(asyncio.wait_for(_smoke(), timeout=90))
+        evidence = asyncio.run(asyncio.wait_for(_smoke(), timeout=args.timeout))
     except Exception as exc:
         print(f"MCP wheel smoke failed: {type(exc).__name__}: {exc}", file=sys.stderr)
         traceback.print_exc()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-bom-sdk"
-version = "0.92.0"
+version = "0.100.0"
 description = "Thin Python alias that re-exports the packaged agent-bom control-plane client."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -85,7 +85,7 @@ Tools (77):
     sync_ticket_status  — Refresh a filed ITSM ticket's status through the stored connector
 
 Resources (6):
-    registry://servers  — Browse the 1013-entry server security metadata registry
+    registry://servers  — Browse the 1081-entry server security metadata registry
     policy://template   — Default security policy template
     metrics://tools     — MCP tool execution metrics and limits
     schema://inventory-v1 — Canonical pushed-inventory schema contract

--- a/src/agent_bom/mcp_server_catalog.py
+++ b/src/agent_bom/mcp_server_catalog.py
@@ -43,7 +43,7 @@ def attach_resources_and_prompts(
 
     @mcp.resource("registry://servers")
     def registry_servers_resource() -> str:
-        """Browse the MCP server security metadata registry (1013 servers).
+        """Browse the MCP server security metadata registry (1081 servers).
 
         Returns the full registry with risk levels (category-derived), tools,
         credential env vars (heuristic-inferred), and verification status

--- a/tests/test_ci_pipefail_gate.py
+++ b/tests/test_ci_pipefail_gate.py
@@ -1,0 +1,180 @@
+"""Contract for the CI pipefail gate (`scripts/check_ci_pipefail.py`).
+
+The gate has to be simultaneously strict (a masked failure is a dead gate) and
+quiet (a noisy gate gets disabled). These tests pin both halves: every shape
+that genuinely masks an exit code must be caught, and every `|` that is data
+rather than a pipeline must be ignored.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "check_ci_pipefail.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_ci_pipefail", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # `@dataclass` resolves annotations through `sys.modules[cls.__module__]`,
+    # so the module must be registered before it executes.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load()
+
+
+def _findings(workflow: str, path: Path | None = None):
+    return gate.check_document(path or (ROOT / ".github" / "workflows" / "synthetic.yml"), workflow)
+
+
+def _workflow(step_body: str) -> str:
+    return "name: t\njobs:\n  j:\n    runs-on: ubuntu-latest\n    steps:\n" + step_body
+
+
+class TestMaskedPipelinesAreCaught:
+    def test_scanner_piped_to_tee_is_a_finding(self):
+        """The exact shape that made the OSV CVE gate dead code."""
+        wf = _workflow("      - name: scan\n        run: |\n          osv-scanner scan --lockfile=uv.lock | tee /tmp/out.txt || exit 1\n")
+        findings = _findings(wf)
+        assert len(findings) == 1
+        assert findings[0].step == "scan"
+
+    def test_capture_piped_to_tail_is_a_finding(self):
+        wf = _workflow("      - name: capture\n        run: |\n          ./capture.sh | tail -100\n")
+        assert len(_findings(wf)) == 1
+
+    def test_set_pipefail_after_the_pipeline_does_not_count(self):
+        """Guarding below the pipeline leaves the pipeline itself unguarded."""
+        wf = _workflow("      - name: late\n        run: |\n          ./thing | tee out\n          set -o pipefail\n")
+        assert len(_findings(wf)) == 1
+
+    def test_reported_line_is_the_absolute_file_line(self):
+        wf = _workflow("      - name: scan\n        run: |\n          echo start\n          ./thing | tee out\n")
+        # Body line 2 of a block scalar that opens on file line 7.
+        assert _findings(wf)[0].line == 9
+
+
+class TestGuardsAreHonoured:
+    def test_shell_bash_is_accepted(self):
+        """GitHub runs `shell: bash` as `bash --noprofile --norc -eo pipefail {0}`."""
+        wf = _workflow("      - name: ok\n        shell: bash\n        run: |\n          ./thing | tee out\n")
+        assert _findings(wf) == []
+
+    def test_set_pipefail_before_the_pipeline_is_accepted(self):
+        wf = _workflow("      - name: ok\n        run: |\n          set -euo pipefail\n          ./thing | tee out\n")
+        assert _findings(wf) == []
+
+    def test_job_level_default_shell_is_accepted(self):
+        wf = textwrap.dedent("""\
+            name: t
+            jobs:
+              j:
+                runs-on: ubuntu-latest
+                defaults:
+                  run:
+                    shell: bash
+                steps:
+                  - name: ok
+                    run: |
+                      ./thing | tee out
+            """)
+        assert _findings(wf) == []
+
+    def test_workflow_level_default_shell_is_accepted(self):
+        wf = textwrap.dedent("""\
+            name: t
+            defaults:
+              run:
+                shell: bash
+            jobs:
+              j:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: ok
+                    run: |
+                      ./thing | tee out
+            """)
+        assert _findings(wf) == []
+
+    @pytest.mark.parametrize("shell", ["pwsh", "powershell", "python"])
+    def test_non_posix_shells_are_exempt(self, shell: str):
+        wf = _workflow(f"      - name: ok\n        shell: {shell}\n        run: |\n          a | b\n")
+        assert _findings(wf) == []
+
+    def test_explicit_sh_is_not_exempt(self):
+        """`shell: sh` runs as `sh -e {0}` — still no pipefail."""
+        wf = _workflow("      - name: nope\n        shell: sh\n        run: |\n          ./thing | tee out\n")
+        assert len(_findings(wf)) == 1
+
+
+class TestPipesThatAreNotPipelines:
+    def test_double_pipe_or_is_not_a_pipeline(self):
+        wf = _workflow("      - name: ok\n        run: |\n          ./thing || echo failed\n")
+        assert _findings(wf) == []
+
+    def test_pipe_inside_single_quotes_is_data(self):
+        """A jq filter is a string argument, not a shell pipeline."""
+        wf = _workflow("      - name: ok\n        run: |\n          gh api x --jq '.a|.b'\n")
+        assert _findings(wf) == []
+
+    def test_markdown_table_echo_is_data(self):
+        wf = _workflow('      - name: ok\n        run: |\n          echo "| col | col |" >> "$GITHUB_STEP_SUMMARY"\n')
+        assert _findings(wf) == []
+
+    def test_pipe_inside_a_heredoc_body_is_not_shell(self):
+        """An embedded Python program's regex alternation is not a pipeline."""
+        body = textwrap.indent(
+            textwrap.dedent("""\
+                python - <<'PY'
+                import re
+                re.match(r'a|b', x)
+                PY
+                """),
+            " " * 10,
+        )
+        assert _findings(_workflow("      - name: ok\n        run: |\n" + body)) == []
+
+    def test_pipeline_on_the_heredoc_opening_line_is_still_caught(self):
+        wf = _workflow("      - name: nope\n        run: |\n          python - <<'PY' | tee out\n          print(1)\n          PY\n")
+        assert len(_findings(wf)) == 1
+
+    def test_case_alternation_arm_is_not_a_pipeline(self):
+        body = textwrap.indent(
+            textwrap.dedent("""\
+                case $x in
+                  a|b)
+                    echo hi
+                    ;;
+                esac
+                """),
+            " " * 10,
+        )
+        assert _findings(_workflow("      - name: ok\n        run: |\n" + body)) == []
+
+    def test_comment_containing_a_pipe_is_ignored(self):
+        wf = _workflow("      - name: ok\n        run: |\n          # pipe a | b here\n          echo hi\n")
+        assert _findings(wf) == []
+
+
+class TestCompositeActions:
+    def test_composite_action_steps_are_scanned(self):
+        action = "runs:\n  using: composite\n  steps:\n    - name: nope\n      run: |\n        ./thing | tee out\n"
+        findings = gate.check_document(ROOT / ".github" / "actions" / "x" / "action.yml", action)
+        assert len(findings) == 1
+
+
+class TestTheRepositoryItself:
+    def test_every_shipped_workflow_passes_the_gate(self):
+        """The whole point: no CI step in this repo may mask a failing command."""
+        findings = [f for path in gate._targets() for f in gate.check_document(path, path.read_text(encoding="utf-8"))]
+        assert findings == [], "masked CI pipelines:\n" + "\n".join(f.render() for f in findings)

--- a/tests/test_compose_contract_gate.py
+++ b/tests/test_compose_contract_gate.py
@@ -1,0 +1,139 @@
+"""Contract for the compose gate (`scripts/check_compose_contract.py`).
+
+Nothing in CI parsed these files before. The risk with a new parse gate is that
+it degenerates into "it exited 0", so the assertions on the RENDERED model are
+tested directly here — a dangling `depends_on`, an imageless service, and a
+read-only bind mount of a missing path each have to be caught.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "check_compose_contract.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_compose_contract", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load()
+
+
+def _has_compose() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    result = subprocess.run(["docker", "compose", "version"], capture_output=True, check=False)
+    return result.returncode == 0
+
+
+requires_compose = pytest.mark.skipif(not _has_compose(), reason="docker compose is not available on this runner")
+
+
+class TestDiscovery:
+    def test_every_shipped_compose_file_is_discovered(self):
+        """Discovery is structural so a new profile cannot be added unguarded."""
+        standalone, overlays = gate.discover()
+        found = {p.relative_to(ROOT).as_posix() for p in [*standalone, *overlays]}
+        expected = {
+            "deploy/docker-compose.yml",
+            "deploy/docker-compose.pilot.yml",
+            "deploy/docker-compose.fullstack.yml",
+            "deploy/docker-compose.platform.yml",
+            "deploy/docker-compose.runtime-example.yml",
+            "deploy/docker-compose.hosted-poc.yml",
+            "deploy/docker-compose.product.yml",
+            "deploy/docker-compose.demo-override.yml",
+            "deploy/supabase/clickhouse/docker-compose.yml",
+            "examples/docker-compose-monitoring.yml",
+        }
+        assert expected <= found
+
+    def test_overlays_are_classified_as_overlays(self):
+        _, overlays = gate.discover()
+        names = {p.relative_to(ROOT).as_posix() for p in overlays}
+        assert names == set(gate.OVERLAY_BASES)
+
+    def test_every_overlay_is_validated_against_a_base(self):
+        """An overlay with no declared base is a target that can never run."""
+        for target in gate.build_targets():
+            assert not target.problems, target.problems
+
+    def test_an_undeclared_overlay_fails_closed(self, monkeypatch):
+        monkeypatch.setattr(gate, "OVERLAY_BASES", {})
+        problems = [p for target in gate.build_targets() for p in target.problems]
+        assert any("no declared base" in p for p in problems)
+
+
+class TestRenderedAssertions:
+    """`docker compose config` exiting 0 is not proof the graph is usable."""
+
+    def _target(self) -> gate.Target:
+        return gate.Target(files=[ROOT / "deploy" / "docker-compose.yml"], label="synthetic")
+
+    def test_service_without_image_or_build_is_caught(self):
+        target = self._target()
+        gate._assert_rendered(target, {"services": {"api": {}}})
+        assert any("neither an image nor a build" in p for p in target.problems)
+
+    def test_dangling_depends_on_is_caught(self):
+        target = self._target()
+        gate._assert_rendered(target, {"services": {"api": {"image": "x", "depends_on": {"ghost": {}}}}})
+        assert any("depends_on 'ghost'" in p for p in target.problems)
+
+    def test_renders_no_services_is_caught(self):
+        target = self._target()
+        gate._assert_rendered(target, {"services": {}})
+        assert any("renders no services" in p for p in target.problems)
+
+    def test_missing_readonly_bind_mount_is_caught(self):
+        target = self._target()
+        volume = {"type": "bind", "read_only": True, "source": str(ROOT / "deploy" / "does-not-exist")}
+        gate._assert_rendered(target, {"services": {"api": {"image": "x", "volumes": [volume]}}})
+        assert any("missing path" in p for p in target.problems)
+
+    def test_existing_readonly_bind_mount_passes(self):
+        target = self._target()
+        volume = {"type": "bind", "read_only": True, "source": str(ROOT / "tests")}
+        gate._assert_rendered(target, {"services": {"api": {"image": "x", "volumes": [volume]}}})
+        assert target.problems == []
+
+    def test_generated_secret_mounts_are_exempt(self):
+        """`make secrets` writes these; they are gitignored by design."""
+        target = self._target()
+        volume = {"type": "bind", "read_only": True, "source": str(ROOT / "deploy" / "secrets" / "api_key")}
+        gate._assert_rendered(target, {"services": {"api": {"image": "x", "volumes": [volume]}}})
+        assert target.problems == []
+
+    def test_host_home_mounts_are_not_asserted(self):
+        target = self._target()
+        volume = {"type": "bind", "read_only": True, "source": "/home/someone/.config"}
+        gate._assert_rendered(target, {"services": {"api": {"image": "x", "volumes": [volume]}}})
+        assert target.problems == []
+
+
+class TestRequiredEnvIsDerived:
+    def test_required_variables_get_a_placeholder(self):
+        """`${VAR:?}` is required by design, not a broken file."""
+        clickhouse = ROOT / "deploy" / "supabase" / "clickhouse" / "docker-compose.yml"
+        env = gate._env_for([clickhouse])
+        assert env.get("GRAFANA_ADMIN_USER") == gate._PLACEHOLDER
+
+
+class TestTheRepositoryItself:
+    @requires_compose
+    def test_every_compose_target_parses_and_renders(self):
+        failed = [(t.label, t.problems) for t in gate.run() if t.problems]
+        assert failed == [], f"compose contract failures: {failed}"

--- a/tests/test_mcp_catalog_drift.py
+++ b/tests/test_mcp_catalog_drift.py
@@ -39,6 +39,34 @@ def test_live_mcp_server_lists_same_tool_names_as_server_card() -> None:
     assert live_names == server_card_tool_names()
 
 
+def test_live_mcp_server_lists_same_resource_uris_as_server_card() -> None:
+    """Live resources must match the card — nothing checked this before.
+
+    The HTTP server-card route replaces ``card["tools"]`` with the live list but
+    serves ``card["resources"]`` and ``card["prompts"]`` verbatim from the static
+    lists. A resource registered but absent from the card (or advertised but
+    never registered) was therefore invisible to every test and every workflow.
+    """
+    pytest.importorskip("mcp", reason="mcp SDK not installed")
+    from agent_bom.mcp_server import create_mcp_server
+    from agent_bom.mcp_server_metadata import _SERVER_CARD_RESOURCES
+
+    server = create_mcp_server()
+    live = {str(resource.uri) for resource in asyncio.run(server.list_resources())}
+    assert live == {str(resource["uri"]) for resource in _SERVER_CARD_RESOURCES}
+
+
+def test_live_mcp_server_lists_same_prompt_names_as_server_card() -> None:
+    """Live prompts must match the card — the other half of the same blind spot."""
+    pytest.importorskip("mcp", reason="mcp SDK not installed")
+    from agent_bom.mcp_server import create_mcp_server
+    from agent_bom.mcp_server_metadata import _SERVER_CARD_PROMPTS
+
+    server = create_mcp_server()
+    live = {prompt.name for prompt in asyncio.run(server.list_prompts())}
+    assert live == {str(prompt["name"]) for prompt in _SERVER_CARD_PROMPTS}
+
+
 def test_no_write_tool_is_labeled_read_only() -> None:
     """A tool whose capability class set includes WRITE must never advertise
     readOnlyHint=True — that mislabel tells a client the call is side-effect free

--- a/tests/test_mcp_wheel_smoke.py
+++ b/tests/test_mcp_wheel_smoke.py
@@ -1,12 +1,33 @@
-"""Release gates must exercise MCP from an unlocked wheel install."""
+"""Release gates must exercise MCP from an unlocked wheel install.
+
+This file previously asserted the smoke script contained the literal
+``EXPECTED_TOOL_COUNT = 77``, which pinned exactly the thing that goes stale.
+It now pins the properties that keep the check honest instead: the expectation
+is derived from the shipped server card, all three JSON-RPC list surfaces are
+exercised, and names are compared rather than counts.
+"""
 
 from __future__ import annotations
 
 import ast
+import importlib.util
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SMOKE = ROOT / "scripts/smoke_mcp_wheel.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("smoke_mcp_wheel", SMOKE)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+smoke = _load()
 
 
 def test_mcp_wheel_smoke_is_real_jsonrpc_and_syntax_valid() -> None:
@@ -15,7 +36,43 @@ def test_mcp_wheel_smoke_is_real_jsonrpc_and_syntax_valid() -> None:
     assert 'importlib.import_module("agent_bom.mcp_server")' in body
     assert "session.initialize()" in body
     assert "session.list_tools()" in body
-    assert "EXPECTED_TOOL_COUNT = 77" in body
+    # The two surfaces that had no live coverage at all before.
+    assert "session.list_resources()" in body
+    assert "session.list_prompts()" in body
+
+
+def test_expected_surface_is_derived_from_the_shipped_server_card() -> None:
+    """A typed-in count is the defect class; the card is the source of truth."""
+    code = SMOKE.read_text(encoding="utf-8").split('"""', 2)[-1]
+    assert "EXPECTED_TOOL_COUNT" not in code
+    expected = smoke._expected_surface()
+    from agent_bom import mcp_server_metadata
+
+    assert expected["tools"] == {str(t["name"]) for t in mcp_server_metadata._SERVER_CARD_TOOLS}
+    assert expected["resources"] == {str(r["uri"]) for r in mcp_server_metadata._SERVER_CARD_RESOURCES}
+    assert expected["prompts"] == {str(p["name"]) for p in mcp_server_metadata._SERVER_CARD_PROMPTS}
+
+
+class TestSurfaceComparison:
+    def test_a_card_entry_never_registered_live_is_caught(self) -> None:
+        problems = smoke._compare("resources", ["a://x"], {"a://x", "a://ghost"})
+        assert any("not registered live" in p for p in problems)
+
+    def test_a_live_entry_missing_from_the_card_is_caught(self) -> None:
+        problems = smoke._compare("tools", ["scan", "undocumented"], {"scan"})
+        assert any("missing from the server card" in p for p in problems)
+
+    def test_duplicates_are_caught(self) -> None:
+        problems = smoke._compare("tools", ["scan", "scan"], {"scan"})
+        assert any("duplicate" in p for p in problems)
+
+    def test_matching_sets_pass(self) -> None:
+        assert smoke._compare("prompts", ["a", "b"], {"b", "a"}) == []
+
+    def test_equal_counts_with_different_names_still_fail(self) -> None:
+        """Counting was never enough — two sets can be the same size and differ."""
+        problems = smoke._compare("tools", ["a", "b"], {"a", "c"})
+        assert problems
 
 
 def test_ci_and_release_use_a_clean_unlocked_wheel_install() -> None:

--- a/tests/test_postgres_schema_parity_gate.py
+++ b/tests/test_postgres_schema_parity_gate.py
@@ -1,0 +1,108 @@
+"""Contract for `scripts/check_postgres_schema_parity.py`.
+
+CI builds an Alembic-only database and an init.sql-bootstrapped database in the
+same job, then compares only their `alembic_version` strings. That proves the two
+paths RAN the same revisions, not that they PRODUCED the same schema. These tests
+pin the normalization (so unrelated dump noise never fails a build) and the
+comparison (so a real column difference always does).
+
+The live end-to-end run needs a Postgres server and belongs to the
+`postgres-integration` CI job; everything below is pure text logic.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "check_postgres_schema_parity.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_postgres_schema_parity", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load()
+
+_TEAMS = textwrap.dedent("""\
+    CREATE TABLE public.teams (
+        team_id text NOT NULL,
+        name text NOT NULL
+    );
+    """)
+
+
+class TestNormalization:
+    def test_server_preamble_is_ignored(self):
+        noisy = "SET statement_timeout = 0;\nSET lock_timeout = 0;\n" + _TEAMS
+        assert gate._statements(noisy) == gate._statements(_TEAMS)
+
+    def test_comments_are_ignored(self):
+        noisy = "--\n-- Name: teams; Type: TABLE\n--\n" + _TEAMS
+        assert gate._statements(noisy) == gate._statements(_TEAMS)
+
+    def test_restrict_meta_commands_are_ignored(self):
+        """Newer pg_dump wraps the body in `\\restrict <random token>`."""
+        a = "\\restrict AAAAAAAAAAAAAAAA\n" + _TEAMS + "\\unrestrict AAAAAAAAAAAAAAAA\n"
+        b = "\\restrict BBBBBBBBBBBBBBBB\n" + _TEAMS + "\\unrestrict BBBBBBBBBBBBBBBB\n"
+        assert gate._statements(a) == gate._statements(b)
+
+    def test_database_level_statements_are_ignored(self):
+        """The two databases have different names and settings by construction."""
+        noisy = "ALTER DATABASE agent_bom SET init.app_password = 'x';\n" + _TEAMS
+        assert gate._statements(noisy) == gate._statements(_TEAMS)
+
+    def test_whitespace_and_ordering_do_not_matter(self):
+        one = _TEAMS + "CREATE INDEX i ON public.teams (name);\n"
+        two = "CREATE INDEX   i   ON public.teams (name);\n" + _TEAMS
+        assert gate._statements(one) == gate._statements(two)
+
+
+class TestComparison:
+    def test_identical_schemas_pass(self):
+        assert gate.compare(_TEAMS, _TEAMS) == []
+
+    def test_a_column_only_the_migration_creates_is_reported(self):
+        with_column = _TEAMS.replace("name text NOT NULL", "name text NOT NULL,\n    extra text")
+        problems = gate.compare(with_column, _TEAMS)
+        assert any("MISSING from the init.sql bootstrap" in p for p in problems)
+
+    def test_a_column_only_init_sql_creates_is_reported(self):
+        with_column = _TEAMS.replace("name text NOT NULL", "name text NOT NULL,\n    extra text")
+        problems = gate.compare(_TEAMS, with_column)
+        assert any("MISSING from `alembic upgrade head`" in p for p in problems)
+
+    def test_a_missing_index_is_reported(self):
+        with_index = _TEAMS + "CREATE INDEX idx_teams_name ON public.teams (name);\n"
+        assert gate.compare(with_index, _TEAMS)
+
+    def test_a_column_type_change_is_reported(self):
+        """`observed_at text` vs `timestamptz` is exactly the drift this caught."""
+        retyped = _TEAMS.replace("name text NOT NULL", "name timestamp with time zone NOT NULL")
+        assert gate.compare(_TEAMS, retyped)
+
+
+class TestSecrets:
+    def test_connection_passwords_are_redacted_in_errors(self):
+        redacted = gate._redact("postgresql://owner:hunter2@127.0.0.1:5432/agent_bom")
+        assert "hunter2" not in redacted
+
+
+class TestCiWiring:
+    def test_the_postgres_job_runs_the_parity_gate(self):
+        ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        assert "scripts/check_postgres_schema_parity.py" in ci
+        assert "--require-extension pg_trgm" in ci
+
+    def test_the_bootstrap_path_replays_what_docker_mounts(self):
+        """Docker loads 01-init.sql AND 02-runtime-schema.sql; CI must match."""
+        ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        assert "-f deploy/supabase/postgres/runtime-schema.sql" in ci

--- a/tests/test_published_counts_gate.py
+++ b/tests/test_published_counts_gate.py
@@ -1,0 +1,119 @@
+"""Contract for the published-counts gate (`scripts/check_published_counts.py`).
+
+The gate's whole value is that it never stores the expected number. These tests
+pin that: the expectation is derived from the shipped registry and server card,
+a stale claim in any published surface is caught, and a number that merely looks
+like a count (a scan result, a ring-buffer size) is left alone.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "check_published_counts.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_published_counts", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load()
+
+
+class TestCountsAreDerivedNotStored:
+    def test_registry_entry_count_comes_from_the_bundled_registry(self):
+        registry = json.loads((ROOT / "src" / "agent_bom" / "mcp_registry.json").read_text(encoding="utf-8"))
+        assert gate.derive_counts()["registry entries"] == len(registry["servers"])
+
+    def test_verified_count_comes_from_the_bundled_registry(self):
+        registry = json.loads((ROOT / "src" / "agent_bom" / "mcp_registry.json").read_text(encoding="utf-8"))
+        expected = sum(1 for entry in registry["servers"].values() if entry.get("verified") is True)
+        assert gate.derive_counts()["registry verified entries"] == expected
+
+    def test_mcp_surface_counts_come_from_the_server_card(self):
+        counts = gate.derive_counts()
+        assert counts["MCP tools"] == len(gate._server_card_list("_SERVER_CARD_TOOLS"))
+        assert counts["MCP resources"] == len(gate._server_card_list("_SERVER_CARD_RESOURCES"))
+        assert counts["MCP prompts"] == len(gate._server_card_list("_SERVER_CARD_PROMPTS"))
+
+    def test_no_expected_count_is_hardcoded_in_the_gate(self):
+        """A literal expectation is the very failure mode this gate exists to stop."""
+        source = SCRIPT.read_text(encoding="utf-8")
+        counts = gate.derive_counts()
+        code = source.split('"""', 2)[-1]  # skip the module docstring, which cites the incident
+        for value in counts.values():
+            assert f"== {value}" not in code and f"= {value}\n" not in code
+
+
+class TestStaleClaimsAreCaught:
+    def _sweep(self, tmp_path: Path, monkeypatch, text: str, suffix: str = ".md"):
+        published = tmp_path / f"surface{suffix}"
+        published.write_text(text, encoding="utf-8")
+        monkeypatch.setattr(gate, "SEARCH_ROOTS", (published,))
+        monkeypatch.setattr(gate, "ROOT", tmp_path)
+        return gate.find_stale_claims(gate.derive_counts())
+
+    def test_stale_registry_entry_claim_is_reported(self, tmp_path, monkeypatch):
+        problems = self._sweep(tmp_path, monkeypatch, "Look it up in the curated registry (999 servers, 3 verified).\n")
+        assert any("999" in p for p in problems)
+
+    def test_stale_verified_claim_is_reported(self, tmp_path, monkeypatch):
+        counts = gate.derive_counts()
+        text = f"agent-bom's curated registry ({counts['registry entries']} servers, 3 verified)\n"
+        problems = self._sweep(tmp_path, monkeypatch, text)
+        assert any("verified" in p and "3" in p for p in problems)
+
+    def test_correct_claim_passes(self, tmp_path, monkeypatch):
+        counts = gate.derive_counts()
+        text = f"registry ({counts['registry entries']} servers, {counts['registry verified entries']} verified)\n"
+        assert self._sweep(tmp_path, monkeypatch, text) == []
+
+    def test_svg_diagram_label_is_swept(self, tmp_path, monkeypatch):
+        """check_release_consistency skips every image suffix; a stale count hid there."""
+        svg = '<text>MCP Registry</text>\n<text class="step-desc">999 servers</text>\n'
+        problems = self._sweep(tmp_path, monkeypatch, svg, suffix=".svg")
+        assert any("999" in p for p in problems)
+
+    def test_shipped_python_prose_is_swept(self, tmp_path, monkeypatch):
+        """Two of the six real stale claims were runtime strings, not docs."""
+        source = '"""Browse the 999-entry server security metadata registry."""\n'
+        problems = self._sweep(tmp_path, monkeypatch, source, suffix=".py")
+        assert any("999" in p for p in problems)
+
+
+class TestNumbersThatAreNotClaims:
+    def _sweep(self, tmp_path, monkeypatch, text: str, suffix: str = ".md"):
+        published = tmp_path / f"surface{suffix}"
+        published.write_text(text, encoding="utf-8")
+        monkeypatch.setattr(gate, "SEARCH_ROOTS", (published,))
+        monkeypatch.setattr(gate, "ROOT", tmp_path)
+        return gate.find_stale_claims(gate.derive_counts())
+
+    def test_a_scan_result_is_not_a_registry_claim(self, tmp_path, monkeypatch):
+        assert self._sweep(tmp_path, monkeypatch, "The scan found 4 MCP servers on my laptop.\n") == []
+
+    def test_a_ring_buffer_size_is_not_a_registry_claim(self, tmp_path, monkeypatch):
+        assert self._sweep(tmp_path, monkeypatch, "evicted from the 1000-entry ring buffer\n") == []
+
+    def test_registry_bundle_itself_is_not_swept(self):
+        """Each of its entries records that server's own tool count."""
+        assert gate.REGISTRY not in gate._files()
+
+
+class TestTheRepositoryItself:
+    def test_every_published_surface_matches_the_shipped_build(self):
+        problems = gate.find_stale_claims(gate.derive_counts())
+        assert problems == [], "stale published counts:\n" + "\n".join(problems)
+
+    def test_registry_header_agrees_with_the_bundle(self):
+        """`_total_servers` is a second answer to one question; keep them equal."""
+        gate.derive_counts()  # raises SystemExit if the header disagrees

--- a/tests/test_release_version_sweep.py
+++ b/tests/test_release_version_sweep.py
@@ -10,8 +10,10 @@ so these tests pin that it stays structural and fails closed.
 from __future__ import annotations
 
 import importlib.util
+import json
 import re
 import sys
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -69,6 +71,51 @@ class TestTheSweepIsStructural:
     def test_sdk_packages_are_covered_by_a_glob(self):
         globs = [glob for glob, _p, _l in crc.VERSION_SWEEP]
         assert any(glob.startswith("sdks/") for glob in globs)
+
+
+class TestPackageJsonPatternIsSafeAndScoped:
+    """The npm pattern must find the top-level version and nothing else — fast.
+
+    It originally read `(?:[^{}]|\\n)*?`. A negated character class already
+    matches newline in Python, so that alternation let the engine consume one
+    character two ways and backtracking went exponential (CodeQL ReDoS, HIGH).
+    """
+
+    @staticmethod
+    def _pattern():
+        return dict((glob, pattern) for glob, pattern, _label in crc.VERSION_SWEEP)["sdks/*/package.json"]
+
+    def test_top_level_version_is_matched(self):
+        package = '{\n  "name": "@agent-bom/client",\n  "version": "1.2.3"\n}\n'
+        assert {m.group(1) for m in self._pattern().finditer(package)} == {"1.2.3"}
+
+    def test_nested_dependency_version_is_not_matched(self):
+        """A dependency's version must never be mistaken for the package's own."""
+        package = '{\n  "name": "x",\n  "dependencies": {\n    "left-pad": "9.9.9",\n    "dep": { "version": "8.8.8" }\n  }\n}\n'
+        assert self._pattern().findall(package) == []
+
+    def test_nested_version_after_a_closed_object_is_not_matched(self):
+        """Once any brace appears, the brace-free run can no longer reach past it."""
+        package = '{\n  "engines": { "node": ">=20" },\n  "version": "7.7.7"\n}\n'
+        assert self._pattern().findall(package) == []
+
+    def test_real_sdk_manifests_match_their_declared_version(self):
+        for manifest in sorted((ROOT / "sdks").glob("*/package.json")):
+            text = manifest.read_text(encoding="utf-8")
+            declared = json.loads(text)["version"]
+            assert {m.group(1) for m in self._pattern().finditer(text)} == {declared}, manifest
+
+    def test_pathological_input_completes_promptly(self):
+        """A brace followed by many newlines and no version must not blow up."""
+        payload = "{" + "\n" * 4000
+        start = time.perf_counter()
+        assert self._pattern().search(payload) is None
+        assert time.perf_counter() - start < 1.0
+
+    def test_no_sweep_pattern_repeats_a_negated_class_alternated_with_newline(self):
+        """Pin the whole class, not just the one instance that was reported."""
+        for glob, pattern, _label in crc.VERSION_SWEEP:
+            assert not re.search(r"\(\?:\[\^[^\]]*\]\|\\n\)", pattern.pattern), glob
 
 
 class TestIndependentVersionsAreDeclared:

--- a/tests/test_release_version_sweep.py
+++ b/tests/test_release_version_sweep.py
@@ -1,0 +1,92 @@
+"""Contract for the derived version sweep in `scripts/check_release_consistency.py`.
+
+`bump-version.py` (the writer) and `check_release_consistency.py` (the checker)
+were both hand-maintained lists. A version-bearing artifact in neither list is
+written by nobody and checked by nobody, which is how `sdks/python/pyproject.toml`
+sat at 0.92.0 against a 0.100.0 platform. The sweep finds such artifacts by shape,
+so these tests pin that it stays structural and fails closed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "check_release_consistency.py"
+BUMP = ROOT / "scripts" / "bump-version.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_release_consistency", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+crc = _load()
+
+
+def _release_version() -> str:
+    match = re.search(r'^version\s*=\s*"([^"]+)"', (ROOT / "pyproject.toml").read_text(encoding="utf-8"), re.M)
+    assert match
+    return match.group(1)
+
+
+class TestTheRepositoryItself:
+    def test_no_artifact_drifts_from_the_release_version(self):
+        problems = crc.sweep_version_drift(_release_version())
+        assert problems == [], "version drift:\n" + "\n".join(problems)
+
+    def test_the_python_sdk_tracks_the_platform_release(self):
+        """The exact artifact that drifted; it is an alias for the shipped client."""
+        sdk = (ROOT / "sdks" / "python" / "pyproject.toml").read_text(encoding="utf-8")
+        assert f'version = "{_release_version()}"' in sdk
+
+    def test_the_writer_also_owns_the_python_sdk(self):
+        """A checker without a matching writer just relocates the manual step."""
+        assert "sdks/python/pyproject.toml" in BUMP.read_text(encoding="utf-8")
+
+
+class TestTheSweepIsStructural:
+    def test_drift_is_detected_for_an_arbitrary_version(self):
+        """Sweeping against a version nothing matches must report, not pass."""
+        problems = crc.sweep_version_drift("9.9.9")
+        assert problems, "sweeping against an impossible version found nothing — the sweep is not reading files"
+
+    def test_every_sweep_entry_is_a_glob_not_a_filename(self):
+        for glob, _pattern, _label in crc.VERSION_SWEEP:
+            assert "*" in glob, f"{glob!r} names a single file; a new sibling would escape the sweep"
+
+    def test_compose_profiles_are_covered_by_a_glob(self):
+        globs = [glob for glob, _p, _l in crc.VERSION_SWEEP]
+        assert any("docker-compose" in glob for glob in globs)
+
+    def test_sdk_packages_are_covered_by_a_glob(self):
+        globs = [glob for glob, _p, _l in crc.VERSION_SWEEP]
+        assert any(glob.startswith("sdks/") for glob in globs)
+
+
+class TestIndependentVersionsAreDeclared:
+    def test_every_exemption_carries_a_reason(self):
+        for path, reason in crc.INDEPENDENTLY_VERSIONED.items():
+            assert len(reason) > 20, f"{path} is exempt without an explanation"
+
+    def test_every_exempt_path_exists(self):
+        """A stale exemption silently un-guards nothing and hides a typo."""
+        for path in crc.INDEPENDENTLY_VERSIONED:
+            assert (ROOT / path).is_file(), f"{path} is exempt but does not exist"
+
+    def test_exemptions_are_exact_paths_not_globs(self):
+        """A glob here would re-open the hole the sweep closes."""
+        for path in crc.INDEPENDENTLY_VERSIONED:
+            assert "*" not in path
+
+    def test_removing_an_exemption_surfaces_that_artifact(self, monkeypatch):
+        monkeypatch.setattr(crc, "INDEPENDENTLY_VERSIONED", {})
+        problems = crc.sweep_version_drift(_release_version())
+        assert any("sdks/typescript" in problem for problem in problems)


### PR DESCRIPTION
Pre-publish drift gates. Every stale claim we found by hand in the last day existed because a number or a contract was written once and never recomputed. Each gate below **derives** the truth from the artifact that ships and compares; where a value is genuinely fixed fixture structure, it is pinned deliberately and said so.

**Every gate was watched failing on real input before it was made to pass.** Six of the failures were live on `main`, not synthetic.

---

## 1. Release consistency — versions, derived instead of listed

**Asserts:** every artifact that embeds a version of *ours* equals the release version. Discovery is **structural** — `sdks/*/pyproject.toml`, `sdks/*/package.json`, every `deploy/docker-compose*.yml`, `deploy/k8s/*.yaml`, `deploy/docker/Dockerfile*`, `integrations/*/server.json` — so a newly added SDK or compose profile is covered the moment it exists. A genuinely independent version must be declared in `INDEPENDENTLY_VERSIONED` **with a reason**; silence fails closed.

**Root cause:** the writer (`bump-version.py`) and the checker (`check_release_consistency.py`) were *both* hand-maintained lists. An artifact in neither is written by nobody and checked by nobody.

**Red I watched:**
```
sdks/python/pyproject.toml has stale SDK package version: ['0.92.0'] != 0.100.0
```
`git log` shows it was bumped by hand once (`chore(sdks): bump Python SDK`) and then forgotten. Fixed, **and added to `bump-version.py`** — a checker without a matching writer just relocates the manual step.

Declared independent: `@agent-bom/runtime` and `@agent-bom/client`, published to npm on their own 0.x line.

---

## 2. External-surface freshness — advertised counts vs what we ship

**Asserts:** registry entries, verified entries, and MCP tool/resource/prompt counts are derived (`mcp_registry.json`, the server card) and swept across READMEs, `docs/`, `site-docs/`, `integrations/`, **SVG diagrams**, and the shipped Python package. No expected number is stored — a test asserts that.

**Red I watched (9 findings, all live on main):**
```
docs/MCP_SECURITY_MODEL.md:248        advertises 1013 registry entries, build ships 1081
docs/images/scan-pipeline-light.svg:101  advertises 1013 …
docs/skills/mcp-server-review.md:29   advertises 1013 … and 940 verified, build ships 60
integrations/cortex-code/README.md:60 advertises 1013 …
src/agent_bom/mcp_server.py:88        advertises 1013 …
src/agent_bom/mcp_server_catalog.py:46 advertises 1013 …
```
Worse than reported: **two are runtime strings** (the `registry://servers` description every MCP client reads), and one is inside an SVG — `check_release_consistency.py` skips every image suffix, so that surface had no coverage at all.

Precision matters or the gate gets muted, so claims are anchored on registry vocabulary. Verified non-findings: a blog's "4 MCP servers" scan result, a `1000-entry ring buffer`, and the registry bundle itself (each of its 1081 entries records that server's own tool count).

---

## 3. Runtime JSON-RPC surface

**Asserts:** boot the real `agent-bom mcp server` over stdio, `initialize` → `tools/list` + `resources/list` + `prompts/list`, and compare **names** (not counts) against the wheel's own server card, plus `serverInfo.version == __version__`.

**What was wrong:** the smoke script asserted `EXPECTED_TOOL_COUNT = 77` — precisely the pattern that becomes the next stale claim — and a test *pinned that literal*. Only `tools/list` was ever exercised; the server-card HTTP route serves resources and prompts **verbatim from the static lists**, so drift there was invisible to every test and workflow.

**Red I watched** (added a resource to the card that nothing registers):
```
MCP wheel smoke failed: live MCP surface disagrees with the shipped server card:
  - resources: advertised by the server card but not registered live: ['registry://ghost']
```
Green: `{"prompt_count": 8, "resource_count": 6, "tool_count": 77, "server_version": "0.100.0"}`.

Also added the per-PR in-process equivalents for resources and prompts to `test_mcp_catalog_drift.py`, so this is caught without a wheel build.

---

## 4. Postgres — schema parity, not just the same head

**Asserts:** the Alembic-only database and the init.sql-bootstrapped database — which the job **already builds** — render an identical schema under `pg_dump --schema-only`, and required extensions are actually installed.

**Why:** matching `alembic_version` proves the two paths *ran* the same revisions, not that they *produced* the same schema. The convention here is that a new column lands in a migration and is back-added to `init.sql`; miss the second edit and fresh installs ship a different database under an identical head. Every existing guard is a regex over SQL text. `pg_trgm` is created in three places, one at runtime where a permission error is deliberately swallowed — "we asked for it" was never "it is there".

**Red I watched** — I reproduced both paths against a real `postgres:16-alpine` and the first run failed immediately, finding a genuine defect:

> CI's bootstrap path replays **only `init.sql`**, while the Docker entrypoint mounts `01-init.sql` **and** `02-runtime-schema.sql`. Without the second file `hub_findings_current_observations` did not exist, so the partition migration found nothing to convert. The two paths ended on the same Alembic head with the table as `p` (partitioned, `observed_at timestamptz`) on one and `r` (plain, `observed_at text`) on the other. Only a schema diff could see this.

CI now replays what Docker mounts, and parity passes. Then, to prove the gate itself:
```
ALTER TABLE teams ADD COLUMN forgotten_in_init_sql text;
→ present after the init.sql bootstrap but MISSING from `alembic upgrade head`
```
and `--require-extension vector` correctly fails closed.

---

## 5. Compose contract

**Asserts:** `docker compose config` parses all 7 standalone files **and** the 3 documented overlay-onto-base combinations, then asserts the **rendered** graph — every service resolves to an image or build, every `depends_on` names a real service, every read-only bind mount exists.

**Why the second half:** "exited 0" is not a test; this repo learned that when `helm template` rendered an ingress with empty `paths` across five profiles. And nothing in CI had *ever* run `docker compose config` — the only caller is `hosted_poc_preflight.py`, whose one automated invocation passes `--skip-compose` — while `docs/DEPLOY_PLATFORM.md` told operators the stack passes it.

**Red I watched (live on main):**
```
deploy/docker-compose.yml: service 'agent-bom' read-only bind mount points at a missing path: deploy/tests
```
`./tests:ro` resolves against the compose file's directory, so it pointed at `deploy/tests`. Docker creates a missing read-only bind source as an **empty directory** rather than failing, so the container silently scanned nothing. Fixed to `../tests`.

Overlays are validated merged onto their base (they fail standalone by design); an overlay with no declared base fails the gate rather than being skipped.

---

## 6. A gate that cannot fail is not a gate — pipefail

GitHub runs an unqualified `run:` as `bash -e {0}` — `-e` but **not** `-o pipefail` (confirmed against the current workflow-syntax docs; `shell: bash` runs `bash --noprofile --norc -eo pipefail {0}`). `scripts/check_ci_pipefail.py` now blocks the class.

**Red I watched: 17 steps across 9 workflows.** The worst is the headline:

> `osv-scanner … | tee` exits with **tee's** status, so the `|| { … }` fixable-CVE branch was **unreachable**. The block-on-fixable-CVE logic was dead code — in `ci.yml` *and* in `release.yml`, where the step is named "block release on fixable CVEs".

Demonstrated on the original shape under the original shell, with a stub scanner reporting a fixable CVE:
```
| GHSA-xxxx | 1.2.3 | 1.2.4 | somepkg |
STEP REACHED THE END — the fixable-CVE branch never ran
OLD_EXIT=0
```
Restructured to capture status explicitly, then verified all three branches: clean → pass, **fixable → blocked**, unfixable-only → pass. I ran the real scanner against all three lockfiles first — **all exit 0 today**, so reviving this blocks nothing spurious.

Two steps needed more than a shell flag, because pipefail alone still left them failing open:
- **JS supply-chain guard** — `find dist … | grep -q .` reported "clean" whenever `dist/` was missing, since grep's exit 1 is indistinguishable from find's failure. Now asserts the build output exists before concluding it is source-map free.
- **MCP config scan** — one `git diff … | grep … || true` made "diff failed" (missing base ref after a shallow fetch) look identical to "no MCP configs changed", silently skipping the scan on a PR that did change them. The diff is now resolved before it is filtered.

The gate is quiet by construction: pipes inside quotes (jq filters, markdown tables), heredoc bodies, `case` alternation arms and `||` are not pipelines. Unit tests pin both halves.

---

## Verification

`make preflight` · `make lint-ruff` · `make format-check` · `mypy` on changed files — all green.
Targeted suites green (~1,060 tests): the 5 new gate suites, plus compose/deployment/manifests, MCP catalog + server + registry, Postgres migrations/schema/authority, release storefront, and every suite that reads workflow files. The full suite is too large to complete locally; CI runs it in its matrix.

## CI cost

No regression to the fast path. The two cheap checks (~2s combined) join the existing `security` job and are deliberately **not** gated on `docs_only` — a stale advertised count *is* a docs-only change. The Postgres diff is a step in the existing `postgres-integration` job (reuses databases it already builds, no new service). Compose validation is a **new path-filtered job** that only runs when a compose file, the SQL/secrets it mounts, or a Dockerfile it builds changes. Concurrency cancel-in-progress and uv caching are untouched.

## Assumption I could not verify locally

The `shell: bash` additions to publish/release workflows (`release-snowflake`, `publish-registries`, `publish-mcp-registry`, `deploy-mcp-sse`, `deployment-freshness`) are correct by the documented invocation, but those workflows only run on tags/schedules, so I could not execute them. They are strictly stricter than before; the intended effect is that a failing `docker save`, `clawhub publish`, or `gh issue list` now surfaces instead of being masked.


---

## 7. The MCP config scanner had never run

The pipefail gate immediately caught a pre-existing defect **on this very PR**, which belongs in the record next to the CVE gate because it is the same lesson.

`mcp-change-scan.yml` checked out with no `fetch-depth`, so the runner produced a depth-1 clone with no `origin/main` ref and the job's `git diff --name-only origin/main...HEAD` could never resolve:

```
fatal: ambiguous argument 'origin/main...HEAD': unknown revision or path not in the working tree
```

Under the old `git diff … | grep … || true` shape, that failure was **indistinguishable from "no MCP configs changed"**. So the scanner reported success on every PR while doing nothing. It was not merely fragile — **it had never run**. Only making the diff fail closed revealed it.

Fixed at the root: `fetch-depth: 0`, and the diff now uses the PR's base/head SHAs — the same pattern `ci.yml`'s path classifier already uses, which avoids depending on a remote branch ref being present. The fail-closed logic is unchanged.

**Verified it does the work, not just that it stopped erroring.** Replaying the step against this PR's real SHAs:

```
RESULT: matched MCP config files:
  deploy/docker-compose.yml
--- scanning deploy/docker-compose.yml (project deploy) ---
Auto-detected project scan surfaces: terraform, iac, python_agents, ai_inventory
  ✓ 39 files scanned — 0 components, all safe
  ✓ deploy: 2 package(s) across 1 manifest directory
Scanning 1 Terraform directory...
SUMMARY: scanned=1 failed=0
```

Three gates in this PR — the CVE gate, this scanner, and the Postgres bootstrap path — were all green while doing nothing. That is the thesis.

## 8. ReDoS in this PR's own new gate (CodeQL HIGH)

CodeQL flagged the npm pattern I added to `VERSION_SWEEP`, and it was right. `(?:[^{}]|\n)*?` is ambiguous: a negated character class **already matches newline** in Python, so the alternation gave the engine two ways to consume the same character and backtracking became exponential. Measured on `"{" + "\n" * n`, which never reaches `"version":` and so forces a full backtrack:

| newlines | vulnerable | fixed |
|---|---|---|
| 18 | 0.0086s | 0.000002s |
| 20 | 0.0346s | 0.000003s |
| 22 | 0.1382s | 0.000006s |
| 24 | 0.5518s | 0.000003s |

Quadrupling every two characters — 40 newlines would be ~40 minutes. Fixed to `[^{}]*?`, which is constant-time and **preserves the point of the anchor**: `\A\{` plus a brace-free run keeps the match on the *top-level* `"version"`, because once a nested object opens `[^{}]` can no longer advance. Tests pin both properties (top-level matched, nested dependency version **not** matched, real SDK manifests match their declared version), plus a pathological-input timing assertion, plus a check that no other sweep pattern has that shape. Not dismissed — we ship a scanner that flags exactly this.

## Follow-ups deliberately NOT in this PR

Kept out to hold the diff minimal ahead of the release tag. Recorded here so they are not lost:

1. **`cflite-pr.yml` — same shallow-checkout class, suspected silent skip.** The `PR-Fuzzing` job checks out at depth 1, and ClusterFuzzLite's `mode: code-change` selects targets by diffing `<base_ref>...HEAD` (oss-fuzz `infra/cifuzz/continuous_integration.py`), which needs a merge base. CFLite fetches the base branch itself, but that fetch leaves a shallow clone shallow, so no common ancestor exists, the changed-file set comes back empty, and the job exits 0 having fuzzed nothing. Established by reading upstream source; **not reproduced end-to-end**, since CFLite cannot run locally here. Suggested fix is one line: `fetch-depth: 0` on that job's checkout (`Batch-Fuzzing` needs no history — it fuzzes everything).
2. **`mcp-change-scan.yml` scan loop still swallows a scanner crash.** Each config is scanned via `… 2>&1 | head -100 >> report || true`, so if `agent-bom agents` crashes, its traceback is written into the PR comment under "Security Scan Results" and the job still goes green. Pre-existing and the same defect class as the two above; worth capturing per-file exit status and failing once the report is complete (posting the comment via `always()` so it can explain itself).

A full sweep of every workflow for the shallow-checkout assumption was run: apart from item 1, every other base-ref/tag/history consumer either sets `fetch-depth: 0` or performs a targeted fetch of exactly the ref it reads, and all fail loudly rather than degrading to a false "nothing changed".
