### PR TITLE
chore(release): the release run owns the Docker MCP pin, and the CHANGELOG records the wave

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,12 @@ jobs:
       - name: Published counts match the shipped build
         run: python scripts/check_published_counts.py
 
+      # Format and reachability only, deliberately not freshness: the release
+      # run moves the pin by PR *after* the tag exists, so between the tag and
+      # that merge the pin is legitimately one release behind.
+      - name: Docker MCP submission pin is a real commit
+        run: python scripts/sync_docker_mcp_pin.py --check
+
       - name: Docker base-image policy
         if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         # Source: scripts/check_docker_base_policy.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1333,6 +1333,98 @@ jobs:
             echo "Updated floating tag $MAJOR → ${{ github.ref_name }}"
           fi
 
+  docker-mcp-pin:
+    name: Sync Docker MCP submission pin
+    # The pin must name the commit the tag points at, which does not exist
+    # until the tag does — so it cannot be written by bump-version.py with the
+    # other version-bearing artifacts. The release run owns it here instead of
+    # SUBMISSION.md asking a human to remember. Never blocks the release: the
+    # artifacts are already published by the time this runs.
+    needs: github-release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-python
+
+      - name: Write the tagged commit into the submission pin
+        id: pin
+        run: |
+          python scripts/sync_docker_mcp_pin.py --set "${{ github.sha }}"
+          if git diff --quiet -- integrations/docker-mcp-registry/server.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure signed automation commits
+        id: signing
+        if: steps.pin.outputs.changed == 'true'
+        env:
+          AUTOMATION_SSH_SIGNING_KEY: ${{ secrets.AUTOMATION_SSH_SIGNING_KEY }}
+        run: |
+          if [ -z "$AUTOMATION_SSH_SIGNING_KEY" ]; then
+            echo "AUTOMATION_SSH_SIGNING_KEY not configured — skipping PR creation."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          mkdir -p "$HOME/.ssh"
+          printf '%s\n' "$AUTOMATION_SSH_SIGNING_KEY" > "$HOME/.ssh/automation_signing_key"
+          chmod 600 "$HOME/.ssh/automation_signing_key"
+          ssh-keygen -y -f "$HOME/.ssh/automation_signing_key" > "$HOME/.ssh/automation_signing_key.pub"
+          eval "$(ssh-agent -s)"
+          ssh-add "$HOME/.ssh/automation_signing_key"
+          git config user.name "github-actions[bot]"
+          git config user.email "34316639+msaad00@users.noreply.github.com"
+          git config gpg.format ssh
+          git config user.signingkey "$HOME/.ssh/automation_signing_key.pub"
+          git config commit.gpgsign true
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open the pin-update PR
+        if: steps.pin.outputs.changed == 'true' && steps.signing.outputs.configured == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          TAGGED_SHA: ${{ github.sha }}
+        run: |
+          BRANCH="chore/docker-mcp-pin-${TAG}"
+          git switch -C "$BRANCH" origin/main
+          python scripts/sync_docker_mcp_pin.py --set "$TAGGED_SHA"
+          git add integrations/docker-mcp-registry/server.yaml
+          git commit -S -m "chore(docker-mcp): pin the submission to ${TAG}"
+          git push --force-with-lease origin "$BRANCH"
+          TITLE="chore(docker-mcp): pin the submission to ${TAG}"
+          BODY="\`integrations/docker-mcp-registry/server.yaml\` builds the published
+          server from \`source.commit\`. That commit is the one \`${TAG}\` points at,
+          so it cannot be written before the tag exists — this PR is opened by the
+          release run instead of the step SUBMISSION.md used to ask a human to
+          remember.
+
+          **Pin:** \`${TAGGED_SHA}\` (\`${TAG}\`)
+
+          Merging this is what makes the next \`docker/mcp-registry\` submission
+          build the released code. Nothing else in the release depends on it."
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --base main --json number --jq '.[0].number')
+          if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
+            gh pr edit "$PR_NUMBER" --title "$TITLE" --body "$BODY"
+          else
+            gh pr create --title "$TITLE" --body "$BODY" --base main
+          fi
+
+      - name: Pin already current
+        if: steps.pin.outputs.changed == 'false'
+        run: echo "Docker MCP submission pin already names ${{ github.sha }}."
+
   deploy-mcp-sse:
     name: Deploy MCP SSE
     needs: github-release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,59 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Fixed
+## [0.100.0] - 2026-08-11
+
+An output-honesty release. Every local gate was already green before this work
+started; nothing here fixes a crash or a build. What it fixes is the gap between
+what agent-bom found and what it told you — findings that were computed and never
+surfaced, bounded reads that claimed to be complete, a scanner that reported
+clean where it had not looked, and two gates on the release path that could not
+have failed if there had been something to catch.
+
+If you run agent-bom against RHEL/UBI images, or read the executive view, or use
+the graph, this release changes what you see.
+
+### Security
+
+- **Two gates on the release path could never fail.** GitHub runs an unqualified
+  `run:` step as `bash -e {0}` — without `-o pipefail` — so `osv-scanner … | tee`
+  exited with `tee`'s status and the `|| { … }` fixable-CVE branch below it was
+  unreachable. That dead branch was the blocking logic in `ci.yml` *and* in
+  `release.yml`, where the step is named "block release on fixable CVEs". Every
+  release that passed that step passed it vacuously. The same defect was found in
+  17 steps across 9 workflows. Both halves are worth stating plainly: the gate
+  could not have reported a vulnerable dependency — and, run for real against all
+  three lockfiles, it reports none, so nothing was shipped vulnerable.
+  `scripts/check_ci_pipefail.py` now blocks the class.
+- CI bootstrapped Postgres from `init.sql` alone while the Docker entrypoint
+  mounts `init.sql` *and* `runtime-schema.sql`. Both paths ended on the same
+  Alembic head with a different schema — `hub_findings_current_observations`
+  partitioned with `observed_at timestamptz` on one and plain with
+  `observed_at text` on the other. Matching heads never proved matching schemas;
+  a `pg_dump --schema-only` diff now does.
+- A read-only bind mount in `deploy/docker-compose.yml` pointed at `deploy/tests`
+  rather than the repository's `tests/`. Docker creates a missing read-only bind
+  source as an empty directory instead of failing, so the container scanned
+  nothing and had no way to say so.
+- Secret scanning no longer reports a file it never opened as clean. Files over
+  the size ceiling and files that could not be read were returned as "no
+  findings" and counted toward `files_scanned`. They are now named in `warnings`
+  and excluded from the coverage count. `.tfstate` and `.tfvars` join the
+  scanned extensions — `.tf` was already there, so the two files in a Terraform
+  repo most likely to hold a plaintext provider credential were never opened at
+  any size.
+- WebSocket streams failed open when the auth posture could not be derived, and
+  DLP excerpts echoed the secret they were redacting.
+- Microsoft Graph pagination is pinned to the origin that issued the token, so a
+  bearer token can no longer follow a `@odata.nextLink` off-origin.
+- The governance audit chain gained the fork guard its sibling chain already had.
+- Ingested `graph_reachable: true` is rejected unless the row names an agent that
+  reaches the finding. `dependency_reach` defines reachable as
+  `bool(reachable_from)`; a claim with no path contradicted that definition and
+  still collected the reachability risk boost, outranking findings the engine had
+  actually proved.
+
+### Fixed — wrong or missing output
 
 - A `min_severity` filter no longer deletes the graph it was meant to narrow.
   Only findings carry a severity, so applying the floor to every node dropped
@@ -32,40 +84,45 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - Unfiltered graph statistics are served from the snapshot row on Postgres
   instead of re-aggregating every node on each page view, matching SQLite. At
   100k nodes: 73.5ms to 30.2ms.
-
-## [0.100.0] - 2026-08-11
-
-An output-honesty release. Every local gate was already green before this work
-started; nothing here fixes a crash or a build. What it fixes is the gap between
-what agent-bom found and what it told you — findings that were computed and never
-surfaced, bounded reads that claimed to be complete, and a scanner that reported
-clean where it had not looked.
-
-If you run agent-bom against RHEL/UBI images, or read the executive view, or use
-the graph, this release changes what you see.
-
-### Security
-
-- Secret scanning no longer reports a file it never opened as clean. Files over
-  the size ceiling and files that could not be read were returned as "no
-  findings" and counted toward `files_scanned`. They are now named in `warnings`
-  and excluded from the coverage count. `.tfstate` and `.tfvars` join the
-  scanned extensions — `.tf` was already there, so the two files in a Terraform
-  repo most likely to hold a plaintext provider credential were never opened at
-  any size.
-- WebSocket streams failed open when the auth posture could not be derived, and
-  DLP excerpts echoed the secret they were redacting.
-- Microsoft Graph pagination is pinned to the origin that issued the token, so a
-  bearer token can no longer follow a `@odata.nextLink` off-origin.
-- The governance audit chain gained the fork guard its sibling chain already had.
-- Ingested `graph_reachable: true` is rejected unless the row names an agent that
-  reaches the finding. `dependency_reach` defines reachable as
-  `bool(reachable_from)`; a claim with no path contradicted that definition and
-  still collected the reachability risk boost, outranking findings the engine had
-  actually proved.
-
-### Fixed — wrong or missing output
-
+- The hosted-demo deploy gate asserted an estate that no longer exists — exact
+  dict equality against 20 assets, 15 observations and 4 correlations, where the
+  seeded estate now builds 3,860 assets, 12,171 observations and 2,322
+  correlations. That gate runs *after* the Release workflow, so a tag would have
+  shipped the release and broken the demo deploy in the same run. It now asserts
+  the contract — shape, floors, and the source breakdown that is genuinely fixed
+  — rather than a snapshot of one day's numbers.
+- `agent-bom demo` printed `http://127.0.0.1:8000/demo-estate` while the API
+  serves 8422.
+- The advertised MCP registry size was stale on six surfaces, **two of them
+  strings the product emits at runtime**: the `registry://servers` resource
+  description every MCP client reads said 1,013 servers while the resource
+  returned 1,081. `docs/skills/mcp-server-review.md` additionally claimed 940
+  verified entries against an actual 60 — a 15x overstatement of verification
+  coverage on a security registry. The count is now derived from the bundled
+  registry at registration time, and a test sweeps whole shipping-surface trees
+  — including SVG diagrams, which the consistency check skipped entirely — rather
+  than a hand-maintained file list.
+- The documented first-run command did not run: `examples/` taught
+  `--no-update-db`, a flag that has never existed. The test written to catch
+  exactly this read `README.md` only and validated only *path* options, so
+  neither the file nor the flag name was in its reach. It now covers every
+  `examples/**.md` and asserts each flag it teaches resolves on the command.
+- `sdks/python` had been at `0.92.0` against a `0.100.0` platform since it was
+  bumped by hand once and then forgotten. It re-exports the client out of the
+  `agent-bom` wheel it depends on, so it tracks the platform and is now owned by
+  `bump-version.py`. The TypeScript SDKs stay independent on their own 0.x npm
+  line — retagging them to 0.100.0 would fabricate ~99 releases for their
+  consumers — and that split is now enforced rather than assumed.
+- The 2D graph canvas grew without bound: `drawGraph` wrote `canvas.height` from
+  `clientHeight` on an in-flow canvas, so each draw grew the element and the
+  `ResizeObserver` triggered the next. On a 1,241-node estate the canvas reached
+  21,604px and the operator was looking at an empty slice of it. Taking it out of
+  flow holds it at 680px.
+- CLI help and docs advertised registry coverage as "112 to 2800+" and a
+  "427-server" bundled registry. Both were long stale and are now stated without
+  a count rather than re-pinned to a new one.
+- `CONTRIBUTING.md` claimed "7,000+ monthly installs", which nothing in this
+  repository can substantiate. Removed rather than restated.
 - **RHEL / UBI / AlmaLinux / Rocky images read zero packages.** The scanner
   queried an `rpmdb.sqlite` schema those images do not ship, so every scan of
   them returned a false clean. This is the most consequential fix in the release.
