### PR TITLE
Populate and surface finding-level owner and SLA due date

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 840,
+      "value": 841,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 840 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 841 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -310,6 +310,40 @@ def _triage_response(exc: Any) -> dict[str, Any]:
     }
 
 
+def build_tenant_triage_owner_index(tenant_id: str) -> list[tuple[Any, str]]:
+    """Return ``(exception, assignee)`` pairs for the tenant's triage entries.
+
+    The finding "owner" is the triage ``assignee``. Only triage entries with an
+    assignee contribute — suppressions and feedback carry an approver, not an
+    owner, and must not be surfaced as ownership. Tenant-scoped read: the store
+    is queried with ``tenant_id`` so one tenant's assignees never leak into
+    another tenant's findings.
+    """
+    index: list[tuple[Any, str]] = []
+    for exc in _get_exception_store().list_all(tenant_id=tenant_id):
+        data = _parse_triage_reason(str(exc.reason))
+        if data is None:
+            continue
+        assignee = str(data.get("assignee") or getattr(exc, "approved_by", "") or "").strip()
+        if assignee:
+            index.append((exc, assignee))
+    return index
+
+
+def triage_owner_for(
+    index: list[tuple[Any, str]],
+    *,
+    vuln_id: str,
+    package: str,
+    server_name: str = "",
+) -> str | None:
+    """Return the triage assignee matching a finding, or ``None`` when unassigned."""
+    for exc, assignee in index:
+        if exc.matches(vuln_id, package, server_name):
+            return assignee
+    return None
+
+
 def _auth_session_state(request: Request) -> dict:
     """Build the current request's auth/session state without leaking secrets."""
     from agent_bom.api.middleware import get_auth_runtime_status

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1029,8 +1029,28 @@ def _iter_scan_findings(job: ScanJob) -> list[dict[str, Any]]:
         _absorb(_attach_reach(row))
 
     findings = [grouped[key] for key in order]
+    # Surface the triage assignee as the finding owner (the simple ownership cut).
+    # Built once per tenant and matched per row; rows with no triage assignee keep
+    # whatever owner the scan spine already set (defaults to "Unassigned" later).
+    from agent_bom.api.routes.enterprise import build_tenant_triage_owner_index, triage_owner_for
+
+    owner_index = build_tenant_triage_owner_index(tenant_id)
     for row in findings:
         _normalize_finding_identifiers(row)
+        if owner_index:
+            raw_asset = row.get("asset")
+            asset = raw_asset if isinstance(raw_asset, dict) else {}
+            raw_evidence = row.get("evidence")
+            evidence = raw_evidence if isinstance(raw_evidence, dict) else {}
+            package = str(row.get("package") or row.get("package_name") or evidence.get("package_name") or asset.get("name") or "")
+            assignee = triage_owner_for(
+                owner_index,
+                vuln_id=str(row.get("vulnerability_id") or row.get("cve_id") or ""),
+                package=package,
+                server_name=str(row.get("server_name") or ""),
+            )
+            if assignee:
+                row["owner"] = assignee
     return findings
 
 

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1031,7 +1031,8 @@ def _iter_scan_findings(job: ScanJob) -> list[dict[str, Any]]:
     findings = [grouped[key] for key in order]
     # Surface the triage assignee as the finding owner (the simple ownership cut).
     # Built once per tenant and matched per row; rows with no triage assignee keep
-    # whatever owner the scan spine already set (defaults to "Unassigned" later).
+    # whatever owner the scan spine already set (an explicit None when unassigned,
+    # rendered "Unassigned" only in the CLI/UI).
     from agent_bom.api.routes.enterprise import build_tenant_triage_owner_index, triage_owner_for
 
     owner_index = build_tenant_triage_owner_index(tenant_id)

--- a/src/agent_bom/cli/_findings_group.py
+++ b/src/agent_bom/cli/_findings_group.py
@@ -64,11 +64,17 @@ def _package_name(row: Mapping[str, object]) -> str:
     return _string(value)
 
 
+def _owner(row: Mapping[str, object]) -> str:
+    from agent_bom.sla import finding_owner
+
+    return finding_owner(row.get("owner"))
+
+
 def _print_findings_table(payload: JsonObject) -> None:
     rows = payload.get("findings")
     if not isinstance(rows, list):
         rows = []
-    click.echo("id\tseverity\tstatus\tpackage\tfirst_seen\tlast_seen\ttitle")
+    click.echo("id\tseverity\tstatus\towner\tpackage\tfirst_seen\tlast_seen\tsla_due_at\ttitle")
     for item in rows:
         if not isinstance(item, dict):
             continue
@@ -78,9 +84,11 @@ def _print_findings_table(payload: JsonObject) -> None:
                     _finding_id(item),
                     _string(item.get("severity")),
                     _string(item.get("status")),
+                    _owner(item),
                     _package_name(item),
                     _string(item.get("first_seen")),
                     _string(item.get("last_seen")),
+                    _string(item.get("sla_due_at")),
                     _string(item.get("title") or item.get("summary") or item.get("message")),
                 ]
             )

--- a/src/agent_bom/cli/_findings_group.py
+++ b/src/agent_bom/cli/_findings_group.py
@@ -65,9 +65,11 @@ def _package_name(row: Mapping[str, object]) -> str:
 
 
 def _owner(row: Mapping[str, object]) -> str:
-    from agent_bom.sla import finding_owner
+    # Presentation layer: the data carries None for an unassigned finding
+    # (honest absence in the API/exports); the CLI table renders it "Unassigned".
+    from agent_bom.graph.sla import finding_owner
 
-    return finding_owner(row.get("owner"))
+    return finding_owner(row.get("owner")) or "Unassigned"
 
 
 def _print_findings_table(payload: JsonObject) -> None:

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -335,6 +335,15 @@ class Finding:
     # workload is clean — summaries carry clean_workload_assertion=False.
     workload_runtime_evidence: Optional[dict] = None
 
+    # Ownership + remediation SLA (additive, optional). ``first_seen`` anchors
+    # the SLA window (scan-observation time for a fresh scan); ``owner`` surfaces
+    # the triage assignee when one exists; ``sla_due_at`` is severity-derived
+    # from ``first_seen`` with a KEV override. All left None by default so
+    # existing findings serialize unchanged and to_dict() derives on demand.
+    first_seen: Optional[str] = None
+    owner: Optional[str] = None
+    sla_due_at: Optional[str] = None
+
     # Unique ID — deterministic UUID v5 based on content (computed in __post_init__)
     # Pass an explicit id= to override (e.g. when ingesting from external scanner)
     id: str = field(default="")
@@ -513,6 +522,14 @@ class Finding:
 
     def to_dict(self) -> dict:
         """Return a JSON-serializable finding payload."""
