### PR TITLE
Compliance drill-through + demo hygiene (no leakage, readable)

### DIFF
--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Suspense, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import {
   api,
@@ -554,15 +555,22 @@ function CompliancePageContent() {
       header: "Findings",
       align: "right",
       width: "5rem",
-      cell: (c) => (
-        <span
-          className={
-            c.findings > 0 ? "font-semibold text-[color:var(--foreground)]" : "text-[color:var(--text-tertiary)]"
-          }
-        >
-          {c.findings}
-        </span>
-      ),
+      cell: (c) =>
+        c.findings > 0 ? (
+          // Drill a non-zero count into the findings queue, scoped to this
+          // control's framework + control id. stopPropagation keeps the row
+          // click (which opens the evidence drawer) from also firing.
+          <Link
+            href={`/findings?framework=${encodeURIComponent(selectedSection?.id ?? "")}&control=${encodeURIComponent(c.code)}`}
+            onClick={(e) => e.stopPropagation()}
+            aria-label={`View ${c.findings} findings for ${c.code}`}
+            className="font-semibold text-[color:var(--accent)] underline-offset-2 hover:underline focus-visible:underline focus-visible:outline-none"
+          >
+            {c.findings}
+          </Link>
+        ) : (
+          <span className="text-[color:var(--text-tertiary)]">{c.findings}</span>
+        ),
     },
   ];
 
@@ -705,7 +713,12 @@ function CompliancePageContent() {
       </div>
 
       {viewMode === "heatmap" && <ComplianceHeatmap data={data} />}
-      {viewMode === "matrix" && <ComplianceMatrix data={data} />}
+      {viewMode === "matrix" && (
+        <ComplianceMatrix
+          data={data}
+          onSelectControl={(selection) => setSelectedControl(selection)}
+        />
+      )}
 
       {viewMode === "detail" ? (
         <>

--- a/ui/components/compliance-matrix.tsx
+++ b/ui/components/compliance-matrix.tsx
@@ -49,6 +49,17 @@ interface MatrixRow {
   low: number;
   affectedPackages: string[];
   affectedAgents: string[];
+  // Carried (not rendered as columns) so a row click can open the shared
+  // ComplianceControlDrawer with the original control + its framework catalog.
+  control: ComplianceControl;
+  catalog: Record<string, string>;
+}
+
+/** Payload emitted when a matrix row is drilled into, shaped for the drawer. */
+export interface ComplianceMatrixSelection {
+  control: ComplianceControl;
+  frameworkLabel: string;
+  catalog: Record<string, string>;
 }
 
 // ─── Data transform ──────────────────────────────────────────────────────────
@@ -83,6 +94,8 @@ function flattenControls(data: ComplianceResponse): MatrixRow[] {
         low: c.severity_breakdown.low ?? 0,
         affectedPackages: c.affected_packages,
         affectedAgents: c.affected_agents,
+        control: c,
+        catalog,
       });
     }
   }
@@ -252,7 +265,14 @@ function exportCsv(rows: MatrixRow[]) {
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
-export function ComplianceMatrix({ data }: { data: ComplianceResponse }) {
+export function ComplianceMatrix({
+  data,
+  onSelectControl,
+}: {
+  data: ComplianceResponse;
+  /** Drill a row into the shared control drawer. When omitted, rows are static. */
+  onSelectControl?: (selection: ComplianceMatrixSelection) => void;
+}) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [globalFilter, setGlobalFilter] = useState("");
@@ -420,10 +440,35 @@ export function ComplianceMatrix({ data }: { data: ComplianceResponse }) {
               ))}
             </thead>
             <tbody className="divide-y divide-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)]">
