### PR TITLE
fix(graph): one severity floor and one bound, not one per backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- A `min_severity` filter no longer deletes the graph it was meant to narrow.
+  Only findings carry a severity, so applying the floor to every node dropped
+  the agents, servers, packages, resources and identities the findings hang
+  off. One backend already exempted them on one code path; every other read
+  path — both `load_graph` implementations, four Postgres sites, the Neptune
+  adapter and the in-memory filter — did not, so the same estate answered
+  differently depending on which store replied. Drift incidents were also
+  missing from the in-memory rated-type list.
+- A graph node budget now bounds the read rather than the result on SQLite,
+  which previously loaded the whole snapshot before trimming it. At 200k nodes
+  under a 5,000-node budget: 270 MB peak and 22.9s before, 6.4 MB and 2.8s
+  after, returning the same nodes.
+- `GET /v1/graph/search` now rejects a deep `offset` past the documented cap,
+  as `/v1/graph` and `/v1/graph/agents` already did; both stores enforce it too.
+- `GET /v1/graph` documented an induced subgraph it has never returned. The
+  edge list deliberately reaches one hop past the node list — that is what keeps
+  a severity-ranked finding page attached to its assets — so the description is
+  corrected and `completeness.boundary_edges` now counts the crossing edges.
+- Unfiltered graph statistics are served from the snapshot row on Postgres
+  instead of re-aggregating every node on each page view, matching SQLite. At
+  100k nodes: 73.5ms to 30.2ms.
+
 ## [0.100.0] - 2026-08-11
 
 An output-honesty release. Every local gate was already green before this work

--- a/deploy/supabase/postgres/alembic/versions/20260812_01_graph_snapshot_node_type_counts.py
+++ b/deploy/supabase/postgres/alembic/versions/20260812_01_graph_snapshot_node_type_counts.py
@@ -1,0 +1,38 @@
+"""Materialise the entity-type breakdown Postgres snapshot stats kept recomputing.
+
+``graph_snapshots`` already carries ``node_count``, ``edge_count`` and
+``risk_summary`` (the severity breakdown) from write time, and the SQLite
+backend also carries ``node_type_counts`` and serves both breakdowns from the
+row. Postgres had neither the column nor the lookup, so every unfiltered
+``snapshot_stats`` — which ``GET /v1/graph`` calls on every page view — re-ran
+two GROUP BYs over ``graph_nodes``, growing with the estate.
+
+Additive and nullable on purpose: snapshots written before this migration read
+NULL and fall back to the live GROUP BY, so no backfill is required and a
+rollback loses only the cache.
+
+Revision ID: 20260812_01
+Revises: 20260810_01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260812_01"
+down_revision = "20260810_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE IF EXISTS graph_snapshots ADD COLUMN IF NOT EXISTS node_type_counts TEXT DEFAULT NULL")
+
+
+def downgrade() -> None:
+    # Non-destructive, matching 20260724_02: the snapshot writer inserts this
+    # column on every save, so dropping it on rollback would leave an otherwise
+    # healthy database unwritable by the running application. The reader already
+    # treats NULL as "not cached" and falls back to the live GROUP BY, so
+    # leaving the column costs nothing.
+    return

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -508,6 +508,7 @@ CREATE TABLE IF NOT EXISTS graph_snapshots (
     node_count   INTEGER DEFAULT 0,
     edge_count   INTEGER DEFAULT 0,
     risk_summary TEXT DEFAULT '{}',
+    node_type_counts TEXT DEFAULT NULL,
     analysis_status TEXT NOT NULL DEFAULT '{}',
     PRIMARY KEY (scan_id, tenant_id)
 );

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-10",
+  "generated_on": "2026-08-12",
   "version": "0.100.0",
   "metrics": [
     {
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 839,
+      "value": 840,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-10`
+- Generated on: `2026-08-12`
 - Version: `0.100.0`
 
 | Metric | Value | Source | Notes |
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 839 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 840 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -20752,7 +20752,7 @@
     },
     "/v1/graph": {
       "get": {
-        "description": "Load the unified graph with filters and pagination.\n\nNodes are paginated (offset/limit). Edges are filtered to only include\nedges between returned nodes.\n\n``stats`` describe the graph this response was computed from, NOT the page:\n``stats.total_nodes`` is every node that survived loading, and\n``stats.total_nodes_source`` is the estate total before any load-time node\nbudget applied. The two are equal on an unbounded load. Read\n``completeness`` for whether the load was bounded and why \u2014\n``completeness.total`` always reconciles with ``stats.total_nodes_source``.",
+        "description": "Load the unified graph with filters and pagination.\n\nNodes are paginated (offset/limit). ``edges`` carries every edge *incident*\nto the page \u2014 including edges whose other endpoint is not on it, which is\nwhat keeps a severity-ranked finding page attached to the assets it hangs\noff. It is therefore not the subgraph induced by ``nodes``;\n``completeness.boundary_edges`` counts the edges that cross the boundary.\n\n``stats`` describe the graph this response was computed from, NOT the page:\n``stats.total_nodes`` is every node that survived loading, and\n``stats.total_nodes_source`` is the estate total before any load-time node\nbudget applied. The two are equal on an unbounded load. Read\n``completeness`` for whether the load was bounded and why \u2014\n``completeness.total`` always reconciles with ``stats.total_nodes_source``.",
         "operationId": "get_graph_v1_graph_get",
         "parameters": [
           {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -13801,13 +13801,16 @@ paths:
   /v1/graph:
     get:
       description: "Load the unified graph with filters and pagination.\n\nNodes are\
-        \ paginated (offset/limit). Edges are filtered to only include\nedges between\
-        \ returned nodes.\n\n``stats`` describe the graph this response was computed\
-        \ from, NOT the page:\n``stats.total_nodes`` is every node that survived loading,\
-        \ and\n``stats.total_nodes_source`` is the estate total before any load-time\
-        \ node\nbudget applied. The two are equal on an unbounded load. Read\n``completeness``\
-        \ for whether the load was bounded and why \u2014\n``completeness.total``\
-        \ always reconciles with ``stats.total_nodes_source``."
+        \ paginated (offset/limit). ``edges`` carries every edge *incident*\nto the\
+        \ page \u2014 including edges whose other endpoint is not on it, which is\n\
+        what keeps a severity-ranked finding page attached to the assets it hangs\n\
+        off. It is therefore not the subgraph induced by ``nodes``;\n``completeness.boundary_edges``\
+        \ counts the edges that cross the boundary.\n\n``stats`` describe the graph\
+        \ this response was computed from, NOT the page:\n``stats.total_nodes`` is\
+        \ every node that survived loading, and\n``stats.total_nodes_source`` is the\
+        \ estate total before any load-time node\nbudget applied. The two are equal\
+        \ on an unbounded load. Read\n``completeness`` for whether the load was bounded\
+        \ and why \u2014\n``completeness.total`` always reconciles with ``stats.total_nodes_source``."
       operationId: get_graph_v1_graph_get
       parameters:
       - description: Filter by scan ID

--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -41,15 +41,7 @@ from agent_bom.graph.completeness import (
     graph_completeness,
     impact_completeness,
 )
-from agent_bom.graph.container import apply_node_budget
-from agent_bom.graph.ocsf import FINDING_ENTITY_TYPES
-
-# Only finding-like nodes (vulnerabilities, misconfigurations, drift) carry a
-# severity; a `min_severity` filter must narrow those findings without dropping
-# the topology/context nodes around them (agents, servers, resources, identities
-# all have rank 0). Matches the in-memory ``filtered_view`` / ``_node_matches_query``
-# behaviour so the SQL paging path and the in-memory path agree.
-_FINDING_ENTITY_VALUES: tuple[str, ...] = tuple(sorted(t.value for t in FINDING_ENTITY_TYPES))
+from agent_bom.graph.severity_floor import severity_floor_sql
 
 # Deep OFFSET paging is O(offset): the store still walks and discards every
 # skipped row, so ``offset=490000`` costs seconds even with the sort indexes.
@@ -58,21 +50,18 @@ _FINDING_ENTITY_VALUES: tuple[str, ...] = tuple(sorted(t.value for t in FINDING_
 MAX_NODE_PAGE_OFFSET = 10_000
 
 
-def _min_severity_clause(
-    min_severity_rank: int,
-    *,
-    column: str = "severity_id",
-    entity_column: str = "entity_type",
-) -> tuple[str, list[Any]]:
-    """Build a severity-floor WHERE fragment that exempts non-finding nodes.
+def _assert_offset_within_cap(offset: int, cursor: str | None) -> None:
+    """Refuse a deep OFFSET at the store, not only at the route.
 
-    Returns ``(sql, params)``; ``sql`` is empty when no floor is requested.
+    Every node-paging read shares the cap, so a caller that reaches a store
+    directly (MCP, a job, a future route) cannot buy an O(offset) scan the HTTP
+    surface would have refused.
     """
