### PR TITLE
chore(release): the release run owns the Docker MCP submission pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,12 @@ jobs:
       - name: Published counts match the shipped build
         run: python scripts/check_published_counts.py
 
+      # Format and reachability only, deliberately not freshness: the release
+      # run moves the pin by PR *after* the tag exists, so between the tag and
+      # that merge the pin is legitimately one release behind.
+      - name: Docker MCP submission pin is a real commit
+        run: python scripts/sync_docker_mcp_pin.py --check
+
       - name: Docker base-image policy
         if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         # Source: scripts/check_docker_base_policy.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1333,6 +1333,98 @@ jobs:
             echo "Updated floating tag $MAJOR → ${{ github.ref_name }}"
           fi
 
+  docker-mcp-pin:
+    name: Sync Docker MCP submission pin
+    # The pin must name the commit the tag points at, which does not exist
+    # until the tag does — so it cannot be written by bump-version.py with the
+    # other version-bearing artifacts. The release run owns it here instead of
+    # SUBMISSION.md asking a human to remember. Never blocks the release: the
+    # artifacts are already published by the time this runs.
+    needs: github-release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-python
+
+      - name: Write the tagged commit into the submission pin
+        id: pin
+        run: |
+          python scripts/sync_docker_mcp_pin.py --set "${{ github.sha }}"
+          if git diff --quiet -- integrations/docker-mcp-registry/server.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure signed automation commits
+        id: signing
+        if: steps.pin.outputs.changed == 'true'
+        env:
+          AUTOMATION_SSH_SIGNING_KEY: ${{ secrets.AUTOMATION_SSH_SIGNING_KEY }}
+        run: |
+          if [ -z "$AUTOMATION_SSH_SIGNING_KEY" ]; then
+            echo "AUTOMATION_SSH_SIGNING_KEY not configured — skipping PR creation."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          mkdir -p "$HOME/.ssh"
+          printf '%s\n' "$AUTOMATION_SSH_SIGNING_KEY" > "$HOME/.ssh/automation_signing_key"
+          chmod 600 "$HOME/.ssh/automation_signing_key"
+          ssh-keygen -y -f "$HOME/.ssh/automation_signing_key" > "$HOME/.ssh/automation_signing_key.pub"
+          eval "$(ssh-agent -s)"
+          ssh-add "$HOME/.ssh/automation_signing_key"
+          git config user.name "github-actions[bot]"
+          git config user.email "34316639+msaad00@users.noreply.github.com"
+          git config gpg.format ssh
+          git config user.signingkey "$HOME/.ssh/automation_signing_key.pub"
+          git config commit.gpgsign true
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open the pin-update PR
+        if: steps.pin.outputs.changed == 'true' && steps.signing.outputs.configured == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          TAGGED_SHA: ${{ github.sha }}
+        run: |
+          BRANCH="chore/docker-mcp-pin-${TAG}"
+          git switch -C "$BRANCH" origin/main
+          python scripts/sync_docker_mcp_pin.py --set "$TAGGED_SHA"
+          git add integrations/docker-mcp-registry/server.yaml
+          git commit -S -m "chore(docker-mcp): pin the submission to ${TAG}"
+          git push --force-with-lease origin "$BRANCH"
+          TITLE="chore(docker-mcp): pin the submission to ${TAG}"
+          BODY="\`integrations/docker-mcp-registry/server.yaml\` builds the published
+          server from \`source.commit\`. That commit is the one \`${TAG}\` points at,
+          so it cannot be written before the tag exists — this PR is opened by the
+          release run instead of the step SUBMISSION.md used to ask a human to
+          remember.
+
+          **Pin:** \`${TAGGED_SHA}\` (\`${TAG}\`)
+
+          Merging this is what makes the next \`docker/mcp-registry\` submission
+          build the released code. Nothing else in the release depends on it."
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --base main --json number --jq '.[0].number')
+          if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
+            gh pr edit "$PR_NUMBER" --title "$TITLE" --body "$BODY"
+          else
+            gh pr create --title "$TITLE" --body "$BODY" --base main
+          fi
+
+      - name: Pin already current
+        if: steps.pin.outputs.changed == 'false'
+        run: echo "Docker MCP submission pin already names ${{ github.sha }}."
+
   deploy-mcp-sse:
     name: Deploy MCP SSE
     needs: github-release

--- a/integrations/docker-mcp-registry/SUBMISSION.md
+++ b/integrations/docker-mcp-registry/SUBMISSION.md
@@ -19,8 +19,17 @@ Submission files for listing agent-bom in the Docker Desktop MCP Toolkit catalog
 ## Update process
 
 When releasing a new version:
-1. Update `source.commit` in `server.yaml` to the new release tag SHA
+1. `source.commit` is updated for you. The release run opens a
+   `chore/docker-mcp-pin-vX.Y.Z` PR against `main` carrying the tagged SHA —
+   the value cannot be written before the tag exists, which is why it is not
+   part of the version bump. Merge that PR.
 2. Submit a PR to `docker/mcp-registry` updating `servers/agent-bom/server.yaml`
+
+To move the pin by hand — a re-tag, or a release whose pin PR was not merged:
+
+```bash
+python scripts/sync_docker_mcp_pin.py --set "$(git rev-parse vX.Y.Z)"
+```
 
 ## Notes
 

--- a/scripts/sync_docker_mcp_pin.py
+++ b/scripts/sync_docker_mcp_pin.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Own the Docker MCP submission's ``source.commit`` from the release run.
+
+``integrations/docker-mcp-registry/server.yaml`` pins the commit Docker builds
+the published server from. Its correct value is the commit a release tag points
+at, which does not exist until the tag does — so it cannot be written by
+``bump-version.py`` along with the version, and it was instead carried as a
+manual step in ``SUBMISSION.md``. It was last updated by hand in a release that
+predates several since.
+
+``--set`` writes the pin; ``--check`` asserts it is a full commit SHA that is
+reachable in this repository. Freshness is not asserted here on purpose: the
+release run opens a PR to move the pin *after* the tag exists, so between the
+tag and that merge the pin is legitimately one release behind, and a gate that
+failed on it would fail every release.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SERVER_YAML = ROOT / "integrations" / "docker-mcp-registry" / "server.yaml"
+
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+COMMIT_LINE = re.compile(r"^([ \t]+commit:[ \t]+)([0-9a-f]{7,40})[ \t]*$")
+
+
+def _pin_line_index(lines: list[str]) -> int | None:
+    """Index of the ``commit:`` line inside the top-level ``source:`` block.
+
+    Scanned by line rather than matched across the document so an unrelated
+    ``commit:`` key elsewhere in the file can never be rewritten by accident.
+    """
+    in_source = False
+    for index, line in enumerate(lines):
+        if not line[:1].isspace() and line.strip():
+            in_source = line.startswith("source:")
+            continue
+        if in_source and COMMIT_LINE.match(line):
+            return index
+    return None
+
+
+def read_pin(text: str) -> str | None:
+    lines = text.splitlines()
+    index = _pin_line_index(lines)
+    if index is None:
+        return None
+    match = COMMIT_LINE.match(lines[index])
+    assert match is not None
+    return match.group(2)
+
+
+def write_pin(text: str, commit: str) -> str:
+    lines = text.splitlines(keepends=True)
+    index = _pin_line_index([line.rstrip("\n") for line in lines])
+    if index is None:
+        raise ValueError("no source.commit pin to write")
+    ending = "\n" if lines[index].endswith("\n") else ""
+    match = COMMIT_LINE.match(lines[index].rstrip("\n"))
+    assert match is not None
+    lines[index] = f"{match.group(1)}{commit}{ending}"
+    return "".join(lines)
+
+
+def _object_exists(commit: str) -> bool:
+    """True when the SHA names a commit present in this checkout.
+
+    A shallow or partial clone legitimately lacks older history, so absence is
+    reported by the caller as unknown rather than as a failure.
+    """
+    result = subprocess.run(
+        ["git", "cat-file", "-e", f"{commit}^{{commit}}"],
+        cwd=ROOT,
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def _is_shallow() -> bool:
+    result = subprocess.run(
+        ["git", "rev-parse", "--is-shallow-repository"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() == "true"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--set", metavar="SHA", help="write this commit as the pin")
+    group.add_argument("--check", action="store_true", help="validate the pin without writing")
+    parser.add_argument(
+        "--print-current",
+        action="store_true",
+        help="print the pin currently in the file and exit",
+    )
+    args = parser.parse_args()
+
+    if not SERVER_YAML.exists():
+        print(f"FAIL: {SERVER_YAML.relative_to(ROOT)} does not exist", file=sys.stderr)
+        return 1
+
+    text = SERVER_YAML.read_text(encoding="utf-8")
+    current = read_pin(text)
+    if current is None:
+        print(
+            f"FAIL: no source.commit pin found in {SERVER_YAML.relative_to(ROOT)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.print_current:
+        print(current)
+        return 0
+
+    if args.check:
+        if not FULL_SHA.match(current):
+            print(
+                f"FAIL: source.commit is not a full 40-character SHA: {current!r}",
+                file=sys.stderr,
+            )
+            return 1
+        if _object_exists(current):
+            print(f"Docker MCP pin OK — {current} is a commit in this repository")
+        elif _is_shallow():
+            print(f"Docker MCP pin {current} not verifiable in a shallow clone")
+        else:
+            print(
+                f"FAIL: source.commit {current} is not a commit in this repository",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    commit = args.set.strip().lower()
+    if not FULL_SHA.match(commit):
+        print(
+            f"FAIL: --set expects a full 40-character SHA, got {args.set!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if commit == current:
+        print(f"Docker MCP pin already {commit} — nothing to do")
+        return 0
+
+    SERVER_YAML.write_text(write_pin(text, commit), encoding="utf-8")
+    print(f"Docker MCP pin {current} -> {commit}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_docker_mcp_pin.py
+++ b/tests/test_docker_mcp_pin.py
@@ -1,0 +1,102 @@
+"""The Docker MCP submission pin is owned by the release run, not by memory.
+
+`integrations/docker-mcp-registry/server.yaml` builds the published server from
+`source.commit`. That value is the commit a release tag points at, so it cannot
+be written alongside the version bump, and it was carried for several releases
+as a line in SUBMISSION.md asking a human to remember.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVER_YAML = ROOT / "integrations" / "docker-mcp-registry" / "server.yaml"
+SUBMISSION = ROOT / "integrations" / "docker-mcp-registry" / "SUBMISSION.md"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+
+
+def _load_script(name: str) -> ModuleType:
+    path = ROOT / "scripts" / name
+    mod_name = name.removesuffix(".py")
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_shipped_pin_is_a_full_sha_reachable_in_this_repository() -> None:
+    pin = _load_script("sync_docker_mcp_pin.py")
+    current = pin.read_pin(SERVER_YAML.read_text(encoding="utf-8"))
+    assert current is not None, "server.yaml lost its source.commit pin"
+    assert re.fullmatch(r"[0-9a-f]{40}", current), f"source.commit must be a full SHA, not a prefix or a branch: {current!r}"
+    resolved = subprocess.run(
+        ["git", "cat-file", "-e", f"{current}^{{commit}}"],
+        cwd=ROOT,
+        capture_output=True,
+    )
+    shallow = subprocess.run(
+        ["git", "rev-parse", "--is-shallow-repository"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if shallow != "true":
+        assert resolved.returncode == 0, f"source.commit {current} is not a commit in this repository"
+
+
+def test_only_the_pin_under_source_is_rewritten() -> None:
+    """A `commit:` key in another block must survive a pin write untouched."""
+    pin = _load_script("sync_docker_mcp_pin.py")
+    document = (
+        "name: agent-bom\n"
+        "provenance:\n"
+        "  commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        "source:\n"
+        "  project: https://example.invalid\n"
+        "  commit: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+        "run:\n"
+        "  commit: cccccccccccccccccccccccccccccccccccccccc\n"
+    )
+    assert pin.read_pin(document) == "b" * 40
+    rewritten = pin.write_pin(document, "d" * 40)
+    assert "  commit: " + "a" * 40 in rewritten
+    assert "  commit: " + "c" * 40 in rewritten
+    assert "  commit: " + "d" * 40 in rewritten
+    assert "b" * 40 not in rewritten
+
+
+def test_set_refuses_anything_short_of_a_full_sha() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "sync_docker_mcp_pin.py"), "--set", "cc4640f"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "full 40-character SHA" in result.stderr
+    assert SERVER_YAML.read_text(encoding="utf-8").count("commit:") == 1
+
+
+def test_the_release_run_owns_the_pin() -> None:
+    """The job is what replaces the manual step; SUBMISSION.md must not re-add it."""
+    workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+    job = workflow["jobs"].get("docker-mcp-pin")
+    assert job is not None, "the release run no longer syncs the pin — SUBMISSION.md promises it does"
+    run_steps = "\n".join(step.get("run", "") for step in job["steps"])
+    assert 'sync_docker_mcp_pin.py --set "${{ github.sha }}"' in run_steps, "the pin job no longer writes the tagged commit"
+    assert job.get("continue-on-error") is True, "the pin job must not be able to fail a release whose artifacts are already published"
+
+    submission = SUBMISSION.read_text(encoding="utf-8")
+    update_section = submission.split("## Update process", 1)[1]
+    first_step = update_section.split("2.", 1)[0]
+    assert "updated for you" in first_step, "the update process reverted to asking a human to edit source.commit"


### PR DESCRIPTION
Closes the first of the two open pre-tag decisions: **the release run should own `server.yaml` the way it now owns `sdks/python`.**

## The problem the pin has that the version bump does not

`integrations/docker-mcp-registry/server.yaml` tells Docker which commit to build the published server from:

```yaml
source:
  commit: cc4640f10e4428f0c76ff989e0dd7bdf5c159239
