### PR TITLE
fix(release): publish the image every surface already tells users to pull

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,6 +357,7 @@ jobs:
       contents: read
       id-token: write       # required for SLSA provenance attestation
       attestations: write   # required for SBOM + provenance attestations
+      packages: write       # required to push the same image to GHCR
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -387,6 +388,21 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # GHCR carried only a stale `latest`: no release ever pushed a versioned
+      # tag there. Nine OpenClaw SKILL.md files instruct users to run
+      # `ghcr.io/msaad00/agent-bom:<version>`, check_release_consistency.py
+      # asserts those pins equal the release version, and
+      # demo-deploy-cloudrun.yml pulls that exact reference to deploy the hosted
+      # demo — so a number was kept perfectly in sync with an artifact that did
+      # not exist. Publishing the same digest to both registries makes the
+      # documented command true rather than merely consistent.
+      - name: Login to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push
         id: build-api-image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -400,6 +416,8 @@ jobs:
           tags: |
             agentbom/agent-bom:${{ steps.meta.outputs.version }}
             agentbom/agent-bom:latest
+            ghcr.io/${{ github.repository_owner }}/agent-bom:${{ steps.meta.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/agent-bom:latest
           labels: |
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}

--- a/tests/test_documented_images_are_published.py
+++ b/tests/test_documented_images_are_published.py
@@ -1,0 +1,70 @@
+"""Every image reference we document must name a registry the release publishes to.
+
+`check_release_consistency.py` already asserts the *version* in
+`ghcr.io/msaad00/agent-bom:<version>` equals the release. It never asserted the
+image exists. The result was a number kept perfectly in sync with an artifact
+that had never been published: GHCR carried only a stale `latest`, while nine
+OpenClaw skills told users to run a versioned tag and the hosted-demo deploy
+pulled that same reference.
+
+Consistency is not truth. This asserts the registry half.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+DEMO_WORKFLOW = ROOT / ".github" / "workflows" / "demo-deploy-cloudrun.yml"
+
+# `owner/name` for a documented reference, ignoring the tag.
+_IMAGE_REF = re.compile(r"(?P<repo>(?:ghcr\.io/)?[a-z0-9][a-z0-9._-]*/agent-bom(?:-[a-z]+)?):(?P<tag>[^\s\"'`]+)")
+
+
+OWNER = "msaad00"
+
+
+def _expand(text: str) -> str:
+    """Resolve the one workflow expression that appears inside an image name."""
+    return re.sub(r"\$\{\{\s*github\.repository_owner\s*\}\}", OWNER, text)
+
+
+def _published_repositories() -> set[str]:
+    """Every image repository the release workflow actually pushes to."""
+    text = _expand(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+    published: set[str] = set()
+    for line in text.splitlines():
+        # `tags:` block entries are bare `repo:tag` lines.
+        match = _IMAGE_REF.fullmatch(line.strip())
+        if match:
+            published.add(match.group("repo"))
+    return published
+
+
+def test_release_publishes_the_image_the_demo_deploy_pulls() -> None:
+    published = _published_repositories()
+    demo = _expand(DEMO_WORKFLOW.read_text(encoding="utf-8"))
+    match = re.search(r"^\s*image:\s*(\S+?):\$\{\{", demo, re.M)
+    assert match, "demo deploy no longer names an image to pull"
+    pulled = match.group(1)
+    assert pulled in published, (
+        f"the hosted demo deploys {pulled!r}, which the release workflow never pushes. Published: {sorted(published)}"
+    )
+
+
+def test_documented_image_references_name_a_published_registry() -> None:
+    published = _published_repositories()
+    offenders: list[str] = []
+    for path in sorted(ROOT.glob("integrations/openclaw/**/SKILL.md")):
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            for match in _IMAGE_REF.finditer(line):
+                repo = match.group("repo")
+                if repo not in published:
+                    offenders.append(f"{path.relative_to(ROOT)}:{number} -> {repo}")
+    assert not offenders, (
+        "documented image references name a registry the release does not publish to:\n  "
+        + "\n  ".join(offenders)
+        + f"\nPublished: {sorted(published)}"
+    )


### PR DESCRIPTION
`ghcr.io/msaad00/agent-bom:<version>` has never existed. Measured against the live registry:

```
:latest    200
:0.100.0   404
:0.99.0    404
:0.98.3    404
```

Nothing ever pushed it. `release.yml` published container images to Docker Hub only; GHCR received just the Helm chart.

## Why that matters more than a broken doc link

Three surfaces depend on that reference:

1. **Nine OpenClaw skills** document `docker: ghcr.io/msaad00/agent-bom:<version>` as the command to run.
2. **`check_release_consistency.py` enforces those pins equal the release version** — so a gate has been faithfully keeping a number in sync with an artifact that was never published. Consistency without existence.
3. **`demo-deploy-cloudrun.yml:129` pulls that exact reference** to deploy the hosted demo.

Point 3 is the one that changes the picture. The hosted demo could never have deployed even with its environment fully configured, because the image it asks for does not exist. That is a second, independent reason the demo is stuck at 0.99.0 — see #4787 for the first.

## The fix

The release pushes the same build to both registries:

```yaml
tags: |
  agentbom/agent-bom:${{ steps.meta.outputs.version }}
  agentbom/agent-bom:latest
  ghcr.io/${{ github.repository_owner }}/agent-bom:${{ steps.meta.outputs.version }}
  ghcr.io/${{ github.repository_owner }}/agent-bom:latest
```

One build, one digest, two registries — plus `packages: write` and a GHCR login. Chosen over rewriting nine skills to point at Docker Hub because the documented command stays stable, the demo deploy keeps working as written, and users get a second registry rather than losing one.

## The gate that was missing

`tests/test_documented_images_are_published.py` derives the set of repositories the release **actually pushes**, then asserts:

- every image reference in the OpenClaw skills names one of them
- the image the demo deploy pulls names one of them

Both assertions were watched failing on the pre-fix tree, and mutation-tested by deleting the new GHCR tags — both fail again. Existing consistency gates check that a *number* matches; this checks the *artifact* exists, which is the half that was missing.

`actionlint`, `lint_release_workflow.py`, `check_ci_pipefail.py` all clean.

## Honest scope

This takes effect on the **next** release. `ghcr.io/msaad00/agent-bom:0.100.0` will still 404 until then — the already-published 0.100.0 cannot be retroactively pushed by a workflow change. If the GHCR tag is needed for 0.100.0 specifically, it can be pushed by hand from the released digest.