### PR TITLE
fix(graph): make dense graphs readable, described, and reachable offline

### DIFF
--- a/ui/app/login/login-page-content.tsx
+++ b/ui/app/login/login-page-content.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect, type ReactNode } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { FileText } from "lucide-react";
 
 import { LoginPanel } from "@/components/login-panel";
 import { useAuthState } from "@/components/auth-provider";
 import { defaultOperatorLanding } from "@/lib/operator-landing";
+import { enableOfflineReportMode } from "@/lib/offline-report-mode";
 import { safeReturnPath } from "@/lib/safe-return-path";
 
 export function LoginPageContent({ trialInvitation }: { trialInvitation: ReactNode }) {
@@ -21,5 +23,27 @@ export function LoginPageContent({ trialInvitation }: { trialInvitation: ReactNo
     }
   }, [loading, returnTo, router, session]);
 
-  return <LoginPanel title="Sign in to agent-bom" trialInvitation={trialInvitation} />;
+  return (
+    <>
+      <LoginPanel title="Sign in to agent-bom" trialInvitation={trialInvitation} />
+      {/*
+        A 401 lands every route here, including the home page that hosts the
+        in-browser report importer. Without this, a user holding a report file
+        and no working sign-in has nowhere left to go.
+      */}
+      <div className="pb-10 text-center">
+        <button
+          type="button"
+          onClick={() => {
+            enableOfflineReportMode();
+            router.replace("/");
+          }}
+          className="inline-flex items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-4 py-2 text-sm text-[var(--foreground)] transition-colors hover:bg-[var(--surface-muted)]"
+        >
+          <FileText className="h-4 w-4" />
+          Continue offline with a report file
+        </button>
+      </div>
+    </>
+  );
 }

--- a/ui/components/auth-gate.tsx
+++ b/ui/components/auth-gate.tsx
@@ -2,10 +2,15 @@
 
 import { useEffect } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { Loader2 } from "lucide-react";
+import { FileText, Loader2, WifiOff } from "lucide-react";
 
 import { useAuthState } from "@/components/auth-provider";
 import { BrandLogo } from "@/components/brand-logo";
+import {
+  disableOfflineReportMode,
+  enableOfflineReportMode,
+  useOfflineReportMode,
+} from "@/lib/offline-report-mode";
 
 function isAuthFailure(message: string): boolean {
   const normalized = message.toLowerCase();
@@ -27,10 +32,30 @@ function isApiReachabilityFailure(message: string): boolean {
   );
 }
 
+/**
+ * Offered on every screen that would otherwise dead-end a user holding a
+ * report file. Pressing it renders the app so the in-browser report importer
+ * can mount; it grants no data, because the API is still unreachable or still
+ * refusing this session.
+ */
+function ContinueOfflineButton() {
+  return (
+    <button
+      type="button"
+      onClick={enableOfflineReportMode}
+      className="mt-5 inline-flex items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-4 py-2 text-sm text-[var(--foreground)] transition-colors hover:bg-[var(--surface-muted)]"
+    >
+      <FileText className="h-4 w-4" />
+      Continue offline with a report file
+    </button>
+  );
+}
+
 export function AuthGate({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
   const { session, loading, error, reconnecting } = useAuthState();
+  const offlineReportMode = useOfflineReportMode();
 
   const needsAuth =
     !loading &&
@@ -38,10 +63,10 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
     (!error || isAuthFailure(error));
 
   useEffect(() => {
-    if (!needsAuth || pathname === "/login") return;
+    if (!needsAuth || offlineReportMode || pathname === "/login") return;
     const returnTo = encodeURIComponent(pathname || "/");
     router.replace(`/login?returnTo=${returnTo}`);
-  }, [needsAuth, pathname, router]);
+  }, [needsAuth, offlineReportMode, pathname, router]);
 
   if (loading) {
     return (
@@ -58,10 +83,40 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
     return <>{children}</>;
   }
 
+  // The user asked to work from a local report. Say so plainly — nothing on
+  // screen below this banner came from the control plane — and keep the way
+  // back to signing in one click away.
+  if (offlineReportMode) {
+    return (
+      <>
+        <div
+          role="status"
+          className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-xl border border-amber-500/40 bg-amber-500/10 dark:bg-amber-950/25 px-4 py-2.5 text-sm text-amber-900 dark:text-amber-100"
+        >
+          <WifiOff className="h-4 w-4 shrink-0" />
+          <span className="min-w-0">
+            Offline. Not signed in to the control plane — only a report you import here is shown.
+          </span>
+          <button
+            type="button"
+            onClick={() => {
+              disableOfflineReportMode();
+              router.replace("/login");
+            }}
+            className="ml-auto shrink-0 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-1.5 text-xs text-[var(--foreground)] transition-colors hover:bg-[var(--surface-muted)]"
+          >
+            Sign in
+          </button>
+        </div>
+        {children}
+      </>
+    );
+  }
+
   if (error && isApiReachabilityFailure(error)) {
     return (
       <div className="flex min-h-[calc(100vh-5rem)] items-center justify-center px-4 py-10">
-        <div className="w-full max-w-xl rounded-3xl border border-amber-900/50 bg-amber-950/20 p-8 text-center shadow-2xl shadow-black/20">
+        <div className="w-full max-w-xl rounded-3xl border border-amber-500/40 bg-amber-500/10 dark:border-amber-900/50 dark:bg-amber-950/20 p-8 text-center shadow-2xl shadow-black/20">
           <div className="mx-auto mb-4 flex justify-center">
             <BrandLogo />
           </div>
@@ -70,6 +125,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
             Authentication could not be verified because the API is offline or returned a server error.
           </p>
           <p className="mt-2 text-xs text-[var(--text-tertiary)]">{error}</p>
+          <ContinueOfflineButton />
         </div>
       </div>
     );
@@ -84,8 +140,9 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div className="flex min-h-[calc(100vh-5rem)] items-center justify-center px-4 py-10">
+    <div className="flex min-h-[calc(100vh-5rem)] flex-col items-center justify-center px-4 py-10">
       <div className="max-w-xl rounded-2xl border border-red-500/30 dark:border-red-900/50 bg-red-500/10 dark:bg-red-950/20 p-6 text-sm text-red-700 dark:text-red-300">{error}</div>
+      <ContinueOfflineButton />
     </div>
   );
 }