@@ -100,6 +157,46 @@ the graph, this release changes what you see.
   advertises the reachable URL rather than its bind address.
 - CI runs the CVE accuracy measurements that already existed and had never been
   wired to a workflow.
+- **Pre-publish drift gates.** Every stale claim in this release existed because
+  a number or a contract was written once and never recomputed, so each gate
+  derives the truth from the artifact that ships: release-version consistency,
+  discovered structurally across `sdks/`, compose files, k8s manifests and
+  Dockerfiles, where a genuinely independent version must declare itself with a
+  reason and silence fails closed; external-surface freshness for registry and
+  MCP tool/resource/prompt counts; a runtime JSON-RPC check that boots the real
+  MCP server over stdio and compares *names* — not counts — against the wheel's
+  own server card; Postgres schema parity by `pg_dump` diff; and a rendered
+  `docker compose config` contract asserting every service resolves, every
+  `depends_on` names a real service, and every read-only bind source exists.
+  Nothing in CI had ever run `docker compose config` while the deploy docs told
+  operators the stack passes it. Every gate was watched failing on real input
+  before it was made to pass, and six of those failures were live on `main`.
+- A text equivalent for the graph canvas. Past 200 nodes / 500 edges the page
+  swaps React Flow for a 2D canvas or a WebGL stage, which offered a screen
+  reader only a widget label and a sentence about the draw budget — no node, no
+  relationship, no severity. Both stages now render a census by node and
+  relationship type, the nodes ranked by severity and connection count, and the
+  connections spelled out as sentences, wired to the canvas by `role="img"` and
+  `aria-describedby`. Every truncation is stated rather than applied silently.
+- **Continue offline with a report file**, on the auth failure screens and the
+  login page. The offline report importer was mounted inside the auth gate, so
+  the feature built for "no working backend" could not render in exactly that
+  situation. It is opt-in, grants no data — every API call behind it fails
+  exactly as it would have — and lives in `sessionStorage`, so it dies with the
+  tab.
+- `SUPPORT.md`, the one community-health file GitHub surfaces that this
+  repository lacked. The only support routing that existed was in
+  `docs/archive/`, a folder whose own README says it holds material that should
+  not crowd the primary documentation. It promises no new SLA: the only
+  committed response time remains the one `SECURITY.md` already makes.
+- `GET /v1/graph` reports `completeness.boundary_edges` — the count of edges
+  reaching past the returned node list — so a client cannot mistake the payload
+  for an induced subgraph.
+- The release run owns the Docker MCP submission pin. `source.commit` names the
+  commit a release tag points at, so it cannot be written before the tag exists
+  and could not ride along with the version bump; it was a line in SUBMISSION.md
+  asking a human to remember, and had not moved in several releases. The release
+  now opens a PR carrying the tagged SHA.
 
 ### Changed
 