+        from agent_bom.sla import finding_owner, sla_due_at
+
+        kev_due_date = self.evidence.get("kev_due_date") if isinstance(self.evidence, dict) else None
+        resolved_sla = self.sla_due_at or sla_due_at(
+            self.effective_severity(),
+            self.first_seen,
+            kev_due_date=kev_due_date,
+        )
         return {
             "schema_version": FINDING_SCHEMA_VERSION,
             "id": self.id,
@@ -595,6 +612,13 @@ class Finding:
             "reachability": self.reachability,
             "is_actionable": self.is_actionable,
             "impact_category": self.impact_category,
+            # Ownership + remediation SLA (derived, single source of truth in
+            # agent_bom.sla). ``owner`` defaults to "Unassigned" so the surface
+            # reads honestly; ``sla_due_at`` is an explicit None when no deadline
+            # can be derived (unrated severity + no anchor/KEV date).
+            "first_seen": self.first_seen,
+            "owner": finding_owner(self.owner),
+            "sla_due_at": resolved_sla,
             # Suppression state — a suppressed finding must never surface as
             # unsuppressed downstream (mirrors BlastRadius / SARIF suppressions[]).
             "suppressed": self.suppressed,

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -522,7 +522,7 @@ class Finding:
 
     def to_dict(self) -> dict:
         """Return a JSON-serializable finding payload."""
-        from agent_bom.sla import finding_owner, sla_due_at
+        from agent_bom.graph.sla import finding_owner, sla_due_at
 
         kev_due_date = self.evidence.get("kev_due_date") if isinstance(self.evidence, dict) else None
         resolved_sla = self.sla_due_at or sla_due_at(
@@ -613,9 +613,10 @@ class Finding:
             "is_actionable": self.is_actionable,
             "impact_category": self.impact_category,
             # Ownership + remediation SLA (derived, single source of truth in
-            # agent_bom.sla). ``owner`` defaults to "Unassigned" so the surface
-            # reads honestly; ``sla_due_at`` is an explicit None when no deadline
-            # can be derived (unrated severity + no anchor/KEV date).
+            # agent_bom.graph.sla). ``owner`` is an explicit None when nobody is
+            # assigned (an honest absence for the API/exports; the CLI/UI render
+            # it as "Unassigned"); ``sla_due_at`` is None when no deadline can be
+            # derived (unrated severity + no anchor/KEV date).
             "first_seen": self.first_seen,
             "owner": finding_owner(self.owner),
             "sla_due_at": resolved_sla,

--- a/src/agent_bom/finding_scope.py
+++ b/src/agent_bom/finding_scope.py
@@ -723,16 +723,15 @@ def canonical_finding_payload(row: Mapping[str, Any]) -> dict[str, Any]:
         elif isinstance(payload["fixed_version"], str) and payload["fixed_version"].strip():
             payload["remediation_versions"] = [payload["fixed_version"]]
 
-    # Ownership + remediation SLA — one source of truth (agent_bom.sla). Any row
-    # that reaches the API without a precomputed value (bulk-ingested / hub
-    # findings) is filled here so ``/v1/findings``, the CLI, the exports, and the
-    # UI read the same owner and deadline the scan spine already carries. Owner
-    # defaults to "Unassigned"; the deadline stays an explicit None when no anchor
-    # or KEV date makes one derivable, never a fabricated date.
-    from agent_bom.sla import finding_owner, sla_due_at
+    # Remediation SLA — one source of truth (agent_bom.graph.sla). Any row that
+    # reaches the API without a precomputed value (bulk-ingested / hub findings)
+    # is filled here so ``/v1/findings``, the CLI, the exports, and the UI read
+    # the same deadline the scan spine already carries. Owner stays an explicit
+    # ``None`` when nobody is assigned (rendered "Unassigned" only in the CLI/UI);
+    # the deadline stays ``None`` when no anchor or KEV date makes one derivable,
+    # never a fabricated date.
+    from agent_bom.graph.sla import sla_due_at
 
-    if payload["owner"] is None:
-        payload["owner"] = finding_owner(None)
     if payload["sla_due_at"] is None:
         anchor = payload.get("first_seen") or payload.get("last_seen") or payload.get("last_observed")
         evidence = payload.get("evidence")

--- a/src/agent_bom/finding_scope.py
+++ b/src/agent_bom/finding_scope.py
@@ -722,6 +722,28 @@ def canonical_finding_payload(row: Mapping[str, Any]) -> dict[str, Any]:
             payload["remediation_versions"] = fixed_versions
         elif isinstance(payload["fixed_version"], str) and payload["fixed_version"].strip():
             payload["remediation_versions"] = [payload["fixed_version"]]
+
+    # Ownership + remediation SLA — one source of truth (agent_bom.sla). Any row
+    # that reaches the API without a precomputed value (bulk-ingested / hub
+    # findings) is filled here so ``/v1/findings``, the CLI, the exports, and the
+    # UI read the same owner and deadline the scan spine already carries. Owner
+    # defaults to "Unassigned"; the deadline stays an explicit None when no anchor
+    # or KEV date makes one derivable, never a fabricated date.
+    from agent_bom.sla import finding_owner, sla_due_at
+
+    if payload["owner"] is None:
+        payload["owner"] = finding_owner(None)
+    if payload["sla_due_at"] is None:
+        anchor = payload.get("first_seen") or payload.get("last_seen") or payload.get("last_observed")
+        evidence = payload.get("evidence")
+        kev_due_date = payload.get("kev_due_date")
+        if kev_due_date is None and isinstance(evidence, Mapping):
+            kev_due_date = evidence.get("kev_due_date")
+        payload["sla_due_at"] = sla_due_at(
+            payload.get("effective_severity") or payload.get("severity"),
+            anchor,
+            kev_due_date=kev_due_date,
+        )
     return payload
 
 

--- a/src/agent_bom/graph/sla.py
+++ b/src/agent_bom/graph/sla.py
@@ -30,6 +30,7 @@ SEVERITY_SLA_DAYS: dict[str, int] = {
     "low": 180,
 }
 
+
 def _parse_iso(value: object) -> datetime | None:
     """Parse a date or datetime string into a tz-aware UTC datetime, or None.
 

--- a/src/agent_bom/graph/sla.py
+++ b/src/agent_bom/graph/sla.py
@@ -30,9 +30,6 @@ SEVERITY_SLA_DAYS: dict[str, int] = {
     "low": 180,
 }
 
-UNASSIGNED_OWNER = "Unassigned"
-
-
 def _parse_iso(value: object) -> datetime | None:
     """Parse a date or datetime string into a tz-aware UTC datetime, or None.
 
@@ -85,16 +82,19 @@ def sla_due_at(
     return min(candidates).isoformat()
 
 
-def finding_owner(assignee: object) -> str:
-    """Return the finding owner label: the triage assignee, else ``Unassigned``.
+def finding_owner(assignee: object) -> str | None:
+    """Return the finding owner: the triage assignee, else ``None``.
 
     The simple ownership cut surfaces the existing triage ``assignee`` as the
-    finding's owner. Absent an assignee the finding is explicitly ``Unassigned``
-    rather than blank, so the surface reads honestly instead of empty.
+    finding's owner. The *data* layer carries an explicit ``None`` when nobody
+    is assigned — an honest absence the API contract and every export
+    (JSON/SARIF/CDX/SPDX) preserve, so a machine consumer never sees a fake
+    owner. The CLI and UI render that ``None`` as "Unassigned" at the
+    presentation layer only.
     """
     if isinstance(assignee, str) and assignee.strip():
         return assignee.strip()
-    return UNASSIGNED_OWNER
+    return None
 
 
-__all__ = ["SEVERITY_SLA_DAYS", "UNASSIGNED_OWNER", "finding_owner", "sla_due_at"]
+__all__ = ["SEVERITY_SLA_DAYS", "finding_owner", "sla_due_at"]

--- a/src/agent_bom/output/cyclonedx_fmt.py
+++ b/src/agent_bom/output/cyclonedx_fmt.py
@@ -149,13 +149,15 @@ def _cdx_score_method(cvss_vector: str | None) -> str:
     return "CVSSv3"
 
 
-def _cyclonedx_vulnerability(vuln: Vulnerability, pkg_ref: str) -> dict:
+def _cyclonedx_vulnerability(vuln: Vulnerability, pkg_ref: str, *, observed_at: str | None = None) -> dict:
     """Build one package-scoped CycloneDX vulnerability observation.
 
     Carries the enrichment other exporters already surface: CWE weaknesses via
     the native ``cwes`` array, EPSS as an ``other``-method rating, and CISA KEV
     plus EPSS detail as namespaced ``agent-bom:`` properties (KEV/EPSS have no
-    first-class CDX 1.7 vulnerability slot).
+    first-class CDX 1.7 vulnerability slot). ``observed_at`` anchors the
+    severity-derived remediation SLA (``agent-bom:sla_due_at``); omitted when no
+    deadline is derivable so a missing property never reads as "no SLA".
     """
     ratings: list[dict[str, object]] = []
     if vuln.cvss_score:
@@ -199,6 +201,13 @@ def _cyclonedx_vulnerability(vuln: Vulnerability, pkg_ref: str) -> dict:
             vuln_properties.append({"name": "agent-bom:kev_date_added", "value": vuln.kev_date_added})
         if vuln.kev_due_date:
             vuln_properties.append({"name": "agent-bom:kev_due_date", "value": vuln.kev_due_date})
+    # Severity-derived remediation SLA (KEV override) — one source of truth in
+    # agent_bom.sla. Only emitted when an anchor + policy make a deadline real.
+    from agent_bom.sla import sla_due_at as _compute_sla_due_at
+
+    sla_due = _compute_sla_due_at(vuln.severity.value, observed_at, kev_due_date=vuln.kev_due_date)
+    if sla_due is not None:
+        vuln_properties.append({"name": "agent-bom:sla_due_at", "value": sla_due})
     if vuln.epss_score is not None:
         vuln_properties.append({"name": "agent-bom:epss_score", "value": str(vuln.epss_score)})
     if vuln.epss_percentile is not None:
@@ -640,7 +649,7 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
                 for vuln in pkg.vulnerabilities:
                     _merge_vulnerability_observation(
                         vulnerabilities_by_id,
-                        _cyclonedx_vulnerability(vuln, pkg_ref),
+                        _cyclonedx_vulnerability(vuln, pkg_ref, observed_at=report.generated_at.isoformat()),
                     )
                 if pkg_ref in seen_component_refs:
                     continue

--- a/src/agent_bom/output/cyclonedx_fmt.py
+++ b/src/agent_bom/output/cyclonedx_fmt.py
@@ -202,8 +202,8 @@ def _cyclonedx_vulnerability(vuln: Vulnerability, pkg_ref: str, *, observed_at: 
         if vuln.kev_due_date:
             vuln_properties.append({"name": "agent-bom:kev_due_date", "value": vuln.kev_due_date})
     # Severity-derived remediation SLA (KEV override) — one source of truth in
-    # agent_bom.sla. Only emitted when an anchor + policy make a deadline real.
-    from agent_bom.sla import sla_due_at as _compute_sla_due_at
+    # agent_bom.graph.sla. Only emitted when an anchor + policy make a deadline real.
+    from agent_bom.graph.sla import sla_due_at as _compute_sla_due_at
 
     sla_due = _compute_sla_due_at(vuln.severity.value, observed_at, kev_due_date=vuln.kev_due_date)
     if sla_due is not None:

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -987,6 +987,15 @@ def to_json(report: AIBOMReport) -> dict:
     from agent_bom.output.finding_views import apply_workload_runtime_evidence_for_export
 
     export_findings = apply_workload_runtime_evidence_for_export(list(report.to_findings()))
+    # Anchor the remediation SLA window: scan completion is the authoritative
+    # first-observation time for a fresh scan's findings, so stamp it when the
+    # finding does not already carry a first-seen history. to_dict() then derives
+    # ``sla_due_at`` from this anchor (with the KEV override) — one source of
+    # truth for the report, the API job result, and every export.
+    scan_observed_at = report.generated_at.isoformat()
+    for finding in export_findings:
+        if not finding.first_seen:
+            finding.first_seen = scan_observed_at
     unified_findings = [finding.to_dict() for finding in export_findings]
     asset_inventory = _build_asset_inventory(unified_findings)
     finding_summary = _build_finding_summary(unified_findings)

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -620,11 +620,11 @@ def _cve_sarif_result(
     related_locations = _exposure_related_locations(exposure_path)
     if related_locations:
         result["relatedLocations"] = related_locations
-    # Ownership + remediation SLA (single source of truth in agent_bom.sla). The
+    # Ownership + remediation SLA (single source of truth in agent_bom.graph.sla). The
     # scan-completion time anchors the deadline when the finding carries no
     # first-seen history, matching the JSON report spine.
-    from agent_bom.sla import finding_owner
-    from agent_bom.sla import sla_due_at as _compute_sla_due_at
+    from agent_bom.graph.sla import finding_owner
+    from agent_bom.graph.sla import sla_due_at as _compute_sla_due_at
 
     finding_sla_due_at = finding.sla_due_at or _compute_sla_due_at(
         finding.effective_severity(),

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -620,7 +620,20 @@ def _cve_sarif_result(
     related_locations = _exposure_related_locations(exposure_path)
     if related_locations:
         result["relatedLocations"] = related_locations
+    # Ownership + remediation SLA (single source of truth in agent_bom.sla). The
+    # scan-completion time anchors the deadline when the finding carries no
+    # first-seen history, matching the JSON report spine.
+    from agent_bom.sla import finding_owner
+    from agent_bom.sla import sla_due_at as _compute_sla_due_at
+
+    finding_sla_due_at = finding.sla_due_at or _compute_sla_due_at(
+        finding.effective_severity(),
+        finding.first_seen or report.generated_at.isoformat(),
+        kev_due_date=evidence(finding, "kev_due_date"),
+    )
     result_properties: dict[str, Any] = {
+        "owner": finding_owner(finding.owner),
+        "sla_due_at": finding_sla_due_at,
         "blast_score": finding.risk_score,
         "match_confidence_tier": evidence(finding, "match_confidence_tier"),
         "cve_ids": _cve_ids_for_finding(finding),

--- a/src/agent_bom/output/spdx_fmt.py
+++ b/src/agent_bom/output/spdx_fmt.py
@@ -348,7 +348,7 @@ def _vulnerability_annotations(
         statements.append(f"agent-bom:kev-date-added={vuln.kev_date_added}")
     if vuln.kev_due_date:
         statements.append(f"agent-bom:kev-due-date={vuln.kev_due_date}")
-    from agent_bom.sla import sla_due_at as _compute_sla_due_at
+    from agent_bom.graph.sla import sla_due_at as _compute_sla_due_at
 
     _severity_value = vuln.severity.value if hasattr(vuln.severity, "value") else str(vuln.severity)
     sla_due = _compute_sla_due_at(_severity_value, observed_at, kev_due_date=vuln.kev_due_date)

--- a/src/agent_bom/output/spdx_fmt.py
+++ b/src/agent_bom/output/spdx_fmt.py
@@ -253,6 +253,7 @@ def to_spdx(report: AIBOMReport) -> dict:
                         vuln,
                         vuln_element_id,
                         compliance_tags=vuln_compliance_tags.get(_vulnerability_key(pkg, vuln), []),
+                        observed_at=report.generated_at.isoformat(),
                     )
                     if vuln_annotations:
                         vuln_element["annotation"] = vuln_annotations
@@ -322,8 +323,19 @@ def export_spdx(report: AIBOMReport, output_path: str) -> None:
     Path(output_path).write_text(json.dumps(data, indent=2))
 
 
-def _vulnerability_annotations(vuln: Any, subject: str, *, compliance_tags: list[str] | None = None) -> list[dict[str, object]]:
-    """Encode non-core vulnerability enrichments as SPDX annotations."""
+def _vulnerability_annotations(
+    vuln: Any,
+    subject: str,
+    *,
+    compliance_tags: list[str] | None = None,
+    observed_at: str | None = None,
+) -> list[dict[str, object]]:
+    """Encode non-core vulnerability enrichments as SPDX annotations.
+
+    ``observed_at`` anchors the severity-derived remediation SLA
+    (``agent-bom:sla-due-at``, KEV override); omitted when no deadline is
+    derivable so a missing statement never reads as "no SLA".
+    """
     statements: list[str] = []
     if vuln.severity_source:
         statements.append(f"agent-bom:severity-source={vuln.severity_source}")
@@ -336,6 +348,12 @@ def _vulnerability_annotations(vuln: Any, subject: str, *, compliance_tags: list
         statements.append(f"agent-bom:kev-date-added={vuln.kev_date_added}")
     if vuln.kev_due_date:
         statements.append(f"agent-bom:kev-due-date={vuln.kev_due_date}")
+    from agent_bom.sla import sla_due_at as _compute_sla_due_at
+
+    _severity_value = vuln.severity.value if hasattr(vuln.severity, "value") else str(vuln.severity)
+    sla_due = _compute_sla_due_at(_severity_value, observed_at, kev_due_date=vuln.kev_due_date)
+    if sla_due is not None:
+        statements.append(f"agent-bom:sla-due-at={sla_due}")
     for cwe_id in vuln.cwe_ids:
         statements.append(f"agent-bom:cwe={cwe_id}")
     compliance_statements = [*list(compliance_tags or []), *_vulnerability_compliance_tags(vuln)]

--- a/src/agent_bom/sla.py
+++ b/src/agent_bom/sla.py
@@ -1,0 +1,100 @@
+"""Finding-level remediation SLA policy — one source of truth for every surface.
+
+A finding's ``sla_due_at`` is a *derived* field: the report spine
+(:meth:`agent_bom.finding.Finding.to_dict`) and the API projection
+(:func:`agent_bom.finding_scope.canonical_finding_payload`) both call
+:func:`sla_due_at` so the CLI table, ``/v1/findings``, the JSON/SARIF/CDX/SPDX
+exports, and the UI cannot disagree about the same finding's deadline.
+
+The policy is deliberately simple (severity → fixed remediation window from the
+finding's first-seen anchor). A KEV-listed finding honors the earlier of its
+severity window and the CISA BOD 22-01 deadline, because the most urgent binding
+deadline is the one that actually governs. When neither a policy window nor a KEV
+deadline can be computed the deadline is an explicit ``None`` — an honest
+"unknown", never a fabricated date.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from agent_bom.graph.severity import normalize_severity
+
+# Severity → remediation window in days from the finding's first-seen anchor.
+# Conservative, industry-typical defaults; ``info``/``unknown`` intentionally
+# carry no fixed deadline (an SLA there would be a fabricated claim).
+SEVERITY_SLA_DAYS: dict[str, int] = {
+    "critical": 7,
+    "high": 30,
+    "medium": 90,
+    "low": 180,
+}
+
+UNASSIGNED_OWNER = "Unassigned"
+
+
+def _parse_iso(value: object) -> datetime | None:
+    """Parse a date or datetime string into a tz-aware UTC datetime, or None.
+
+    Accepts full ISO-8601 datetimes and bare ``YYYY-MM-DD`` dates (CISA KEV due
+    dates are date-only). Naive values are treated as UTC.
+    """
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def sla_due_at(
+    severity: object,
+    first_seen: object,
+    *,
+    kev_due_date: object = None,
+) -> str | None:
+    """Return the ISO-8601 remediation deadline for a finding, or ``None``.
+
+    ``first_seen`` anchors the severity window; ``kev_due_date`` (when present)
+    competes as an alternative deadline and the *earlier* of the two wins. The
+    result is a full tz-aware ISO datetime so it round-trips through the finding
+    response timestamp validators. ``None`` means no deadline could be honestly
+    derived (unrated severity and no KEV deadline, or no usable anchor).
+    """
+    candidates: list[datetime] = []
+
+    days = SEVERITY_SLA_DAYS.get(normalize_severity(severity if isinstance(severity, str) else None))
+    anchor = _parse_iso(first_seen)
+    if days is not None and anchor is not None:
+        from datetime import timedelta
+
+        candidates.append(anchor + timedelta(days=days))
+
+    kev = _parse_iso(kev_due_date)
+    if kev is not None:
+        candidates.append(kev)
+
+    if not candidates:
+        return None
+    return min(candidates).isoformat()
+
+
+def finding_owner(assignee: object) -> str:
+    """Return the finding owner label: the triage assignee, else ``Unassigned``.
+
+    The simple ownership cut surfaces the existing triage ``assignee`` as the
+    finding's owner. Absent an assignee the finding is explicitly ``Unassigned``
+    rather than blank, so the surface reads honestly instead of empty.
+    """
+    if isinstance(assignee, str) and assignee.strip():
+        return assignee.strip()
+    return UNASSIGNED_OWNER
+
+
+__all__ = ["SEVERITY_SLA_DAYS", "UNASSIGNED_OWNER", "finding_owner", "sla_due_at"]

--- a/tests/api/test_findings_owner_sla.py
+++ b/tests/api/test_findings_owner_sla.py
@@ -21,9 +21,9 @@ from agent_bom.api.routes.enterprise import _triage_reason
 from agent_bom.api.routes.scan import iter_tenant_scan_spine_findings
 from agent_bom.api.store import InMemoryJobStore
 from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+from agent_bom.graph.sla import SEVERITY_SLA_DAYS
 from agent_bom.models import AIBOMReport
 from agent_bom.output import to_json
-from agent_bom.graph.sla import SEVERITY_SLA_DAYS
 
 
 def _completed_job(tenant_id: str, findings: list[Finding], *, generated_at: datetime) -> ScanJob:

--- a/tests/api/test_findings_owner_sla.py
+++ b/tests/api/test_findings_owner_sla.py
@@ -3,7 +3,8 @@
 Locks the P0 fix: finding-level ``owner`` and ``sla_due_at`` are declared in the
 response contract but were never populated. The scan spine now derives an SLA
 deadline (severity policy from the scan-observation anchor, KEV override) and
-surfaces the triage assignee as the owner, defaulting to "Unassigned".
+surfaces the triage assignee as the owner — an explicit ``None`` when nobody is
+assigned (the CLI/UI render that as "Unassigned").
 """
 
 from __future__ import annotations
@@ -22,7 +23,7 @@ from agent_bom.api.store import InMemoryJobStore
 from agent_bom.finding import Asset, Finding, FindingSource, FindingType
 from agent_bom.models import AIBOMReport
 from agent_bom.output import to_json
-from agent_bom.sla import SEVERITY_SLA_DAYS
+from agent_bom.graph.sla import SEVERITY_SLA_DAYS
 
 
 def _completed_job(tenant_id: str, findings: list[Finding], *, generated_at: datetime) -> ScanJob:
@@ -76,7 +77,7 @@ def test_scan_spine_finding_defaults_owner_and_populates_sla(isolated_job_store,
     assert rows, "expected the seeded critical finding on the scan spine"
     row = rows[0]
 
-    assert row["owner"] == "Unassigned"
+    assert row["owner"] is None
     assert row["sla_due_at"] is not None
     delta = datetime.fromisoformat(row["sla_due_at"]) - generated_at
     assert delta.days == SEVERITY_SLA_DAYS["critical"]
@@ -101,7 +102,7 @@ def test_scan_spine_owner_reflects_triage_assignee(isolated_job_store, isolated_
     rows = iter_tenant_scan_spine_findings("default")
     # The assignee is surfaced as owner; the API masks the email for privacy.
     assert rows[0]["owner"] == mask_email("secops@example.com")
-    assert rows[0]["owner"] != "Unassigned"
+    assert rows[0]["owner"] is not None
 
 
 def test_triage_owner_does_not_leak_across_tenants(isolated_job_store, isolated_exception_store):
@@ -127,4 +128,4 @@ def test_triage_owner_does_not_leak_across_tenants(isolated_job_store, isolated_
 
     assert alpha[0]["owner"] == mask_email("alpha-owner@example.com")
     # tenant-beta must not inherit tenant-alpha's assignee.
-    assert beta[0]["owner"] == "Unassigned"
+    assert beta[0]["owner"] is None

--- a/tests/api/test_findings_owner_sla.py
+++ b/tests/api/test_findings_owner_sla.py
@@ -1,0 +1,130 @@
+"""Owner + SLA are populated on the scan-spine finding surface.
+
+Locks the P0 fix: finding-level ``owner`` and ``sla_due_at`` are declared in the
+response contract but were never populated. The scan spine now derives an SLA
+deadline (severity policy from the scan-observation anchor, KEV override) and
+surfaces the triage assignee as the owner, defaulting to "Unassigned".
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from agent_bom.api import stores as api_stores
+from agent_bom.api.exception_store import ExceptionStatus, InMemoryExceptionStore, VulnException
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+from agent_bom.api.routes import enterprise
+from agent_bom.api.routes.enterprise import _triage_reason
+from agent_bom.api.routes.scan import iter_tenant_scan_spine_findings
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+from agent_bom.models import AIBOMReport
+from agent_bom.output import to_json
+from agent_bom.sla import SEVERITY_SLA_DAYS
+
+
+def _completed_job(tenant_id: str, findings: list[Finding], *, generated_at: datetime) -> ScanJob:
+    report = AIBOMReport(agents=[], blast_radii=[], findings=findings, generated_at=generated_at)
+    return ScanJob(
+        job_id=f"job-{tenant_id}",
+        tenant_id=tenant_id,
+        status=JobStatus.DONE,
+        created_at=generated_at.isoformat(),
+        completed_at=generated_at.isoformat(),
+        request=ScanRequest(),
+        result=to_json(report),
+    )
+
+
+def _critical_finding() -> Finding:
+    return Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(name="demo-lib", asset_type="package", identifier="pkg:pypi/demo-lib@1.0.0"),
+        severity="critical",
+        cve_id="CVE-2026-4242",
+        title="CVE-2026-4242: demo-lib@1.0.0",
+        evidence={"package_name": "demo-lib", "package_version": "1.0.0"},
+    )
+
+
+@pytest.fixture
+def isolated_job_store():
+    original = api_stores._store
+    store = InMemoryJobStore()
+    api_stores.set_job_store(store)
+    try:
+        yield store
+    finally:
+        api_stores.set_job_store(original)
+
+
+@pytest.fixture
+def isolated_exception_store(monkeypatch):
+    store = InMemoryExceptionStore()
+    monkeypatch.setattr(enterprise, "_get_exception_store", lambda: store)
+    return store
+
+
+def test_scan_spine_finding_defaults_owner_and_populates_sla(isolated_job_store, isolated_exception_store):
+    generated_at = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    isolated_job_store.put(_completed_job("default", [_critical_finding()], generated_at=generated_at))
+
+    rows = iter_tenant_scan_spine_findings("default")
+    assert rows, "expected the seeded critical finding on the scan spine"
+    row = rows[0]
+
+    assert row["owner"] == "Unassigned"
+    assert row["sla_due_at"] is not None
+    delta = datetime.fromisoformat(row["sla_due_at"]) - generated_at
+    assert delta.days == SEVERITY_SLA_DAYS["critical"]
+
+
+def test_scan_spine_owner_reflects_triage_assignee(isolated_job_store, isolated_exception_store):
+    generated_at = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    isolated_job_store.put(_completed_job("default", [_critical_finding()], generated_at=generated_at))
+    isolated_exception_store.put(
+        VulnException(
+            vuln_id="CVE-2026-4242",
+            package_name="demo-lib",
+            reason=_triage_reason({"queue_state": "open", "assignee": "secops@example.com"}),
+            approved_by="secops@example.com",
+            status=ExceptionStatus.ACTIVE,
+            tenant_id="default",
+        )
+    )
+
+    from agent_bom.security import mask_email
+
+    rows = iter_tenant_scan_spine_findings("default")
+    # The assignee is surfaced as owner; the API masks the email for privacy.
+    assert rows[0]["owner"] == mask_email("secops@example.com")
+    assert rows[0]["owner"] != "Unassigned"
+
+
+def test_triage_owner_does_not_leak_across_tenants(isolated_job_store, isolated_exception_store):
+    generated_at = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    # Same finding in two tenants; only tenant-alpha has a triage assignee.
+    isolated_job_store.put(_completed_job("tenant-alpha", [_critical_finding()], generated_at=generated_at))
+    isolated_job_store.put(_completed_job("tenant-beta", [_critical_finding()], generated_at=generated_at))
+    isolated_exception_store.put(
+        VulnException(
+            vuln_id="CVE-2026-4242",
+            package_name="demo-lib",
+            reason=_triage_reason({"queue_state": "open", "assignee": "alpha-owner@example.com"}),
+            approved_by="alpha-owner@example.com",
+            status=ExceptionStatus.ACTIVE,
+            tenant_id="tenant-alpha",
+        )
+    )
+
+    from agent_bom.security import mask_email
+
+    alpha = iter_tenant_scan_spine_findings("tenant-alpha")
+    beta = iter_tenant_scan_spine_findings("tenant-beta")
+
+    assert alpha[0]["owner"] == mask_email("alpha-owner@example.com")
+    # tenant-beta must not inherit tenant-alpha's assignee.
+    assert beta[0]["owner"] == "Unassigned"

--- a/tests/test_cli_findings.py
+++ b/tests/test_cli_findings.py
@@ -30,9 +30,11 @@ class FakeFindingsClient:
                     "id": "finding-1",
                     "severity": "high",
                     "status": "open",
+                    "owner": "secops@example.com",
                     "package": "requests",
                     "first_seen": "2026-07-01T00:00:00Z",
                     "last_seen": "2026-07-03T00:00:00Z",
+                    "sla_due_at": "2026-07-31T00:00:00Z",
                     "title": "Reachable CVE",
                 }
             ],