--- a/ui/components/graph-text-alternative.tsx
+++ b/ui/components/graph-text-alternative.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useMemo } from "react";
+
+import {
+  buildGraphTextAlternative,
+  type GraphTextAlternativeOptions,
+} from "@/lib/graph-text-alternative";
+import type {
+  LargeGraphOverviewModel,
+  LargeGraphOverviewSummary,
+} from "@/lib/large-graph-overview";
+
+interface GraphTextAlternativeProps extends GraphTextAlternativeOptions {
+  /** Referenced by the canvas's `aria-describedby`. */
+  id: string;
+  /** Which renderer this describes, so the reading names the surface. */
+  renderer: string;
+  model: LargeGraphOverviewModel;
+  summary: LargeGraphOverviewSummary;
+}
+
+/**
+ * The screen-reader equivalent of a canvas graph: a named region carrying the
+ * same census, nodes, and relationships the canvas paints. Visually hidden —
+ * sighted users have the canvas itself, and the design language keeps the
+ * content the hero rather than stacking a second representation beside it.
+ */
+export function GraphTextAlternative({
+  id,
+  renderer,
+  model,
+  summary,
+  maxRows,
+  maxConnections,
+}: GraphTextAlternativeProps) {
+  const text = useMemo(
+    () => buildGraphTextAlternative(model, summary, { maxRows, maxConnections }),
+    [maxConnections, maxRows, model, summary],
+  );
+
+  return (
+    <section id={id} className="sr-only" aria-label="Graph contents, text equivalent">
+      <p>
+        {renderer}. {text.headline}
+      </p>
+
+      <h3>Nodes by type</h3>
+      <ul>
+        {text.nodeTypes.map((item) => (
+          <li key={item.nodeType}>
+            {item.nodeType}: {item.count.toLocaleString()}
+          </li>
+        ))}
+      </ul>
+
+      <h3>Relationships by kind</h3>
+      <ul>
+        {text.relationships.map((item) => (
+          <li key={item.relationship}>
+            {item.relationship.replace(/[_-]+/g, " ")}: {item.count.toLocaleString()}
+          </li>
+        ))}
+      </ul>
+
+      <table>
+        <caption>Nodes drawn on the graph. {text.rowsNote}</caption>
+        <thead>
+          <tr>
+            <th scope="col">Node</th>
+            <th scope="col">Type</th>
+            <th scope="col">Severity</th>
+            <th scope="col">Connections</th>
+          </tr>
+        </thead>
+        <tbody>
+          {text.rows.map((row) => (
+            <tr key={row.id}>
+              <th scope="row">{row.label}</th>
+              <td>{row.nodeType}</td>
+              <td>{row.severity}</td>
+              <td>{row.connections.toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3>Connections</h3>
+      <p>{text.connectionsNote}</p>
+      <ul>
+        {text.connections.map((sentence) => (
+          <li key={sentence}>{sentence}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/ui/components/large-graph-overview.tsx
+++ b/ui/components/large-graph-overview.tsx
@@ -6,6 +6,11 @@ import { Activity, GitBranch, Layers3, Network, ShieldAlert } from "lucide-react
 
 import type { LineageNodeData } from "@/components/lineage-nodes";
 import { GraphLegend } from "@/components/graph-chrome";
+import { GraphTextAlternative } from "@/components/graph-text-alternative";
+import {
+  useGraphCanvasPalette,
+  type GraphCanvasPalette,
+} from "@/lib/graph-canvas-theme";
 import type { LegendItem } from "@/lib/graph-utils";
 import { useCaptureMode } from "@/lib/use-capture-mode";
 import {
@@ -42,9 +47,9 @@ function StatPill({
 }) {
   const toneClass = {
     zinc: "border-[var(--border-subtle)] bg-[var(--background)]/70 text-[var(--text-secondary)]",
-    red: "border-red-500/30 bg-red-950/25 text-red-100",
-    amber: "border-amber-500/30 bg-amber-950/25 text-amber-100",
-    cyan: "border-cyan-500/30 bg-cyan-950/25 text-cyan-100",
+    red: "border-red-500/30 bg-red-500/10 dark:bg-red-950/25 text-red-800 dark:text-red-100",
+    amber: "border-amber-500/30 bg-amber-500/10 dark:bg-amber-950/25 text-amber-800 dark:text-amber-100",
+    cyan: "border-cyan-500/30 bg-cyan-500/10 dark:bg-cyan-950/25 text-cyan-800 dark:text-cyan-100",
   }[tone];
 
   return (
@@ -112,6 +117,7 @@ function drawGraph(
   model: ReturnType<typeof buildLargeGraphOverviewModel>,
   viewport: Viewport,
   selectedNodeId: string | null,
+  palette: GraphCanvasPalette,
 ) {
   const ctx = canvas.getContext("2d");
   if (!ctx) return;
@@ -123,7 +129,7 @@ function drawGraph(
   ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
   ctx.clearRect(0, 0, width, height);
 
-  ctx.fillStyle = "#050505";
+  ctx.fillStyle = palette.stage;
   ctx.fillRect(0, 0, width, height);
   ctx.save();
   ctx.translate(viewport.offsetX, viewport.offsetY);
@@ -154,14 +160,14 @@ function drawGraph(
     const selected = selectedNodeId === node.id;
     const dimmed = selectedNodeId !== null && !selected;
     ctx.globalAlpha = dimmed ? 0.34 : 1;
-    ctx.fillStyle = selected ? "#f8fafc" : node.color;
+    ctx.fillStyle = selected ? palette.selected : node.color;
     ctx.beginPath();
     ctx.arc(node.x, node.y, selected ? node.size * 1.9 : node.size, 0, Math.PI * 2);
     ctx.fill();
     if (selected || node.forceLabel) {
       ctx.globalAlpha = selected ? 1 : 0.78;
       ctx.font = `${Math.max(10, 12 / viewport.scale)}px Inter, ui-sans-serif, system-ui, sans-serif`;
-      ctx.fillStyle = "#e4e4e7";
+      ctx.fillStyle = palette.label;
       ctx.fillText(node.label, node.x + node.size + 4 / viewport.scale, node.y - node.size);
     }
   }
@@ -177,6 +183,7 @@ export function LargeGraphOverview({
   onNodeSelect,
 }: LargeGraphOverviewProps) {
   const captureMode = useCaptureMode();
+  const palette = useGraphCanvasPalette();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const dragRef = useRef<{ x: number; y: number; offsetX: number; offsetY: number } | null>(null);
   const model = useMemo(() => buildLargeGraphOverviewModel(nodes, edges), [nodes, edges]);
@@ -198,8 +205,8 @@ export function LargeGraphOverview({
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    drawGraph(canvas, model, viewport, selectedNodeId);
-  }, [model, selectedNodeId, viewport]);
+    drawGraph(canvas, model, viewport, selectedNodeId, palette);
+  }, [model, palette, selectedNodeId, viewport]);
 
   return (
     <div className="flex h-full min-h-[72vh] flex-col overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] shadow-2xl shadow-black/30" data-testid="large-graph-overview">
@@ -219,7 +226,7 @@ export function LargeGraphOverview({
             {model.edges.length.toLocaleString()}/{model.sourceEdgeCount.toLocaleString()} edges.
           </span>
           {isBudgeted && (
-            <span className="text-amber-300">
+            <span className="text-amber-700 dark:text-amber-300">
               Lower-signal items are omitted from this overview; use search, filters, or drill-in for exact detail.
             </span>
           )}
@@ -236,11 +243,22 @@ export function LargeGraphOverview({
         </div>
       </div>
 
-      <div className="relative min-h-0 flex-1 bg-[radial-gradient(circle_at_25%_15%,rgba(16,185,129,0.10),transparent_28%),radial-gradient(circle_at_75%_65%,rgba(59,130,246,0.10),transparent_30%),#050505]">
+      {/*
+        The canvas is taken out of flow on purpose. `drawGraph` writes
+        `canvas.height` from `clientHeight`, and an in-flow canvas takes that
+        attribute as its intrinsic height — so each draw grew the element, the
+        ResizeObserver fired, and the next draw grew it again. Measured on the
+        1,241-node fixture: a 21,604px-tall canvas showing an empty slice of
+        stage. Absolute inset-0 makes the parent the sole source of size, which
+        breaks the loop.
+      */}
+      <div className="relative min-h-[58vh] flex-1 bg-[var(--background)]">
         <canvas
           ref={canvasRef}
-          className="h-full min-h-[58vh] w-full cursor-grab active:cursor-grabbing"
+          className="absolute inset-0 h-full w-full cursor-grab active:cursor-grabbing"
+          role="img"
           aria-label="Large security graph overview"
+          aria-describedby="large-graph-overview-text"
           data-testid="large-graph-overview-canvas"
           onMouseDown={(event) => {
             dragRef.current = {
@@ -296,6 +314,12 @@ export function LargeGraphOverview({
               offsetY: event.clientY - rect.top - before.y * nextScale,
             });
           }}
+        />
+        <GraphTextAlternative
+          id="large-graph-overview-text"
+          renderer="2D canvas graph overview"
+          model={model}
+          summary={summary}
         />
         <div className="pointer-events-auto absolute right-3 top-3">
           <GraphLegend items={legendItems} />

--- a/ui/components/sigma-graph-overview.tsx
+++ b/ui/components/sigma-graph-overview.tsx
@@ -6,7 +6,9 @@ import type { Edge, Node } from "@xyflow/react";
 import { Activity, GitBranch, Layers3, Network, ShieldAlert, Sparkles } from "lucide-react";
 
 import { GraphLegend } from "@/components/graph-chrome";
+import { GraphTextAlternative } from "@/components/graph-text-alternative";
 import type { LineageNodeData } from "@/components/lineage-nodes";
+import { useGraphCanvasPalette } from "@/lib/graph-canvas-theme";
 import type { LegendItem } from "@/lib/graph-utils";
 import type { UnifiedGraphData } from "@/lib/graph-schema";
 import type { UnifiedGraphFlowFilters } from "@/lib/unified-graph-flow";
@@ -55,9 +57,9 @@ function StatPill({
 }) {
   const toneClass = {
     zinc: "border-[var(--border-subtle)] bg-[var(--background)]/70 text-[var(--text-secondary)]",
-    red: "border-red-500/30 bg-red-950/25 text-red-100",
-    amber: "border-amber-500/30 bg-amber-950/25 text-amber-100",
-    emerald: "border-emerald-500/30 bg-emerald-950/25 text-emerald-100",
+    red: "border-red-500/30 bg-red-500/10 dark:bg-red-950/25 text-red-800 dark:text-red-100",
+    amber: "border-amber-500/30 bg-amber-500/10 dark:bg-amber-950/25 text-amber-800 dark:text-amber-100",
+    emerald: "border-emerald-500/30 bg-emerald-500/10 dark:bg-emerald-950/25 text-emerald-800 dark:text-emerald-100",
   }[tone];
 
   return (
@@ -97,6 +99,7 @@ export function SigmaGraphOverview({
   onNodeSelect,
 }: SigmaGraphOverviewProps) {
   const captureMode = useCaptureMode();
+  const palette = useGraphCanvasPalette();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const rendererRef = useRef<Sigma<SigmaNodeAttributes, SigmaEdgeAttributes> | null>(null);
   const selectedNodeIdRef = useRef<string | null>(null);
@@ -135,13 +138,13 @@ export function SigmaGraphOverview({
           allowInvalidContainer: true,
           autoCenter: true,
           autoRescale: true,
-          defaultEdgeColor: "#52525b",
-          defaultNodeColor: "#71717a",
+          defaultEdgeColor: palette.defaultEdge,
+          defaultNodeColor: palette.defaultNode,
           enableEdgeEvents: false,
           hideEdgesOnMove: true,
           hideLabelsOnMove: true,
           itemSizesReference: "positions",
-          labelColor: { color: "#e4e4e7" },
+          labelColor: { color: palette.label },
           labelDensity: 0.08,
           labelFont: "Inter, ui-sans-serif, system-ui, sans-serif",
           labelGridCellSize: 180,
@@ -159,13 +162,13 @@ export function SigmaGraphOverview({
             const dimmedBySelection = selectedNodeIdRef.current !== null && !selected;
             return {
               ...data,
-              color: selected ? "#f8fafc" : data.color,
+              color: selected ? palette.selected : data.color,
               forceLabel: selected || data.forceLabel,
               hidden: data.hidden,
               highlighted: selected || data.highlighted,
               size: selected ? data.size * 1.65 : data.size,
               zIndex: selected ? 4 : data.zIndex,
-              ...(dimmedBySelection ? { color: "#3f3f46" } : {}),
+              ...(dimmedBySelection ? { color: palette.dimmed } : {}),
             };
           },
           edgeReducer: (_edge, data) => {
@@ -175,7 +178,7 @@ export function SigmaGraphOverview({
               : false;
             return {
               ...data,
-              color: selectedEdge ? data.color : selected ? "#27272a" : data.color,
+              color: selectedEdge ? data.color : selected ? palette.dimmed : data.color,
               hidden: data.hidden,
               size: selectedEdge ? data.size * 2.3 : data.size,
               zIndex: selectedEdge ? 3 : data.zIndex,
@@ -207,7 +210,7 @@ export function SigmaGraphOverview({
       rendererRef.current = null;
       container.replaceChildren();
     };
-  }, [model]);
+  }, [model, palette]);
 
   return (
     <div
@@ -234,7 +237,7 @@ export function SigmaGraphOverview({
             {model.overview.edges.length.toLocaleString()}/{model.overview.sourceEdgeCount.toLocaleString()} edges.
           </span>
           {isBudgeted && (
-            <span className="text-amber-300">
+            <span className="text-amber-700 dark:text-amber-300">
               Lower-signal items are omitted from this overview; use search, filters, or drill-in for exact detail.
             </span>
           )}
@@ -251,15 +254,23 @@ export function SigmaGraphOverview({
         </div>
       </div>
 
-      <div className="relative min-h-0 flex-1 bg-[#050505]">
+      <div className="relative min-h-0 flex-1 bg-[var(--background)]">
         <div
           ref={containerRef}
           className="h-full min-h-[58vh] w-full"
+          role="img"
           aria-label="WebGL security graph overview"
+          aria-describedby="sigma-graph-overview-text"
           data-testid="sigma-graph-overview-canvas"
         />
+        <GraphTextAlternative
+          id="sigma-graph-overview-text"
+          renderer="WebGL graph overview"
+          model={model.overview}
+          summary={model.summary}
+        />
         {renderError && (
-          <div className="absolute inset-4 flex items-center justify-center rounded-xl border border-red-500/30 bg-red-950/30 p-4 text-sm text-red-100">
+          <div className="absolute inset-4 flex items-center justify-center rounded-xl border border-red-500/30 bg-red-500/10 dark:bg-red-950/30 p-4 text-sm text-red-800 dark:text-red-100">
             WebGL renderer unavailable: {renderError}
           </div>
         )}

--- a/ui/e2e/large-graph-overview.spec.ts
+++ b/ui/e2e/large-graph-overview.spec.ts
@@ -375,6 +375,121 @@ test("large graph overview renders above threshold", async ({ page }, testInfo: 
   );
 });
 
+/**
+ * Both overview renderers used to paint a fixed `#050505` stage with near-white
+ * labels, so on a light page the biggest element on screen was a black
+ * rectangle. Canvas and WebGL cannot use CSS classes, so the only way to know
+ * they track the theme is to read what they actually painted.
+ */
+for (const theme of ["dark", "light"] as const) {
+  test(`large graph overview paints the ${theme} page background`, async ({ page }, testInfo: TestInfo) => {
+    test.setTimeout(60_000);
+    await routeLargeGraphPage(page);
+    await page.addInitScript((selected) => {
+      window.localStorage.setItem("agent-bom-theme", selected);
+    }, theme);
+
+    await page.goto("/graph?vulnOnly=0&severity=&depth=3&pageSize=500&layers=agent,package", {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page.getByTestId("large-graph-overview")).toBeVisible();
+    await expectCanvasHasPixels(page);
+
+    const painted = await page
+      .getByTestId("large-graph-overview-canvas")
+      .evaluate((element) => {
+        const canvas = element as HTMLCanvasElement;
+        const viewportHeight = window.innerHeight;
+        const pixel = canvas
+          .getContext("2d")!
+          .getImageData(2, 2, 1, 1).data;
+        const style = getComputedStyle(document.body);
+        return {
+          stage: [pixel[0], pixel[1], pixel[2]],
+          background: style.getPropertyValue("--background").trim(),
+          height: canvas.clientHeight,
+          viewportHeight,
+        };
+      });
+
+    // Writing `canvas.height` from `clientHeight` used to feed the element's
+    // own intrinsic size, so every draw grew it: 21,604px on this fixture,
+    // with the user looking at an empty slice of stage.
+    expect(painted.height).toBeLessThan(painted.viewportHeight * 1.5);
+
+    // The stage is the page background, so its luminance has to sit on the
+    // correct side of mid-grey for the theme in play.
+    const luminance =
+      (painted.stage[0]! + painted.stage[1]! + painted.stage[2]!) / 3;
+    if (theme === "light") expect(luminance).toBeGreaterThan(160);
+    else expect(luminance).toBeLessThan(96);
+
+    await captureRenderedRegion(
+      page,
+      page.getByTestId("large-graph-overview"),
+      testInfo.outputPath(`large-graph-overview-${theme}.png`),
+    );
+  });
+
+  test(`webgl overview stage follows the ${theme} theme`, async ({ page }, testInfo: TestInfo) => {
+    test.setTimeout(60_000);
+    await routeLargeGraphPage(page);
+    await page.addInitScript((selected) => {
+      window.localStorage.setItem("agent-bom-theme", selected);
+    }, theme);
+
+    await page.goto(
+      "/graph?renderer=webgl&vulnOnly=0&severity=&depth=3&pageSize=500&layers=agent,package",
+      { waitUntil: "domcontentloaded" },
+    );
+    const sigma = page.getByTestId("sigma-graph-overview");
+    await expect(sigma).toBeVisible({ timeout: 30_000 });
+    await expectSigmaCanvases(page);
+
+    // Sigma's own canvases are transparent; the stage is the element behind
+    // them, which used to be a hardcoded `bg-[#050505]`.
+    const stage = await page
+      .getByTestId("sigma-graph-overview-canvas")
+      .evaluate((element) => getComputedStyle(element.parentElement!).backgroundColor);
+    const channels = stage.match(/\d+/g)!.slice(0, 3).map(Number);
+    const luminance = (channels[0]! + channels[1]! + channels[2]!) / 3;
+    if (theme === "light") expect(luminance).toBeGreaterThan(160);
+    else expect(luminance).toBeLessThan(96);
+
+    await captureRenderedRegion(page, sigma, testInfo.outputPath(`sigma-webgl-${theme}.png`));
+  });
+}
+
+/**
+ * The canvas renderers hand assistive technology nothing on their own. Both
+ * carry a text equivalent naming every node and relationship they draw.
+ */
+test("canvas overview exposes its nodes and edges as text", async ({ page }) => {
+  test.setTimeout(60_000);
+  await routeLargeGraphPage(page);
+
+  await page.goto("/graph?vulnOnly=0&severity=&depth=3&pageSize=500&layers=agent,package", {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page.getByTestId("large-graph-overview")).toBeVisible();
+
+  const canvas = page.getByTestId("large-graph-overview-canvas");
+  await expect(canvas).toHaveAttribute("role", "img");
+  await expect(canvas).toHaveAttribute("aria-describedby", "large-graph-overview-text");
+
+  const equivalent = page.getByRole("region", {
+    name: "Graph contents, text equivalent",
+    includeHidden: true,
+  });
+  await expect(equivalent).toBeAttached();
+  await expect(equivalent.getByRole("table", { includeHidden: true })).toBeAttached();
+  // Real rows, not an empty shell: the fixture draws well over a thousand nodes.
+  const rows = equivalent.locator("tbody tr");
+  expect(await rows.count()).toBeGreaterThan(10);
+  await expect(equivalent).toContainText(/Listing \d+ of [\d,]+ drawn nodes/);
+  await expect(equivalent).toContainText(/Listing \d+ of [\d,]+ drawn relationships/);
+});
+
 test("sigma webgl overview renders when explicitly requested", async ({ page }, testInfo: TestInfo) => {
   test.setTimeout(60_000);
   await routeLargeGraphPage(page);
@@ -385,7 +500,8 @@ test("sigma webgl overview renders when explicitly requested", async ({ page }, 
 
   const sigma = page.getByTestId("sigma-graph-overview");
   await expect(sigma).toBeVisible({ timeout: 30_000 });
-  await expect(sigma.getByText("WebGL graph overview")).toBeVisible();
+  // Exact: the surface's screen-reader text equivalent names the renderer too.
+  await expect(sigma.getByText("WebGL graph overview", { exact: true })).toBeVisible();
   await expect(sigma.getByText(/Sigma\.js renderer for broad estate scans/)).toBeVisible();
   await expectSigmaCanvases(page);
   await captureRenderedRegion(page, sigma, testInfo.outputPath("sigma-webgl-overview.png"));

--- a/ui/lib/dagre-layout.ts
+++ b/ui/lib/dagre-layout.ts
@@ -94,6 +94,129 @@ export interface LayoutOptions {
    * never touch even when the real card renders larger than the declared box.
    */
   minSeparation?: MinSeparationOptions;
+  /**
+   * Width:height ratio of the canvas this layout is dropped into. When set,
+   * {@link fitRanksToAspect} reflows over-tall ranks so the result is shaped
+   * like that canvas instead of a tower `fitView` can only answer with a
+   * 2px-label zoom. LR layouts only — see the function docs.
+   */
+  fitAspect?: number | undefined;
+}
+
+/**
+ * Reflow an LR dagre layout so its bounding box is shaped like the canvas.
+ *
+ * Dagre gives every node in a rank the same x and stacks the rank downwards,
+ * with no notion of the viewport. A shallow, wide DAG — one agent fanning out
+ * to 40 servers — therefore becomes a ~776 x 7784 tower dropped into a ~1322 x
+ * 610 landscape canvas, and `fitView`, working exactly as designed, resolves to
+ * a scale where nothing is readable.
+ *
+ * This pass wraps each rank's nodes into sub-columns, picking the single row
+ * count (shared by every rank, so ranks stay visually aligned) that maximises
+ * the fit scale on a canvas of ratio `aspect`. Ranks are then laid out
+ * left-to-right in their original order, so every node of rank *r* still sits
+ * entirely left of every node of rank *r+1* and edges keep reading as flow.
+ * Within a rank the dagre y-order — which is crossing-minimised — is preserved
+ * down each sub-column in turn.
+ *
+ * It is a no-op when dagre's own layout already fits at least as well, so
+ * small graphs keep the exact one-node-per-rank reading they have today.
+ */
+const MIN_ASPECT_FIT_GAIN = 1.25;
+
+export function fitRanksToAspect(
+  nodes: Node[],
+  options: {
+    aspect: number;
+    nodeWidth: number;
+    nodeHeight: number;
+    rankSep: number;
+    nodeSep: number;
+  },
+): Node[] {
+  const { aspect, nodeWidth, nodeHeight, rankSep, nodeSep } = options;
+  if (nodes.length < 3 || !(aspect > 0)) return nodes;
+
+  // Dagre assigns one x per rank for equal-width boxes; round away float noise.
+  const ranks = new Map<number, Node[]>();
+  for (const node of nodes) {
+    const key = Math.round(node.position.x);
+    const bucket = ranks.get(key);
+    if (bucket) bucket.push(node);
+    else ranks.set(key, [node]);
+  }
+  const rankKeys = [...ranks.keys()].sort((a, b) => a - b);
+  const rankSizes = rankKeys.map((key) => ranks.get(key)!.length);
+  const tallestRank = Math.max(...rankSizes);
+  if (tallestRank < 2) return nodes;
+
+  const columnStep = nodeWidth + nodeSep;
+  const rowStep = nodeHeight + nodeSep;
+
+  const measure = (rows: number) => {
+    let width = 0;
+    rankSizes.forEach((size, index) => {
+      width += Math.ceil(size / rows) * columnStep - nodeSep;
+      if (index < rankSizes.length - 1) width += rankSep;
+    });
+    return { width, height: Math.min(rows, tallestRank) * rowStep - nodeSep };
+  };
+
+  // Scale on a canvas of `aspect` x 1. Ties keep the taller layout, which is
+  // the one closest to what dagre already produced.
+  let bestRows = tallestRank;
+  let bestScale = -Infinity;
+  for (let rows = 1; rows <= tallestRank; rows += 1) {
+    const { width, height } = measure(rows);
+    const scale = Math.min(aspect / width, 1 / height);
+    if (scale > bestScale + 1e-9) {
+      bestScale = scale;
+      bestRows = rows;
+    }
+  }
+  if (bestRows >= tallestRank) return nodes;
+
+  // Wrapping costs the reader the one-column-per-rank reading, so it has to
+  // buy a materially better fit — not the few percent a nearly-square graph
+  // would gain. Compared against dagre's real box, not a model of it.
+  const xs = nodes.map((node) => node.position.x);
+  const ys = nodes.map((node) => node.position.y);
+  const dagreScale = Math.min(
+    aspect / (Math.max(...xs) - Math.min(...xs) + nodeWidth),
+    1 / (Math.max(...ys) - Math.min(...ys) + nodeHeight),
+  );
+  if (bestScale < dagreScale * MIN_ASPECT_FIT_GAIN) return nodes;
+
+  const totalHeight = measure(bestRows).height;
+  const positions = new Map<string, { x: number; y: number }>();
+  let cursorX = 0;
+  for (const key of rankKeys) {
+    const rank = [...ranks.get(key)!].sort(
+      (a, b) =>
+        a.position.y - b.position.y || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+    );
+    const columns = Math.ceil(rank.length / bestRows);
+    const rowsUsed = Math.min(bestRows, rank.length);
+    // Centre each rank block so short ranks sit beside the middle of their
+    // neighbours instead of hugging the top edge.
+    const offsetY = (totalHeight - (rowsUsed * rowStep - nodeSep)) / 2;
+    rank.forEach((node, index) => {
+      positions.set(node.id, {
+        x: cursorX + Math.floor(index / bestRows) * columnStep,
+        y: offsetY + (index % bestRows) * rowStep,
+      });
+    });
+    cursorX += columns * columnStep - nodeSep + rankSep;
+  }
+
+  return nodes.map((node) => {
+    const next = positions.get(node.id);
+    if (!next || (next.x === node.position.x && next.y === node.position.y)) {
+      return node;
+    }
+    return { ...node, position: next };
+  });
 }
 
 export function applyDagreLayout(
@@ -108,6 +231,7 @@ export function applyDagreLayout(
     rankSep = 80,
     nodeSep = 30,
     minSeparation,
+    fitAspect,
   } = options;
 
   const g = new dagre.graphlib.Graph();
@@ -139,10 +263,21 @@ export function applyDagreLayout(
     };
   });
 
+  const fittedNodes =
+    isHorizontal && fitAspect
+      ? fitRanksToAspect(layoutNodes, {
+          aspect: fitAspect,
+          nodeWidth,
+          nodeHeight,
+          rankSep,
+          nodeSep,
+        })
+      : layoutNodes;
+
   return {
     nodes: minSeparation
-      ? enforceMinNodeSeparation(layoutNodes, minSeparation)
-      : layoutNodes,
+      ? enforceMinNodeSeparation(fittedNodes, minSeparation)
+      : fittedNodes,
     edges,
   };
 }

--- a/ui/lib/graph-canvas-theme.ts
+++ b/ui/lib/graph-canvas-theme.ts
@@ -1,0 +1,82 @@
+/**
+ * Theme palette for the graph surfaces that draw into a canvas.
+ *
+ * The 2D overview and the sigma/WebGL stage cannot style themselves with CSS
+ * classes, so they used to carry a private near-black palette: a `#050505`
+ * stage with `#e4e4e7` labels, painted identically in both themes. On a light
+ * page that made the largest element on the screen a black rectangle with its
+ * own contrast rules.
+ *
+ * These read the same `globals.css` tokens every other surface uses, at draw
+ * time, so the canvas tracks the theme. Fallbacks are the real dark token
+ * values so a pre-computed-style render never flashes an invented colour.
+ */
+
+import { useMemo } from "react";
+
+import { readThemeColor } from "@/lib/theme-colors";
+import { useThemeMode, type ThemeMode } from "@/lib/theme-mode";
+
+export interface GraphCanvasPalette {
+  /** Stage fill behind the graph. */
+  stage: string;
+  /** Node labels drawn over the stage. */
+  label: string;
+  /** The selected node, which must read as brighter than every data colour. */
+  selected: string;
+  /** Nodes muted because something else is selected. */
+  dimmed: string;
+  /** Node with no type colour of its own. */
+  defaultNode: string;
+  /** Edge with no relationship colour of its own. */
+  defaultEdge: string;
+}
+
+/**
+ * Values of the same tokens in `globals.css`, used only when the computed
+ * style is not available yet (server render, detached document). Keyed by
+ * mode so a light-theme first paint never flashes the dark stage.
+ */
+const TOKEN_FALLBACKS: Record<ThemeMode, Record<string, string>> = {
+  dark: {
+    "--background": "#14161d",
+    "--foreground": "#f4f5f8",
+    "--text-secondary": "#d0d4dc",
+    "--text-tertiary": "#a8aebc",
+  },
+  light: {
+    "--background": "#e6eaf1",
+    "--foreground": "#12141a",
+    "--text-secondary": "#374151",
+    "--text-tertiary": "#55627a",
+  },
+};
+
+export function getGraphCanvasPalette(mode: ThemeMode = "dark"): GraphCanvasPalette {
+  const token = (name: keyof (typeof TOKEN_FALLBACKS)["dark"]) =>
+    readThemeColor(name, TOKEN_FALLBACKS[mode][name]!);
+  const foreground = token("--foreground");
+  const tertiary = token("--text-tertiary");
+  return {
+    stage: token("--background"),
+    label: foreground,
+    selected: foreground,
+    dimmed: tertiary,
+    defaultNode: tertiary,
+    defaultEdge: token("--text-secondary"),
+  };
+}
+
+/**
+ * Hook variant. Subscribes to the theme mode so the canvas redraws — and
+ * re-reads the tokens — the moment the user flips light/dark, instead of
+ * keeping the previous theme's paint until the next data-driven render.
+ *
+ * The result is memoised on the theme mode because the WebGL renderer takes
+ * the palette as a construction option: a fresh object every render would
+ * re-create the renderer on every render, and the renderer sets state.
+ */
+export function useGraphCanvasPalette(): GraphCanvasPalette {
+  const mode = useThemeMode();
+  return useMemo(() => getGraphCanvasPalette(mode), [mode]);
+}

--- a/ui/lib/graph-node-dimensions.ts
+++ b/ui/lib/graph-node-dimensions.ts
@@ -21,6 +21,15 @@ export const LINEAGE_NODE_HEIGHT = 140;
 /** Minimum clear gap enforced between any two lineage cards, at any scale. */
 export const GRAPH_NODE_MIN_GAP = 48;
 
+/**
+ * Width:height ratio of a graph canvas. Measured at ~1322 x 610 on `/graph` at
+ * a 1440px viewport; the roll-up grid derives its column count from the same
+ * assumption. Dagre knows nothing about the viewport, so without this a wide
+ * fan-out becomes a portrait tower that `fitView` can only answer with an
+ * unreadable zoom.
+ */
+export const LINEAGE_CANVAS_ASPECT = 2.2;
+
 /** Collision footprint shared by the layout and the separation guarantee. */
 export const LINEAGE_MIN_SEPARATION: MinSeparationOptions = {
   width: LINEAGE_NODE_WIDTH,
@@ -41,6 +50,7 @@ export const READABLE_LINEAGE_DAGRE_LR: DagreLrOptions = {
   rankSep: 176,
   nodeSep: 56,
   minSeparation: LINEAGE_MIN_SEPARATION,
+  fitAspect: LINEAGE_CANVAS_ASPECT,
 };
 
 /**
@@ -55,5 +65,6 @@ export function readableLineageDagreLr(
     ...READABLE_LINEAGE_DAGRE_LR,
     ...overrides,
     minSeparation: overrides.minSeparation ?? LINEAGE_MIN_SEPARATION,
+    fitAspect: overrides.fitAspect ?? LINEAGE_CANVAS_ASPECT,
   };
 }

--- a/ui/lib/graph-text-alternative.ts
+++ b/ui/lib/graph-text-alternative.ts
@@ -1,0 +1,155 @@
+/**
+ * Text equivalent of a canvas-rendered graph.
+ *
+ * Past the large-graph thresholds `/graph` swaps React Flow — whose nodes and
+ * edges are real DOM with real labels — for the 2D canvas or the sigma/WebGL
+ * stage. Both paint pixels, so assistive technology is left with the widget's
+ * name and nothing about what is in it. This builds the same graph as text:
+ * a census by node type and relationship, the most significant nodes, and the
+ * connections between them.
+ *
+ * Counts are derived from the drawn model, never re-invented, and every
+ * truncation is stated rather than applied silently — the overview is already
+ * budgeted, and a text equivalent that implies it shows everything would be
+ * less honest than the canvas it replaces.
+ */
+
+import type {
+  LargeGraphEdge,
+  LargeGraphNode,
+  LargeGraphOverviewModel,
+  LargeGraphOverviewSummary,
+} from "@/lib/large-graph-overview";
+
+export interface GraphTextRow {
+  id: string;
+  label: string;
+  nodeType: string;
+  severity: string;
+  connections: number;
+}
+
+export interface GraphTextAlternativeModel {
+  headline: string;
+  nodeTypes: Array<{ nodeType: string; count: number }>;
+  relationships: Array<{ relationship: string; count: number }>;
+  rows: GraphTextRow[];
+  rowsNote: string;
+  connections: string[];
+  connectionsNote: string;
+}
+
+export interface GraphTextAlternativeOptions {
+  /** Nodes listed individually. Bounded so the hidden DOM stays cheap. */
+  maxRows?: number | undefined;
+  /** Connection sentences listed individually. */
+  maxConnections?: number | undefined;
+}
+
+const DEFAULT_MAX_ROWS = 40;
+const DEFAULT_MAX_CONNECTIONS = 30;
+
+const SEVERITY_ORDER = ["critical", "high", "medium", "low"] as const;
+
+function severityRank(severity: string | undefined): number {
+  const index = SEVERITY_ORDER.indexOf(
+    String(severity ?? "").toLowerCase() as (typeof SEVERITY_ORDER)[number],
+  );
+  return index === -1 ? -1 : SEVERITY_ORDER.length - index;
+}
+
+function severityLabel(severity: string | undefined): string {
+  const normalized = String(severity ?? "").toLowerCase();
+  return SEVERITY_ORDER.includes(normalized as (typeof SEVERITY_ORDER)[number])
+    ? normalized
+    : "unrated";
+}
+
+/** `exposes_cred` reads as "exposes cred" when spoken aloud. */
+function spoken(relationship: string): string {
+  return relationship.replace(/[_-]+/g, " ").trim();
+}
+
+function census<T>(items: T[], key: (item: T) => string) {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const value = key(item);
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([value, count]) => ({ value, count }));
+}
+
+function connectionDegrees(edges: LargeGraphEdge[]): Map<string, number> {
+  const degrees = new Map<string, number>();
+  for (const edge of edges) {
+    degrees.set(edge.source, (degrees.get(edge.source) ?? 0) + 1);
+    degrees.set(edge.target, (degrees.get(edge.target) ?? 0) + 1);
+  }
+  return degrees;
+}
+
+export function buildGraphTextAlternative(
+  model: LargeGraphOverviewModel,
+  summary: LargeGraphOverviewSummary,
+  options: GraphTextAlternativeOptions = {},
+): GraphTextAlternativeModel {
+  const maxRows = options.maxRows ?? DEFAULT_MAX_ROWS;
+  const maxConnections = options.maxConnections ?? DEFAULT_MAX_CONNECTIONS;
+
+  const visibleNodes = model.nodes.filter((node) => !node.hidden);
+  const visibleEdges = model.edges.filter(
+    (edge) => !edge.hidden && model.nodeById.has(edge.source) && model.nodeById.has(edge.target),
+  );
+  const degrees = connectionDegrees(visibleEdges);
+
+  const ranked = [...visibleNodes].sort((left, right) => {
+    const bySeverity = severityRank(right.severity) - severityRank(left.severity);
+    if (bySeverity !== 0) return bySeverity;
+    const byDegree = (degrees.get(right.id) ?? 0) - (degrees.get(left.id) ?? 0);
+    if (byDegree !== 0) return byDegree;
+    return left.label.localeCompare(right.label) || left.id.localeCompare(right.id);
+  });
+
+  const rows: GraphTextRow[] = ranked.slice(0, maxRows).map((node) => ({
+    id: node.id,
+    label: node.label,
+    nodeType: node.nodeType,
+    severity: severityLabel(node.severity),
+    connections: degrees.get(node.id) ?? 0,
+  }));
+
+  const label = (id: string): string => model.nodeById.get(id)?.label ?? id;
+  const rankedEdges = [...visibleEdges].sort((left, right) => {
+    const byDegree =
+      (degrees.get(right.source) ?? 0) + (degrees.get(right.target) ?? 0) -
+      ((degrees.get(left.source) ?? 0) + (degrees.get(left.target) ?? 0));
+    if (byDegree !== 0) return byDegree;
+    return left.id.localeCompare(right.id);
+  });
+  const connections = rankedEdges
+    .slice(0, maxConnections)
+    .map((edge) => `${label(edge.source)} ${spoken(edge.relationship)} ${label(edge.target)}`);
+
+  const drawn = `${model.nodes.length.toLocaleString()} nodes and ${model.edges.length.toLocaleString()} relationships`;
+  const scope = `${summary.nodes.toLocaleString()} nodes and ${summary.edges.toLocaleString()} relationships`;
+  const headline =
+    summary.nodes === model.nodes.length && summary.edges === model.edges.length
+      ? `Graph of ${scope}. ${summary.findings.toLocaleString()} findings, of which ${summary.criticalFindings.toLocaleString()} critical; ${summary.credentials.toLocaleString()} credentials and ${summary.tools.toLocaleString()} tools.`
+      : `Graph of ${scope} in scope. The overview draws the highest-signal ${drawn}; ${model.omittedNodeCount.toLocaleString()} nodes and ${model.omittedEdgeCount.toLocaleString()} relationships are omitted from it. ${summary.findings.toLocaleString()} findings, of which ${summary.criticalFindings.toLocaleString()} critical; ${summary.credentials.toLocaleString()} credentials and ${summary.tools.toLocaleString()} tools.`;
+
+  return {
+    headline,
+    nodeTypes: census(visibleNodes, (node: LargeGraphNode) => node.nodeType).map(
+      ({ value, count }) => ({ nodeType: value, count }),
+    ),
+    relationships: census(visibleEdges, (edge: LargeGraphEdge) => edge.relationship).map(
+      ({ value, count }) => ({ relationship: value, count }),
+    ),
+    rows,
+    rowsNote: `Listing ${rows.length.toLocaleString()} of ${visibleNodes.length.toLocaleString()} drawn nodes, highest severity and most connected first.`,
+    connections,
+    connectionsNote: `Listing ${connections.length.toLocaleString()} of ${visibleEdges.length.toLocaleString()} drawn relationships, busiest first.`,
+  };
+}

--- a/ui/lib/offline-report-mode.ts
+++ b/ui/lib/offline-report-mode.ts
@@ -1,0 +1,74 @@
+/**
+ * Opt-in "I have a report file, let me in" mode.
+ *
+ * `ApiOfflineState` can import a scan report entirely in the browser — read the
+ * file, validate it, render it — with no backend involved. It is mounted by
+ * `app/page.tsx`, which sits inside `AuthGate`, so every auth-probe failure
+ * (401 redirect, unreachable control plane, unexpected error) replaced it.
+ * The one feature designed for "no working backend" was unreachable in exactly
+ * that situation.
+ *
+ * This flag is what the user sets by pressing "Continue offline with a report
+ * file". It is deliberately narrow:
+ *
+ *  - it is never on by default, so the gate still blocks by default;
+ *  - it grants no data — every API call behind it fails exactly as it would
+ *    have, and only a file the user supplies is ever rendered;
+ *  - it lives in `sessionStorage`, so it dies with the tab rather than
+ *    quietly weakening the shell of every future visit.
+ *
+ * Mirrors the `theme-mode` store so components re-render when it changes.
+ */
+
+import { useSyncExternalStore } from "react";
+
+const OFFLINE_STORAGE_KEY = "agent-bom-offline-report";
+const OFFLINE_CHANGE_EVENT = "agent-bom-offline-report-change";
+
+export function isOfflineReportMode(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.sessionStorage.getItem(OFFLINE_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function setOfflineReportMode(enabled: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (enabled) window.sessionStorage.setItem(OFFLINE_STORAGE_KEY, "1");
+    else window.sessionStorage.removeItem(OFFLINE_STORAGE_KEY);
+  } catch {
+    // A blocked storage still gets the event; the mode just will not persist
+    // across a reload, which is a better failure than throwing at the user.
+  }
+  window.dispatchEvent(new Event(OFFLINE_CHANGE_EVENT));
+}
+
+export function enableOfflineReportMode(): void {
+  setOfflineReportMode(true);
+}
+
+export function disableOfflineReportMode(): void {
+  setOfflineReportMode(false);
+}
+
+export function subscribeOfflineReportMode(onChange: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const handleChange = () => onChange();
+  window.addEventListener("storage", handleChange);
+  window.addEventListener(OFFLINE_CHANGE_EVENT, handleChange);
+  return () => {
+    window.removeEventListener("storage", handleChange);
+    window.removeEventListener(OFFLINE_CHANGE_EVENT, handleChange);
+  };
+}
+
+export function useOfflineReportMode(): boolean {
+  return useSyncExternalStore(
+    subscribeOfflineReportMode,
+    isOfflineReportMode,
+    () => false,
+  );
+}

--- a/ui/lib/use-dagre-layout.ts
+++ b/ui/lib/use-dagre-layout.ts
@@ -34,8 +34,11 @@ function optionsKey(options: LayoutOptions): string {
     rankSep: options.rankSep ?? 80,
     nodeSep: options.nodeSep ?? 30,
     // Kept in the key so the min-separation guarantee survives the JSON
-    // round-trip into both the sync layout and the web worker.
+    // round-trip into both the sync layout and the web worker. The key IS the
+    // options object both paths run on, so anything omitted here is silently
+    // dropped before it ever reaches `applyDagreLayout`.
     minSeparation: options.minSeparation ?? null,
+    fitAspect: options.fitAspect ?? null,
   });
 }
 

--- a/ui/tests/auth-gate-offline-import.test.tsx
+++ b/ui/tests/auth-gate-offline-import.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * The offline report importer is mounted by `app/page.tsx`, inside `AuthGate`.
+ * Every way the auth probe can fail replaces that content: a 401 redirects to
+ * `/login`, and an unreachable API renders "Control plane unreachable". So the
+ * one feature built for "no working backend" was the one feature a user with a
+ * report file and no working auth could never reach.
+ *
+ * The gate now offers an explicit way through. It is opt-in — the default is
+ * still to block, which `auth-gate.test.tsx` keeps guarding — and it grants no
+ * data: every API call behind it fails exactly as before. What it grants is the
+ * ability to render a report the user already has on disk.
+ */
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AuthGate } from "@/components/auth-gate";
+import { AuthProvider } from "@/components/auth-provider";
+import { clearSessionApiKey } from "@/lib/auth";
+import {
+  disableOfflineReportMode,
+  enableOfflineReportMode,
+  isOfflineReportMode,
+} from "@/lib/offline-report-mode";
+
+const mockReplace = vi.fn();
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace, push: mockPush }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  window.__AGENT_BOM_CONFIG__ = undefined;
+  clearSessionApiKey();
+  disableOfflineReportMode();
+  mockReplace.mockReset();
+  mockPush.mockReset();
+  vi.restoreAllMocks();
+});
+
+function unreachableApi() {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 503,
+    statusText: "Service Unavailable",
+    json: () => Promise.resolve({ detail: "503 Service Unavailable" }),
+    headers: new Headers(),
+    url: "/v1/auth/me",
+  }) as typeof fetch;
+}
+
+function unauthenticatedApi() {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 401,
+    statusText: "Unauthorized",
+    json: () => Promise.resolve({ detail: "Unauthorized — invalid API key" }),
+  }) as typeof fetch;
+}
+
+function renderGate() {
+  return render(
+    <AuthProvider>
+      <AuthGate>
+        <div>page-level offline state</div>
+      </AuthGate>
+    </AuthProvider>,
+  );
+}
+
+describe("offline report mode", () => {
+  it("is off until the user asks for it", () => {
+    expect(isOfflineReportMode()).toBe(false);
+    enableOfflineReportMode();
+    expect(isOfflineReportMode()).toBe(true);
+    disableOfflineReportMode();
+    expect(isOfflineReportMode()).toBe(false);
+  });
+});
+
+describe("AuthGate offline escape hatch", () => {
+  it("offers a way through when the control plane is unreachable", async () => {
+    unreachableApi();
+    renderGate();
+
+    await waitFor(() =>
+      expect(screen.getByText("Control plane unreachable")).toBeInTheDocument(),
+    );
+    // Blocked by default — the audit guard in auth-gate.test.tsx still holds.
+    expect(screen.queryByText("page-level offline state")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /continue offline with a report file/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the page once the user continues offline, so the importer mounts", async () => {
+    unreachableApi();
+    renderGate();
+
+    const button = await screen.findByRole("button", {
+      name: /continue offline with a report file/i,
+    });
+    await userEvent.click(button);
+
+    expect(await screen.findByText("page-level offline state")).toBeInTheDocument();
+  });
+
+  it("stops bouncing an unauthenticated user back out to /login", async () => {
+    unauthenticatedApi();
+    act(() => {
+      enableOfflineReportMode();
+    });
+    renderGate();
+
+    expect(await screen.findByText("page-level offline state")).toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("says it is offline and offers the way back to signing in", async () => {
+    unreachableApi();
+    renderGate();
+
+    await userEvent.click(
+      await screen.findByRole("button", {
+        name: /continue offline with a report file/i,
+      }),
+    );
+
+    const banner = screen.getByRole("status");
+    expect(banner).toHaveTextContent(/offline/i);
+
+    await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    expect(isOfflineReportMode()).toBe(false);
+    await waitFor(() =>
+      expect(screen.queryByText("page-level offline state")).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/ui/tests/graph-canvas-theme.test.tsx
+++ b/ui/tests/graph-canvas-theme.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * The two overview renderers a large estate falls back to painted a fixed
+ * near-black stage (`#050505`) with near-white labels (`#e4e4e7`), regardless
+ * of theme. In light mode the rest of the page is `#e6eaf1` and the graph —
+ * the largest element on the screen — was a black hole with its own private
+ * palette. Canvas and WebGL cannot use CSS classes, so they have to read the
+ * tokens at runtime and re-read them when the theme flips.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  getGraphCanvasPalette,
+  useGraphCanvasPalette,
+} from "@/lib/graph-canvas-theme";
+
+const UI_ROOT = process.cwd();
+
+const CANVAS_SURFACES = [
+  "components/large-graph-overview.tsx",
+  "components/sigma-graph-overview.tsx",
+] as const;
+
+/** Raw hex paint. Tailwind's own `#`-free utilities are unaffected. */
+const HEX_LITERAL = /#[0-9a-fA-F]{3,8}\b/g;
+
+const TOKENS = [
+  "--background",
+  "--foreground",
+  "--text-tertiary",
+  "--text-secondary",
+];
+
+afterEach(() => {
+  const root = document.documentElement;
+  for (const token of TOKENS) root.style.removeProperty(token);
+  delete root.dataset.theme;
+});
+
+describe("getGraphCanvasPalette", () => {
+  it("paints the stage with the page background, not a private black", () => {
+    document.documentElement.style.setProperty("--background", "rgb(230, 234, 241)");
+    expect(getGraphCanvasPalette().stage).toBe("rgb(230, 234, 241)");
+  });
+
+  it("takes every colour from a live token so light and dark both track", () => {
+    const root = document.documentElement;
+    root.style.setProperty("--background", "rgb(230, 234, 241)");
+    root.style.setProperty("--foreground", "rgb(18, 20, 26)");
+    root.style.setProperty("--text-tertiary", "rgb(85, 98, 122)");
+    root.style.setProperty("--text-secondary", "rgb(55, 65, 81)");
+
+    const palette = getGraphCanvasPalette();
+    expect(palette).toEqual({
+      stage: "rgb(230, 234, 241)",
+      label: "rgb(18, 20, 26)",
+      selected: "rgb(18, 20, 26)",
+      dimmed: "rgb(85, 98, 122)",
+      defaultNode: "rgb(85, 98, 122)",
+      defaultEdge: "rgb(55, 65, 81)",
+    });
+  });
+
+  it("falls back to real token values, per theme, when none are computed yet", () => {
+    // Server render / detached document. A single dark fallback set would
+    // flash a black stage on a light first paint, which is the very defect
+    // this replaces.
+    const dark = getGraphCanvasPalette("dark");
+    const light = getGraphCanvasPalette("light");
+    for (const value of [...Object.values(dark), ...Object.values(light)]) {
+      expect(value).toMatch(/^#[0-9a-f]{6}$/);
+    }
+    expect(light.stage).not.toBe(dark.stage);
+    expect(light.label).not.toBe(dark.label);
+  });
+});
+
+describe("useGraphCanvasPalette", () => {
+  it("re-reads the tokens the moment the theme toggles", () => {
+    const root = document.documentElement;
+    root.style.setProperty("--background", "rgb(20, 22, 29)");
+
+    const { result } = renderHook(() => useGraphCanvasPalette());
+    expect(result.current.stage).toBe("rgb(20, 22, 29)");
+
+    act(() => {
+      root.dataset.theme = "light";
+      root.style.setProperty("--background", "rgb(230, 234, 241)");
+      window.dispatchEvent(new Event("agent-bom-theme-change"));
+    });
+
+    expect(result.current.stage).toBe("rgb(230, 234, 241)");
+  });
+});
+
+describe("large graph surfaces carry no dark-only paint", () => {
+  it("keeps every colour on a token in both overview renderers", () => {
+    const violations: string[] = [];
+    for (const rel of CANVAS_SURFACES) {
+      const source = readFileSync(path.join(UI_ROOT, rel), "utf8");
+      for (const match of source.matchAll(HEX_LITERAL)) {
+        violations.push(`${rel}: ${match[0]}`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("keeps the stage itself off a hardcoded backdrop class", () => {
+    for (const rel of CANVAS_SURFACES) {
+      const source = readFileSync(path.join(UI_ROOT, rel), "utf8");
+      expect(source, rel).not.toMatch(/bg-\[#/);
+      expect(source, rel).toContain("useGraphCanvasPalette");
+    }
+  });
+});

--- a/ui/tests/graph-lineage-layout-fits-the-canvas.test.ts
+++ b/ui/tests/graph-lineage-layout-fits-the-canvas.test.ts
@@ -1,0 +1,210 @@
+/**
+ * The raw lineage graph must not build a tower that no canvas can fit.
+ *
+ * `graph-rollup-layout-fits-the-canvas.test.ts` fixed the same defect for the
+ * roll-up grid, but the roll-up never calls dagre — it emits its own grid. The
+ * raw lineage branch goes through `applyDagreLayout`, which has no notion of
+ * the canvas it lands on, so a shallow-but-wide DAG (one agent fanning out to
+ * 40 servers is the common shape) puts every sibling in one rank and stacks
+ * them vertically forever.
+ *
+ * Measured on this layout before the fix, on the same ~1322 x 610 canvas:
+ *
+ *     one agent -> 40 servers   776 x 7784  (aspect 0.10)  fit 0.064
+ *     one agent -> 80 servers   776 x 15624 (aspect 0.05)  fit 0.032
+ *     3 x 12 x 4 fan-out       1728 x 28168 (aspect 0.06)  fit 0.018
+ *
+ * React Flow floors `/graph` at `minZoom={0.16}`, so every one of those opens
+ * clamped at 0.16 with the graph running far off the bottom of the canvas. A
+ * 300x140 card at 0.16 is 48x22px and its label is unreadable.
+ *
+ * The fix reflows over-tall ranks into sub-columns so the laid-out box is
+ * shaped like the landscape canvas it is dropped into. Rank order (the
+ * left-to-right blast-radius flow) is preserved: every rank still sits
+ * entirely to the right of the rank before it.
+ */
+import { describe, expect, it } from "vitest";
+import type { Edge, Node } from "@xyflow/react";
+
+import { applyDagreLayout } from "@/lib/dagre-layout";
+import {
+  LINEAGE_MIN_SEPARATION,
+  LINEAGE_NODE_HEIGHT,
+  LINEAGE_NODE_WIDTH,
+  READABLE_LINEAGE_DAGRE_LR,
+} from "@/lib/graph-node-dimensions";
+
+/** The `/graph` canvas measured in the browser at a 1440px-wide viewport. */
+const CANVAS_WIDTH = 1322;
+const CANVAS_HEIGHT = 610;
+/** `graphFitViewOptions` padding for a dense (>80 node) lineage graph. */
+const FIT_PADDING = 0.18;
+
+function boundingBox(nodes: Node[]) {
+  const xs = nodes.map((n) => n.position.x);
+  const ys = nodes.map((n) => n.position.y);
+  return {
+    width: Math.max(...xs) - Math.min(...xs) + LINEAGE_NODE_WIDTH,
+    height: Math.max(...ys) - Math.min(...ys) + LINEAGE_NODE_HEIGHT,
+  };
+}
+
+/** The scale `fitView` resolves to for a laid-out graph on the real canvas. */
+function fitScale(nodes: Node[]): number {
+  const { width, height } = boundingBox(nodes);
+  return Math.min(
+    (CANVAS_WIDTH * (1 - FIT_PADDING)) / width,
+    (CANVAS_HEIGHT * (1 - FIT_PADDING)) / height,
+  );
+}
+
+/** agent -> servers -> packages -> findings, the real lineage fan-out shape. */
+function fanout(levels: number[]): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = [{ id: "root", position: { x: 0, y: 0 }, data: {} }];
+  const edges: Edge[] = [];
+  let previous = ["root"];
+  levels.forEach((count, depth) => {
+    const layer: string[] = [];
+    previous.forEach((parent, parentIndex) => {
+      for (let i = 0; i < count; i += 1) {
+        const id = `n${depth}-${parentIndex}-${i}`;
+        layer.push(id);
+        nodes.push({ id, position: { x: 0, y: 0 }, data: {} });
+        edges.push({ id: `e-${parent}-${id}`, source: parent, target: id });
+      }
+    });
+    previous = layer;
+  });
+  return { nodes, edges };
+}
+
+function layout(levels: number[]): { nodes: Node[]; edges: Edge[] } {
+  const key = levels.join("x");
+  const cached = layoutCache.get(key);
+  if (cached) return cached;
+  const { nodes, edges } = fanout(levels);
+  const result = applyDagreLayout(nodes, edges, {
+    ...READABLE_LINEAGE_DAGRE_LR,
+    direction: "LR",
+  });
+  layoutCache.set(key, result);
+  return result;
+}
+
+function everyPairClear(nodes: Node[]): boolean {
+  const { width, height, gap } = LINEAGE_MIN_SEPARATION;
+  const eps = 1e-6;
+  for (let i = 0; i < nodes.length; i += 1) {
+    for (let j = i + 1; j < nodes.length; j += 1) {
+      const dx = Math.abs(nodes[i]!.position.x - nodes[j]!.position.x);
+      const dy = Math.abs(nodes[i]!.position.y - nodes[j]!.position.y);
+      if (dx + eps < width + gap && dy + eps < height + gap) return false;
+    }
+  }
+  return true;
+}
+
+const DENSE_SHAPES: Array<[string, number[]]> = [
+  ["one agent -> 40 servers", [40]],
+  ["one agent -> 80 servers", [80]],
+  ["3 servers x 12 packages x 4 findings", [3, 12, 4]],
+  ["4 x 8", [4, 8]],
+  ["6 x 10", [6, 10]],
+  ["2 x 5 x 6", [2, 5, 6]],
+  ["12 x 3", [12, 3]],
+];
+
+/** Each shape is laid out repeatedly across this file; dagre is deterministic. */
+const layoutCache = new Map<string, { nodes: Node[]; edges: Edge[] }>();
+
+describe("the raw lineage layout is shaped like the canvas it lands on", () => {
+  it("opens a 40-sibling fan-out at a legible zoom", () => {
+    // 0.064 was the measured defect. A 300x140 card at 0.35 is 105x49 — small,
+    // but the label reads and the severity border is unmistakable.
+    expect(fitScale(layout([40]).nodes)).toBeGreaterThan(0.35);
+  });
+
+  it("never builds a portrait tower, at any dense shape", () => {
+    for (const [name, levels] of DENSE_SHAPES) {
+      const { width, height } = boundingBox(layout(levels).nodes);
+      // The canvas is landscape; a taller-than-wide layout wastes horizontal
+      // room and pays for it in zoom.
+      expect(width, name).toBeGreaterThan(height);
+    }
+  });
+
+  it("clears React Flow's 0.16 zoom floor instead of being clamped by it", () => {
+    // Below `minZoom` the graph is not merely small, it runs off the canvas:
+    // fitView cannot honour the requested scale, so nodes sit past the fold.
+    for (const [name, levels] of DENSE_SHAPES) {
+      expect(fitScale(layout(levels).nodes), name).toBeGreaterThan(0.16);
+    }
+  });
+
+  it("lands within reach of the best fit any target aspect could achieve", () => {
+    // The real invariant: the layout's job is to sit near the geometric
+    // ceiling at every shape, which is a property worth asserting where a
+    // magic constant is not. Kept to a few shapes and probes — each probe is
+    // a full dagre run, and this suite shares a worker pool.
+    for (const levels of [[40], [4, 8], [6, 10]]) {
+      const chosen = fitScale(layout(levels).nodes);
+      const { nodes, edges } = fanout(levels);
+      const best = Math.max(
+        ...[0.5, 1, 2.2, 4, 8].map((aspect) =>
+          fitScale(
+            applyDagreLayout(nodes, edges, {
+              ...READABLE_LINEAGE_DAGRE_LR,
+              direction: "LR",
+              fitAspect: aspect,
+            }).nodes,
+          ),
+        ),
+      );
+      expect(chosen, levels.join("x")).toBeGreaterThan(best * 0.75);
+    }
+  });
+
+  it("keeps the left-to-right rank order every edge is drawn against", () => {
+    for (const [name, levels] of DENSE_SHAPES) {
+      const { nodes, edges } = layout(levels);
+      const x = new Map(nodes.map((n) => [n.id, n.position.x]));
+      for (const edge of edges) {
+        expect(x.get(edge.source)!, `${name} ${edge.id}`).toBeLessThan(
+          x.get(edge.target)!,
+        );
+      }
+    }
+  });
+
+  it("still keeps every pair of cards clear of each other", () => {
+    for (const [name, levels] of DENSE_SHAPES) {
+      expect(everyPairClear(layout(levels).nodes), name).toBe(true);
+    }
+  });
+
+  it("leaves a graph that already fits exactly as dagre laid it out", () => {
+    // A 4-node chain and a 3-sibling fan already fit; reflowing them would
+    // churn the layout for no gain and break the one-node-per-rank reading.
+    for (const levels of [[1, 1, 1], [3]]) {
+      const withFit = layout(levels).nodes.map((n) => n.position);
+      const { nodes, edges } = fanout(levels);
+      const plain = applyDagreLayout(nodes, edges, {
+        ...READABLE_LINEAGE_DAGRE_LR,
+        direction: "LR",
+        fitAspect: undefined,
+      }).nodes.map((n) => n.position);
+      expect(withFit).toEqual(plain);
+    }
+  });
+
+  it("is deterministic for identical input", () => {
+    const run = () => {
+      const { nodes, edges } = fanout([6, 10]);
+      return applyDagreLayout(nodes, edges, {
+        ...READABLE_LINEAGE_DAGRE_LR,
+        direction: "LR",
+      }).nodes.map((n) => n.position);
+    };
+    expect(run()).toEqual(run());
+  });
+});

--- a/ui/tests/graph-text-alternative.test.tsx
+++ b/ui/tests/graph-text-alternative.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * The two overview renderers that a large estate falls back to — the 2D canvas
+ * and the sigma/WebGL stage — paint pixels and nothing else. A screen-reader
+ * user reaching `/graph` past 200 nodes got a bare `aria-label` naming the
+ * widget and a sentence about the draw budget: no node, no relationship, no
+ * severity. The product's core value has to have a text equivalent.
+ */
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { GraphTextAlternative } from "@/components/graph-text-alternative";
+import { buildGraphTextAlternative } from "@/lib/graph-text-alternative";
+import type {
+  LargeGraphOverviewModel,
+  LargeGraphOverviewSummary,
+  LargeGraphNode,
+  LargeGraphEdge,
+} from "@/lib/large-graph-overview";
+import type { LineageNodeType } from "@/components/lineage-nodes";
+
+function node(
+  id: string,
+  nodeType: LineageNodeType,
+  label: string,
+  severity?: string,
+): LargeGraphNode {
+  return {
+    id,
+    x: 0,
+    y: 0,
+    label,
+    color: "#000",
+    size: 4,
+    nodeType,
+    severity,
+    highlighted: false,
+    hidden: false,
+    forceLabel: false,
+  };
+}
+
+function edge(source: string, target: string, relationship: string): LargeGraphEdge {
+  return {
+    id: `${source}->${target}`,
+    source,
+    target,
+    relationship,
+    color: "#000",
+    size: 1,
+    hidden: false,
+  };
+}
+
+const NODES: LargeGraphNode[] = [
+  node("a1", "agent", "checkout-agent"),
+  node("s1", "server", "payments-api"),
+  node("s2", "server", "billing-api"),
+  node("p1", "package", "requests 2.31.0"),
+  node("v1", "vulnerability", "CVE-2026-1111", "critical"),
+  node("v2", "vulnerability", "CVE-2026-2222", "low"),
+  node("c1", "credential", "STRIPE_KEY"),
+];
+
+const EDGES: LargeGraphEdge[] = [
+  edge("a1", "s1", "calls"),
+  edge("a1", "s2", "calls"),
+  edge("s1", "p1", "depends_on"),
+  edge("p1", "v1", "has_finding"),
+  edge("p1", "v2", "has_finding"),
+  edge("s1", "c1", "exposes_cred"),
+];
+
+function model(
+  overrides: Partial<LargeGraphOverviewModel> = {},
+): LargeGraphOverviewModel {
+  return {
+    nodes: NODES,
+    edges: EDGES,
+    nodeById: new Map(NODES.map((n) => [n.id, n])),
+    sourceNodeCount: NODES.length,
+    sourceEdgeCount: EDGES.length,
+    omittedNodeCount: 0,
+    omittedEdgeCount: 0,
+    ...overrides,
+  };
+}
+
+const SUMMARY: LargeGraphOverviewSummary = {
+  nodes: 7,
+  edges: 6,
+  findings: 2,
+  criticalFindings: 1,
+  credentials: 1,
+  tools: 0,
+  topRelationships: [{ relationship: "calls", count: 2 }],
+};
+
+describe("buildGraphTextAlternative", () => {
+  it("counts every drawn node by type, not just the ones the canvas labels", () => {
+    const text = buildGraphTextAlternative(model(), SUMMARY);
+    expect(text.nodeTypes).toEqual(
+      expect.arrayContaining([
+        { nodeType: "server", count: 2 },
+        { nodeType: "vulnerability", count: 2 },
+        { nodeType: "agent", count: 1 },
+        { nodeType: "credential", count: 1 },
+      ]),
+    );
+    expect(text.nodeTypes.reduce((sum, item) => sum + item.count, 0)).toBe(7);
+  });
+
+  it("counts every drawn relationship by kind", () => {
+    const text = buildGraphTextAlternative(model(), SUMMARY);
+    expect(text.relationships).toEqual([
+      { relationship: "calls", count: 2 },
+      { relationship: "has_finding", count: 2 },
+      { relationship: "depends_on", count: 1 },
+      { relationship: "exposes_cred", count: 1 },
+    ]);
+  });
+
+  it("leads with the highest severity, then the most connected", () => {
+    const text = buildGraphTextAlternative(model(), SUMMARY);
+    expect(text.rows[0]).toMatchObject({
+      label: "CVE-2026-1111",
+      severity: "critical",
+    });
+    const labels = text.rows.map((row) => row.label);
+    // requests 2.31.0 has 3 edges, payments-api 3, billing-api 1 — the
+    // unrated nodes rank among themselves by how connected they are.
+    expect(labels.indexOf("payments-api")).toBeLessThan(
+      labels.indexOf("billing-api"),
+    );
+  });
+
+  it("reports connection counts from the edges actually drawn", () => {
+    const text = buildGraphTextAlternative(model(), SUMMARY);
+    const byLabel = new Map(text.rows.map((row) => [row.label, row]));
+    expect(byLabel.get("payments-api")!.connections).toBe(3);
+    expect(byLabel.get("billing-api")!.connections).toBe(1);
+    expect(byLabel.get("STRIPE_KEY")!.connections).toBe(1);
+  });
+
+  it("names both endpoints and the relationship in every connection sentence", () => {
+    const text = buildGraphTextAlternative(model(), SUMMARY);
+    expect(text.connections).toContain(
+      "payments-api exposes cred STRIPE_KEY",
+    );
+    expect(text.connections).toContain("checkout-agent calls payments-api");
+  });
+
+  it("states the omitted counts instead of silently truncating", () => {
+    const text = buildGraphTextAlternative(
+      model({ sourceNodeCount: 12_400, sourceEdgeCount: 41_000, omittedNodeCount: 12_393, omittedEdgeCount: 40_994 }),
+      { ...SUMMARY, nodes: 12_400, edges: 41_000 },
+      { maxRows: 3, maxConnections: 2 },
+    );
+    expect(text.headline).toContain("12,400");
+    expect(text.headline).toContain("41,000");
+    expect(text.rows).toHaveLength(3);
+    expect(text.rowsNote).toContain("3");
+    expect(text.rowsNote).toContain("7");
+    expect(text.connections).toHaveLength(2);
+    expect(text.connectionsNote).toContain("6");
+  });
+
+  it("survives an empty graph without inventing content", () => {
+    const empty = buildGraphTextAlternative(
+      model({ nodes: [], edges: [], nodeById: new Map(), sourceNodeCount: 0, sourceEdgeCount: 0 }),
+      { ...SUMMARY, nodes: 0, edges: 0, findings: 0, criticalFindings: 0, credentials: 0, tools: 0, topRelationships: [] },
+    );
+    expect(empty.rows).toEqual([]);
+    expect(empty.connections).toEqual([]);
+    expect(empty.headline).toContain("0 nodes");
+  });
+});
+
+describe("<GraphTextAlternative>", () => {
+  it("exposes the graph as a named region a screen reader can reach", () => {
+    render(
+      <GraphTextAlternative
+        id="overview-text"
+        renderer="2D canvas overview"
+        model={model()}
+        summary={SUMMARY}
+      />,
+    );
+    const region = screen.getByRole("region", {
+      name: /graph contents, text equivalent/i,
+    });
+    expect(region).toBeInTheDocument();
+  });
+
+  it("renders every node as a real table row with its type and severity", () => {
+    render(
+      <GraphTextAlternative
+        id="overview-text"
+        renderer="2D canvas overview"
+        model={model()}
+        summary={SUMMARY}
+      />,
+    );
+    const table = screen.getByRole("table", { name: /nodes drawn/i });
+    const rows = within(table).getAllByRole("row");
+    // 7 nodes + the header row.
+    expect(rows).toHaveLength(8);
+    const critical = within(table).getByRole("row", { name: /CVE-2026-1111/ });
+    expect(critical).toHaveTextContent("vulnerability");
+    expect(critical).toHaveTextContent("critical");
+  });
+
+  it("spells out the relationships, so the edges are not canvas-only either", () => {
+    render(
+      <GraphTextAlternative
+        id="overview-text"
+        renderer="2D canvas overview"
+        model={model()}
+        summary={SUMMARY}
+      />,
+    );
+    expect(
+      screen.getByText("payments-api depends on requests 2.31.0"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not take up any of the canvas it describes", () => {
+    const { container } = render(
+      <GraphTextAlternative
+        id="overview-text"
+        renderer="2D canvas overview"
+        model={model()}
+        summary={SUMMARY}
+      />,
+    );
+    expect(container.firstElementChild).toHaveClass("sr-only");
+  });
+});


### PR DESCRIPTION
Four pre-release findings against the graph surfaces. Each was reproduced before it was fixed, and the one that did not reproduce is called out below.

## Reproduced and fixed

### 1. Dense lineage graphs opened at an unreadable zoom

The roll-up grid was already fixed by deriving its column count from the container count, but the raw lineage branch never enters that code — it goes through `applyDagreLayout`, which gives every node in a rank the same x and stacks the rank downwards with no notion of the viewport. A shallow, wide DAG (one agent fanning out to 40 servers is the common shape) becomes a portrait tower dropped into a landscape canvas, so `fitView` resolves below the `minZoom={0.16}` floor and is clamped there with most of the estate below the fold.

Measured on the `/graph` canvas geometry (~1322 x 610, 0.18 padding):

| shape | box before | fit before | box after | fit after |
|---|---|---|---|---|
| 1 agent → 40 servers | 776 x 7784 | **0.064** | 2556 x 1316 | **0.380** |
| 1 agent → 80 servers | 776 x 15624 | **0.032** | 3624 x 1708 | **0.293** |
| 3 x 12 x 4 (184 nodes) | 1728 x 28168 | **0.018** | 6000 x 2688 | **0.181** |
| 4 x 8 | 1252 x 6216 | 0.080 | 2676 x 1316 | 0.380 |
| 12 x 3 | 1252 x 7000 | 0.071 | 3032 x 1512 | 0.331 |

`fitRanksToAspect` reflows over-tall ranks into sub-columns at the single row count that best fits a landscape canvas. Rank order is preserved — every node of rank *r* still sits entirely left of rank *r+1*, so edges keep reading as flow — and the pass is a no-op unless it buys a materially better fit, so a graph that already fits is left exactly as dagre laid it out.

One trap worth flagging: `optionsKey` in `use-dagre-layout.ts` serialises a fixed set of keys, and that key *is* the options object both the sync and worker paths run on. A new option not added there is silently dropped before it ever reaches the layout.

### 2. Canvas nodes and edges had no accessible text equivalent

Past 200 nodes / 500 edges the page swaps React Flow — real DOM with real labels and per-edge aria — for a 2D canvas or a sigma/WebGL stage. Both offered only a widget `aria-label` and an sr-only sentence about the draw budget: no node, no relationship, no severity.

Both now render a `GraphTextAlternative` region carrying the same graph as text — a census by node type and by relationship, the nodes ranked by severity then connection count, and the connections spelled out as sentences ("payments-api exposes cred STRIPE_KEY") — with the canvas wired to it via `role="img"` + `aria-describedby`. Every truncation is stated rather than applied silently, and the drawn-vs-in-scope counts reconcile with the stat pills above the canvas rather than implying the overview shows everything.

### 3. Offline report import was unreachable behind the auth failure screen

Confirmed, and in every failure mode rather than only one. The importer is mounted at `app/page.tsx:332`, inside `AuthGate`: a 401 redirects past it to `/login`, and an unreachable API replaces it with "Control plane unreachable". The feature built for "no working backend" could not render in exactly that situation.

The failure screens and the login page now offer **Continue offline with a report file**. It is opt-in, so the default still blocks and the existing regression guard in `auth-gate.test.tsx` is untouched. It grants no data — every API call behind it fails exactly as it would have, and only a file the user supplies is rendered — and the shell says so, with a one-click way back to signing in. The flag lives in `sessionStorage` so it dies with the tab.

### 4. Large graph surfaces rendered dark-only

Both overview renderers painted a fixed `#050505` stage with `#e4e4e7` labels regardless of theme, so on a light page the largest element on screen was a black rectangle with its own contrast rules. Proven, not assumed: on the pre-fix component the canvas pixel reads `5,5,5` in **both** themes; after, `20,22,29` in dark and `230,234,241` in light. The severity chips on those surfaces had the mirror-image problem — `text-red-100` on a near-white tint — and now carry light values too, as does the "Control plane unreachable" panel.

Canvas and WebGL cannot use CSS classes, so `getGraphCanvasPalette` reads the `globals.css` tokens at draw time and `useGraphCanvasPalette` re-reads them when the theme flips. It is memoised on the theme mode because the WebGL renderer takes the palette as a construction option.

### 5. Found while verifying: the 2D canvas grew without bound

Not in the original report, but it makes this exact surface unreadable, so it is fixed here. `drawGraph` writes `canvas.height` from `clientHeight`; an in-flow canvas takes that attribute as its intrinsic height, so each draw grew the element, the `ResizeObserver` fired, and the next draw grew it again. On the 1,241-node fixture the canvas reached **21,604px** (page body 22,440px) and the user was looking at an empty slice of stage. Taking the canvas out of flow makes the parent the only source of size: **680px**, page body 1,516px, and the graph is actually visible. Confirmed pre-existing by reverting the component to its `main` version and re-measuring.

## Did not reproduce

Nothing in this report failed to reproduce. All four items were confirmed against the running app before any code changed.

## Verified in both themes

Yes — and against the rendered page, not only in tests. New Playwright coverage loads `/graph` in light and dark for both renderers, reads the pixel the 2D canvas actually painted and the computed stage colour behind the WebGL canvases, asserts each sits on the correct side of mid-grey for the theme in play, and asserts the canvas height stays bounded. Screenshots of both themes for both renderers, plus the offline escape hatch, were reviewed by eye. Running those same assertions against the pre-fix component fails them.

## Gates

| gate | result |
|---|---|
| `npm run typecheck` | pass |
| `npm run lint` | pass — 0 errors, only the 2 pre-existing `inventory-context.tsx` warnings |
| `npx vitest run` | **1120 passed / 180 files**, three consecutive clean full runs (was 1090 / 176) |
| `npm run build` | pass |
| `node scripts/check-bundle-budget.mjs` | pass — total 3736.8/3760.0 KiB, largest chunk 379.8/927.7 KiB, shared runtime 434.6/439.5 KiB |
| `npx playwright test` (whole suite) | 40 passed |

One first-run failure was chased down rather than retried: the new layout property test ran 91 dagre layouts and timed out at 17s, starving the worker pool and taking an unrelated suite with it. The baseline was re-run twice on a clean tree to confirm it was mine, then the test was made cheap. Three clean full runs since.

Neither large UI file was reformatted — the diffs there are 46 and 37 lines.