@@ -111,6 +208,23 @@ the graph, this release changes what you see.
   cards.
 - ATLAS is an applicability overlay, not 65 failing controls.
 - TanStack Table upgraded to v9.
+- A non-zero `scan` exit reads as a verdict rather than a crash. The exit code
+  itself is unchanged; what changed is that the CLI names the gate that fired and
+  links the contract, `scan --help` documents the two gates that fail closed with
+  no flag set — a known-malicious package, and a scan that did not complete —
+  rather than implying exit 1 is reachable only via `--fail-on-*`, and
+  `docs/FIRST_RUN.md` no longer contradicts itself between §1 and §5. The note is
+  suppressed under `--quiet` so CI output stays machine-clean.
+- Dense lineage graphs open at a readable zoom. The roll-up grid had already been
+  fixed, but the raw lineage branch lays out through dagre, which stacks a wide,
+  shallow DAG into a portrait tower dropped into a landscape canvas — one agent
+  fanning out to 40 servers fit at 0.064. Ranks now reflow into sub-columns when
+  it materially improves the fit, preserving rank order; the same shape opens at
+  0.380.
+- The large graph surfaces render in light mode. Both overview renderers painted
+  a fixed `#050505` stage with light labels regardless of theme, so on a light
+  page the largest element on screen was a black rectangle with its own contrast
+  rules. The severity chips on those surfaces had the mirror-image problem.
 
 ## [0.99.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,12 @@ the graph, this release changes what you see.
 - `GET /v1/graph` reports `completeness.boundary_edges` — the count of edges
   reaching past the returned node list — so a client cannot mistake the payload
   for an induced subgraph.