@@ -112,9 +114,11 @@ def test_findings_list_table_includes_lifecycle_columns(monkeypatch) -> None:
 
     assert result.exit_code == 0, result.output
     lines = result.output.strip().splitlines()
-    assert lines[0].startswith("id\tseverity\tstatus\tpackage\tfirst_seen\tlast_seen\ttitle")
+    assert lines[0].startswith("id\tseverity\tstatus\towner\tpackage\tfirst_seen\tlast_seen\tsla_due_at\ttitle")
     assert "open" in lines[1]
     assert "2026-07-01T00:00:00Z" in lines[1]
+    assert "secops@example.com" in lines[1]
+    assert "2026-07-31T00:00:00Z" in lines[1]
 
 
 def test_findings_list_outputs_json_and_passes_filters(monkeypatch) -> None:

--- a/tests/test_export_enrichment_parity.py
+++ b/tests/test_export_enrichment_parity.py
@@ -789,18 +789,18 @@ def _plain_critical_vuln() -> Vulnerability:
 
 
 def test_sarif_result_carries_owner_and_sla_due_at() -> None:
-    from agent_bom.sla import SEVERITY_SLA_DAYS
+    from agent_bom.graph.sla import SEVERITY_SLA_DAYS
 
     report = _report_with_vuln(_plain_critical_vuln())
     result = next(r for r in to_sarif(report)["runs"][0]["results"] if r["ruleId"] == "CVE-2026-7777")
     props = result["properties"]