-              {table.getRowModel().rows?.map((row) => (
+              {table.getRowModel().rows?.map((row) => {
+                const select = onSelectControl
+                  ? () =>
+                      onSelectControl({
+                        control: row.original.control,
+                        frameworkLabel: row.original.framework,
+                        catalog: row.original.catalog,
+                      })
+                  : undefined;
+                return (
                 <tr
                   key={row.id}
-                  className="hover:bg-[color:var(--surface)]/50 transition-colors"
+                  className={`transition-colors hover:bg-[color:var(--surface)]/50 ${
+                    select ? "cursor-pointer" : ""
+                  }`}
+                  {...(select
+                    ? {
+                        role: "button",
+                        tabIndex: 0,
+                        "aria-label": `Open evidence for ${row.original.framework} ${row.original.code}`,
+                        onClick: select,
+                        onKeyDown: (e: React.KeyboardEvent<HTMLTableRowElement>) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            select();
+                          }
+                        },
+                      }
+                    : {})}
                 >
                   {row.getVisibleCells().map((cell) => (
                     <td key={cell.id} className="px-3 py-2.5">
@@ -434,7 +479,8 @@ export function ComplianceMatrix({ data }: { data: ComplianceResponse }) {
                     </td>
                   ))}
                 </tr>
-              ))}
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/ui/components/role-access.tsx
+++ b/ui/components/role-access.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Check, Eye, Lock, ShieldCheck, TriangleAlert, Wrench, X } from "lucide-react";
+import { Check, ChevronDown, Eye, Lock, ShieldCheck, TriangleAlert, Wrench, X } from "lucide-react";
 
+import { useDemoMode } from "@/hooks/use-demo-mode";
 import type { AuthMeResponse } from "@/lib/api";
 import {
   ROLE_LADDER,
@@ -51,51 +52,76 @@ export function PermissionDeniedNotice({
   action?: string;
   className?: string;
 }) {
+  // On the public demo, the caller is an anonymous read-only visitor. Operator
+  // env-var / config guidance (AGENT_BOM_NO_AUTH_ROLE, AGENT_BOM_DEMO_ESTATE)
+  // is internal ops instruction that must never reach that visitor — surface a
+  // neutral read-only line instead. The self-host operator path keeps the full
+  // elevation guidance.
+  const { isDemoMode } = useDemoMode();
   const roleId = activeRoleId(session);
   const current = ROLE_LADDER.find((r) => r.id === roleId);
   const authRequired = Boolean(session?.auth_required);
   const neededLabel = ROLE_LADDER.find((r) => r.id === needed)?.label ?? "Contributor";
   const roleAlreadySufficient = roleRank(roleId) >= roleRank(needed);
-  const guidance = roleAlreadySufficient
-    ? {
-        title: "Review this environment's write policy",
-        steps: [
-          `The current role already meets the ${neededLabel} requirement; an environment policy is denying writes.`,
-          "Public demo estates remain read-only. On a self-hosted instance, review the demo clamp and deployment policy before enabling writes.",
-        ],
-      }
-    : roleElevationGuidance({ authRequired, needed });
+
+  const headline = isDemoMode
+    ? "This is a read-only public demo."
+    : current && !roleAlreadySufficient
+      ? `Your ${current.label} role is read-only for this action.`
+      : roleAlreadySufficient
+        ? "This environment is read-only for this action."
+        : "This action needs a higher role.";
+
+  const secondary = isDemoMode
+    ? "Connect, scan, and other write actions are disabled here so anyone can explore safely."
+    : roleAlreadySufficient
+      ? `Your ${current?.label ?? "current"} role meets the ${neededLabel} requirement, but writes are disabled here.`
+      : `To ${action} you need the ${neededLabel} role or higher.`;
+
+  // Operator elevation steps are shown only off the public demo.
+  const guidance = isDemoMode
+    ? null
+    : roleAlreadySufficient
+      ? {
+          title: "Review this environment's write policy",
+          steps: [
+            `The current role already meets the ${neededLabel} requirement; an environment policy is denying writes.`,
+            "Public demo estates remain read-only. On a self-hosted instance, review the demo clamp and deployment policy before enabling writes.",
+          ],
+        }
+      : roleElevationGuidance({ authRequired, needed });
 
   return (
-    <div
+    <details
       role="note"
-      className={`rounded-xl border border-amber-500/25 bg-amber-500/10 p-4 text-sm text-amber-100 ${className}`}
+      className={`group rounded-lg border border-amber-500/30 bg-amber-500/10 text-sm text-amber-900 dark:text-amber-100 ${className}`}
     >
-      <p className="inline-flex items-center gap-2 font-medium">
-        <TriangleAlert className="h-4 w-4 shrink-0" />
-        {current && !roleAlreadySufficient
-          ? `Your ${current.label} role is read-only for this action.`
-          : roleAlreadySufficient
-            ? "This environment is read-only for this action."
-            : "This action needs a higher role."}
-      </p>
-      <p className="mt-1.5 text-[13px] leading-6 text-amber-100/90">
-        {roleAlreadySufficient
-          ? `Your ${current?.label ?? "current"} role meets the ${neededLabel} requirement, but writes are disabled here.`
-          : `To ${action} you need the ${neededLabel} role or higher.`}
-      </p>
-      <p className="mt-3 text-[12px] font-semibold uppercase tracking-[0.12em] text-amber-700 dark:text-amber-200/90">
-        {guidance.title}
-      </p>
-      <ul className="mt-1.5 space-y-1 text-[13px] leading-6 text-amber-100/90">
-        {guidance.steps.map((step) => (
-          <li key={step} className="flex items-start gap-2">
-            <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-amber-300/80" />
-            <span>{step}</span>
-          </li>
-        ))}
-      </ul>
-    </div>
+      <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 font-medium marker:content-none [&::-webkit-details-marker]:hidden">
+        <TriangleAlert className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-300" />
+        <span className="min-w-0 flex-1">{headline}</span>
+        <ChevronDown className="h-4 w-4 shrink-0 text-amber-600 transition-transform group-open:rotate-180 dark:text-amber-300" />
+      </summary>
+      <div className="space-y-2 border-t border-amber-500/20 px-3 pb-3 pt-2">
+        <p className="text-[13px] leading-6 text-amber-800 dark:text-amber-100/90">
+          {secondary}
+        </p>
+        {guidance ? (
+          <>
+            <p className="mt-2 text-[12px] font-semibold uppercase tracking-[0.12em] text-amber-700 dark:text-amber-200/90">
+              {guidance.title}
+            </p>
+            <ul className="space-y-1 text-[13px] leading-6 text-amber-800 dark:text-amber-100/90">
+              {guidance.steps.map((step) => (
+                <li key={step} className="flex items-start gap-2">
+                  <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500/70 dark:bg-amber-300/80" />
+                  <span>{step}</span>
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : null}
+      </div>
+    </details>
   );
 }
 

--- a/ui/tests/compliance-matrix.test.tsx
+++ b/ui/tests/compliance-matrix.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { fireEvent, render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { ComplianceMatrix } from "@/components/compliance-matrix";
 import type { ComplianceResponse } from "@/lib/api";
@@ -122,5 +122,32 @@ describe("ComplianceMatrix", () => {
   it("keeps the evidence-triage disclaimer visible", () => {
     render(<ComplianceMatrix data={matrixData()} />);
     expect(screen.getByTestId("compliance-matrix-helper-disclaimer")).toBeVisible();
+  });
+
+  it("makes matrix rows drillable via onSelectControl", () => {
+    const onSelect = vi.fn();
+    render(<ComplianceMatrix data={matrixData()} onSelectControl={onSelect} />);
+
+    const row = screen.getByText("LLM01").closest("tr");
+    expect(row).not.toBeNull();
+    fireEvent.click(row as HTMLElement);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    const payload = onSelect.mock.calls[0]![0];
+    expect(payload.control.code).toBe("LLM01");
+    expect(payload.frameworkLabel).toBe("OWASP LLM");
+    // The catalog map travels with the control so the drawer can resolve names.
+    expect(typeof payload.catalog).toBe("object");
+  });
+
+  it("opens the drawer on keyboard activation of a row", () => {
+    const onSelect = vi.fn();
+    render(<ComplianceMatrix data={matrixData()} onSelectControl={onSelect} />);
+
+    const row = screen.getByText("MCP01").closest("tr") as HTMLElement;
+    row.focus();
+    fireEvent.keyDown(row, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0]![0].control.code).toBe("MCP01");
   });
 });

--- a/ui/tests/compliance-page.test.tsx
+++ b/ui/tests/compliance-page.test.tsx
@@ -7,6 +7,23 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams(""),
 }));
 
+// Render next/link as a plain anchor so href assertions are deterministic and
+// no app-router context is required in the test environment.
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    href: string;
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
 // CIS drill-down fetches its own benchmark data on mount — stub it so the
 // compliance page test stays focused on the dense framework/control surface.
 vi.mock("@/components/cis-benchmark-detail", () => ({
@@ -139,6 +156,30 @@ describe("CompliancePage (dense restyle)", () => {
     await waitFor(() =>
       expect(screen.getByText("Prompt Injection")).toBeInTheDocument(),
     );
+  });
+
+  it("links a non-zero findings count to the framework/control-filtered queue", async () => {
+    render(<CompliancePage />);
+    await screen.findByTestId("compliance-kpi-strip");
+    await screen.findByText("Prompt Injection");
+
+    // LLM01 has 4 findings → a click-through into the findings queue.
+    const link = screen.getByRole("link", { name: /4 findings for LLM01/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "/findings?framework=owasp-llm&control=LLM01",
+    );
+  });
+
+  it("keeps a zero findings count non-interactive", async () => {
+    render(<CompliancePage />);
+    await screen.findByTestId("compliance-kpi-strip");
+    await screen.findByText("Prompt Injection");
+
+    // LLM02 has 0 findings → plain text, no link.
+    expect(
+      screen.queryByRole("link", { name: /findings for LLM02/i }),
+    ).toBeNull();
   });
 
   it("opens the control drawer when a control row is clicked", async () => {

--- a/ui/tests/role-access.test.tsx
+++ b/ui/tests/role-access.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   PermissionDeniedNotice,
@@ -7,6 +7,17 @@ import {
   RolePermissionsPanel,
 } from "@/components/role-access";
 import type { AuthMeResponse } from "@/lib/api";
+
+// Demo detection is read from the shared hook; keep it mutable so a test can
+// flip the deployment into the public-demo posture without a real /health call.
+const demoState = { isDemoMode: false, loading: false };
+vi.mock("@/hooks/use-demo-mode", () => ({
+  useDemoMode: () => demoState,
+}));
+
+beforeEach(() => {
+  demoState.isDemoMode = false;
+});
 
 function session(overrides: Partial<AuthMeResponse> = {}): AuthMeResponse {
   return {
@@ -100,6 +111,31 @@ describe("PermissionDeniedNotice", () => {
     );
     expect(screen.getByText(/AGENT_BOM_NO_AUTH_ROLE=analyst/)).toBeInTheDocument();
     expect(screen.getByText(/AGENT_BOM_DEMO_ESTATE/)).toBeInTheDocument();
+  });
+
+  it("never leaks operator env-var config to a public demo visitor", () => {
+    demoState.isDemoMode = true;
+    render(
+      <PermissionDeniedNotice
+        session={session({ role: "viewer", auth_required: false })}
+      />,
+    );
+    // The self-host env-var elevation steps must not reach a demo visitor.
+    expect(screen.queryByText(/AGENT_BOM_NO_AUTH_ROLE/)).toBeNull();
+    expect(screen.queryByText(/AGENT_BOM_DEMO_ESTATE/)).toBeNull();
+    // A concise, neutral read-only line replaces them.
+    expect(screen.getByText(/read-only public demo/i)).toBeInTheDocument();
+  });
+
+  it("renders as a collapsible details notice, not an always-open band", () => {
+    const { container } = render(
+      <PermissionDeniedNotice session={session({ role: "viewer" })} />,
+    );
+    const details = container.querySelector("details");
+    expect(details).not.toBeNull();
+    // Compact by default: the guidance is disclosed on demand, not pre-expanded.
+    expect(details).not.toHaveAttribute("open");
+    expect(container.querySelector("summary")).not.toBeNull();
   });
 
   it("attributes denial to environment policy when the current role is already sufficient", () => {


### PR DESCRIPTION
Part of epic #4790 (workstreams 2 & 3).

## What

**Drill-through (workstream 2)**
- Compliance "Findings" count cells now click through to `/findings?framework=…&control=…` when non-zero (accessible link, `--accent` token, stops row-drawer propagation). Zero counts stay plain.
- Matrix-view rows are now drillable — each row opens the same `ComplianceControlDrawer` the Detail view uses (reused state, no duplicated drawer logic).

**Demo hygiene (workstream 3)** — Connections `PermissionDeniedNotice`
- **Stops leaking operator config on the public demo:** on demo estate (`useDemoMode()`), the `AGENT_BOM_NO_AUTH_ROLE` / `AGENT_BOM_DEMO_ESTATE` "restart the API" steps are suppressed and replaced with a neutral "This is a read-only public demo." Non-demo self-host still gets the full role-elevation guidance.
- **Shrunk + readable:** the oversized full-width amber band is now a compact collapsible `<details>`, contrast fixed for both themes (`text-amber-900 dark:text-amber-100`).
- Demo-estate data spot-checked: all account IDs synthetic/reserved (e.g. `555555555555`, reserved `123456789012`); no real emails/domains/IPs.

## Why

Direct demo feedback: the amber band was oversized, low-contrast, and leaked internal env-var/ops guidance to public visitors; compliance finding counts were dead-ends.

## How verified
- `vitest` role-access + compliance-matrix + compliance-page: 20 passed; regression suites (frameworks/status/reconciliation/scope, connections, first-run): 16 + 51 passed
- `typecheck` clean · `eslint` (6 files) clean · `npm run build` + `NEXT_EXPORT=1 npm run build` pass

## Known dependency (not silent)
The finding-count links are created and correct, but `/findings` does not yet parse `framework`/`control` query params, so the links currently land on an unfiltered queue. That param parsing lives in `ui/app/findings/page.tsx` (owned by the owner/SLA branch) and will land with that work — tracked so the filter completes. Demo hygiene and Matrix drill-through are fully wired and independent of it.