### PR TITLE
Tighten Overview header, label Findings nav badges, densify Remediation

### DIFF
--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -353,7 +353,7 @@ body {
 /* Dense remediation rows share these styles outside route JavaScript so the
    command center stays compact without duplicating long utility strings. */
 .risk-campaign-card { @apply rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] shadow-sm; }
-.risk-campaign-summary { @apply grid cursor-pointer list-none gap-2 px-3 py-3 md:grid-cols-[minmax(0,1fr)_auto_auto_auto] md:items-center; }
+.risk-campaign-summary { @apply grid cursor-pointer list-none gap-x-2 gap-y-1 px-3 py-2 md:grid-cols-[minmax(0,1fr)_auto_auto_auto] md:items-center; }
 .risk-campaign-summary::-webkit-details-marker,
 .risk-campaign-queue-summary::-webkit-details-marker { display: none; }
 .risk-campaign-severity { @apply rounded-full border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--status-danger)]; }
@@ -406,7 +406,7 @@ body {
 .risk-entry-layout { @apply flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between; }
 .risk-proof-note { @apply flex items-center gap-2 text-xs text-[color:var(--text-tertiary)]; }
 .risk-card-title { @apply truncate text-sm font-semibold text-[color:var(--foreground)]; }
-.risk-card-meta { @apply mt-1 truncate text-[11px] text-[color:var(--text-tertiary)]; }
+.risk-card-meta { @apply mt-0.5 truncate text-[11px] text-[color:var(--text-tertiary)]; }
 .risk-number { @apply font-semibold tabular-nums text-[color:var(--foreground)]; }
 .risk-queue-body { @apply border-t border-[color:var(--border-subtle)] px-3 pb-3; }
 .risk-entry-title { @apply text-sm font-semibold text-[color:var(--foreground)]; }

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -355,7 +355,7 @@ export default function Dashboard() {
       : null;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <PageLaneHeader
         lane="command"
         title="Overview"

--- a/ui/app/remediation/page.tsx
+++ b/ui/app/remediation/page.tsx
@@ -681,6 +681,18 @@ function RemediationPage() {
                 </button>
               </div>
             </div>
+
+            {/* Page-position caption near the top so the reader knows the pager
+                below is a slice, not the whole list (mirrors Findings). */}
+            <p className="flex flex-wrap items-center gap-x-1.5 text-xs text-[var(--text-tertiary)]">
+              <span className="font-semibold text-[var(--text-secondary)]">
+                {displayed.length} matching package{displayed.length === 1 ? "" : "s"}
+              </span>
+              <span aria-hidden="true">·</span>
+              <span>{paged.length} on this page</span>
+              <span aria-hidden="true">·</span>
+              <span>{PAGE_SIZE} per page</span>
+            </p>
           </div>
 
           {/* Table */}

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -633,14 +633,28 @@ export function Nav() {
                           </span>
                         )}
 
-                        {/* Vuln count badges */}
+                        {/* Vuln count badges — severity-colored, but bare
+                            numbers are ambiguous, so the group carries a
+                            screen-reader label and a hover tooltip spelling
+                            out "N critical, N high". */}
                         {showVulnBadge && (
-                          <span className="ml-auto flex items-center gap-1">
-                            <span className="text-[9px] font-mono font-bold text-red-400 bg-red-950/60 border border-red-800/40 rounded-full px-1.5 py-0 leading-4">
+                          <span
+                            role="group"
+                            aria-label={`${counts.critical} critical${counts.high > 0 ? `, ${counts.high} high` : ""} open findings`}
+                            title={`${counts.critical} critical${counts.high > 0 ? `, ${counts.high} high` : ""} open findings`}
+                            className="ml-auto flex items-center gap-1"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="text-[9px] font-mono font-bold text-red-400 bg-red-950/60 border border-red-800/40 rounded-full px-1.5 py-0 leading-4"
+                            >
                               {counts.critical}
                             </span>
                             {counts.high > 0 && (
-                              <span className="text-[9px] font-mono font-bold text-orange-400 bg-orange-950/60 border border-orange-800/40 rounded-full px-1.5 py-0 leading-4">
+                              <span
+                                aria-hidden="true"
+                                className="text-[9px] font-mono font-bold text-orange-400 bg-orange-950/60 border border-orange-800/40 rounded-full px-1.5 py-0 leading-4"
+                              >
                                 {counts.high}
                               </span>
                             )}

--- a/ui/components/risk-campaign-command-center.tsx
+++ b/ui/components/risk-campaign-command-center.tsx
@@ -631,7 +631,7 @@ export function RiskCampaignCommandCenter() {
       <VerificationQueue />
       {!loading && !error && campaigns.length > 0 ? (
         <>
-          <div className="grid gap-2">
+          <div className="grid gap-1.5">
             {campaigns.map((campaign) => <CampaignCard key={campaign.id} campaign={campaign} onChanged={updateCampaign} connections={connections} onReload={() => void load()} />)}
           </div>
           <div className="risk-proof-note">

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -240,6 +240,75 @@ describe('Nav', () => {
     expect(links.some((l) => l.getAttribute('href') === '/remediation')).toBe(true)
   })
 
+  it('labels the Findings severity count badges for screen readers and hover', async () => {
+    const { api } = await import('@/lib/api')
+    vi.mocked(api.getPostureCounts).mockResolvedValueOnce({
+      critical: 440,
+      high: 1337,
+      medium: 0,
+      low: 0,
+      total: 1777,
+      kev: 0,
+      compound_issues: 0,
+      deployment_mode: 'local',
+      has_mcp_context: false,
+      has_agent_context: false,
+      has_local_scan: true,
+      has_fleet_ingest: false,
+      has_cluster_scan: false,
+      has_ci_cd_scan: false,
+      has_mesh: false,
+      has_gateway: false,
+      has_proxy: false,
+      has_traces: false,
+      has_registry: false,
+      scan_sources: ['sbom'],
+      scan_count: 1,
+    })
+
+    renderExpandedNav()
+
+    const badges = await screen.findByRole('group', {
+      name: /440 critical, 1337 high open findings/i,
+    })
+    expect(badges).toHaveAttribute('title', '440 critical, 1337 high open findings')
+    expect(within(badges).getByText('440')).toBeInTheDocument()
+    expect(within(badges).getByText('1337')).toBeInTheDocument()
+  })
+
+  it('drops the high badge from the accessible label when there are no high findings', async () => {
+    const { api } = await import('@/lib/api')
+    vi.mocked(api.getPostureCounts).mockResolvedValueOnce({
+      critical: 5,
+      high: 0,
+      medium: 0,
+      low: 0,
+      total: 5,
+      kev: 0,
+      compound_issues: 0,
+      deployment_mode: 'local',
+      has_mcp_context: false,
+      has_agent_context: false,
+      has_local_scan: true,
+      has_fleet_ingest: false,
+      has_cluster_scan: false,
+      has_ci_cd_scan: false,
+      has_mesh: false,
+      has_gateway: false,
+      has_proxy: false,
+      has_traces: false,
+      has_registry: false,
+      scan_sources: ['sbom'],
+      scan_count: 1,
+    })
+
+    renderExpandedNav()
+
+    const badges = await screen.findByRole('group', { name: /^5 critical open findings$/i })
+    expect(within(badges).getByText('5')).toBeInTheDocument()
+    expect(within(badges).queryByText('0')).not.toBeInTheDocument()
+  })
+
   it('exposes one Investigation entry under Posture', () => {
     renderExpandedNav()
     const links = screen.getAllByRole('link', { name: /^investigation$/i })

--- a/ui/tests/remediation-page.test.tsx
+++ b/ui/tests/remediation-page.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import RemediationPage from "@/app/remediation/page";
+
+const { apiMock, navigationState } = vi.hoisted(() => ({
+  apiMock: {
+    listJobs: vi.fn(),
+    getRemediation: vi.fn(),
+    listTickets: vi.fn(),
+    listRiskCampaigns: vi.fn(),
+    listRiskCampaignVerificationQueue: vi.fn(),
+    listTicketingConnections: vi.fn(),
+  },
+  navigationState: { query: "" },
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(navigationState.query),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: apiMock,
+  };
+});
+
+function remediationItem(pkg: string, severity: string) {
+  return {
+    package: pkg,
+    current_version: "1.0.0",
+    fixed_version: "1.0.1",
+    severity,
+    vulnerabilities: [`CVE-2026-${pkg}`],
+    is_kev: false,
+    impact_score: 7.2,
+    affected_agents: ["agent-a"],
+    exposed_credentials: [],
+    owasp_tags: ["LLM01"],
+    atlas_tags: [],
+    reachable_tools: [],
+    risk_narrative: "",
+    command: "",
+    verify_command: "",
+  };
+}
+
+describe("RemediationPage", () => {
+  beforeEach(() => {
+    navigationState.query = "";
+    vi.clearAllMocks();
+    apiMock.listJobs.mockResolvedValue({
+      jobs: [{ job_id: "job-1", status: "done", created_at: "2026-08-12T00:00:00Z" }],
+    });
+    apiMock.listTickets.mockResolvedValue({ tickets: [] });
+    // Command center is rendered above the plan; keep it in an honest empty
+    // state so the test isolates the package-plan density caption.
+    apiMock.listRiskCampaigns.mockResolvedValue({
+      schema_version: "risk-campaigns.v1",
+      tenant_id: "tenant-a",
+      count: 0,
+      finding_window_days: 90,
+      finding_limit: 1000,
+      truncated: false,
+      total_findings: 0,
+      total_approximate: false,
+      membership_complete: true,
+      campaigns: [],
+    });
+    apiMock.listRiskCampaignVerificationQueue.mockResolvedValue({
+      schema_version: "risk-campaign-verification-queue.v1",
+      tenant_id: "tenant-a",
+      entries: [],
+      count: 0,
+      has_more: false,
+      next_cursor: null,
+      limit: 25,
+    });
+    apiMock.listTicketingConnections.mockResolvedValue({
+      schema_version: "ticketing.connections.v1",
+      tenant_id: "tenant-a",
+      count: 0,
+      connections: [],
+    });
+  });
+
+  it("surfaces a top-of-page page-position caption for the package plan", async () => {
+    const items = Array.from({ length: 30 }, (_, i) => remediationItem(`pkg${i}`, i < 5 ? "critical" : "high"));
+    apiMock.getRemediation.mockResolvedValue(items);
+
+    render(<RemediationPage />);
+
+    // 30 matching, 25 on the first page, 25 per page.
+    await waitFor(() => {
+      expect(screen.getByText(/30 matching packages/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/25 on this page/i)).toBeInTheDocument();
+    expect(screen.getByText(/25 per page/i)).toBeInTheDocument();
+  });
+
+  it("singularizes the caption for a single matching package", async () => {
+    apiMock.getRemediation.mockResolvedValue([remediationItem("openssl", "critical")]);
+
+    render(<RemediationPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 matching package(?!s)/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/1 on this page/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

UI polish across three shipped surfaces (Existing lane, presentation-only):

1. **Overview header** — tighten the gap between the page header and the Command center (`space-y-6` → `space-y-4`).
2. **Findings nav badges** — the two bare colored counts (critical/high) were unlabeled and read as mystery numbers. They now sit in a `role="group"` with `aria-label`/`title` = "N critical, N high open findings"; the count spans keep their severity colors as the visual cue and are `aria-hidden` so screen readers get one clean announcement.
3. **Remediation density** — add a top-of-page "N matching · N on this page · 25 per page" indicator (mirrors the Findings caption) so the existing pager reads as a slice, and tighten campaign-row spacing. Pagination, filters, sorting, expand/collapse, and data fetching are unchanged (they already existed).

## Why

Direct user feedback walking the 0.100.0 demo: the header felt oversized, the 440/1337 nav badges were unexplained, and the Remediation list felt endless because the pager sat far below the fold. Density + a visible pager indicator address that without changing behavior.

## How verified

- `npm run typecheck` — pass
- `vitest` on nav / risk-campaign-command-center / remediation — 67 passed, incl. 2 new nav-badge tests + a new remediation caption suite
- `eslint` on touched files — clean
- `npm run build` and `NEXT_EXPORT=1 npm run build` (static export release gate) — pass; `/remediation` prerenders static

Visual tightness (both themes) to be eyeballed at the next demo image rebuild.