```

That value is the commit a release tag points at — so unlike every other version-bearing artifact, it **cannot be written before the tag exists**. `bump-version.py` runs before tagging and structurally cannot own it. So it was carried as prose instead:

> `SUBMISSION.md` step 1: Update `source.commit` in `server.yaml` to the new release tag SHA

That is exactly the shape #4774 gated everywhere else — a value a human is asked to remember — and it drifted the same way: the pin has not moved in several releases.

## What now owns it

A `docker-mcp-pin` job runs after `github-release`, writes `${{ github.sha }}` into the pin and opens `chore/docker-mcp-pin-vX.Y.Z`.

- **Branch + PR, not a push to `main`** — matching `mcp-registry-sync.yml` and `uv-lock-upgrade.yml`, the repo's existing convention for CI-authored changes, and the same SSH-signed automation commit with the same graceful skip when `AUTOMATION_SSH_SIGNING_KEY` is unset.
- **`continue-on-error: true`, gated on `refs/tags/v`** — by the time it runs, PyPI, Docker Hub, Helm and the GitHub Release are already published. A pin PR that fails to open must not turn a shipped release red. A test asserts this, so it cannot be removed quietly.

## What CI gates — and what it deliberately does not

`sync_docker_mcp_pin.py --check` asserts the pin is a full 40-character SHA that is a real commit in this repository (a prefix or a branch name fails; a shallow clone reports unverifiable rather than failing).

**Freshness is deliberately not gated.** The release run moves the pin by PR *after* the tag exists, so between the tag and that merge the pin is legitimately one release behind. A freshness gate would fail every release — the precise reason to say so here rather than discover it during the next one.

## Verified

Each path was watched failing before it was made to pass:

| input | result |
|---|---|
| `--set deadbeef` | rejected — not a full SHA |
| `--set <real sha>` | `cc4640f1…` → `8675f48e…`, one line changed |
| `--set` same SHA again | no-op |
| pin truncated to `cc4640f` | `--check` fails |
| pin set to 40 zeroes | `--check` fails — not a commit here |

Four mutations, each confirmed to fail the guard that claims to catch it: deleting the `docker-mcp-pin` job, removing `continue-on-error`, reverting SUBMISSION.md to the manual step, and making `write_pin` rewrite every `commit:` key rather than only the one under `source:`.

Also green: `lint_release_workflow.py` (the release call-graph guard), `check_ci_pipefail.py`, `check_release_consistency.py`, `check_published_counts.py`, ruff, mypy.

## One thing found while writing this

My first implementation matched the pin with a `(?ms)` regex. Under `DOTALL`, `.` inside the lazy repeat swallowed newlines and the match backtracked catastrophically — it hung for over two minutes on a 47-line file rather than failing. Replaced with a line scanner, which is both bounded and easier to read. Flagging it because a ReDoS-shaped regex in a release-path script is worth not repeating.