-    assert props["owner"] == "Unassigned"
+    assert props.get("owner") is None
     due = datetime.fromisoformat(props["sla_due_at"])
     assert (due - report.generated_at).days == SEVERITY_SLA_DAYS["critical"]
 
 
 def test_cyclonedx_vulnerability_carries_sla_due_at() -> None:
-    from agent_bom.sla import SEVERITY_SLA_DAYS
+    from agent_bom.graph.sla import SEVERITY_SLA_DAYS
 
     report = _report_with_vuln(_plain_critical_vuln())
     doc = to_cyclonedx(report)

--- a/tests/test_export_enrichment_parity.py
+++ b/tests/test_export_enrichment_parity.py
@@ -771,3 +771,66 @@ def test_findings_api_payload_carries_the_provenance_status() -> None:
     # The response model carries every field explicitly, so the unknown verdict
     # is an explicit null beside the status that explains it.
     assert payload["package_provenance_attested"] is None
+
+
+# ---------------------------------------------------------------------------
+# Owner + SLA reach every finding-shaped export (P0 parity)
+# ---------------------------------------------------------------------------
+
+
+def _plain_critical_vuln() -> Vulnerability:
+    return Vulnerability(
+        id="CVE-2026-7777",
+        summary="RCE in flask",
+        severity=Severity.CRITICAL,
+        cvss_score=9.8,
+        fixed_version="2.3.0",
+    )
+
+
+def test_sarif_result_carries_owner_and_sla_due_at() -> None:
+    from agent_bom.sla import SEVERITY_SLA_DAYS
+
+    report = _report_with_vuln(_plain_critical_vuln())
+    result = next(r for r in to_sarif(report)["runs"][0]["results"] if r["ruleId"] == "CVE-2026-7777")
+    props = result["properties"]
+    assert props["owner"] == "Unassigned"
+    due = datetime.fromisoformat(props["sla_due_at"])
+    assert (due - report.generated_at).days == SEVERITY_SLA_DAYS["critical"]
+
+
+def test_cyclonedx_vulnerability_carries_sla_due_at() -> None:
+    from agent_bom.sla import SEVERITY_SLA_DAYS
+
+    report = _report_with_vuln(_plain_critical_vuln())
+    doc = to_cyclonedx(report)
+    vuln = next(v for v in doc["vulnerabilities"] if v["id"] == "CVE-2026-7777")
+    props = {p["name"]: p["value"] for p in vuln.get("properties", [])}
+    due = datetime.fromisoformat(props["agent-bom:sla_due_at"])
+    assert (due - report.generated_at).days == SEVERITY_SLA_DAYS["critical"]
+
+
+def test_cyclonedx_sla_honors_kev_due_date_override() -> None:
+    # high policy = 30 days from Jan 1 -> Jan 31; the KEV deadline (Jan 23) is
+    # earlier and therefore governs (most-urgent binding deadline wins).
+    vuln = Vulnerability(
+        id="CVE-2026-8888",
+        summary="SSRF in flask",
+        severity=Severity.HIGH,
+        cvss_score=7.5,
+        is_kev=True,
+        kev_due_date="2026-01-23",
+    )
+    report = _report_with_vuln(vuln)
+    doc = to_cyclonedx(report)
+    entry = next(v for v in doc["vulnerabilities"] if v["id"] == "CVE-2026-8888")
+    props = {p["name"]: p["value"] for p in entry.get("properties", [])}
+    assert datetime.fromisoformat(props["agent-bom:sla_due_at"]) == datetime(2026, 1, 23, tzinfo=timezone.utc)
+
+
+def test_spdx_annotations_carry_the_sla_due_at() -> None:
+    from agent_bom.output.spdx_fmt import to_spdx
+
+    report = _report_with_vuln(_plain_critical_vuln())
+    doc = to_spdx(report)
+    assert "agent-bom:sla-due-at=" in json.dumps(doc)

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -754,3 +754,66 @@ def test_report_dual_write_findings_field():
     # to_findings() returns the already-populated list
     assert len(report.to_findings()) == 1
     assert report.to_findings()[0].cve_id == "CVE-2024-9999"  # vuln_id maps to cve_id
