### PR TITLE
ci(demo): a release that does not deploy the demo must not report success

### DIFF
--- a/.github/workflows/demo-deploy-cloudrun.yml
+++ b/.github/workflows/demo-deploy-cloudrun.yml
@@ -63,6 +63,8 @@ jobs:
           SERVICE: ${{ vars.DEMO_CLOUD_RUN_SERVICE }}
           PROJECT: ${{ vars.DEMO_GCP_PROJECT }}
           PROVIDER: ${{ secrets.DEMO_GCP_WIF_PROVIDER }}
+          IS_FORK: ${{ github.event.repository.fork }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           if [ -z "${SERVICE}" ] || [ -z "${PROJECT}" ] || [ -z "${PROVIDER}" ]; then
@@ -84,8 +86,20 @@ jobs:
               echo ""
               echo "See docs/HOSTED_POC.md → Demo redeploy."
             } >> "$GITHUB_STEP_SUMMARY"
-            echo "::notice::Cloud Run demo deploy is inert — see job summary for the vars/secrets to configure."
             echo "configured=false" >> "$GITHUB_OUTPUT"
+            # Staying inert is correct for a fork or an unconfigured clone —
+            # that is what the header promises. It is NOT correct for this
+            # repository after a release: the job reported `success` while
+            # deploying nothing for both 0.99.0 and 0.100.0, so the hosted demo
+            # silently sat a release behind and no signal ever said so. A green
+            # check that means "did nothing" is the defect class this project
+            # spent 0.100.0 removing, so on a release-triggered run in the
+            # upstream repo this now fails loudly instead.
+            if [ "${IS_FORK}" != "true" ] && [ "${EVENT_NAME}" = "workflow_run" ]; then
+              echo "::error::Hosted demo did NOT deploy for this release — the demo environment is not configured. See the job summary for the required vars/secrets."
+              exit 1
+            fi
+            echo "::notice::Cloud Run demo deploy is inert — see job summary for the vars/secrets to configure."
           else
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
The hosted demo is a release behind, and nothing said so.

## What I found

The demo deploy job reported **`success` while deploying nothing** — for **two consecutive releases**. Same line in both run logs:

```
##[notice]Cloud Run demo deploy is inert — see job summary for the vars/secrets to configure.
```

| release | demo deploy job | actually deployed |
|---|---|---|
| 0.99.0 | success | no |
| 0.100.0 | success | no |

Measured live: `agent-bom-demo-…run.app/health` returns **200, version `0.99.0`** while `main` is `0.100.0`. The demo is healthy — just stale, and it got to 0.99.0 by some path that is not this workflow.

**Root cause:** the `demo` environment still holds the **retired AWS EC2** configuration (`AWS_REGION`, `DEMO_DEPLOY_DIR`, `DEMO_INSTANCE_ID`, secret `DEMO_DEPLOY_ROLE_ARN`). The Cloud Run settings the workflow actually reads — `vars.DEMO_CLOUD_RUN_SERVICE`, `vars.DEMO_GCP_PROJECT`, `secrets.DEMO_GCP_WIF_PROVIDER`, `secrets.DEMO_GCP_SERVICE_ACCOUNT` — exist at neither repo nor environment scope. The demo moved to Cloud Run; its deploy configuration never followed.

**Second-order cost:** #4773 fixed the demo-deploy contract to assert the real estate (3,860 assets, 12,171 observations, 2,322 correlations) rather than a stale 20-asset snapshot. **That gate has never executed**, because the deploy exits before reaching it.

## What changed

Staying inert is correct for a fork or an unconfigured clone — the workflow header promises exactly that, and it is unchanged. It is not correct for this repository after a release.

| run | before | after |
|---|---|---|
| upstream, release-triggered, unconfigured | ✅ silent no-op | ❌ **fails loudly** |
| fork, release-triggered, unconfigured | notice | notice (unchanged) |
| manual dispatch, unconfigured | notice | notice (unchanged) |
| configured | deploys | deploys |

All four paths simulated. `actionlint` clean, `check_ci_pipefail.py` exit 0.

## What this deliberately does not do

It does not configure the demo. That needs a GCP project, a Cloud Run service, a Workload Identity provider and a service account — owner-supplied, not something a workflow change can conjure. This makes the absence **visible instead of green**, which is the same correction 0.100.0 applied to the two security gates that could never fail.

Until the environment is configured, the demo stays at 0.99.0 — the difference is that the next release will say so instead of printing a green check.