### PR TITLE
chore(deps): forward dashboard pip floor bumps (plotly, pandas)

### DIFF
--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,3 +1,3 @@
 streamlit>=1.55.0
-plotly>=5.18.0
-pandas>=2.0.0
+plotly>=5.24.0
+pandas>=2.2.0


### PR DESCRIPTION
Carries the non-deceptive part of the first-time-contributor dependency PRs and rejects the deceptive part.

## What
| package | from | to | where |
|---|---|---|---|
| `plotly` | `>=5.18.0` | `>=5.24.0` | `dashboard/requirements.txt` |
| `pandas` | `>=2.0.0` | `>=2.2.0` | `dashboard/requirements.txt` |

Both targets verified present on PyPI. `streamlit` stays `>=1.55.0`.

## Excluded (rejected)
`streamlit >=1.55.0 → >=1.39.0` from #4798/#4799 — this **lowers** the floor and re-admits older 1.39–1.54 releases, while those PR bodies claim to "fix CVEs in older versions." The change does the opposite of its stated intent, so it is not carried.

Closes #4798
Closes #4799

## Verified
Modest forward floor bumps; `pip-audit` runs in CI (it never ran on the contributor PRs, which were opened without CI).