-    if not min_severity_rank:
-        return "", []
-    placeholders = ",".join("?" for _ in _FINDING_ENTITY_VALUES)
-    sql = f"({column} >= ? OR {entity_column} NOT IN ({placeholders}))"
-    return sql, [min_severity_rank, *_FINDING_ENTITY_VALUES]
+    if not cursor and offset > MAX_NODE_PAGE_OFFSET:
+        raise ValueError(
+            f"offset={offset} exceeds the maximum supported node offset ({MAX_NODE_PAGE_OFFSET}); "
+            "use the cursor= keyset parameter from the previous page's next_cursor for deep pagination."
+        )
 
 
 _CREATE_PRESET_TABLE_SQLITE = """\
@@ -1611,18 +1600,18 @@ class SQLiteGraphStore:
         if conn is None:
             return UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id)
         try:
-            graph = sqlite_graph_store.load_graph(
+            # The budget is pushed into the query, as Postgres does: bounding
+            # after materialization declared the right completeness while still
+            # having read every row.
+            return sqlite_graph_store.load_graph(
                 conn,
                 tenant_id=tenant_id,
                 scan_id=scan_id,
                 entity_types=entity_types,
                 min_severity_rank=min_severity_rank,
                 relationship_types=relationship_types,
+                node_budget=node_budget,
             )
-            # This backend has no query-side limit, so the cap is applied after
-            # the load. Memory is not saved, but the declared contract stays
-            # identical across backends.
-            return apply_node_budget(graph, node_budget)
         finally:
             conn.close()
 
@@ -1801,7 +1790,7 @@ class SQLiteGraphStore:
                 placeholders = ",".join("?" for _ in entity_types)
                 node_where.append(f"entity_type IN ({placeholders})")
                 params.extend(sorted(entity_types))
-            sev_sql, sev_params = _min_severity_clause(min_severity_rank)
+            sev_sql, sev_params = severity_floor_sql(min_severity_rank)
             if sev_sql:
                 node_where.append(sev_sql)
                 params.extend(sev_params)
@@ -1918,11 +1907,7 @@ class SQLiteGraphStore:
         limit: int = 500,
     ) -> tuple[str, str, list[UnifiedNode], int, str | None]:
         tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
-        if not cursor and offset > MAX_NODE_PAGE_OFFSET:
-            raise ValueError(
-                f"offset={offset} exceeds the maximum supported node offset ({MAX_NODE_PAGE_OFFSET}); "
-                "use the cursor= keyset parameter from the previous page's next_cursor for deep pagination."
-            )
+        _assert_offset_within_cap(offset, cursor)
         conn = self._open_ro_conn()
         if conn is None:
             return scan_id, "", [], 0, None
@@ -1936,7 +1921,7 @@ class SQLiteGraphStore:
                 placeholders = ",".join("?" for _ in entity_types)
                 where.append(f"entity_type IN ({placeholders})")
                 params.extend(sorted(entity_types))
-            sev_sql, sev_params = _min_severity_clause(min_severity_rank)
+            sev_sql, sev_params = severity_floor_sql(min_severity_rank)
             if sev_sql:
                 where.append(sev_sql)
                 params.extend(sev_params)
@@ -2031,6 +2016,7 @@ class SQLiteGraphStore:
         limit: int = 50,
     ) -> tuple[list[UnifiedNode], int, str | None]:
         tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
+        _assert_offset_within_cap(offset, cursor)
         conn = self._open_ro_conn()
         if conn is None:
             return [], 0, None
@@ -2060,7 +2046,7 @@ class SQLiteGraphStore:
                     placeholders = ",".join("?" for _ in entity_types)
                     local_where.append(f"gn.entity_type IN ({placeholders})")
                     local_params.extend(sorted(entity_types))
-                sev_sql, sev_params = _min_severity_clause(min_severity_rank, column="gn.severity_id", entity_column="gn.entity_type")
+                sev_sql, sev_params = severity_floor_sql(min_severity_rank, column="gn.severity_id", entity_column="gn.entity_type")
                 if sev_sql:
                     local_where.append(sev_sql)
                     local_params.extend(sev_params)

--- a/src/agent_bom/api/neptune_graph.py
+++ b/src/agent_bom/api/neptune_graph.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping, NoReturn, Protocol, ca
 from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
 from agent_bom.graph.analysis import GraphAnalysisStatus, analysis_status_map_from_dict, analysis_status_map_to_dict
 from agent_bom.graph.container import apply_node_budget
+from agent_bom.graph.severity_floor import node_passes_severity_floor
 
 if TYPE_CHECKING:
     from agent_bom.graph.delta_digest import PriorSnapshotDigest
@@ -359,7 +360,9 @@ class NeptuneGraphStore:
             entity_value = node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type)
             if entity_types and entity_value not in entity_types:
                 continue
-            if min_severity_rank and int(node.severity_id or 0) < min_severity_rank:
+            if not node_passes_severity_floor(
+                entity_type=node.entity_type, severity_id=int(node.severity_id or 0), min_severity_rank=min_severity_rank
+            ):
                 continue
             graph.add_node(node)
         edge_rows = self._edge_rows(tenant_id=tenant, scan_id=scan)

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 from agent_bom.api.graph_store import (
     _DYNAMIC_RELATIONSHIP_VALUES,
-    MAX_NODE_PAGE_OFFSET,
+    _assert_offset_within_cap,
     _escape_like_query,
     _node_search_text,
     decode_graph_cursor,
@@ -33,6 +33,7 @@ from agent_bom.graph.completeness import (
     graph_completeness,
     impact_completeness,
 )
+from agent_bom.graph.severity_floor import severity_floor_sql
 from agent_bom.security import sanitize_text
 
 from .postgres_common import (
@@ -346,11 +347,15 @@ class PostgresGraphStore:
                     node_count INTEGER DEFAULT 0,
                     edge_count INTEGER DEFAULT 0,
                     risk_summary TEXT DEFAULT '{}',
+                    node_type_counts TEXT DEFAULT NULL,
                     analysis_status TEXT NOT NULL DEFAULT '{}',
                     PRIMARY KEY (scan_id, tenant_id)
                 )
                 """
             )