+- `youcom_search`, an optional MCP tool returning live web and news context
+  alongside the local threat-intel database, contributed by @mouse-value-add.
+  It is the only tool that sends a query to a third party, so it is off unless
+  `YDC_API_KEY` is set, and the credentialed request is pinned to the You.com
+  origin over TLS — `YOUCOM_BASE_URL` cannot redirect the key to another host.
+  This brings the MCP surface to 78 tools.
 - The release run owns the Docker MCP submission pin. `source.commit` names the
   commit a release tag points at, so it cannot be written before the tag exists
   and could not ride along with the version bump; it was a line in SUBMISSION.md

--- a/integrations/docker-mcp-registry/SUBMISSION.md
+++ b/integrations/docker-mcp-registry/SUBMISSION.md
@@ -19,8 +19,17 @@ Submission files for listing agent-bom in the Docker Desktop MCP Toolkit catalog
 ## Update process
 
 When releasing a new version:
-1. Update `source.commit` in `server.yaml` to the new release tag SHA
+1. `source.commit` is updated for you. The release run opens a
+   `chore/docker-mcp-pin-vX.Y.Z` PR against `main` carrying the tagged SHA —
+   the value cannot be written before the tag exists, which is why it is not
+   part of the version bump. Merge that PR.
 2. Submit a PR to `docker/mcp-registry` updating `servers/agent-bom/server.yaml`
