### PR TITLE
feat: add optional You.com search intel tool

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -87,7 +87,7 @@ The self-hosted operator surface. Same evidence, multi-tenant, audited.
 | Subsystem | Path | Responsibility |
 |---|---|---|
 | API | `api/` | FastAPI app and route modules; middleware handles HTTP auth/tenant/limits/audit. SQLite and Postgres are the primary stores, Neptune is optional graph persistence, ClickHouse is optional analytics, and Snowflake implements selected store/warehouse paths. |
-| MCP server | `mcp_server*.py`, `mcp_tools/` | FastMCP server advertising 77 tools, 6 resources, and 8 workflow prompts (mostly read-only; Shield write actions fail closed). |
+| MCP server | `mcp_server*.py`, `mcp_tools/` | FastMCP server advertising 78 tools, 6 resources, and 8 workflow prompts (mostly read-only; Shield write actions fail closed). |
 | Runtime enforcement | `proxy*.py`, `gateway*.py`, `firewall*.py`, `shield.py`, `runtime/`, `enforcement.py` | MCP traffic proxy, secure-by-default gateway, inline firewall, Shield enforcement. **Spread by design** — see [Runtime enforcement spread](#runtime-enforcement-spread). |
 | Auth / tenancy | `rbac.py`, `permissions.py`, `entitlements.py`, `mcp_tenant.py`, `api/auth.py`, `api/oidc.py` | RBAC roles, tenant scoping, API keys, OIDC/SAML/SCIM. |
 | Fleet | `fleet/`, `fleet_scan.py` | Endpoint/collector inventory pushed into one control plane. |

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -115,7 +115,7 @@ helm upgrade --install agent-bom deploy/helm/agent-bom \
 - **Blast radius + attack-path fusion** — multi-hop exposure paths over one `UnifiedGraph`, from package → finding → MCP server → credentials → connected agents
 - **CWE-aware impact** — RCE shows credential exposure, DoS does not; symbol-level CVE reachability joins CWE/CVE/CPE advisory context when OSV/GHSA carry affected symbols (Python, npm, Go)
 - **Portable outputs** — SARIF, CycloneDX, SPDX, OCSF, HTML, graph, JSON, ZIP evidence bundles, and more
-- **MCP server mode** — 77 MCP tools, 6 resources, and 8 workflow prompts exposed to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
+- **MCP server mode** — 78 MCP tools, 6 resources, and 8 workflow prompts exposed to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
 - **Skill bundle identity** — stable bundle hashes for skill and instruction file review
 - **Dependency confusion detection** — flags internal naming patterns
 - **VEX generation** — auto-triage with CWE/CVE/CPE-aware reachability (package + function-level when advisory symbols exist)

--- a/README.md
+++ b/README.md
@@ -184,11 +184,15 @@ real identity, TLS, PostgreSQL, encryption, and audit keys before exposing it.
 | GitHub CI | `uses: msaad00/agent-bom@v0.100.0` | SARIF, PR summary, and a policy exit code |
 | Cloud evidence | `agent-bom connect aws` | Stored connection reference; run scans from the control plane |
 | Runtime gateway | `agent-bom gateway serve --from-control-plane http://127.0.0.1:8422 --bind 127.0.0.1:8090` | Allow, warn, and block audit events |
-| Agent interface | `agent-bom mcp server` | 77 MCP tools, 6 resources, and 8 workflow prompts |
+| Agent interface | `agent-bom mcp server` | 78 MCP tools, 6 resources, and 8 workflow prompts |
 | Agent distribution | [Smithery manifest](integrations/smithery.yaml) · [Glama](glama.json) · [MCP registry](integrations/mcp-registry) · [Docker MCP](integrations/docker-mcp-registry) | Registry-specific installation metadata |
 
-MCP server mode exposes 77 MCP tools, 6 resources, and 8 workflow prompts, all
+MCP server mode exposes 78 MCP tools, 6 resources, and 8 workflow prompts, all
 read-first: discovery and analysis never mutate a scanned target.
+
+Set `YDC_API_KEY` to enable the optional `youcom_search` MCP tool for live web
+and news context when you want current external intelligence alongside the
+local threat-intel database.
 
 The CLI, Docker, API, Helm chart, MCP server, gateway, and SDK are distribution
 surfaces of the same product. The Snowflake SPCS / Native App lane runs inside

--- a/README.md
+++ b/README.md
@@ -191,8 +191,10 @@ MCP server mode exposes 78 MCP tools, 6 resources, and 8 workflow prompts, all
 read-first: discovery and analysis never mutate a scanned target.
 
 Set `YDC_API_KEY` to enable the optional `youcom_search` MCP tool for live web
-and news context when you want current external intelligence alongside the
-local threat-intel database.
+and news context alongside the local threat-intel database. It is the only tool
+that sends your query to a third party, it is off unless the key is set, and the
+request is pinned to the You.com origin over TLS — so the key cannot be
+redirected to another host by configuration.
 
 The CLI, Docker, API, Helm chart, MCP server, gateway, and SDK are distribution
 surfaces of the same product. The Snowflake SPCS / Native App lane runs inside

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -1,6 +1,6 @@
 # MCP Server — Streamable HTTP transport for remote clients.
 #
-# Exposes agent-bom's 77 MCP tools over streamable HTTP so that Smithery, Claude
+# Exposes agent-bom's 78 MCP tools over streamable HTTP so that Smithery, Claude
 # Desktop (remote mode), and any other MCP client can connect via public URL.
 #
 # Build:   docker build -f deploy/docker/Dockerfile.sse -t agent-bom-sse .

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -22,7 +22,7 @@ the caller wants to explore or to invoke — not by whether it is human.
 
 | Area | Shipped today |
 |---|---|
-| MCP security tools | 77 tools, 6 resources, 8 workflow prompts |
+| MCP security tools | 78 tools, 6 resources, 8 workflow prompts |
 | REST API | 382 operations across 45 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -465,7 +465,7 @@ graph TB
 | Output | `src/agent_bom/output/__init__.py` | JSON, CycloneDX, SARIF, SPDX, console |
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine (17 conditions) |
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
-| MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (77 tools across core, operator, runtime-catalog, and specialized modules) |
+| MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (78 tools across core, operator, runtime-catalog, and specialized modules) |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse estate inventory; CIS posture where published and Databricks security best practices |
 | Cloud side-scan | `src/agent_bom/cloud/side_scan.py`, `src/agent_bom/cloud/side_scan_targets.py`, `src/agent_bom/cloud/side_scan_lifecycle.py`, `src/agent_bom/cloud/side_scan_provider_adapters.py` | Agentless workload side-scan (CWPP) — AWS EBS CLI executor; injected-SDK Azure Managed Disk and GCP Persistent Disk lifecycle adapters with durable ownership/cleanup state; Azure/GCP scheduler/CLI wiring and live credentialed proof are not shipped |
 | Registry sweep | `src/agent_bom/cloud/registry_sweep.py` | Registry-wide image enumeration + scan (ECR/ACR/GAR), digest-deduped, capped |

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -59,7 +59,7 @@ claude mcp add agent-bom -- uvx agent-bom mcp server
 
 ## What users get inside Claude
 
-`agent-bom mcp server` exposes 77 MCP tools for:
+`agent-bom mcp server` exposes 78 MCP tools for:
 
 - agent and MCP discovery
 - package and registry checks

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -237,7 +237,7 @@ For cross-agent correlation, use the broader runtime protection engine (`agent-b
 agent-bom mcp server
 ```
 
-Exposes 77 tools to any MCP-compatible AI assistant. Your agent can run scans,
+Exposes 78 tools to any MCP-compatible AI assistant. Your agent can run scans,
 check packages, query ExposurePaths, ask for deploy decisions, query threat
 intel, inspect runtime posture, run admin-gated Shield actions, and generate
 compliance reports without leaving the chat:

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -182,10 +182,10 @@ agent-bom proxy-bootstrap \
 | **AI supply chain** | `dataset_card_scan`, `training_pipeline_scan`, `browser_extension_scan`, `model_provenance_scan`, `prompt_scan`, `model_file_scan`, `ingest_external_scan`, `runtime_evidence_ingest` | Scan AI artifacts, prompts, model files, and browser extensions; import tool-agnostic SARIF/SBOM/scanner evidence without executing its producer; merge CWPP runtime signals |
 
 <details>
-<summary>Complete current catalog (77 tools)</summary>
+<summary>Complete current catalog (78 tools)</summary>
 
 `scan`, `check`, `intel_lookup`, `intel_match`, `intel_sources`,
-`intel_daily_brief`, `blast_radius`, `exposure_paths`, `should_i_deploy`,
+`intel_daily_brief`, `youcom_search`, `blast_radius`, `exposure_paths`, `should_i_deploy`,
 `policy_check`, `registry_lookup`, `generate_sbom`, `compliance`, `remediate`,
 `skill_scan`, `skill_verify`, `skill_trust`, `verify`, `inventory_summary`,
 `inventory_list`, `inventory_asset`, `where`, `tool_risk_assessment`,

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,6 +1,6 @@
 # MCP Server — Connect agent-bom to AI Assistants
 
-agent-bom exposes 77 MCP tools as an MCP server. Any MCP-compatible client can
+agent-bom exposes 78 MCP tools as an MCP server. Any MCP-compatible client can
 connect and get vulnerability scanning, blast radius analysis, compliance
 checks, runtime posture, and supply-chain verification through natural
 conversation.
@@ -165,7 +165,7 @@ agent-bom proxy-bootstrap \
 
 `proxy-configure` is best for JSON MCP clients such as Claude Desktop, Cursor, Windsurf, and Cortex CoCo. TOML-based clients like Codex CLI need manual proxy wrapping.
 
-## Tool Categories (77 tools)
+## Tool Categories (78 tools)
 
 | Category | Tools | What They Do |
 |----------|-------|-------------|

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -131,7 +131,7 @@ notes discuss agent-native product direction.
 | Area | Shipped today | Not yet shipped |
 |---|---|---|
 | Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
-| Agent interface | 77 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated write actions | long-lived posture subscription tool, autonomous remediation actions |
+| Agent interface | 78 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated write actions | long-lived posture subscription tool, autonomous remediation actions |
 | Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, Python/Go/TypeScript control-plane clients, TypeScript runtime detector package | full scanner SDKs |
 | Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions, **webhook outbox** for posture events | Kafka connectors, cloud-log ingestion connectors, Kinesis/Firehose adapter, and MCP posture subscriptions |
 | Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -4,7 +4,7 @@
   "metrics": [
     {
       "name": "MCP tools",
-      "value": 77,
+      "value": 78,
       "source": "src/agent_bom/mcp_server_metadata.py",
       "notes": "Counted from the advertised server-card tools."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -10,7 +10,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |
-| MCP tools | 77 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
+| MCP tools | 78 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 
 ## AI / agent developers (MCP · clients · tools)
 
-- [`MCP_SERVER.md`](MCP_SERVER.md) — run the MCP server, 77 tools
+- [`MCP_SERVER.md`](MCP_SERVER.md) — run the MCP server, 78 tools
 - [`MCP_CLIENT_GUIDES.md`](MCP_CLIENT_GUIDES.md) — connect MCP clients
 - [`PYTHON_API.md`](PYTHON_API.md) — Python control-plane client
 - [`PLUGIN_ENTRYPOINTS.md`](PLUGIN_ENTRYPOINTS.md) — opt-in plugin entry-point loader and author contract

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -102,7 +102,7 @@ scan a repo by URL.
 
 ```bash
 pip install 'agent-bom[mcp-server]'
-agent-bom mcp server                      # stdio MCP server: 77 tools, 6 resources, 8 prompts
+agent-bom mcp server                      # stdio MCP server: 78 tools, 6 resources, 8 prompts
 ```
 
 - MCP server setup + client guides: [`MCP_SERVER.md`](MCP_SERVER.md),

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -107,7 +107,7 @@ agent-bom mcp server                      # stdio MCP server: 78 tools, 6 resour
 
 - MCP server setup + client guides: [`MCP_SERVER.md`](MCP_SERVER.md),
   [`MCP_CLIENT_GUIDES.md`](MCP_CLIENT_GUIDES.md)
-- Tool catalog (77 tools; sensitive writes remain admin-gated): see the
+- Tool catalog (78 tools; sensitive writes remain admin-gated): see the
   `Tools (77)` block in
   [`../src/agent_bom/mcp_server.py`](../src/agent_bom/mcp_server.py)
 - Typed control-plane clients: [`PYTHON_API.md`](PYTHON_API.md),

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -91,7 +91,7 @@
 <rect x="488" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="496" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
 <text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">MCP server</text>
-<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">77 tools</text>
+<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">78 tools</text>
 <rect x="706" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="714" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(718,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
 <text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Fleet jobs</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -91,7 +91,7 @@
 <rect x="488" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="496" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
 <text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">MCP server</text>
-<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">77 tools</text>
+<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">78 tools</text>
 <rect x="706" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="714" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(718,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
 <text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Fleet jobs</text>

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -18,7 +18,7 @@
 <rect x="35" y="126" width="378" height="52" rx="8" fill="none" stroke="#fb7185" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#fb7185"/>
 <text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">382 API ops · 77 MCP tools · SARIF</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">382 API ops · 78 MCP tools · SARIF</text>
 <rect x="439" y="18" width="402" height="174" rx="12" fill="#2dd4bf"/>
 <rect x="439" y="22" width="402" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="453" y="32" width="40" height="40" rx="11" fill="#2dd4bf" opacity="0.16"/><g transform="translate(457,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#2dd4bf"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#2dd4bf"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#2dd4bf"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#2dd4bf" stroke-width="1.05"/></g></g>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -18,7 +18,7 @@
 <rect x="35" y="126" width="378" height="52" rx="8" fill="none" stroke="#e11d48" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#e11d48"/>
 <text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#18181b">Agent-native surface</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">382 API ops · 77 MCP tools · SARIF</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">382 API ops · 78 MCP tools · SARIF</text>
 <rect x="439" y="18" width="402" height="174" rx="12" fill="#0d9488"/>
 <rect x="439" y="22" width="402" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="453" y="32" width="40" height="40" rx="11" fill="#0d9488" opacity="0.10"/><g transform="translate(457,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0d9488"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0d9488"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0d9488"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#ffffff" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#0d9488" stroke-width="1.05"/></g></g>

--- a/glama.json
+++ b/glama.json
@@ -5,7 +5,7 @@
   ],
   "name": "agent-bom",
   "title": "agent-bom",
-  "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 77 read-first MCP tools for headless security agents.",
+  "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 78 read-first MCP tools for headless security agents.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/integrations/docker-mcp-registry/SUBMISSION.md
+++ b/integrations/docker-mcp-registry/SUBMISSION.md
@@ -5,7 +5,7 @@ Submission files for listing agent-bom in the Docker Desktop MCP Toolkit catalog
 ## Files
 
 - `server.yaml` — server metadata, image, allowed hosts, optional secrets
-- `tools.json` — all 77 MCP tools with descriptions and parameters
+- `tools.json` — all 78 MCP tools with descriptions and parameters
 - `readme.md` — Docker MCP Toolkit detail page content
 
 ## How to submit

--- a/integrations/docker-mcp-registry/server.yaml
+++ b/integrations/docker-mcp-registry/server.yaml
@@ -29,6 +29,8 @@ run:
   env:
     - name: NVD_API_KEY
       description: NVD API key for higher rate limits on vulnerability enrichment (optional)
+    - name: YDC_API_KEY
+      description: You.com API key enabling the optional youcom_search tool (optional)
   allowHosts:
     - api.osv.dev:443
     - services.nvd.nist.gov:443
@@ -37,6 +39,8 @@ run:
     - registry.npmjs.org:443
     - pypi.org:443
     - proxy.golang.org:443
+    # Only reached by youcom_search, and only when YDC_API_KEY is set.
+    - ydc-index.io:443
 
 config:
   secrets:
@@ -44,3 +48,7 @@ config:
       env: NVD_API_KEY
       example: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       description: "NVD API key — optional, increases rate limits for vulnerability enrichment"
+    - name: agent-bom.ydc_api_key
+      env: YDC_API_KEY
+      example: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      description: "You.com API key — optional, enables the youcom_search tool for live web/news context"

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -120,6 +120,52 @@
     ]
   },
   {
+    "name": "youcom_search",
+    "description": "Search You.com for current web/news context when YDC_API_KEY is configured.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "Free-text query for You.com web/news search"
+      },
+      {
+        "name": "count",
+        "type": "integer",
+        "desc": "Results per section, 1-100 (default 10)"
+      },
+      {
+        "name": "freshness",
+        "type": "string",
+        "desc": "Optional freshness filter: day, week, month, year, or YYYY-MM-DDtoYYYY-MM-DD"
+      },
+      {
+        "name": "country",
+        "type": "string",
+        "desc": "Optional two-letter country code, e.g. US"
+      },
+      {
+        "name": "language",
+        "type": "string",
+        "desc": "Optional BCP 47 language code, e.g. en"
+      },
+      {
+        "name": "safesearch",
+        "type": "string",
+        "desc": "Optional safesearch level: off, moderate, strict"
+      },
+      {
+        "name": "livecrawl",
+        "type": "string",
+        "desc": "Optional livecrawl mode: web, news, or all"
+      },
+      {
+        "name": "crawl_timeout",
+        "type": "integer",
+        "desc": "Optional livecrawl timeout in seconds, 1-60"
+      }
+    ]
+  },
+  {
     "name": "blast_radius",
     "description": "Look up the blast radius of a specific CVE \u2014 shows which agents, credentials, and tools are affected.",
     "arguments": [

--- a/integrations/smithery.yaml
+++ b/integrations/smithery.yaml
@@ -3,7 +3,7 @@
 # The startCommand / configSchema / commandFunction block below is the runtime
 # contract Smithery executes — do not change its shape.
 name: agent-bom
-description: "Open security scanner and self-hosted control plane for AI/MCP infrastructure — agents, MCP servers, runtime, and blast radius. Exposes 77 MCP tools for scanning, compliance, and graph analysis."
+description: "Open security scanner and self-hosted control plane for AI/MCP infrastructure — agents, MCP servers, runtime, and blast radius. Exposes 78 MCP tools for scanning, compliance, and graph analysis."
 homepage: "https://github.com/msaad00/agent-bom"
 
 runtime: "python"

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -546,7 +546,7 @@ def main() -> int:
     tools = len(tool_names)
     resources = len(resource_uris)
     prompts = len(prompt_names)
-    if (tools, resources, prompts) != (77, 6, 8):
+    if (tools, resources, prompts) != (78, 6, 8):
         _fail(f"MCP server card count changed unexpectedly: tools={tools}, resources={resources}, prompts={prompts}")
     docker_mcp_tool_names = [str(tool["name"]) for tool in json.loads(DOCKER_MCP_TOOLS.read_text())]
     if docker_mcp_tool_names != tool_names:

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Setup
 
-agent-bom runs as an MCP server, exposing 77 MCP tools to any MCP client.
+agent-bom runs as an MCP server, exposing 78 MCP tools to any MCP client.
 The server card also advertises 6 resources and 8 workflow prompts so agents can
 choose structured playbooks instead of guessing tool order.
 Most tools are read-only. Fourteen write-annotated tools cover scan-history

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -73,7 +73,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|---|
 | **CLI / CI** | developers and pipelines | local scans, SARIF/SBOM/HTML/JSON, graph exports, deterministic gates |
 | **REST API** | security platforms, SIEM jobs, custom services | self-hosted control-plane routes for scans, normalized bulk findings, dataset versions, evaluation runs, graph evidence, audit, and governance |
-| **MCP tools** | AI agents and coding assistants | 77 tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture, audited write actions |
+| **MCP tools** | AI agents and coding assistants | 78 tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture, audited write actions |
 | **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
 | **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |
 | **UI cockpit** | security teams and auditors | graph cockpit, compliance, audit, and evidence review over the same backend data |

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -11,10 +11,10 @@ admin role, the tool-specific write scope, and an audit reason; stdio cannot
 invoke them.
 
 <details>
-<summary>Complete current catalog (77 tools)</summary>
+<summary>Complete current catalog (78 tools)</summary>
 
 `scan`, `check`, `intel_lookup`, `intel_match`, `intel_sources`,
-`intel_daily_brief`, `blast_radius`, `exposure_paths`, `should_i_deploy`,
+`intel_daily_brief`, `youcom_search`, `blast_radius`, `exposure_paths`, `should_i_deploy`,
 `policy_check`, `registry_lookup`, `generate_sbom`, `compliance`, `remediate`,
 `skill_scan`, `skill_verify`, `skill_trust`, `verify`, `inventory_summary`,
 `inventory_list`, `inventory_asset`, `where`, `tool_risk_assessment`,

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -1075,7 +1075,7 @@ def mcp_server_cmd(
       docs/MCP_WORKFLOWS.md
 
     \b
-    Exposes 77 security tools via MCP protocol, organized behind 8 workflow
+    Exposes 78 security tools via MCP protocol, organized behind 8 workflow
     prompts. Advanced direct tools include skill_scan, skill_verify,
     compliance, and remediate.
 

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -879,10 +879,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
         query: Annotated[
             str,
             Field(
-                description=(
-                    "Free-text query for You.com web/news search, e.g. "
-                    "'CVE-2026-12345 exploit' or 'latest MCP security news'."
-                )
+                description=("Free-text query for You.com web/news search, e.g. 'CVE-2026-12345 exploit' or 'latest MCP security news'.")
             ),
         ],
         count: Annotated[int, Field(description="Results per section, 1-100.")] = 10,

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -5,13 +5,14 @@ Start with:
     agent-bom mcp server --transport sse          # SSE transport (for remote clients)
     agent-bom mcp server --transport streamable-http
 
-Tools (77):
+Tools (78):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
     intel_lookup        — Look up a CVE, GHSA, or OSV advisory from local threat intel
     intel_match         — Match package inventory coordinates to local advisory intel
     intel_sources       — Return canonical intel sources and local feed-run freshness
     intel_daily_brief   — Return a local analyst threat brief from governed intel sources
+    youcom_search       — Search You.com for current web/news context when YDC_API_KEY is configured
     blast_radius        — Look up blast radius for a specific CVE
     exposure_paths      — Return ranked ExposurePath JSON for headless agents and MCP clients
     should_i_deploy     — Return allow/warn/block from ExposurePath risk
@@ -557,7 +558,13 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
         policy_check_impl,
     )
     from agent_bom.mcp_tools.graph import deploy_decision_impl, exposure_paths_impl
-    from agent_bom.mcp_tools.intel import intel_daily_brief_impl, intel_lookup_impl, intel_match_impl, intel_sources_impl
+    from agent_bom.mcp_tools.intel import (
+        intel_daily_brief_impl,
+        intel_lookup_impl,
+        intel_match_impl,
+        intel_sources_impl,
+        youcom_search_impl,
+    )
     from agent_bom.mcp_tools.inventory import inventory_asset_impl, inventory_list_impl, inventory_summary_impl
     from agent_bom.mcp_tools.registry import registry_lookup_impl
     from agent_bom.mcp_tools.runtime import verify_impl
@@ -864,6 +871,44 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
             epss_threshold=epss_threshold,
             kev_window_hours=kev_window_hours,
             limit=limit,
+            _truncate_response=_truncate_response,
+        )
+
+    @mcp.tool(annotations=_READ_ONLY, title="Threat Intel You.com Search")
+    async def youcom_search(
+        query: Annotated[
+            str,
+            Field(
+                description=(
+                    "Free-text query for You.com web/news search, e.g. "
+                    "'CVE-2026-12345 exploit' or 'latest MCP security news'."
+                )
+            ),
+        ],
+        count: Annotated[int, Field(description="Results per section, 1-100.")] = 10,
+        freshness: Annotated[
+            str | None,
+            Field(description="Optional freshness filter: day, week, month, year, or YYYY-MM-DDtoYYYY-MM-DD."),
+        ] = None,
+        country: Annotated[str | None, Field(description="Optional two-letter country code, e.g. US.")] = None,
+        language: Annotated[str | None, Field(description="Optional BCP 47 language code, e.g. en.")] = None,
+        safesearch: Annotated[str | None, Field(description="Optional safesearch level: off, moderate, strict.")] = None,
+        livecrawl: Annotated[str | None, Field(description="Optional livecrawl mode: web, news, or all.")] = None,
+        crawl_timeout: Annotated[int, Field(description="Optional livecrawl timeout in seconds, 1-60.")] = 10,
+    ) -> str:
+        """Search You.com for current web or news context."""
+
+        return await _execute_tool_async(
+            "youcom_search",
+            youcom_search_impl,
+            query=query,
+            count=count,
+            freshness=freshness,
+            country=country,
+            language=language,
+            safesearch=safesearch,
+            livecrawl=livecrawl,
+            crawl_timeout=crawl_timeout,
             _truncate_response=_truncate_response,
         )
 

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -30,6 +30,11 @@ _SERVER_CARD_TOOLS = [
         "description": "Return a local analyst threat brief from governed intel sources",
         "annotations": {"readOnlyHint": True},
     },
+    {
+        "name": "youcom_search",
+        "description": "Search You.com for current web/news context when YDC_API_KEY is configured",
+        "annotations": {"readOnlyHint": True},
+    },
     {"name": "blast_radius", "description": "Look up blast radius for a specific CVE", "annotations": {"readOnlyHint": True}},
     {
         "name": "exposure_paths",

--- a/src/agent_bom/mcp_tools/intel.py
+++ b/src/agent_bom/mcp_tools/intel.py
@@ -4,12 +4,51 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+from typing import Any
 
+from agent_bom import __version__
+from agent_bom.http_client import create_client, request_with_retry
 from agent_bom.intel_lookup import build_daily_brief, list_intel_sources, lookup_advisory, match_packages
-from agent_bom.mcp_errors import CODE_INTERNAL_UNEXPECTED, CODE_VALIDATION_INVALID_ARGUMENT, mcp_error_json
+from agent_bom.mcp_errors import (
+    CODE_INTERNAL_UNEXPECTED,
+    CODE_UPSTREAM_UNAVAILABLE,
+    CODE_VALIDATION_INVALID_ARGUMENT,
+    CODE_VALIDATION_MISSING_REQUIRED,
+    mcp_error_json,
+)
 from agent_bom.security import sanitize_error
 
 logger = logging.getLogger(__name__)
+
+_YDC_BASE_URL = "https://ydc-index.io"
+
+
+def _youcom_result_summary(result: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact, stable view of a You.com search result."""
+    snippets = result.get("snippets") or []
+    if not isinstance(snippets, list):
+        snippets = [snippets]
+
+    summary = {
+        "title": result.get("title", ""),
+        "url": result.get("url", ""),
+        "description": result.get("description", ""),
+        "snippets": [str(snippet) for snippet in snippets if snippet][:3],
+        "page_age": result.get("page_age", ""),
+        "favicon_url": result.get("favicon_url", ""),
+        "thumbnail_url": result.get("thumbnail_url", ""),
+    }
+
+    contents = result.get("contents")
+    if isinstance(contents, dict):
+        summary["contents"] = {
+            key: contents[key]
+            for key in ("markdown", "html")
+            if contents.get(key)
+        }
+
+    return summary
 
 
 async def intel_lookup_impl(*, advisory_id: str, _truncate_response=lambda value: value) -> str:
@@ -111,3 +150,120 @@ async def intel_daily_brief_impl(
     except Exception as exc:  # pragma: no cover - defensive redaction
         logger.exception("MCP intel daily brief failed")
         return mcp_error_json(CODE_INTERNAL_UNEXPECTED, "Intel daily brief failed.", details={"error": sanitize_error(exc)})
+
+
+async def youcom_search_impl(
+    *,
+    query: str,
+    count: int = 10,
+    freshness: str | None = None,
+    country: str | None = None,
+    language: str | None = None,
+    safesearch: str | None = None,
+    livecrawl: str | None = None,
+    crawl_timeout: int = 10,
+    _truncate_response=lambda value: value,
+) -> str:
+    """Search You.com for current web or news context."""
+
+    try:
+        q = (query or "").strip()
+        if not q:
+            return mcp_error_json(
+                CODE_VALIDATION_INVALID_ARGUMENT,
+                "query is required",
+                details={"argument": "query"},
+            )
+
+        api_key = (os.environ.get("YDC_API_KEY") or "").strip()
+        if not api_key:
+            return mcp_error_json(
+                CODE_VALIDATION_MISSING_REQUIRED,
+                "YDC_API_KEY is required for You.com search.",
+                details={"environment_variable": "YDC_API_KEY"},
+            )
+
+        base_url = (os.environ.get("YOUCOM_BASE_URL") or _YDC_BASE_URL).rstrip("/")
+        params: dict[str, Any] = {
+            "query": q,
+            "count": max(1, min(int(count or 10), 100)),
+        }
+        if freshness:
+            params["freshness"] = freshness.strip()
+        if country:
+            params["country"] = country.strip().upper()
+        if language:
+            params["language"] = language.strip()
+        if safesearch:
+            params["safesearch"] = safesearch.strip()
+        if livecrawl:
+            params["livecrawl"] = livecrawl.strip()
+        if crawl_timeout:
+            params["crawl_timeout"] = max(1, min(int(crawl_timeout), 60))
+
+        async with create_client(timeout=20.0) as client:
+            response = await request_with_retry(
+                client,
+                "GET",
+                f"{base_url}/v1/search",
+                headers={
+                    "X-API-Key": api_key,
+                    "User-Agent": f"agent-bom/{__version__} youdotcom-integration/agent-bom",
+                },
+                params=params,
+            )
+
+        if response is None:
+            return mcp_error_json(
+                CODE_UPSTREAM_UNAVAILABLE,
+                "You.com search request failed.",
+                details={"upstream": "youcom_search", "reason": "request_exhausted"},
+            )
+
+        if response.status_code != 200:
+            return mcp_error_json(
+                CODE_UPSTREAM_UNAVAILABLE,
+                "You.com search returned an error.",
+                details={
+                    "upstream": "youcom_search",
+                    "status_code": response.status_code,
+                    "response": (response.text or "")[:500],
+                },
+            )
+
+        payload = response.json()
+        results = payload.get("results") if isinstance(payload, dict) else {}
+        web_results = results.get("web") if isinstance(results, dict) else []
+        news_results = results.get("news") if isinstance(results, dict) else []
+        metadata = payload.get("metadata") if isinstance(payload, dict) else {}
+
+        compact = {
+            "schema_version": "youcom.search.v1",
+            "query": q,
+            "metadata": {
+                "search_uuid": metadata.get("search_uuid", "") if isinstance(metadata, dict) else "",
+                "latency": metadata.get("latency", None) if isinstance(metadata, dict) else None,
+                "count": params["count"],
+                "freshness": params.get("freshness"),
+                "country": params.get("country"),
+                "language": params.get("language"),
+                "safesearch": params.get("safesearch"),
+                "livecrawl": params.get("livecrawl"),
+                "crawl_timeout": params.get("crawl_timeout"),
+                "base_url": base_url,
+            },
+            "results": {
+                "web": [_youcom_result_summary(item) for item in web_results if isinstance(item, dict)],
+                "news": [_youcom_result_summary(item) for item in news_results if isinstance(item, dict)],
+            },
+        }
+        return _truncate_response(json.dumps(compact, indent=2, default=str))
+    except ValueError as exc:
+        return mcp_error_json(
+            CODE_VALIDATION_INVALID_ARGUMENT,
+            sanitize_error(exc),
+            details={"argument": "youcom_search"},
+        )
+    except Exception as exc:  # pragma: no cover - defensive redaction
+        logger.exception("MCP You.com search failed")
+        return mcp_error_json(CODE_INTERNAL_UNEXPECTED, "You.com search failed.", details={"error": sanitize_error(exc)})

--- a/src/agent_bom/mcp_tools/intel.py
+++ b/src/agent_bom/mcp_tools/intel.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import logging
 import os
 from typing import Any
+from urllib.parse import urlsplit
 
 from agent_bom import __version__
 from agent_bom.http_client import create_client, request_with_retry
@@ -22,6 +24,42 @@ from agent_bom.security import sanitize_error
 logger = logging.getLogger(__name__)
 
 _YDC_BASE_URL = "https://ydc-index.io"
+_YDC_ALLOWED_HOSTS = frozenset({"ydc-index.io", "api.ydc-index.io"})
+
+
+def _resolve_youcom_base_url(raw: str | None) -> str:
+    """Return a base URL safe to send ``YDC_API_KEY`` to.
+
+    The request carries the caller's API key, so the host it goes to is not a
+    free parameter. An override is honoured only when it stays on a You.com
+    origin over TLS, or points at loopback — the same posture
+    ``ai_enrich._url_is_loopback`` takes for ``OPENAI_API_BASE``, and the one
+    ``cloud/azure_graph.py`` takes for credentialed Graph pagination.
+    """
+    if not raw or not raw.strip():
+        return _YDC_BASE_URL
+
+    candidate = raw.strip().rstrip("/")
+    parsed = urlsplit(candidate)
+    hostname = (parsed.hostname or "").strip().lower().rstrip(".")
+    if parsed.scheme not in {"http", "https"} or not hostname:
+        raise ValueError("YOUCOM_BASE_URL must be an http(s) URL")
+
+    is_loopback = hostname == "localhost" or hostname.endswith(".localhost")
+    if not is_loopback:
+        try:
+            is_loopback = ipaddress.ip_address(hostname).is_loopback
+        except ValueError:
+            is_loopback = False
+
+    if is_loopback:
+        return candidate
+
+    if parsed.scheme != "https":
+        raise ValueError("YOUCOM_BASE_URL must use https for a non-loopback host")
+    if hostname not in _YDC_ALLOWED_HOSTS and not hostname.endswith(".ydc-index.io"):
+        raise ValueError(f"refusing to send YDC_API_KEY off-origin to {hostname}")
+    return candidate
 
 
 def _youcom_result_summary(result: dict[str, Any]) -> dict[str, Any]:
@@ -42,11 +80,7 @@ def _youcom_result_summary(result: dict[str, Any]) -> dict[str, Any]:
 
     contents = result.get("contents")
     if isinstance(contents, dict):
-        summary["contents"] = {
-            key: contents[key]
-            for key in ("markdown", "html")
-            if contents.get(key)
-        }
+        summary["contents"] = {key: contents[key] for key in ("markdown", "html") if contents.get(key)}
 
     return summary
 
@@ -183,7 +217,7 @@ async def youcom_search_impl(
                 details={"environment_variable": "YDC_API_KEY"},
             )
 
-        base_url = (os.environ.get("YOUCOM_BASE_URL") or _YDC_BASE_URL).rstrip("/")
+        base_url = _resolve_youcom_base_url(os.environ.get("YOUCOM_BASE_URL"))
         params: dict[str, Any] = {
             "query": q,
             "count": max(1, min(int(count or 10), 100)),
@@ -227,14 +261,19 @@ async def youcom_search_impl(
                 details={
                     "upstream": "youcom_search",
                     "status_code": response.status_code,
-                    "response": (response.text or "")[:500],
+                    # Redacted before it reaches an MCP client: an upstream body
+                    # can echo the request, and the request carries the API key.
+                    "response": sanitize_error((response.text or "")[:500]),
                 },
             )
 
         payload = response.json()
         results = payload.get("results") if isinstance(payload, dict) else {}
-        web_results = results.get("web") if isinstance(results, dict) else []
-        news_results = results.get("news") if isinstance(results, dict) else []
+        # `or []` rather than a bare .get: You.com omits a section entirely when
+        # it has no hits, and iterating that None would surface as an internal
+        # error rather than an empty result set.
+        web_results = (results.get("web") or []) if isinstance(results, dict) else []
+        news_results = (results.get("news") or []) if isinstance(results, dict) else []
         metadata = payload.get("metadata") if isinstance(payload, dict) else {}
 
         compact = {

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -121,7 +121,7 @@ class TestAgentBom:
         assert "quick-audit" in r.output
         assert "gateway-fleet-live-demo" in r.output
         assert "full tool catalog" in r.output
-        assert "Exposes 77 security tools via MCP protocol" in r.output
+        assert "Exposes 78 security tools via MCP protocol" in r.output
         assert "organized behind 8 workflow" in r.output
 
     def test_secrets_help_has_common_output_flags(self):

--- a/tests/test_intel_lookup.py
+++ b/tests/test_intel_lookup.py
@@ -448,6 +448,87 @@ async def test_youcom_search_returns_compact_results(monkeypatch: pytest.MonkeyP
     assert body["results"]["news"][0]["title"] == "You.com News"
 
 
+@pytest.mark.parametrize(
+    "override",
+    [
+        "https://attacker.example",
+        "http://ydc-index.io",
+        "https://ydc-index.io.attacker.example",
+        "ftp://ydc-index.io",
+    ],
+)
+@pytest.mark.asyncio
+async def test_youcom_search_never_sends_the_key_off_origin(monkeypatch: pytest.MonkeyPatch, override: str) -> None:
+    """The request carries YDC_API_KEY, so its destination is not a free parameter."""
+    monkeypatch.setenv("YDC_API_KEY", "test-key")
+    monkeypatch.setenv("YOUCOM_BASE_URL", override)
+
+    def _no_client(**_kwargs):  # noqa: ANN003
+        raise AssertionError(f"a request was attempted against {override}")
+
+    monkeypatch.setattr("agent_bom.mcp_tools.intel.create_client", _no_client)
+
+    body = json.loads(await youcom_search_impl(query="agentic search"))
+
+    assert body["error"]["code"].endswith("VALIDATION_INVALID_ARGUMENT")
+
+
+@pytest.mark.asyncio
+async def test_youcom_search_allows_a_loopback_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Loopback stays usable for local testing, matching ai_enrich's posture."""
+    monkeypatch.setenv("YDC_API_KEY", "test-key")
+    monkeypatch.setenv("YOUCOM_BASE_URL", "http://127.0.0.1:8931")
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    seen: dict[str, str] = {}
+
+    async def _fake_request(_client, _method, url, **_kwargs):
+        seen["url"] = url
+        payload = {"results": {"web": [], "news": []}, "metadata": {}}
+        return SimpleNamespace(status_code=200, json=lambda: payload, text=json.dumps(payload))
+
+    monkeypatch.setattr("agent_bom.mcp_tools.intel.create_client", lambda timeout=20.0: _Client())
+    monkeypatch.setattr("agent_bom.mcp_tools.intel.request_with_retry", _fake_request)
+
+    body = json.loads(await youcom_search_impl(query="agentic search"))
+
+    assert body["schema_version"] == "youcom.search.v1"
+    assert seen["url"] == "http://127.0.0.1:8931/v1/search"
+
+
+@pytest.mark.asyncio
+async def test_youcom_search_defaults_to_the_youcom_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("YDC_API_KEY", "test-key")
+    monkeypatch.delenv("YOUCOM_BASE_URL", raising=False)
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    seen: dict[str, str] = {}
+
+    async def _fake_request(_client, _method, url, **_kwargs):
+        seen["url"] = url
+        payload = {"results": {"web": [], "news": []}, "metadata": {}}
+        return SimpleNamespace(status_code=200, json=lambda: payload, text=json.dumps(payload))
+
+    monkeypatch.setattr("agent_bom.mcp_tools.intel.create_client", lambda timeout=20.0: _Client())
+    monkeypatch.setattr("agent_bom.mcp_tools.intel.request_with_retry", _fake_request)
+
+    await youcom_search_impl(query="agentic search")
+
+    assert seen["url"] == "https://ydc-index.io/v1/search"
+
+
 @pytest.mark.asyncio
 async def test_governed_raw_artifact_fetch_records_metadata(monkeypatch, tmp_path) -> None:  # noqa: ANN001
     source = next(source for source in list_intel_sources()["sources"] if source["source_id"] == "cisa_kev")

--- a/tests/test_intel_lookup.py
+++ b/tests/test_intel_lookup.py
@@ -16,7 +16,13 @@ from agent_bom.intel_fetch import (
     store_raw_artifact,
 )
 from agent_bom.intel_lookup import build_daily_brief, list_intel_sources, lookup_advisory, match_packages
-from agent_bom.mcp_tools.intel import intel_daily_brief_impl, intel_lookup_impl, intel_match_impl, intel_sources_impl
+from agent_bom.mcp_tools.intel import (
+    intel_daily_brief_impl,
+    intel_lookup_impl,
+    intel_match_impl,
+    intel_sources_impl,
+    youcom_search_impl,
+)
 from tests.auth_helpers import PROXY_SECRET
 
 VIEWER_HEADERS = {
@@ -376,6 +382,70 @@ async def test_mcp_intel_tools_return_agent_native_json(intel_db) -> None:  # no
 
     brief = json.loads(await intel_daily_brief_impl(packages=[{"purl": "pkg:pypi/requests@2.31.0"}]))
     assert brief["schema_version"] == "intel.daily_brief.v1"
+
+
+@pytest.mark.asyncio
+async def test_youcom_search_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("YDC_API_KEY", raising=False)
+
+    body = json.loads(await youcom_search_impl(query="agentic search"))
+
+    assert body["error"]["code"].endswith("VALIDATION_MISSING_REQUIRED")
+    assert body["error"]["message"] == "YDC_API_KEY is required for You.com search."
+    assert body["error"]["details"] == {"environment_variable": "YDC_API_KEY"}
+
+
+@pytest.mark.asyncio
+async def test_youcom_search_returns_compact_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("YDC_API_KEY", "test-key")
+    monkeypatch.setenv("YOUCOM_BASE_URL", "https://ydc-index.io")
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    payload = {
+        "results": {
+            "web": [
+                {
+                    "title": "Agentic Search",
+                    "url": "https://example.com/agentic-search",
+                    "description": "Search results for agents.",
+                    "snippets": ["First snippet", "Second snippet"],
+                    "page_age": "2026-08-11T00:00:00",
+                }
+            ],
+            "news": [
+                {
+                    "title": "You.com News",
+                    "url": "https://example.com/news",
+                    "description": "News snippet.",
+                    "snippets": ["News snippet"],
+                }
+            ],
+        },
+        "metadata": {"search_uuid": "abc-123", "latency": 0.321},
+    }
+
+    async def _fake_request(_client, _method, _url, **_kwargs):
+        return SimpleNamespace(status_code=200, json=lambda: payload, text=json.dumps(payload))
+
+    monkeypatch.setattr("agent_bom.mcp_tools.intel.create_client", lambda timeout=20.0: _Client())
+    monkeypatch.setattr("agent_bom.mcp_tools.intel.request_with_retry", _fake_request)
+
+    body = json.loads(await youcom_search_impl(query="agentic search", count=3, freshness="week", country="us"))
+
+    assert body["schema_version"] == "youcom.search.v1"
+    assert body["query"] == "agentic search"
+    assert body["metadata"]["search_uuid"] == "abc-123"
+    assert body["metadata"]["count"] == 3
+    assert body["metadata"]["country"] == "US"
+    assert body["results"]["web"][0]["title"] == "Agentic Search"
+    assert body["results"]["web"][0]["snippets"] == ["First snippet", "Second snippet"]
+    assert body["results"]["news"][0]["title"] == "You.com News"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_tool_output_contract.py
+++ b/tests/test_mcp_tool_output_contract.py
@@ -105,6 +105,9 @@ def _minimal_args(name: str, workdir: Path) -> dict[str, Any]:
             "signals_json": "[]",
         },
         "intel_lookup": {"advisory_id": "GHSA-xxxx-xxxx-xxxx"},
+        # No YDC_API_KEY in CI, so this returns the structured missing-key
+        # error without touching the network — which is the contract.
+        "youcom_search": {"query": "agent-bom"},
         "inventory_asset": {"asset_id": "asset-does-not-exist"},
         "license_compliance_scan": {"scan_json": "{}"},
         "marketplace_check": {"package": "requests"},

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -2809,7 +2809,7 @@ function CodingAgentDrawer({ open, onClose }: { open: boolean; onClose: () => vo
       }
       headerAside={
         <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 dark:border-emerald-900/60 bg-emerald-500/10 dark:bg-emerald-950/30 px-2.5 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
-          <Bot className="h-3 w-3" /> 77 MCP tools
+          <Bot className="h-3 w-3" /> 78 MCP tools
         </span>
       }
     >

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -839,7 +839,7 @@ describe("ConnectionsPage — Connect segment", () => {
 
     const drawer = await screen.findByRole("dialog", { name: /Connect a coding agent/ });
     expect(within(drawer).getByText("agent-bom mcp-server")).toBeInTheDocument();
-    expect(within(drawer).getByText(/77 MCP tools/)).toBeInTheDocument();
+    expect(within(drawer).getByText(/78 MCP tools/)).toBeInTheDocument();
   });
 
   it("syncs the segmented tab to the URL", async () => {


### PR DESCRIPTION
This adds an optional You.com-backed search tool to the existing threat-intel MCP surface.

Why this fits here:
- `agent-bom` already has threat-intel, advisory, and daily-brief tools, so a live search helper is a natural extension for current context and news.
- I kept it opt-in: the tool only works when `YDC_API_KEY` is set.

What changed:
- Added `youcom_search` to the MCP server and server-card metadata.
- Implemented a compact You.com Search API helper that returns web/news results as JSON.
- Documented the new tool in the README and updated the MCP tool count.
- Added tests for the missing-key path and a mocked success path.

Setup:
- `YDC_API_KEY` enables the tool.
- `YOUCOM_BASE_URL` can override the default You.com host.

Usage example:
```text
agent-bom mcp server
# then call youcom_search from an MCP client
```

Fallback / error handling:
- If `YDC_API_KEY` is missing, the tool returns a clear validation error.
- Upstream API failures return a structured upstream-unavailable error.
- Existing default behavior is unchanged for users who do not set the new env var.

Validation:
- `uv sync --extra dev-all`
- `uv run python -m pytest tests/test_intel_lookup.py tests/test_mcp_server.py -q`
- `uv run ruff check src/agent_bom/mcp_tools/intel.py src/agent_bom/mcp_server.py src/agent_bom/mcp_server_metadata.py tests/test_intel_lookup.py tests/test_mcp_server.py`

Tracking issue:
- https://github.com/youdotcom-oss/integration-tracking/issues/185