+
+
+# ---------------------------------------------------------------------------
+# Owner + SLA (P0: finding-level owner + SLA populated on the spine)
+# ---------------------------------------------------------------------------
+
+
+def test_finding_to_dict_populates_owner_and_sla_from_first_seen():
+    from datetime import datetime
+
+    from agent_bom.sla import SEVERITY_SLA_DAYS
+
+    finding = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(name="pkg", asset_type="package", identifier="pkg:pypi/torch@2.3.0"),
+        severity="critical",
+        first_seen="2026-08-01T00:00:00+00:00",
+    )
+    payload = finding.to_dict()
+    assert payload["owner"] == "Unassigned"
+    assert payload["first_seen"] == "2026-08-01T00:00:00+00:00"
+    due = datetime.fromisoformat(payload["sla_due_at"])
+    anchor = datetime.fromisoformat("2026-08-01T00:00:00+00:00")
+    assert (due - anchor).days == SEVERITY_SLA_DAYS["critical"]
+
+
+def test_finding_to_dict_owner_surfaces_assignee():
+    finding = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(name="pkg", asset_type="package", identifier="pkg:pypi/torch@2.3.0"),
+        severity="high",
+        owner="alice@example.com",
+    )
+    assert finding.to_dict()["owner"] == "alice@example.com"
+
+
+def test_finding_to_dict_sla_none_without_anchor():
+    finding = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(name="pkg", asset_type="package", identifier="pkg:pypi/torch@2.3.0"),
+        severity="critical",
+    )
+    # Honest unknown: no first_seen anchor and no KEV date -> no fabricated date.
+    assert finding.to_dict()["sla_due_at"] is None
+
+
+def test_finding_to_dict_kev_due_date_overrides_sla():
+    from datetime import datetime
+
+    finding = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(name="pkg", asset_type="package", identifier="pkg:pypi/torch@2.3.0"),
+        severity="high",
+        first_seen="2026-08-01T00:00:00+00:00",
+        is_kev=True,
+        evidence={"kev_due_date": "2026-08-10"},
+    )
+    due = datetime.fromisoformat(finding.to_dict()["sla_due_at"])
+    assert due == datetime.fromisoformat("2026-08-10T00:00:00+00:00")

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -764,7 +764,7 @@ def test_report_dual_write_findings_field():
 def test_finding_to_dict_populates_owner_and_sla_from_first_seen():
     from datetime import datetime
 