+
+To move the pin by hand — a re-tag, or a release whose pin PR was not merged:
+
+```bash
+python scripts/sync_docker_mcp_pin.py --set "$(git rev-parse vX.Y.Z)"
+```
 
 ## Notes
 

--- a/scripts/sync_docker_mcp_pin.py
+++ b/scripts/sync_docker_mcp_pin.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Own the Docker MCP submission's ``source.commit`` from the release run.
+
+``integrations/docker-mcp-registry/server.yaml`` pins the commit Docker builds
+the published server from. Its correct value is the commit a release tag points
+at, which does not exist until the tag does — so it cannot be written by
+``bump-version.py`` along with the version, and it was instead carried as a
+manual step in ``SUBMISSION.md``. It was last updated by hand in a release that
+predates several since.
+
+``--set`` writes the pin; ``--check`` asserts it is a full commit SHA that is
+reachable in this repository. Freshness is not asserted here on purpose: the
+release run opens a PR to move the pin *after* the tag exists, so between the
+tag and that merge the pin is legitimately one release behind, and a gate that
+failed on it would fail every release.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SERVER_YAML = ROOT / "integrations" / "docker-mcp-registry" / "server.yaml"
+
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+COMMIT_LINE = re.compile(r"^([ \t]+commit:[ \t]+)([0-9a-f]{7,40})[ \t]*$")
+
+
+def _pin_line_index(lines: list[str]) -> int | None:
+    """Index of the ``commit:`` line inside the top-level ``source:`` block.
+
+    Scanned by line rather than matched across the document so an unrelated
+    ``commit:`` key elsewhere in the file can never be rewritten by accident.
+    """
+    in_source = False
+    for index, line in enumerate(lines):
+        if not line[:1].isspace() and line.strip():
+            in_source = line.startswith("source:")
+            continue
+        if in_source and COMMIT_LINE.match(line):
+            return index
+    return None
+
+
+def read_pin(text: str) -> str | None:
+    lines = text.splitlines()
+    index = _pin_line_index(lines)
+    if index is None:
+        return None
+    match = COMMIT_LINE.match(lines[index])
+    assert match is not None
+    return match.group(2)
+
+
+def write_pin(text: str, commit: str) -> str:
+    lines = text.splitlines(keepends=True)
+    index = _pin_line_index([line.rstrip("\n") for line in lines])
+    if index is None:
+        raise ValueError("no source.commit pin to write")
+    ending = "\n" if lines[index].endswith("\n") else ""
+    match = COMMIT_LINE.match(lines[index].rstrip("\n"))
+    assert match is not None
+    lines[index] = f"{match.group(1)}{commit}{ending}"
+    return "".join(lines)
+
+
+def _object_exists(commit: str) -> bool:
+    """True when the SHA names a commit present in this checkout.
+
+    A shallow or partial clone legitimately lacks older history, so absence is
+    reported by the caller as unknown rather than as a failure.
+    """
+    result = subprocess.run(
+        ["git", "cat-file", "-e", f"{commit}^{{commit}}"],
+        cwd=ROOT,
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def _is_shallow() -> bool:
+    result = subprocess.run(
+        ["git", "rev-parse", "--is-shallow-repository"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() == "true"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--set", metavar="SHA", help="write this commit as the pin")
+    group.add_argument("--check", action="store_true", help="validate the pin without writing")
+    parser.add_argument(
+        "--print-current",
+        action="store_true",
+        help="print the pin currently in the file and exit",
+    )
+    args = parser.parse_args()
+
+    if not SERVER_YAML.exists():
+        print(f"FAIL: {SERVER_YAML.relative_to(ROOT)} does not exist", file=sys.stderr)
+        return 1
+
+    text = SERVER_YAML.read_text(encoding="utf-8")
+    current = read_pin(text)
+    if current is None:
+        print(
+            f"FAIL: no source.commit pin found in {SERVER_YAML.relative_to(ROOT)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.print_current:
+        print(current)
+        return 0
+
+    if args.check:
+        if not FULL_SHA.match(current):
+            print(
+                f"FAIL: source.commit is not a full 40-character SHA: {current!r}",
+                file=sys.stderr,
+            )
+            return 1
+        if _object_exists(current):
+            print(f"Docker MCP pin OK — {current} is a commit in this repository")
+        elif _is_shallow():
+            print(f"Docker MCP pin {current} not verifiable in a shallow clone")
+        else:
+            print(
+                f"FAIL: source.commit {current} is not a commit in this repository",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    commit = args.set.strip().lower()
+    if not FULL_SHA.match(commit):
+        print(
+            f"FAIL: --set expects a full 40-character SHA, got {args.set!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if commit == current:
+        print(f"Docker MCP pin already {commit} — nothing to do")
+        return 0
+
+    SERVER_YAML.write_text(write_pin(text, commit), encoding="utf-8")
+    print(f"Docker MCP pin {current} -> {commit}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_docker_mcp_pin.py
+++ b/tests/test_docker_mcp_pin.py
@@ -1,0 +1,102 @@
+"""The Docker MCP submission pin is owned by the release run, not by memory.
+
+`integrations/docker-mcp-registry/server.yaml` builds the published server from
+`source.commit`. That value is the commit a release tag points at, so it cannot
+be written alongside the version bump, and it was carried for several releases
+as a line in SUBMISSION.md asking a human to remember.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVER_YAML = ROOT / "integrations" / "docker-mcp-registry" / "server.yaml"
+SUBMISSION = ROOT / "integrations" / "docker-mcp-registry" / "SUBMISSION.md"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+
+
+def _load_script(name: str) -> ModuleType:
+    path = ROOT / "scripts" / name
+    mod_name = name.removesuffix(".py")
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_shipped_pin_is_a_full_sha_reachable_in_this_repository() -> None:
+    pin = _load_script("sync_docker_mcp_pin.py")
+    current = pin.read_pin(SERVER_YAML.read_text(encoding="utf-8"))
+    assert current is not None, "server.yaml lost its source.commit pin"
+    assert re.fullmatch(r"[0-9a-f]{40}", current), f"source.commit must be a full SHA, not a prefix or a branch: {current!r}"
+    resolved = subprocess.run(
+        ["git", "cat-file", "-e", f"{current}^{{commit}}"],
+        cwd=ROOT,
+        capture_output=True,
+    )
+    shallow = subprocess.run(
+        ["git", "rev-parse", "--is-shallow-repository"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if shallow != "true":
+        assert resolved.returncode == 0, f"source.commit {current} is not a commit in this repository"
+
+
+def test_only_the_pin_under_source_is_rewritten() -> None:
+    """A `commit:` key in another block must survive a pin write untouched."""
+    pin = _load_script("sync_docker_mcp_pin.py")
+    document = (
+        "name: agent-bom\n"
+        "provenance:\n"
+        "  commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        "source:\n"
+        "  project: https://example.invalid\n"
+        "  commit: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+        "run:\n"
+        "  commit: cccccccccccccccccccccccccccccccccccccccc\n"
+    )
+    assert pin.read_pin(document) == "b" * 40
+    rewritten = pin.write_pin(document, "d" * 40)
+    assert "  commit: " + "a" * 40 in rewritten
+    assert "  commit: " + "c" * 40 in rewritten
+    assert "  commit: " + "d" * 40 in rewritten
+    assert "b" * 40 not in rewritten
+
+
+def test_set_refuses_anything_short_of_a_full_sha() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "sync_docker_mcp_pin.py"), "--set", "cc4640f"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "full 40-character SHA" in result.stderr
+    assert SERVER_YAML.read_text(encoding="utf-8").count("commit:") == 1
+
+
+def test_the_release_run_owns_the_pin() -> None:
+    """The job is what replaces the manual step; SUBMISSION.md must not re-add it."""
+    workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+    job = workflow["jobs"].get("docker-mcp-pin")
+    assert job is not None, "the release run no longer syncs the pin — SUBMISSION.md promises it does"
+    run_steps = "\n".join(step.get("run", "") for step in job["steps"])
+    assert 'sync_docker_mcp_pin.py --set "${{ github.sha }}"' in run_steps, "the pin job no longer writes the tagged commit"
+    assert job.get("continue-on-error") is True, "the pin job must not be able to fail a release whose artifacts are already published"
+
+    submission = SUBMISSION.read_text(encoding="utf-8")
+    update_section = submission.split("## Update process", 1)[1]
+    first_step = update_section.split("2.", 1)[0]
+    assert "updated for you" in first_step, "the update process reverted to asking a human to edit source.commit"


### PR DESCRIPTION
Combines #4780 and #4781, which are being closed in favour of this. **Merge this last** — it documents everything else in the wave, including #4782.

---

# 1. The release run owns the Docker MCP submission pin

Closes the pre-tag decision: `integrations/docker-mcp-registry/server.yaml` should be owned by the release the way `sdks/python` now is.

`source.commit` tells Docker which commit to build the published server from. Unlike every other version-bearing artifact it **cannot be written before the tag exists** — it names the commit the tag points at — so `bump-version.py` structurally cannot own it. It was carried as prose instead:

> `SUBMISSION.md` step 1: Update `source.commit` in `server.yaml` to the new release tag SHA

That is the exact shape #4774 gated everywhere else, and it drifted the same way: the pin had not moved in several releases.

A `docker-mcp-pin` job now runs after `github-release`, writes `${{ github.sha }}` and opens `chore/docker-mcp-pin-vX.Y.Z`.

- **Branch + PR, never a push to `main`** — matching `mcp-registry-sync.yml` and `uv-lock-upgrade.yml`, with the same signed automation commit and the same graceful skip when `AUTOMATION_SSH_SIGNING_KEY` is unset.
- **`continue-on-error`, tag-gated** — PyPI, Docker Hub, Helm and the GitHub Release are already published by the time it runs. A pin PR that fails to open must not turn a shipped release red. A test asserts this so it cannot be dropped quietly.

**CI gates format and reachability, deliberately not freshness.** The release moves the pin by PR *after* the tag exists, so between tag and merge the pin is legitimately one release behind — a freshness gate would fail every release.

Each path was watched failing before it passed: `--set deadbeef` rejected; a real SHA written; the same SHA a no-op; a truncated pin and a 40-zero pin both failing `--check`. Four mutations each confirmed to fail their guard — deleting the job, removing `continue-on-error`, reverting SUBMISSION.md, and making `write_pin` rewrite every `commit:` key.

One note worth recording: my first implementation matched the pin with a `(?ms)` regex. Under `DOTALL`, `.` inside the lazy repeat swallowed newlines and backtracked catastrophically — it hung for over two minutes on a 47-line file rather than failing. Replaced with a line scanner. A ReDoS-shaped regex on the release path is worth not repeating.

---

# 2. The CHANGELOG records the wave it was written before

The `0.100.0` entry was merged in #4772, *before* the audit wave. Everything after it was absent from the release notes — and the omissions were the security findings, so tagging on that text would have understated the release in the direction that matters.

| Was missing | From |
|---|---|
| Two release gates that could never fail | #4774 |
| Postgres CI-vs-Docker schema divergence | #4774 |
| Compose bind mount resolving to a missing directory | #4774 |
| Severity filter that deleted the topology | #4776 |
| SQLite budget applied after materialization — an OOM path | #4776 |
| Demo-deploy gate asserting a 20-asset estate against 3,860 | #4773 |
| Advertised registry counts stale on six surfaces, two at runtime | #4777 |
| `sdks/python` frozen at 0.92.0 | #4777 |
| A documented first-run flag that never existed | #4777 |
| Canvas growing to 21,604px; graph text alternative; offline import | #4775 |
| Exit-code contract, `SUPPORT.md` | #4778 |
| The Docker MCP pin | this PR |
| `youcom_search` | #4782 |

**`[Unreleased]` is folded into `0.100.0`.** #4776 filed its graph entries under `[Unreleased]`, correct when written and wrong once all of this was decided to ship in one release. `[Unreleased]` is now empty.

**The intro names the dead gates.** A release whose headline finding is *our own security gate could not fail* should not bury it under Fixed. That entry states both halves deliberately — the gate could not have reported a vulnerable dependency, **and** run for real against all three lockfiles it reports none, so nothing was shipped vulnerable. Either half alone misleads.

---

## Verified

- `tests/test_docker_mcp_pin.py` + `tests/test_release_tag_is_new.py` — 11 passed.
- `scripts/lint_release_workflow.py` — exit 0 (the release call-graph guard, which is what catches a `needs:` typo that GitHub reports as a startup failure with no logs).
- The release `version-guard` regex `^## \[0.100.0\](?:\s|$)` still matches — checked directly, since this PR moves that header.
- `[Unreleased]` parses as empty; the compare links are untouched.

Every CHANGELOG entry is drawn from the merged PR that shipped it, not from the audit that requested it — the measured numbers (270MB→6.4MB, 21,604px→680px, 0.064→0.380, 1,013 vs 1,081, 940 vs 60) are the ones those PRs recorded.