+            # Additive and nullable, matching the SQLite column: snapshots written
+            # before it existed read NULL and fall back to the live GROUP BY.
+            conn.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS node_type_counts TEXT DEFAULT NULL")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_snapshots_recent ON graph_snapshots(tenant_id, created_at DESC)")
             conn.execute(
                 """
@@ -620,6 +625,9 @@ class PostgresGraphStore:
         node_count = 0
         edge_count = 0
         severity_counts: dict[str, int] = defaultdict(int)
+        # Mirrors UnifiedGraph.stats(): severity_counts covers only rated nodes,
+        # type_counts covers every node.
+        type_counts: dict[str, int] = defaultdict(int)
 
         node_insert = """
             INSERT INTO graph_nodes (
@@ -724,6 +732,7 @@ class PostgresGraphStore:
                 node_count += 1
                 et = node.entity_type.value if hasattr(node.entity_type, "value") else node.entity_type
                 et_search = node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type)
+                type_counts[str(et)] += 1
                 if node.severity:
                     severity_counts[node.severity] += 1
                 node_batch.append(
@@ -964,13 +973,14 @@ class PostgresGraphStore:
             conn.execute(
                 """
                 INSERT INTO graph_snapshots
-                    (scan_id, tenant_id, created_at, node_count, edge_count, risk_summary, analysis_status)
-                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                    (scan_id, tenant_id, created_at, node_count, edge_count, risk_summary, node_type_counts, analysis_status)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (scan_id, tenant_id) DO UPDATE SET
                     created_at = EXCLUDED.created_at,
                     node_count = EXCLUDED.node_count,
                     edge_count = EXCLUDED.edge_count,
                     risk_summary = EXCLUDED.risk_summary,
+                    node_type_counts = EXCLUDED.node_type_counts,
                     analysis_status = EXCLUDED.analysis_status
                 """,
                 (
@@ -980,6 +990,7 @@ class PostgresGraphStore:
                     node_count,
                     edge_count,
                     json.dumps(dict(severity_counts)),
+                    json.dumps(dict(type_counts)),
                     json.dumps(analysis_status_map_to_dict(analysis_status or {})),
                 ),
             )
@@ -1094,7 +1105,6 @@ class PostgresGraphStore:
         tenant_id = normalize_graph_tenant_id(tenant_id)
         _assert_allowed_entity_types(entity_types)
         from agent_bom.graph import (
-            SEVERITY_RANK,
             AttackPath,
             InteractionRisk,
             RelationshipType,
@@ -1126,6 +1136,14 @@ class PostgresGraphStore:
                 placeholders = ",".join(["%s"] * len(entity_types))
                 query += f" AND entity_type IN ({placeholders})"
                 params.extend(sorted(entity_types))
+            # The floor belongs in the WHERE clause, not after the LIMIT: a
+            # post-filter both deletes the topology the findings hang off and
+            # spends the budget on rows it then discards, so the page comes back
+            # short of its own budget and `total` counts a different population.
+            sev_sql, sev_params = severity_floor_sql(min_severity_rank, placeholder="%s")
+            if sev_sql:
+                query += f" AND {sev_sql}"
+                params.extend(sev_params)
 
             budget = resolve_node_budget(node_budget)
             total_nodes = 0
@@ -1147,9 +1165,6 @@ class PostgresGraphStore:
 
             node_ids: set[str] = set()
             for row in conn.execute(query, params).fetchall():
-                severity = row[8] or ""
-                if min_severity_rank and SEVERITY_RANK.get(severity, 0) < min_severity_rank:
-                    continue
                 graph.add_node(self._node_from_row(row))
                 node_ids.add(row[0])
 
@@ -2402,9 +2417,10 @@ class PostgresGraphStore:
             placeholders = ",".join(["%s"] * len(entity_types))
             node_where.append(f"entity_type IN ({placeholders})")
             params.extend(sorted(entity_types))
-        if min_severity_rank:
-            node_where.append("severity_id >= %s")
-            params.append(min_severity_rank)
+        sev_sql, sev_params = severity_floor_sql(min_severity_rank, placeholder="%s")
+        if sev_sql:
+            node_where.append(sev_sql)
+            params.extend(sev_params)
         where_sql = " AND ".join(node_where)
 
         with _tenant_connection(self._pool) as conn:
@@ -2415,24 +2431,33 @@ class PostgresGraphStore:
             analysis_status = analysis_status_map_to_dict(
                 analysis_status_map_from_dict(_decode_json_object(analysis_row[0] if analysis_row else None))
             )
-            # Unfiltered node/edge totals are already materialised on the snapshot
-            # row at write time. Re-deriving the edge count here re-scans
-            # graph_edges with a double id-membership subquery (~seconds at 500k
-            # edges on every paged /v1/graph call), so read the stored counts and
-            # only fall back to COUNT(*) when the snapshot row is missing or the
-            # counts were never populated. Any active entity-type or severity
-            # filter narrows the set, so the recompute path still runs then.
+            # Unfiltered node/edge totals AND the entity-type / severity breakdowns
+            # are materialised on the snapshot row at write time. Re-deriving them
+            # here costs two GROUP BYs over graph_nodes plus a double id-membership
+            # edge subquery on every paged /v1/graph call — O(estate) per page view
+            # of an estate that only grows. Read the stored values and fall back to
+            # the live queries only when the snapshot row is missing or the
+            # breakdown was never populated (snapshots older than the column). Any
+            # active entity-type or severity filter narrows the set, so the
+            # recompute path still runs then. Kept identical to the SQLite backend:
+            # a count that depends on which store answered is not a count.
             filters_active = bool(entity_types) or bool(min_severity_rank)
             stored_node_count: int | None = None
             stored_edge_count: int | None = None
+            cached_node_types: dict[str, int] | None = None
+            cached_severity_counts: dict[str, int] | None = None
             if not filters_active:
                 snap_row = conn.execute(
-                    "SELECT node_count, edge_count FROM graph_snapshots WHERE scan_id = %s AND tenant_id = %s",
+                    "SELECT node_count, edge_count, risk_summary, node_type_counts "
+                    "FROM graph_snapshots WHERE scan_id = %s AND tenant_id = %s",
                     (effective_scan_id, tenant_id),
                 ).fetchone()
                 if snap_row is not None:
                     stored_node_count = snap_row[0] if snap_row[0] is not None else None
                     stored_edge_count = snap_row[1] if snap_row[1] is not None else None
+                    if snap_row[3] is not None:
+                        cached_node_types = {str(k): int(v) for k, v in _decode_json_object(snap_row[3]).items()}
+                        cached_severity_counts = {str(k): int(v) for k, v in _decode_json_object(snap_row[2]).items() if k}
 
             if stored_node_count is not None:
                 total_nodes = int(stored_node_count)
@@ -2442,14 +2467,22 @@ class PostgresGraphStore:
                     params,
                 ).fetchone()
                 total_nodes = int((total_nodes_row[0] if total_nodes_row else 0) or 0)
-            node_type_rows = conn.execute(
-                f"SELECT entity_type, COUNT(*) FROM graph_nodes WHERE {where_sql} GROUP BY entity_type",  # nosec B608 - where_sql is built from static clause fragments
-                params,
-            ).fetchall()
-            severity_rows = conn.execute(
-                f"SELECT severity, COUNT(*) FROM graph_nodes WHERE {where_sql} AND severity <> '' GROUP BY severity",  # nosec B608 - where_sql is built from static clause fragments
-                params,
-            ).fetchall()
+            if cached_node_types is not None:
+                node_types = cached_node_types
+            else:
+                node_type_rows = conn.execute(
+                    f"SELECT entity_type, COUNT(*) FROM graph_nodes WHERE {where_sql} GROUP BY entity_type",  # nosec B608 - where_sql is built from static clause fragments
+                    params,
+                ).fetchall()
+                node_types = {str(row[0]): int(row[1]) for row in node_type_rows}
+            if cached_severity_counts is not None:
+                severity_counts = cached_severity_counts
+            else:
+                severity_rows = conn.execute(
+                    f"SELECT severity, COUNT(*) FROM graph_nodes WHERE {where_sql} AND severity <> '' GROUP BY severity",  # nosec B608 - where_sql is built from static clause fragments
+                    params,
+                ).fetchall()
+                severity_counts = {str(row[0]): int(row[1]) for row in severity_rows}
             if stored_edge_count is not None:
                 total_edges = int(stored_edge_count)
             else:
@@ -2501,8 +2534,8 @@ class PostgresGraphStore:
             return {
                 "total_nodes": total_nodes,
                 "total_edges": total_edges,
-                "node_types": {str(row[0]): int(row[1]) for row in node_type_rows},
-                "severity_counts": {str(row[0]): int(row[1]) for row in severity_rows},
+                "node_types": node_types,
+                "severity_counts": severity_counts,
                 "relationship_types": {str(row[0]): int(row[1]) for row in rel_rows},
                 "attack_path_count": int((attack_row[0] if attack_row else 0) or 0),
                 "interaction_risk_count": int((interaction_row[0] if interaction_row else 0) or 0),
@@ -2524,11 +2557,7 @@ class PostgresGraphStore:
     ) -> tuple[str, str, list[Any], int, str | None]:
         tenant_id = normalize_graph_tenant_id(tenant_id)
         _assert_allowed_entity_types(entity_types)
-        if not cursor and offset > MAX_NODE_PAGE_OFFSET:
-            raise ValueError(
-                f"offset={offset} exceeds the maximum supported node offset ({MAX_NODE_PAGE_OFFSET}); "
-                "use the cursor= keyset parameter from the previous page's next_cursor for deep pagination."
-            )
+        _assert_offset_within_cap(offset, cursor)
         effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
         if not effective_scan_id:
             return scan_id, "", [], 0, None
@@ -2543,9 +2572,10 @@ class PostgresGraphStore:
                 placeholders = ",".join(["%s"] * len(entity_types))
                 where.append(f"entity_type IN ({placeholders})")
                 params.extend(sorted(entity_types))
-            if min_severity_rank:
-                where.append("severity_id >= %s")
-                params.append(min_severity_rank)
+            sev_sql, sev_params = severity_floor_sql(min_severity_rank, placeholder="%s")
+            if sev_sql:
+                where.append(sev_sql)
+                params.extend(sev_params)
             where_sql = " AND ".join(where)
             total_row = conn.execute(
                 f"SELECT COUNT(*) FROM graph_nodes WHERE {where_sql}",  # nosec B608 - where_sql is built from static clause fragments
@@ -2653,6 +2683,7 @@ class PostgresGraphStore:
     ) -> tuple[list[UnifiedNode], int, str | None]:
         tenant_id = normalize_graph_tenant_id(tenant_id)
         _assert_allowed_entity_types(entity_types)
+        _assert_offset_within_cap(offset, cursor)
         effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
         if not effective_scan_id:
             return [], 0, None
@@ -2669,9 +2700,12 @@ class PostgresGraphStore:
                 placeholders = ",".join(["%s"] * len(entity_types))
                 search_where.append(f"gn.entity_type IN ({placeholders})")
                 params.extend(sorted(entity_types))
-            if min_severity_rank:
-                search_where.append("gn.severity_id >= %s")
-                params.append(min_severity_rank)
+            sev_sql, sev_params = severity_floor_sql(
+                min_severity_rank, column="gn.severity_id", entity_column="gn.entity_type", placeholder="%s"
+            )
+            if sev_sql:
+                search_where.append(sev_sql)
+                params.extend(sev_params)
             if compliance_prefixes:
                 prefix_filters = []
                 for prefix in sorted(compliance_prefixes):

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -749,11 +749,6 @@ def _path_matches_focus(graph: UnifiedGraph, path: AttackPath, *, cve: str, pack
     return True
 
 
-def _is_finding_like_node(node: UnifiedNode) -> bool:
-    entity_type = node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type)
-    return entity_type in {EntityType.VULNERABILITY.value, EntityType.MISCONFIGURATION.value}
-
-
 def _rel_value(edge: UnifiedEdge) -> str:
     return edge.relationship.value if hasattr(edge.relationship, "value") else str(edge.relationship)
 
@@ -849,6 +844,22 @@ def _joined_edges(*groups: list[UnifiedEdge]) -> list[UnifiedEdge]:
             seen.add(key)
             joined.append(edge)
     return joined
+
+
+def _boundary_edge_count(edges: list[UnifiedEdge], node_ids: set[str]) -> int:
+    """How many returned edges have an endpoint the response did not return.
+
+    ``edges_for_node_ids`` matches ``source OR target`` deliberately: a page is
+    ranked by severity, so on a dense finding page the asset each finding hangs
+    off is usually not on the page, and dropping those edges would hand back a
+    scatter of unattached findings (and would break the containment-ancestor
+    walk, which finds parents precisely by looking at edges reaching in from
+    outside). So the payload is *not* an induced subgraph — but a client that
+    assumes it is will silently drop these edges or invent phantom endpoints.
+    Counting them is the fail-closed half: the response says how much of its
+    edge list reaches past its node list instead of leaving it to be discovered.
+    """
+    return sum(1 for edge in edges if edge.source not in node_ids or edge.target not in node_ids)
 
 
 def _edge_relationships_for_hops(hops: list[str], edges: list[UnifiedEdge]) -> list[str]:
@@ -1994,13 +2005,16 @@ def _node_matches_query(
     compliance_prefixes: set[str],
     data_sources: set[str],
 ) -> bool:
-    from agent_bom.graph import SEVERITY_RANK
+    from agent_bom.graph.severity_floor import node_passes_severity_floor
 
     if entity_types:
         entity_type = node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type)
         if entity_type not in entity_types:
             return False
-    if min_severity_rank and _is_finding_like_node(node) and SEVERITY_RANK.get(node.severity.lower(), 0) < min_severity_rank:
+    # This used a local predicate that knew only two of the three rated entity
+    # types, so a drift incident below the floor stayed on the page here and was
+    # dropped by the stores.
+    if not node_passes_severity_floor(entity_type=node.entity_type, severity=node.severity, min_severity_rank=min_severity_rank):
         return False
     if compliance_prefixes:
         prefixes = {tag.split("-")[0].upper() if "-" in tag else tag.upper() for tag in node.compliance_tags}
@@ -2164,8 +2178,11 @@ async def get_graph(
 ) -> dict:
     """Load the unified graph with filters and pagination.
 
-    Nodes are paginated (offset/limit). Edges are filtered to only include
-    edges between returned nodes.
+    Nodes are paginated (offset/limit). ``edges`` carries every edge *incident*
+    to the page — including edges whose other endpoint is not on it, which is
+    what keeps a severity-ranked finding page attached to the assets it hangs
+    off. It is therefore not the subgraph induced by ``nodes``;
+    ``completeness.boundary_edges`` counts the edges that cross the boundary.
 
     ``stats`` describe the graph this response was computed from, NOT the page:
     ``stats.total_nodes`` is every node that survived loading, and
@@ -2280,13 +2297,15 @@ async def get_graph(
         "total_nodes_source": max(int(snapshot_stats.get("total_nodes", 0)), total),
     }
     response_nodes = [*paged_nodes, *ancestor_nodes]
+    response_node_ids = {node.id for node in response_nodes}
+    response_edges = _joined_edges(paged_edges, ancestor_edges)
     page_truncated = bool(next_cursor) or offset + len(paged_nodes) < total
     return {
         "scan_id": effective_scan_id,
         "tenant_id": tenant,
         "created_at": created_at,
         "nodes": [n.to_dict() for n in response_nodes],
-        "edges": [e.to_dict() for e in _joined_edges(paged_edges, ancestor_edges)],
+        "edges": [e.to_dict() for e in response_edges],
         "attack_paths": [
             _serialize_attack_path(path, paged_edges, nodes_by_id=nodes_by_id, scan_id=effective_scan_id) for path in source_attack_paths
         ],
@@ -2306,6 +2325,10 @@ async def get_graph(
             # and the extra nodes read as a paging bug.
             "ranked": len(paged_nodes),
             "context_nodes": len(ancestor_nodes),
+            # See ``_boundary_edge_count``: the edge list deliberately reaches
+            # one hop past the node list, so say by how much rather than letting
+            # a client read the payload as an induced subgraph.
+            "boundary_edges": _boundary_edge_count(response_edges, response_node_ids),
         },
     }
 
@@ -2781,6 +2804,7 @@ async def search_graph(
     limit: int = Query(50, ge=1, le=500, description="Max results"),
 ) -> dict:
     """Search graph nodes by label, type, tags, and attributes."""
+    _enforce_node_offset_cap(offset, cursor)
     entity_type_filters = _parse_entity_type_filter(entity_types)
     min_rank = SEVERITY_RANK.get(min_severity.lower(), 0) if min_severity else 0
     prefix_filters = {value.strip().upper() for value in compliance_prefixes.split(",") if value.strip()} if compliance_prefixes else None

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     from agent_bom.graph.delta_digest import PriorSnapshotDigest
 
 from agent_bom.graph import (
-    SEVERITY_RANK,
     AttackPath,
     EntityType,
     InteractionRisk,
@@ -42,6 +41,8 @@ from agent_bom.graph.analysis import (
     analysis_status_map_to_dict,
     not_recorded_analysis_status,
 )
+from agent_bom.graph.container import GraphCompleteness, resolve_node_budget
+from agent_bom.graph.severity_floor import severity_floor_sql
 from agent_bom.security import sanitize_text
 
 logger = logging.getLogger(__name__)
@@ -1078,8 +1079,15 @@ def load_graph(
     entity_types: set[str] | None = None,
     min_severity_rank: int = 0,
     relationship_types: frozenset[str] | None = None,
+    node_budget: int | None = None,
 ) -> UnifiedGraph:
-    """Load a UnifiedGraph from a specific scan snapshot."""
+    """Load a UnifiedGraph from a specific scan snapshot.
+
+    ``node_budget`` bounds the read in SQL and is reported on
+    ``graph.completeness``; it defaults to unbounded because callers that
+    compute differences (snapshot diff, compare) are only correct on a whole
+    graph — a trimmed one reads as deletions that never happened.
+    """
     tenant_id = normalize_graph_tenant_id(tenant_id)
     effective_scan_id, created_at = _resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
     graph = UnifiedGraph(scan_id=effective_scan_id, tenant_id=tenant_id, created_at=created_at)
@@ -1096,18 +1104,38 @@ def load_graph(
         if not graph.analysis_status:
             graph.analysis_status["attack_path_fusion"] = not_recorded_analysis_status()
 
-    query = "SELECT * FROM graph_nodes WHERE tenant_id = ? AND scan_id = ?"
+    where = "tenant_id = ? AND scan_id = ?"
     params: list[Any] = [tenant_id, effective_scan_id]
     if entity_types:
         placeholders = ",".join("?" * len(entity_types))
-        query += f" AND entity_type IN ({placeholders})"
+        where += f" AND entity_type IN ({placeholders})"
         params.extend(entity_types)
+    sev_sql, sev_params = severity_floor_sql(min_severity_rank)
+    if sev_sql:
+        where += f" AND {sev_sql}"
+        params.extend(sev_params)
+
+    query = f"SELECT * FROM graph_nodes WHERE {where}"  # nosec B608 - where is built from static clause fragments
+    budget = resolve_node_budget(node_budget)
+    total_nodes = 0
+    if budget is not None:
+        # The budget has to bound the *read*, not the result. Trimming after a
+        # full materialization declares the same completeness while still having
+        # paid for every row: at 200k nodes that is ~783 MB the cap was
+        # introduced to avoid. Risk-ranked so a trimmed view keeps what matters,
+        # id breaking ties so the selection is deterministic — the same order
+        # Postgres uses, so the two backends return the same nodes.
+        count_row = conn.execute(
+            f"SELECT COUNT(*) FROM graph_nodes WHERE {where}",  # nosec B608 - where is built from static clause fragments
+            params,
+        ).fetchone()
+        total_nodes = int(count_row[0]) if count_row else 0
+        query += " ORDER BY risk_score DESC, id LIMIT ?"
+        params.append(budget)
 
     node_ids: set[str] = set()
     for row in conn.execute(query, params):
         sev = row["severity"] or ""
-        if min_severity_rank and SEVERITY_RANK.get(sev, 0) < min_severity_rank:
-            continue
         graph.add_node(
             UnifiedNode(
                 id=row["id"],
@@ -1129,6 +1157,17 @@ def load_graph(
             )
         )
         node_ids.add(row["id"])
+
+    returned_nodes = len(node_ids)
+    if budget is None:
+        total_nodes = returned_nodes
+    graph.completeness = GraphCompleteness(
+        truncated=budget is not None and total_nodes > returned_nodes,
+        node_budget=budget,
+        total_nodes=total_nodes,
+        returned_nodes=returned_nodes,
+        reason="node_budget" if budget is not None and total_nodes > returned_nodes else "",
+    )
 
     eq = "SELECT * FROM graph_edges WHERE tenant_id = ? AND scan_id = ?"
     eparams: list[Any] = [tenant_id, effective_scan_id]
@@ -1308,9 +1347,11 @@ def iter_graph_nodes(
         placeholders = ",".join("?" * len(entity_types))
         query += f" AND entity_type IN ({placeholders})"  # nosec B608 - placeholders are only "?" markers
         params.extend(sorted(entity_types))
+    sev_sql, sev_params = severity_floor_sql(min_severity_rank)
+    if sev_sql:
+        query += f" AND {sev_sql}"  # nosec B608 - fragment is built from a static template
+        params.extend(sev_params)
     for row in conn.execute(query, params):
-        if min_severity_rank and SEVERITY_RANK.get(row["severity"] or "", 0) < min_severity_rank:
-            continue
         yield _node_from_snapshot_row(row)
 
 

--- a/src/agent_bom/graph/severity_floor.py
+++ b/src/agent_bom/graph/severity_floor.py
@@ -1,0 +1,67 @@
+"""What a ``min_severity`` floor means, defined once for every read path.
+
+Only finding-like nodes carry a severity: a vulnerability, a misconfiguration
+and a drift incident are rated, while the agents, servers, packages, cloud
+resources and identities they hang off all rank 0. So a floor applied to
+*every* node does not narrow the estate — it deletes the estate and leaves the
+findings floating unattached, which is the difference between "here are your
+critical findings and what they sit on" and "here are seven dots".
+
+Every backend and every read path answers this one question, so it lives here
+rather than being re-derived per store: :func:`node_passes_severity_floor` for
+in-memory rows, :func:`severity_floor_sql` for a pushed-down WHERE fragment on
+either driver's placeholder style. The SQL and the predicate are pinned against
+each other by ``tests/test_graph_backend_semantics.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_bom.graph.ocsf import FINDING_ENTITY_TYPES
+from agent_bom.graph.severity import SEVERITY_RANK
+
+#: Entity types a severity floor is allowed to filter on. Everything else is
+#: topology and survives any floor.
+FINDING_ENTITY_VALUES: tuple[str, ...] = tuple(sorted(entity_type.value for entity_type in FINDING_ENTITY_TYPES))
+
+
+def node_passes_severity_floor(
+    *,
+    entity_type: Any,
+    severity: str = "",
+    severity_id: int | None = None,
+    min_severity_rank: int = 0,
+) -> bool:
+    """Whether a node survives ``min_severity_rank``.
+
+    ``severity_id`` (the stored OCSF id) is preferred when a caller has it;
+    both scales are 0-5 and agree, so the string is an equivalent fallback.
+    """
+    if not min_severity_rank:
+        return True
+    value = entity_type.value if hasattr(entity_type, "value") else str(entity_type)
+    if value not in FINDING_ENTITY_VALUES:
+        return True
+    rank = int(severity_id) if severity_id is not None else SEVERITY_RANK.get((severity or "").lower(), 0)
+    return rank >= min_severity_rank
+
+
+def severity_floor_sql(
+    min_severity_rank: int,
+    *,
+    column: str = "severity_id",
+    entity_column: str = "entity_type",
+    placeholder: str = "?",
+) -> tuple[str, list[Any]]:
+    """Build the same judgement as a WHERE fragment.
+
+    ``placeholder`` is ``?`` for SQLite and ``%s`` for psycopg. Returns
+    ``(sql, params)``; ``sql`` is empty when no floor is requested, so callers
+    can append it unconditionally.
+    """
+    if not min_severity_rank:
+        return "", []
+    placeholders = ",".join(placeholder for _ in FINDING_ENTITY_VALUES)
+    sql = f"({column} >= {placeholder} OR {entity_column} NOT IN ({placeholders}))"
+    return sql, [min_severity_rank, *FINDING_ENTITY_VALUES]

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -344,11 +344,19 @@ class TestGraphEndpointLogic:
         assert all(n.entity_type == EntityType.AGENT for n in loaded.nodes.values())
 
     def test_load_with_severity_filter(self, graph_db):
+        """A floor narrows the findings; the topology around them survives.
+
+        This asserted one surviving node, which is what happens when the floor
+        is applied to every row: only finding-like nodes carry a severity, so
+        the agents and servers the finding hangs off all rank 0 and were deleted
+        with it. The paging path was corrected in #2879; ``load_graph`` kept the
+        old behaviour, so the same estate answered differently depending on
+        which query parameters the caller set.
+        """
         _build_persisted_graph(graph_db)
         loaded = load_graph(graph_db, scan_id="test-scan-001", min_severity_rank=5)
-        # Only critical vuln passes
-        assert len(loaded.nodes) == 1
         assert "vuln:CVE-2024-1" in loaded.nodes
+        assert {"agent:a", "agent:b", "server:a:fs"} <= set(loaded.nodes)
 
     def test_diff_between_scans(self, graph_db):
         from agent_bom.db.graph_store import diff_snapshots

--- a/tests/test_graph_backend_semantics.py
+++ b/tests/test_graph_backend_semantics.py
@@ -1,0 +1,447 @@
+"""One graph, one set of answers — whichever backend and whichever read path.
+
+Five semantics that had drifted apart, all pre-dating the completeness (#4760)
+and edge-dedup (#4762) work:
+
+1. **A severity floor narrows findings; it must not delete the topology.** Only
+   finding-like nodes (vulnerability, misconfiguration, drift incident) carry a
+   severity — agents, servers, packages, resources and identities all rank 0. A
+   floor applied to every node collapses a populated estate to a scatter of
+   disconnected findings. SQLite's paging path learned this in #2879; Postgres,
+   both backends' ``load_graph``, and the in-memory filter never did, so the
+   same question got two answers depending on which store answered and which
+   query parameters were set.
+
+2. **A node budget must bound the read, not the result.** Postgres pushes the
+   budget into SQL; SQLite materialized the whole snapshot and trimmed
+   afterwards — a bound that is declared but applied too late to help.
+
+3. **Deep ``offset`` is O(offset).** ``/v1/graph`` and ``/v1/graph/agents``
+   reject it past a cap; ``/v1/graph/search`` accepted any offset.
+
+4. **``GET /v1/graph`` documented an induced subgraph it has never returned.**
+   ``edges_for_node_ids`` matches ``source OR target`` on purpose — that is what
+   keeps a severity-ranked finding page attached to its assets, and it is how
+   the containment-ancestor walk finds parents. The docstring was the defect,
+   not the behaviour; the response now says how many edges cross the boundary.
+
+5. **An unfiltered stats read must be served, not recomputed.** SQLite reads the
+   entity-type and severity breakdowns materialised on the snapshot row;
+   Postgres re-ran both GROUP BYs over ``graph_nodes`` on every page view.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api import stores as api_stores
+from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.api.server import app
+from agent_bom.api.stores import set_graph_store
+from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
+
+CONTEXT_NODES = {"agent:a", "server:fs", "pkg:express", "cloud:bucket", "role:deploy"}
+HIGH_FLOOR = 4  # "high"
+
+
+def _estate(scan_id: str = "sev-topo") -> UnifiedGraph:
+    """A connected estate: context nodes plus one critical and one low finding."""
+    g = UnifiedGraph(scan_id=scan_id, tenant_id="default")
+    g.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="billing-agent"))
+    g.add_node(UnifiedNode(id="server:fs", entity_type=EntityType.SERVER, label="mcp-fs"))
+    g.add_node(UnifiedNode(id="pkg:express", entity_type=EntityType.PACKAGE, label="express@4"))
+    g.add_node(UnifiedNode(id="cloud:bucket", entity_type=EntityType.CLOUD_RESOURCE, label="pii-bucket"))
+    g.add_node(UnifiedNode(id="role:deploy", entity_type=EntityType.ROLE, label="deploy-role"))
+    g.add_node(UnifiedNode(id="vuln:crit", entity_type=EntityType.VULNERABILITY, label="CVE-CRIT", severity="critical", risk_score=9.5))
+    g.add_node(UnifiedNode(id="vuln:low", entity_type=EntityType.VULNERABILITY, label="CVE-LOW", severity="low", risk_score=2.0))
+    g.add_edge(UnifiedEdge(source="agent:a", target="server:fs", relationship=RelationshipType.USES))
+    g.add_edge(UnifiedEdge(source="server:fs", target="pkg:express", relationship=RelationshipType.DEPENDS_ON))
+    g.add_edge(UnifiedEdge(source="pkg:express", target="vuln:crit", relationship=RelationshipType.VULNERABLE_TO))
+    g.add_edge(UnifiedEdge(source="pkg:express", target="vuln:low", relationship=RelationshipType.VULNERABLE_TO))
+    g.add_edge(UnifiedEdge(source="role:deploy", target="cloud:bucket", relationship=RelationshipType.CAN_ACCESS))
+    return g
+
+
+# ── 1. one judgement about what a severity floor means ──────────────────────
+
+
+class TestSeverityFloorJudgement:
+    """The predicate itself, so every backend has one thing to agree with."""
+
+    def test_non_finding_nodes_are_never_dropped_by_a_floor(self) -> None:
+        from agent_bom.graph.severity_floor import node_passes_severity_floor
+
+        for entity_type in (EntityType.AGENT, EntityType.SERVER, EntityType.PACKAGE, EntityType.CLOUD_RESOURCE, EntityType.ROLE):
+            assert node_passes_severity_floor(entity_type=entity_type, severity="", min_severity_rank=5), (
+                f"{entity_type} carries no severity; a floor must not delete it"
+            )
+
+    def test_findings_below_the_floor_are_dropped(self) -> None:
+        from agent_bom.graph.severity_floor import node_passes_severity_floor
+
+        assert not node_passes_severity_floor(entity_type=EntityType.VULNERABILITY, severity="low", min_severity_rank=HIGH_FLOOR)
+        assert node_passes_severity_floor(entity_type=EntityType.VULNERABILITY, severity="critical", min_severity_rank=HIGH_FLOOR)
+
+    def test_drift_incidents_are_findings_like_their_siblings(self) -> None:
+        """The route's in-memory predicate knew only two of the three finding types."""
+        from agent_bom.graph.severity_floor import node_passes_severity_floor
+
+        assert not node_passes_severity_floor(entity_type=EntityType.DRIFT_INCIDENT, severity="low", min_severity_rank=HIGH_FLOOR)
+        assert node_passes_severity_floor(entity_type=EntityType.DRIFT_INCIDENT, severity="critical", min_severity_rank=HIGH_FLOOR)
+
+    def test_no_floor_admits_everything(self) -> None:
+        from agent_bom.graph.severity_floor import node_passes_severity_floor
+
+        assert node_passes_severity_floor(entity_type=EntityType.VULNERABILITY, severity="", min_severity_rank=0)
+
+    @pytest.mark.parametrize("placeholder", ["?", "%s"])
+    def test_sql_fragment_matches_the_predicate_for_both_drivers(self, placeholder: str) -> None:
+        from agent_bom.graph.severity_floor import severity_floor_sql
+
+        sql, params = severity_floor_sql(0, placeholder=placeholder)
+        assert sql == "" and params == [], "no floor means no clause"
+
+        sql, params = severity_floor_sql(HIGH_FLOOR, placeholder=placeholder)
+        assert placeholder in sql
+        assert sql.count(placeholder) == len(params)
+        assert "entity_type NOT IN" in sql, "the clause must exempt non-finding entity types"
+
+
+# ── the backends, exercised the same way ────────────────────────────────────
+
+
+@pytest.fixture
+def sqlite_store(tmp_path: Path) -> SQLiteGraphStore:
+    store = SQLiteGraphStore(tmp_path / "graph.db")
+    store.save_graph(_estate())
+    return store
+
+
+@pytest.fixture
+def postgres_store() -> Iterator[Any]:
+    """Live Postgres when one is configured; skipped otherwise.
+
+    The source-level pin below runs everywhere, so a runner without a database
+    still fails if Postgres re-grows its own severity judgement.
+    """
+    if not os.environ.get("AGENT_BOM_POSTGRES_URL"):
+        pytest.skip("AGENT_BOM_POSTGRES_URL not set")
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_graph import PostgresGraphStore
+
+    store = PostgresGraphStore()
+    token = set_current_tenant("default")
+    try:
+        store.save_graph(_estate())
+        yield store
+    finally:
+        reset_current_tenant(token)
+
+
+@pytest.fixture(params=["sqlite", "postgres"])
+def graph_store(request: pytest.FixtureRequest) -> Any:
+    return request.getfixturevalue(f"{request.param}_store")
+
+
+class TestSeverityFloorKeepsTopologyOnEveryBackend:
+    def test_page_nodes(self, graph_store: Any) -> None:
+        _scan, _created, nodes, total, _cursor = graph_store.page_nodes(tenant_id="default", min_severity_rank=HIGH_FLOOR, limit=100)
+        ids = {n.id for n in nodes}
+        assert CONTEXT_NODES <= ids, f"severity floor deleted the topology: {sorted(ids)}"
+        assert "vuln:crit" in ids
+        assert "vuln:low" not in ids
+        assert total == len(ids), "the page total must count the same nodes the page returns"
+
+    def test_snapshot_stats(self, graph_store: Any) -> None:
+        stats = graph_store.snapshot_stats(tenant_id="default", min_severity_rank=HIGH_FLOOR)
+        assert stats["total_nodes"] == len(CONTEXT_NODES) + 1
+
+    def test_search_nodes(self, graph_store: Any) -> None:
+        results, total, _cursor = graph_store.search_nodes(tenant_id="default", query="express", min_severity_rank=HIGH_FLOOR, limit=50)
+        assert {n.id for n in results} == {"pkg:express"}, "a package matched the query and carries no severity"
+        assert total == 1
+
+    def test_load_graph_keeps_the_graph_connected(self, graph_store: Any) -> None:
+        graph = graph_store.load_graph(tenant_id="default", min_severity_rank=HIGH_FLOOR)
+        assert CONTEXT_NODES <= set(graph.nodes), f"severity floor deleted the topology: {sorted(graph.nodes)}"
+        assert "vuln:crit" in graph.nodes
+        assert "vuln:low" not in graph.nodes
+        # The path pkg:express -> vuln:crit survives, so the finding is still
+        # attached to something rather than floating alone.
+        assert any(e.source == "pkg:express" and e.target == "vuln:crit" for e in graph.edges)
+
+
+def test_postgres_does_not_hand_roll_its_own_severity_floor() -> None:
+    """Enforced on every runner, database or not.
+
+    Postgres compared ``severity_id >= %s`` against every node in four separate
+    places. The shared fragment is the only permitted spelling.
+    """
+    import inspect
+
+    from agent_bom.api.postgres_graph import PostgresGraphStore
+
+    for method in ("load_graph", "snapshot_stats", "page_nodes", "search_nodes"):
+        source = inspect.getsource(getattr(PostgresGraphStore, method))
+        assert "severity_id >= " not in source, (
+            f"PostgresGraphStore.{method} still compares severity_id directly, which drops every "
+            "context node the finding hangs off; use severity_floor_sql"
+        )
+        assert "severity_floor" in source, f"PostgresGraphStore.{method} should build its floor with the shared helper"
+
+
+# ── 2. a node budget must bound the read, not just the result ───────────────
+
+
+class TestNodeBudgetBoundsTheRead:
+    def test_sqlite_load_graph_does_not_materialize_the_whole_snapshot(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Count the nodes the load actually builds, not the ones it returns.
+
+        SQLite read every row and trimmed afterwards, so a 5,000-node snapshot
+        under a 50-node budget still built 5,000 ``UnifiedNode`` objects. At the
+        200k-node estate the investigation budget exists to protect, that is the
+        ~783 MB the budget was introduced to avoid.
+        """
+        from agent_bom.db import graph_store as sqlite_graph_store
+
+        estate_size = 5_000
+        budget = 50
+
+        big = UnifiedGraph(scan_id="budget-scan", tenant_id="default")
+        for i in range(estate_size):
+            big.add_node(UnifiedNode(id=f"asset:{i}", entity_type=EntityType.CLOUD_RESOURCE, label=f"asset-{i}", risk_score=i / 100.0))
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        store.save_graph(big)
+
+        built = 0
+        real_node = sqlite_graph_store.UnifiedNode
+
+        def counting_node(*args: Any, **kwargs: Any) -> UnifiedNode:
+            nonlocal built
+            built += 1
+            return real_node(*args, **kwargs)
+
+        monkeypatch.setattr(sqlite_graph_store, "UnifiedNode", counting_node)
+        graph = store.load_graph(tenant_id="default", node_budget=budget)
+
+        assert len(graph.nodes) == budget
+        assert built <= budget, f"built {built} nodes to return {budget}: the budget was applied after materialization"
+        assert graph.completeness.truncated is True
+        assert graph.completeness.total_nodes == estate_size
+        assert graph.completeness.returned_nodes == budget
+        assert graph.completeness.reason == "node_budget"
+
+    def test_sqlite_budget_keeps_the_highest_risk_nodes(self, tmp_path: Path) -> None:
+        """Bounding earlier must not change *which* nodes survive."""
+        big = UnifiedGraph(scan_id="budget-rank", tenant_id="default")
+        for i in range(200):
+            big.add_node(UnifiedNode(id=f"asset:{i}", entity_type=EntityType.CLOUD_RESOURCE, label=f"asset-{i}", risk_score=float(i)))
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        store.save_graph(big)
+
+        graph = store.load_graph(tenant_id="default", node_budget=10)
+        assert set(graph.nodes) == {f"asset:{i}" for i in range(190, 200)}
+
+    def test_sqlite_unbounded_load_still_reports_complete(self, sqlite_store: SQLiteGraphStore) -> None:
+        graph = sqlite_store.load_graph(tenant_id="default")
+        assert graph.completeness.truncated is False
+        assert graph.completeness.returned_nodes == len(graph.nodes)
+
+    def test_sqlite_budgeted_load_keeps_only_edges_between_kept_nodes(self, tmp_path: Path) -> None:
+        big = UnifiedGraph(scan_id="budget-edges", tenant_id="default")
+        for i in range(50):
+            big.add_node(UnifiedNode(id=f"asset:{i}", entity_type=EntityType.CLOUD_RESOURCE, label=f"a{i}", risk_score=float(i)))
+        for i in range(49):
+            big.add_edge(UnifiedEdge(source=f"asset:{i}", target=f"asset:{i + 1}", relationship=RelationshipType.DEPENDS_ON))
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        store.save_graph(big)
+
+        graph = store.load_graph(tenant_id="default", node_budget=10)
+        for edge in graph.edges:
+            assert edge.source in graph.nodes and edge.target in graph.nodes
+
+
+# ── the API surfaces ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def client(sqlite_store: SQLiteGraphStore) -> Iterator[TestClient]:
+    original = api_stores._graph_store
+    set_graph_store(sqlite_store)
+    try:
+        yield TestClient(app)
+    finally:
+        set_graph_store(original)
+
+
+# ── 3. deep offset is O(offset) on every paged surface ──────────────────────
+
+
+@pytest.mark.parametrize(
+    ("path", "params"),
+    [
+        ("/v1/graph", {}),
+        ("/v1/graph/agents", {}),
+        ("/v1/graph/search", {"q": "express"}),
+    ],
+)
+def test_deep_offset_is_rejected_on_every_node_paging_surface(client: TestClient, path: str, params: dict[str, str]) -> None:
+    from agent_bom.api.graph_store import MAX_NODE_PAGE_OFFSET
+
+    response = client.get(path, params={**params, "offset": MAX_NODE_PAGE_OFFSET + 1, "limit": 1})
+    assert response.status_code == 422, f"{path} accepted an offset past the cap"
+    assert "cursor" in response.json()["detail"], "the rejection must name the supported alternative"
+
+
+def test_shallow_offset_still_works_on_search(client: TestClient) -> None:
+    response = client.get("/v1/graph/search", params={"q": "express", "offset": 0, "limit": 10})
+    assert response.status_code == 200
+
+
+# ── 4. the graph response is the induced subgraph it documents ──────────────
+
+
+def _paged_estate(scan_id: str = "dangle") -> UnifiedGraph:
+    """High-risk nodes that fill page one, each attached to a low-risk neighbour."""
+    g = UnifiedGraph(scan_id=scan_id, tenant_id="default")
+    for i in range(3):
+        g.add_node(UnifiedNode(id=f"agent:{i}", entity_type=EntityType.AGENT, label=f"agent-{i}", risk_score=9.0 - i))
+        g.add_node(UnifiedNode(id=f"server:{i}", entity_type=EntityType.SERVER, label=f"srv-{i}", risk_score=0.0))
+        g.add_edge(UnifiedEdge(source=f"agent:{i}", target=f"server:{i}", relationship=RelationshipType.USES))
+    return g
+
+
+@pytest.fixture
+def paged_client(tmp_path: Path) -> Iterator[TestClient]:
+    store = SQLiteGraphStore(tmp_path / "paged.db")
+    store.save_graph(_paged_estate())
+    original = api_stores._graph_store
+    set_graph_store(store)
+    try:
+        yield TestClient(app)
+    finally:
+        set_graph_store(original)
+
+
+def test_graph_page_counts_the_edges_that_cross_its_boundary(paged_client: TestClient) -> None:
+    """The payload is not induced — so it must say how far past its nodes it reaches.
+
+    Dropping these edges was the wrong fix and was tried first: a page ranked by
+    severity puts the findings on it and their assets off it, so an induced page
+    hands back unattached dots (and starves the containment-ancestor walk, which
+    finds parents by looking at exactly these edges). The defect was the claim,
+    not the behaviour.
+    """
+    response = paged_client.get("/v1/graph", params={"limit": 3})
+    assert response.status_code == 200
+    body = response.json()
+    node_ids = {n["id"] for n in body["nodes"]}
+    crossing = [(e["source"], e["target"]) for e in body["edges"] if e["source"] not in node_ids or e["target"] not in node_ids]
+    assert crossing, "fixture no longer produces a boundary-crossing page, so this proves nothing"
+    assert body["completeness"]["boundary_edges"] == len(crossing), (
+        "the response must declare how many of its edges reach past its node list"
+    )
+
+
+def test_a_whole_page_declares_no_boundary_edges(paged_client: TestClient) -> None:
+    """When the page holds the whole estate, nothing crosses the boundary."""
+    response = paged_client.get("/v1/graph", params={"limit": 500})
+    body = response.json()
+    node_ids = {n["id"] for n in body["nodes"]}
+    assert len(node_ids) == 6
+    assert len(body["edges"]) == 3
+    assert body["completeness"]["boundary_edges"] == 0
+
+
+def test_the_documented_contract_matches_what_the_route_returns(paged_client: TestClient) -> None:
+    """The docstring claimed an induced subgraph the route has never returned."""
+    from agent_bom.api.routes.graph import get_graph
+
+    doc = get_graph.__doc__ or ""
+    assert "only include edges between returned nodes" not in doc
+    assert "boundary_edges" in doc
+
+
+# ── 5. an unfiltered stats read is served, not recomputed ───────────────────
+
+
+class TestSnapshotStatsReadsMaintainedCounts:
+    """``/v1/graph`` calls ``snapshot_stats`` on every page.
+
+    The entity-type and severity breakdowns are accumulated at write time, so an
+    unfiltered read is an O(1) lookup on the snapshot row. SQLite does that;
+    Postgres re-ran both GROUP BYs over ``graph_nodes`` on every request, which
+    is O(N) per page view of an estate that only gets bigger. The two backends
+    must answer this from the same place — and, whichever place, with the same
+    numbers.
+    """
+
+    def test_sqlite_serves_the_breakdown_from_the_snapshot_row(self, sqlite_store: SQLiteGraphStore) -> None:
+        import sqlite3
+
+        conn = sqlite3.connect(sqlite_store._db_path)
+        conn.execute(
+            "UPDATE graph_snapshots SET node_type_counts = ?, risk_summary = ? WHERE scan_id = 'sev-topo'",
+            ('{"agent": 41}', '{"critical": 42}'),
+        )
+        conn.commit()
+        conn.close()
+
+        stats = sqlite_store.snapshot_stats(tenant_id="default", scan_id="sev-topo")
+        assert stats["node_types"] == {"agent": 41}
+        assert stats["severity_counts"] == {"critical": 42}
+
+    def test_postgres_serves_the_breakdown_from_the_snapshot_row(self, postgres_store: Any) -> None:
+        """Tampered sentinels come back only if the read never touched graph_nodes."""
+        from agent_bom.api.postgres_common import _tenant_connection
+
+        with _tenant_connection(postgres_store._pool) as conn:
+            conn.execute(
+                "UPDATE graph_snapshots SET node_type_counts = %s, risk_summary = %s WHERE scan_id = %s AND tenant_id = %s",
+                ('{"agent": 41}', '{"critical": 42}', "sev-topo", "default"),
+            )
+            conn.commit()
+
+        stats = postgres_store.snapshot_stats(tenant_id="default", scan_id="sev-topo")
+        assert stats["node_types"] == {"agent": 41}, "Postgres re-aggregated graph_nodes instead of reading the maintained counts"
+        assert stats["severity_counts"] == {"critical": 42}
+
+    def test_postgres_falls_back_to_the_live_group_by_for_legacy_snapshots(self, postgres_store: Any) -> None:
+        """Rows written before the column existed are NULL; they must not read as empty."""
+        from agent_bom.api.postgres_common import _tenant_connection
+
+        with _tenant_connection(postgres_store._pool) as conn:
+            conn.execute(
+                "UPDATE graph_snapshots SET node_type_counts = NULL WHERE scan_id = %s AND tenant_id = %s",
+                ("sev-topo", "default"),
+            )
+            conn.commit()
+
+        stats = postgres_store.snapshot_stats(tenant_id="default", scan_id="sev-topo")
+        assert stats["node_types"] == {"agent": 1, "server": 1, "package": 1, "cloud_resource": 1, "role": 1, "vulnerability": 2}
+        assert stats["severity_counts"] == {"critical": 1, "low": 1}
+
+    def test_the_maintained_breakdown_equals_the_live_one(self, graph_store: Any) -> None:
+        """A cached count that disagrees with the estate is worse than a slow one."""
+        cached = graph_store.snapshot_stats(tenant_id="default", scan_id="sev-topo")
+        # An entity-type filter that admits everything forces the recompute path
+        # without narrowing the population it counts.
+        live = graph_store.snapshot_stats(
+            tenant_id="default",
+            scan_id="sev-topo",
+            entity_types={"agent", "server", "package", "cloud_resource", "role", "vulnerability"},
+        )
+        assert cached["node_types"] == live["node_types"]
+        assert cached["severity_counts"] == live["severity_counts"]
+        assert cached["total_nodes"] == live["total_nodes"]
+
+    def test_both_backends_report_the_same_stats(self, sqlite_store: SQLiteGraphStore, postgres_store: Any) -> None:
+        sqlite_stats = sqlite_store.snapshot_stats(tenant_id="default", scan_id="sev-topo")
+        postgres_stats = postgres_store.snapshot_stats(tenant_id="default", scan_id="sev-topo")
+        for key in ("total_nodes", "total_edges", "node_types", "severity_counts", "relationship_types"):
+            assert sqlite_stats[key] == postgres_stats[key], f"backends disagree on {key}"

--- a/tests/test_postgres_graph_streaming.py
+++ b/tests/test_postgres_graph_streaming.py
@@ -170,12 +170,15 @@ def test_streaming_snapshot_tally_matches_nodes(monkeypatch):
 
     # graph_snapshots row: counts plus serialized analysis execution state.
     assert conn.snapshot_params is not None
-    scan, tenant, _now, node_count, edge_count, risk_summary, analysis_status = conn.snapshot_params
+    scan, tenant, _now, node_count, edge_count, risk_summary, node_type_counts, analysis_status = conn.snapshot_params
     assert (scan, tenant, node_count, edge_count) == ("scan-2", "t1", 4, 0)
     import json
 
     # Two of four nodes carry "critical" severity (odd indices).
     assert json.loads(risk_summary) == {"critical": 2}
+    # The entity-type breakdown is accumulated in the same single pass, so an
+    # unfiltered stats read never has to GROUP BY graph_nodes again.
+    assert json.loads(node_type_counts) == {"agent": 2, "vulnerability": 2}
     assert json.loads(analysis_status)["attack_path_fusion"] == {
         "status": "skipped",
         "reason_codes": ["node_cap_exceeded"],

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -46,7 +46,7 @@ _FORK_GUARD_INDEX_CANON = "createuniqueindexifnotexistsaudit_log_team_prevsig_un
 
 # The newest migration. One place to update when a revision lands, so the
 # single-head property and the head's identity do not drift apart.
-ALEMBIC_HEAD = "20260810_01"
+ALEMBIC_HEAD = "20260812_01"
 
 
 def _canonical_sql(text: str) -> str:


### PR DESCRIPTION
Five graph read-path semantics answered the same question differently depending on which store replied and which query parameters were set. Every audit claim was reproduced against current code before anything changed; one did not hold up in the direction it was reported and is called out as such rather than "fixed".

**All five are pre-existing. None is a regression from #4760 or #4762.** Origins traced below — that distinction matters for release risk and a reviewer cannot derive it from the diff.

---

# The two that carry numbers

## 1. A severity filter DELETED the topology — it returned 1 of 5 nodes

*Pre-existing: #2879 (2026-06-04) fixed this for SQLite's paging path only.*

Only finding-like nodes carry a severity. Agents, servers, packages, cloud resources and identities all rank 0, so a floor applied to every row does not narrow the estate — it deletes the estate and leaves the findings floating unattached. **A filter that silently disconnects the graph is worse than a slow one:** the operator sees a scatter of dots and concludes there is no path to the critical finding.

Reproduced against a live Postgres, six-node estate, `min_severity_rank=4`:

| read path | SQLite | Postgres |
|---|---|---|
| `page_nodes` | `agent:a, cloud:bucket, pkg:express, server:fs, vuln:crit` (**5**) | `vuln:crit` (**1**) |
| `snapshot_stats.total_nodes` | 5 | 1 |
| `load_graph` | `vuln:crit` (**1**) | `vuln:crit` (**1**) |

It was worse than reported. **Both** backends' `load_graph` also collapsed the graph, so `GET /v1/graph?min_severity=high` answered differently depending on whether `relationships=` / `static_only` / `dynamic_only` was *also* set — those switch the route onto the `load_graph` branch. Same estate, same filter, two answers.

Five implementations, two answers:

| site | before |
|---|---|
| `api/graph_store.py::_min_severity_clause` | exempted non-findings ✅ |
| `api/postgres_graph.py` × 4 (`load_graph`, `snapshot_stats`, `page_nodes`, `search_nodes`) | raw floor ❌ |
| `db/graph_store.py` (`load_graph`, `iter_graph_nodes`) | raw floor ❌ |
| `api/neptune_graph.py::load_graph` | raw floor ❌ |
| `api/routes/graph.py::_node_matches_query` | exempted — but knew only 2 of the 3 rated entity types, so a drift incident survived here and was dropped by the stores |

The judgement now lives once, in `graph/severity_floor.py`: `node_passes_severity_floor()` for in-memory rows and `severity_floor_sql()` for a pushed-down `WHERE` fragment on either placeholder style, pinned against each other by test.

Postgres also applied its floor *after* the `LIMIT`, so a budgeted+filtered load returned fewer rows than its own budget while `total` counted a different population. Moving the floor into the `WHERE` clause fixes that as a side effect.

**On the seeded demo estate this is the visible payoff:** `?min_severity=critical` now returns 1,013 nodes — misconfiguration 323, role 138, vulnerability 113, package 111, environment 76 — instead of findings with nothing underneath them.

## 2. The SQLite node budget bounded the result, not the read — a real OOM path

*Pre-existing: #4479.*

`SQLiteGraphStore.load_graph` materialized the whole snapshot and called `apply_node_budget` afterwards; the comment admitted "Memory is not saved". Postgres pushed the limit into SQL. The budget exists precisely to stop a large estate from being loaded into memory, so applying it after materialization is a bound that is declared but applied too late to help.

Measured on a 200,000-node snapshot under a 5,000-node budget — **identical result both times** (5,000 nodes, `truncated=True`, `total=200000`):

| | peak allocation | wall |
|---|---|---|
| before | **270.2 MB** | **22.9 s** |
| after | **6.4 MB** | **2.8 s** |

Several of these can run concurrently on one worker, which is what makes it an OOM path rather than a slow path.

The gating test is deterministic rather than timing-based: it counts the `UnifiedNode` objects the load *constructs* — 5,000 built to return 5,000, where previously 5,000 were built for every 50 returned.

---

# The rest

## 3. `/v1/graph/search` had no deep-offset cap

*Pre-existing: #3669 added the cap to the node-paging routes only.*

`/v1/graph` and `/v1/graph/agents` reject `offset` past `MAX_NODE_PAGE_OFFSET`; `/v1/graph/search` accepted any value, and deep `OFFSET` is O(offset) because the store still walks and discards every skipped row. The route now enforces it, and **both stores** enforce it too, so a caller reaching a store directly (MCP, a job, a future route) cannot buy a scan the HTTP surface would refuse. Verified on the demo estate: `offset=999999` → 422.

## 5. Postgres re-aggregated every node on every unfiltered stats read

*Pre-existing.*

`GET /v1/graph` calls `snapshot_stats` on every page view. SQLite serves the entity-type and severity breakdowns from the `graph_snapshots` row; Postgres stored the severity breakdown, read neither, had no entity-type column at all, and re-ran both `GROUP BY`s over `graph_nodes` on every request — O(estate) per page view of an estate that only grows.

Adds `graph_snapshots.node_type_counts` (additive, nullable, live `GROUP BY` fallback for rows written before it existed), accumulates it in the same single write pass, and reads both breakdowns from the row.

Unfiltered `snapshot_stats` on live Postgres: **73.5 ms → 30.2 ms at 100k nodes.**

Honest remainder: both backends still aggregate `graph_edges` for `relationship_types`, which neither materializes, so stats are not yet flat in the estate. SQLite additionally pays a double id-membership subquery there that Postgres skips. I did **not** equalize that — removing SQLite's membership check would over-count if a snapshot ever persisted an edge whose endpoint is absent, and `save_graph_streaming` does not enforce that invariant. Flagged rather than silently traded away.

---

# Did not reproduce as reported

## 4. "Edge docs say induced subgraphs, but edges can dangle"

The dangling edges are real. **The documentation was the defect, not the behaviour.** `edges_for_node_ids` matches `source OR target` deliberately, for two reasons:

* a page is ranked by severity, so on a dense finding page the asset each finding hangs off is *not* on the page — an induced page returns unattached dots;
* `_containment_ancestors` finds parents *precisely* by looking at edges reaching in from outside the page.

I implemented the induced-subgraph fix first, and it broke three suites that pin this connectivity on purpose: `test_persisted_graph_routes_return_incident_edges_for_dense_finding_pages` (asserts ≥200 incident edges on a 200-node finding page), `test_containment_parents_still_reach_the_page`, and `test_demo_estate_graph_incident_chain_is_traversable`. That is the evidence the behaviour is intended, so I reverted the change rather than rewrite three deliberate tests.

The docstring is corrected to describe what the route actually returns and — fail closed — `completeness.boundary_edges` now counts the edges reaching past the node list, so a client cannot silently mistake the payload for an induced set. No new status word: the shared `graph_completeness()` envelope is untouched; this sits alongside the existing `ranked` / `context_nodes` keys, which the TS `GraphCompleteness` interface likewise does not declare, so it is additive-safe for the dashboard.

Verified on the demo estate: `boundary_edges: 23`, actual crossing edges 23.

---

# Pre-existing vs regression

| # | claim | origin | regression from #4760/#4762? |
|---|---|---|---|
| 1 | severity floor deletes topology | #2879 fixed SQLite paging only | **no** |
| 2 | budget applied after materialization | #4479 | **no** |
| 3 | no cap on search offset | #3669 capped node-paging routes only | **no** |
| 4 | edge docstring vs behaviour | #1289 (docstring), #1761/#2323 (OR match), #4679 (ancestors) | **no** |
| 5 | stats re-aggregation | pre-dates both | **no** |

# Test changed rather than added

`test_load_with_severity_filter` asserted that one node survives a floor over a four-node graph — exactly what the un-exempted floor produces. It encoded the behaviour #2879 declared wrong. It now asserts the topology survives alongside the critical finding. Two further tests were updated for the new column's shape (Alembic single-head constant; the streamed snapshot tally, which now unpacks `node_type_counts`).

# Blast radius

Schema (`graph_snapshots.node_type_counts` + Alembic `20260812_01` + `init.sql`) → stores (SQLite, Postgres, Neptune) → routes (`/v1/graph`, `/v1/graph/search`) → OpenAPI (regenerated) → tests → CHANGELOG. The migration is additive and nullable; its downgrade is deliberately non-destructive (matching `20260724_02`) because the writer inserts the column on every save. No backfill needed. No UI change: the field is an API/agent-facing diagnostic and the TS contract is unaffected.

# Verified

`origin/main` (#4773, #4775) is merged into this branch, not rebased. The merge touches nothing this PR touches — those two changed only `ui/`, `.github/`, and `cli/_demo.py`, and this PR changes no UI file.

**On the merged result:**

* Full `-k "graph"` sweep — **1,323 passed, 34 skipped, 0 failed** (838.9s).
* `test_graph_backend_semantics.py` + `test_postgres_migrations.py` + `test_postgres_graph_streaming.py` + `test_graph_min_severity_topology.py` + `test_compliance_summary_says_when_it_is_bounded.py` + `test_graph_scale_quickwins.py` — **106 passed** against **live Postgres 17** and SQLite through one parameterized fixture.
* `make preflight` · `make lint-ruff` · `make format-check` — green.
* `mypy` on all six changed modules — clean.

**On the pre-merge tree:**

* `-k "inventory or postgres"` — 862 passed.
* `-k "graph"` — 1,315 passed / 5 failed on an intermediate revision; all five were then addressed and re-verified green (three were the reverted induced-subgraph attempt, one the stale severity expectation, one the Alembic head constant).
* The previously-failing edge/demo suites — 59 passed.

Every new test was confirmed red for a *product* reason before the fix, not a harness error. Alembic `upgrade head` verified against both an existing database and a from-scratch one.