-    from agent_bom.sla import SEVERITY_SLA_DAYS
+    from agent_bom.graph.sla import SEVERITY_SLA_DAYS
 
     finding = Finding(
         finding_type=FindingType.CVE,
@@ -774,7 +774,7 @@ def test_finding_to_dict_populates_owner_and_sla_from_first_seen():
         first_seen="2026-08-01T00:00:00+00:00",
     )
     payload = finding.to_dict()
-    assert payload["owner"] == "Unassigned"
+    assert payload["owner"] is None
     assert payload["first_seen"] == "2026-08-01T00:00:00+00:00"
     due = datetime.fromisoformat(payload["sla_due_at"])
     anchor = datetime.fromisoformat("2026-08-01T00:00:00+00:00")

--- a/tests/test_finding_field_surfacing.py
+++ b/tests/test_finding_field_surfacing.py
@@ -42,6 +42,14 @@ _NEW_JSON_FINDING_KEYS = {
     "reachability",
     "is_actionable",
     "impact_category",
+    # Additive ownership + remediation-SLA fields (owner/SLA PR). ``sla_due_at``
+    # and ``first_seen`` are context-dependent — the report spine anchors
+    # first_seen at scan-completion time so a deadline is derivable, while a bare
+    # Finding.to_dict has no anchor — so they are excluded from the legacy
+    # snapshot comparison, same as the other additive keys.
+    "owner",
+    "sla_due_at",
+    "first_seen",
 }
 _NEW_SARIF_RESULT_PROPERTY_KEYS = {
     "affected_servers",

--- a/tests/test_finding_scope.py
+++ b/tests/test_finding_scope.py
@@ -317,7 +317,7 @@ def test_canonical_payload_defaults_owner_to_unassigned() -> None:
     from agent_bom.finding_scope import canonical_finding_payload
 
     payload = canonical_finding_payload({"severity": "high"})
-    assert payload["owner"] == "Unassigned"
+    assert payload["owner"] is None
 
 
 def test_canonical_payload_preserves_existing_owner() -> None:
@@ -331,7 +331,7 @@ def test_canonical_payload_derives_sla_from_first_seen() -> None:
     from datetime import datetime
 
     from agent_bom.finding_scope import canonical_finding_payload
-    from agent_bom.sla import SEVERITY_SLA_DAYS
+    from agent_bom.graph.sla import SEVERITY_SLA_DAYS
 
     payload = canonical_finding_payload({"severity": "high", "first_seen": "2026-08-01T00:00:00+00:00"})
     assert payload["sla_due_at"] is not None

--- a/tests/test_finding_scope.py
+++ b/tests/test_finding_scope.py
@@ -306,3 +306,57 @@ def test_known_source_routing_is_unchanged_by_the_lenient_parse() -> None:
     assert lenses_for_row({"source": "SBOM", "finding_type": "CVE"}) == frozenset({"vuln", "aspm"})
     assert domain_for_row({"source": "MCP_SCAN", "finding_type": "TOOL_DRIFT"}) == "aispm"
     assert domain_for_row({"source": "CLOUD_CIS", "finding_type": "CIS_FAIL", "evidence": {"benchmark": "CIS"}}) == "cspm"
+
+
+# ---------------------------------------------------------------------------
+# Owner + SLA derivation on the canonical API projection
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_payload_defaults_owner_to_unassigned() -> None:
+    from agent_bom.finding_scope import canonical_finding_payload
+
+    payload = canonical_finding_payload({"severity": "high"})
+    assert payload["owner"] == "Unassigned"
+
+
+def test_canonical_payload_preserves_existing_owner() -> None:
+    from agent_bom.finding_scope import canonical_finding_payload
+
+    payload = canonical_finding_payload({"severity": "high", "owner": "alice@example.com"})
+    assert payload["owner"] == "alice@example.com"
+
+
+def test_canonical_payload_derives_sla_from_first_seen() -> None:
+    from datetime import datetime
+
+    from agent_bom.finding_scope import canonical_finding_payload
+    from agent_bom.sla import SEVERITY_SLA_DAYS
+
+    payload = canonical_finding_payload({"severity": "high", "first_seen": "2026-08-01T00:00:00+00:00"})
+    assert payload["sla_due_at"] is not None
+    delta = datetime.fromisoformat(payload["sla_due_at"]) - datetime.fromisoformat("2026-08-01T00:00:00+00:00")
+    assert delta.days == SEVERITY_SLA_DAYS["high"]
+
+
+def test_canonical_payload_sla_falls_back_to_last_seen_anchor() -> None:
+    from agent_bom.finding_scope import canonical_finding_payload
+
+    payload = canonical_finding_payload({"severity": "critical", "last_seen": "2026-08-01T00:00:00+00:00"})
+    assert payload["sla_due_at"] is not None
+
+
+def test_canonical_payload_preserves_precomputed_sla() -> None:
+    from agent_bom.finding_scope import canonical_finding_payload
+
+    payload = canonical_finding_payload(
+        {"severity": "high", "first_seen": "2026-08-01T00:00:00+00:00", "sla_due_at": "2026-08-05T00:00:00+00:00"}
+    )
+    assert payload["sla_due_at"] == "2026-08-05T00:00:00+00:00"
+
+
+def test_canonical_payload_sla_none_without_anchor() -> None:
+    from agent_bom.finding_scope import canonical_finding_payload
+
+    payload = canonical_finding_payload({"severity": "critical"})
+    assert payload["sla_due_at"] is None

--- a/tests/test_sla.py
+++ b/tests/test_sla.py
@@ -1,0 +1,92 @@
+"""Unit tests for the finding SLA remediation-deadline policy."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from agent_bom.sla import (
+    SEVERITY_SLA_DAYS,
+    UNASSIGNED_OWNER,
+    finding_owner,
+    sla_due_at,
+)
+
+
+def _dt(text: str) -> datetime:
+    return datetime.fromisoformat(text.replace("Z", "+00:00"))
+
+
+def test_critical_due_date_is_first_seen_plus_policy() -> None:
+    due = sla_due_at("critical", "2026-08-01T00:00:00+00:00")
+    assert due is not None
+    delta = _dt(due) - _dt("2026-08-01T00:00:00+00:00")
+    assert delta.days == SEVERITY_SLA_DAYS["critical"]
+
+
+def test_each_rated_severity_maps_to_its_policy_window() -> None:
+    anchor = "2026-01-01T00:00:00+00:00"
+    for severity, days in SEVERITY_SLA_DAYS.items():
+        due = sla_due_at(severity, anchor)
+        assert due is not None, severity
+        assert (_dt(due) - _dt(anchor)).days == days, severity
+
+
+def test_severity_input_is_normalized() -> None:
+    assert sla_due_at("CRITICAL", "2026-08-01T00:00:00+00:00") == sla_due_at("critical", "2026-08-01T00:00:00+00:00")
+    assert sla_due_at("Informational", "2026-08-01T00:00:00+00:00") is None
+
+
+def test_unknown_or_info_severity_has_no_deadline() -> None:
+    assert sla_due_at("info", "2026-08-01T00:00:00+00:00") is None
+    assert sla_due_at("bogus", "2026-08-01T00:00:00+00:00") is None
+    assert sla_due_at(None, "2026-08-01T00:00:00+00:00") is None
+
+
+def test_missing_anchor_yields_none_when_no_kev() -> None:
+    # Honest unknown: cannot compute a deadline without an observation anchor.
+    assert sla_due_at("critical", None) is None
+    assert sla_due_at("critical", "") is None
+    assert sla_due_at("critical", "not-a-date") is None
+
+
+def test_kev_due_date_overrides_when_earlier() -> None:
+    # high policy = 30d from first_seen would land 2026-08-31; KEV deadline is
+    # earlier, so the more-urgent KEV date governs.
+    due = sla_due_at("high", "2026-08-01T00:00:00+00:00", kev_due_date="2026-08-10")
+    assert due is not None
+    assert _dt(due) == _dt("2026-08-10T00:00:00+00:00")
+
+
+def test_kev_due_date_ignored_when_policy_is_earlier() -> None:
+    # critical policy = 7d -> 2026-08-08; a later KEV date must not relax it.
+    due = sla_due_at("critical", "2026-08-01T00:00:00+00:00", kev_due_date="2026-12-31")
+    assert due is not None
+    assert _dt(due) == _dt("2026-08-08T00:00:00+00:00")
+
+
+def test_kev_due_date_used_when_no_policy_anchor() -> None:
+    # No usable first_seen but a real KEV deadline: honor the KEV date.
+    due = sla_due_at("info", None, kev_due_date="2026-08-10")
+    assert due is not None
+    assert _dt(due) == _dt("2026-08-10T00:00:00+00:00")
+
+
+def test_due_date_is_full_iso_datetime_with_timezone() -> None:
+    due = sla_due_at("medium", "2026-08-01")
+    assert due is not None
+    parsed = _dt(due)
+    assert parsed.tzinfo is not None
+    # Date-only anchor is normalized to a tz-aware midnight.
+    assert parsed == datetime(2026, 8, 1, tzinfo=timezone.utc) + (_dt(due) - datetime(2026, 8, 1, tzinfo=timezone.utc))
+
+
+def test_finding_owner_prefers_assignee() -> None:
+    assert finding_owner("alice@example.com") == "alice@example.com"
+    assert finding_owner("  bob  ") == "bob"
+
+
+def test_finding_owner_defaults_to_unassigned() -> None:
+    assert finding_owner(None) == UNASSIGNED_OWNER
+    assert finding_owner("") == UNASSIGNED_OWNER
+    assert finding_owner("   ") == UNASSIGNED_OWNER
+    assert finding_owner(123) == UNASSIGNED_OWNER  # type: ignore[arg-type]

--- a/tests/test_sla.py
+++ b/tests/test_sla.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from agent_bom.sla import (
+from agent_bom.graph.sla import (
     SEVERITY_SLA_DAYS,
-    UNASSIGNED_OWNER,
     finding_owner,
     sla_due_at,
 )
@@ -85,8 +84,9 @@ def test_finding_owner_prefers_assignee() -> None:
     assert finding_owner("  bob  ") == "bob"
 
 
-def test_finding_owner_defaults_to_unassigned() -> None:
-    assert finding_owner(None) == UNASSIGNED_OWNER
-    assert finding_owner("") == UNASSIGNED_OWNER
-    assert finding_owner("   ") == UNASSIGNED_OWNER
-    assert finding_owner(123) == UNASSIGNED_OWNER  # type: ignore[arg-type]
+def test_finding_owner_is_none_when_unassigned() -> None:
+    # Data layer carries None (honest absence); the CLI/UI render "Unassigned".
+    assert finding_owner(None) is None
+    assert finding_owner("") is None
+    assert finding_owner("   ") is None
+    assert finding_owner(123) is None  # type: ignore[arg-type]

--- a/ui/components/findings-queue.tsx
+++ b/ui/components/findings-queue.tsx
@@ -10,6 +10,7 @@ import {
   findingSecondaryText,
   findingStatusClass,
   formatFindingTimestamp,
+  formatSlaDue,
   vulnRowKey,
 } from "@/lib/findings-view";
 import { getOsvVulnerabilityUrl } from "@/lib/vulnerabilities";
@@ -467,6 +468,7 @@ function EngineeringCells({
   onMarkFP: () => void;
 }) {
   const verifyCommand = vuln.remediation_items.find((item) => item.verify_command)?.verify_command;
+  const sla = formatSlaDue(vuln.sla_due_at);
   return (
     <>
       <td className="px-4 py-3">
@@ -511,9 +513,16 @@ function EngineeringCells({
       <td className="px-4 py-3">
         <div className="flex flex-col gap-1 text-xs">
           <span className="text-[var(--text-secondary)]">{vuln.owner || triage?.assignee || "Unassigned"}</span>
-          <span className="text-[var(--text-tertiary)]">
-            {vuln.sla_due_at ? `SLA ${formatFindingTimestamp(vuln.sla_due_at)}` : "SLA unavailable"}
-          </span>
+          {sla ? (
+            <span
+              className={sla.overdue ? "font-medium text-[color:var(--status-danger)]" : "text-[var(--text-tertiary)]"}
+              title={`SLA due ${sla.absolute}`}
+            >
+              {sla.label}
+            </span>
+          ) : (
+            <span className="text-[var(--text-tertiary)]">SLA unavailable</span>
+          )}
         </div>
       </td>
       <td className="px-4 py-3 text-xs font-mono text-[var(--text-secondary)]">

--- a/ui/lib/findings-view.ts
+++ b/ui/lib/findings-view.ts
@@ -108,6 +108,38 @@ export function formatFindingTimestamp(value: string | undefined | null): string
   });
 }
 
+export interface SlaDue {
+  /** Absolute deadline, formatted for the row tooltip. */
+  absolute: string;
+  /** Short relative label, e.g. "SLA in 5d", "SLA overdue 3d", "SLA due today". */
+  label: string;
+  /** True when the deadline is in the past — surfaced with the danger token. */
+  overdue: boolean;
+}
+
+/**
+ * Render a finding's remediation SLA as a relative deadline with an overdue
+ * state. Returns null when no deadline is known (an explicit "SLA unavailable"),
+ * never a fabricated date.
+ */
+export function formatSlaDue(value: string | undefined | null, now: number = Date.now()): SlaDue | null {
+  if (!value || !value.trim()) return null;
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return null;
+  const absolute = formatFindingTimestamp(value);
+  const dayMs = 24 * 60 * 60 * 1000;
+  // Compare on calendar days so a deadline later today reads "due today".
+  const days = Math.round((parsed - now) / dayMs);
+  if (days < 0) {
+    const overdueDays = Math.abs(days);
+    return { absolute, label: `SLA overdue ${overdueDays}d`, overdue: true };
+  }
+  if (days === 0) {
+    return { absolute, label: "SLA due today", overdue: false };
+  }
+  return { absolute, label: `SLA in ${days}d`, overdue: false };
+}
+
 export function findingStatusLabel(status: string | undefined): string {
   const normalized = (status ?? "").trim().toLowerCase();
   if (normalized === "open" || normalized === "resolved" || normalized === "reopened") {

--- a/ui/tests/findings-view.test.ts
+++ b/ui/tests/findings-view.test.ts
@@ -5,6 +5,7 @@ import {
   findingStatusLabel,
   cvssVersion,
   formatFindingTimestamp,
+  formatSlaDue,
   hasLifecycleMetadata,
   officialAdvisoryLinks,
   vulnRowKey,
@@ -44,6 +45,35 @@ describe("findings lifecycle helpers", () => {
   it("detects lifecycle metadata on enriched rows", () => {
     expect(hasLifecycleMetadata([sampleVuln()])).toBe(false);
     expect(hasLifecycleMetadata([sampleVuln({ lifecycle_status: "open", last_seen: "2026-07-01T00:00:00Z" })])).toBe(true);
+  });
+});
+
+describe("formatSlaDue", () => {
+  const now = Date.parse("2026-08-10T00:00:00Z");
+
+  it("returns null when no deadline is known", () => {
+    expect(formatSlaDue(undefined, now)).toBeNull();
+    expect(formatSlaDue("", now)).toBeNull();
+    expect(formatSlaDue("not-a-date", now)).toBeNull();
+  });
+
+  it("renders a future deadline as a relative, non-overdue label", () => {
+    const sla = formatSlaDue("2026-08-15T00:00:00Z", now);
+    expect(sla).not.toBeNull();
+    expect(sla?.overdue).toBe(false);
+    expect(sla?.label).toBe("SLA in 5d");
+  });
+
+  it("flags a past deadline as overdue", () => {
+    const sla = formatSlaDue("2026-08-07T00:00:00Z", now);
+    expect(sla?.overdue).toBe(true);
+    expect(sla?.label).toBe("SLA overdue 3d");
+  });
+
+  it("labels a same-day deadline as due today", () => {
+    const sla = formatSlaDue("2026-08-10T00:00:00Z", now);
+    expect(sla?.overdue).toBe(false);
+    expect(sla?.label).toBe("SLA due today");
   });
 });
 


### PR DESCRIPTION
Closes workstream 1 of epic #4790 (the P0).

## Problem

`owner` and `sla_due_at` were declared on the finding response and rendered as a UI column, but **nothing ever populated them** — the column shipped permanently "Unassigned / Unavailable", a visible defect. SLA/owner were implemented only for risk campaigns (keyed by campaign, not finding).

## What

- **New single-source policy** `src/agent_bom/sla.py`: severity → SLA days (critical/high/medium/low = 7/30/90/180) anchored at `first_seen`; **KEV override** takes the earlier of the policy window and the CISA BOD 22-01 `kev_due_date`; explicit `None` when severity is unrated or no anchor exists — never a fabricated date. `finding_owner()` = triage assignee, else "Unassigned".
- **Threaded full-stack:** `finding.py` (fields + `to_dict`), `json_fmt.py` (anchors `first_seen` at scan completion), `finding_scope.py` (bulk/hub rows), API `scan.py` + `enterprise.py` (tenant-scoped triage-owner join), CLI `findings list` columns, SARIF/CycloneDX/SPDX exporters, and the UI findings cell (relative due date + overdue state via token).
- Owner emails masked on read (privacy). Auto owner-derivation from asset/agent ownership intentionally deferred (kept to the simple cut) — owner is the assignee or "Unassigned".

## How verified

- `pytest` touched suites: 243 passed + `test_findings_read_scale.py` 67 passed + regression 24 passed; new `test_sla.py`, `test_findings_owner_sla.py` (incl. **cross-tenant isolation**), export-parity + finding + scope + CLI tests
- `mypy` clean · `ruff` clean · OpenAPI `--check` OK · `check-counts` OK
- UI: `npm ci`, typecheck clean, lint 0 errors, `npm run build` + `NEXT_EXPORT=1 npm run build` pass, `vitest` 11 passed

Before: `scan --demo` findings had no owner/sla keys. After: all 24 carry them — non-KEV critical → `sla_due_at = first_seen + 7d`; a KEV high → KEV due date overriding the 30-day window.