### PR TITLE
Wire compliance drill-through: framework/control finding filter (API + CLI + UI)

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -17183,6 +17183,44 @@
             }
           },
           {
+            "description": "Compliance framework drill-through, e.g. soc2 / nist-csf (compliance section id)",
+            "in": "query",
+            "name": "framework",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 64,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Compliance framework drill-through, e.g. soc2 / nist-csf (compliance section id)",
+              "title": "Framework"
+            }
+          },
+          {
+            "description": "Framework control code, narrows within framework (e.g. CC6.1)",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 64,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Framework control code, narrows within framework (e.g. CC6.1)",
+              "title": "Control"
+            }
+          },
+          {
             "in": "query",
             "name": "include_facets",
             "required": false,

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -11554,6 +11554,30 @@ paths:
           - type: 'null'
           description: Only known-exploited (KEV) findings, or only non-KEV when false
           title: Kev
+      - description: Compliance framework drill-through, e.g. soc2 / nist-csf (compliance
+          section id)
+        in: query
+        name: framework
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          description: Compliance framework drill-through, e.g. soc2 / nist-csf (compliance
+            section id)
+          title: Framework
+      - description: Framework control code, narrows within framework (e.g. CC6.1)
+        in: query
+        name: control
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          description: Framework control code, narrows within framework (e.g. CC6.1)
+          title: Control
       - in: query
         name: include_facets
         required: false

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -2150,6 +2150,8 @@ def _canonical_scope_filters(
     finding_class: str | None = None,
     q: str | None = None,
     kev: bool | None = None,
+    framework: str | None = None,
+    control: str | None = None,
 ) -> dict[str, str]:
     """Normalize the optional scope/domain filters into an active-filter map.
 
@@ -2157,8 +2159,26 @@ def _canonical_scope_filters(
     and empty inputs dropped. Unknown values are kept (not rejected) so the
     endpoint never raises on ad-hoc input — an unmatched value simply returns no
     findings. ``account`` maps to the finding's ``account_ref``.
+
+    ``framework`` / ``control`` power the compliance drill-through (epic #4790):
+    the framework identifier (a UI section id such as ``nist-csf`` / ``iso27001``)
+    is resolved once here to the finding's ``*_tags`` field and canonical slug so
+    the per-row predicate stays a cheap containment check. An unresolved
+    framework is stored raw so the predicate returns an honest empty match.
+    ``control`` is only meaningful alongside a framework and is dropped otherwise.
     """
     filters: dict[str, str] = {}
+    if framework and framework.strip():
+        from agent_bom.compliance_coverage import resolve_framework_filter
+
+        meta = resolve_framework_filter(framework)
+        if meta is not None:
+            filters["framework_tag_field"] = meta.tag_field
+            filters["framework_slug"] = meta.slug
+        else:
+            filters["framework"] = framework.strip().lower()
+        if control and control.strip():
+            filters["control"] = control.strip()
     if provider and provider.strip():
         filters["provider"] = provider.strip().lower()
     if account and account.strip():
@@ -2433,6 +2453,14 @@ async def list_findings(
     status: Annotated[str, Query(max_length=16)] = _DEFAULT_FINDING_STATUS,
     finding_class: FindingClass | None = None,
     kev: Annotated[bool | None, Query(description="Only known-exploited (KEV) findings, or only non-KEV when false")] = None,
+    framework: Annotated[
+        str | None,
+        Query(max_length=64, description="Compliance framework drill-through, e.g. soc2 / nist-csf (compliance section id)"),
+    ] = None,
+    control: Annotated[
+        str | None,
+        Query(max_length=64, description="Framework control code, narrows within framework (e.g. CC6.1)"),
+    ] = None,
     include_facets: bool = False,
 ) -> dict:
     """List unified findings aggregated from completed scan results.
@@ -2479,6 +2507,8 @@ async def list_findings(
                 finding_class,
                 kev,
                 include_facets,
+                framework,
+                control,
             )
     except BackpressureRejectedError as exc:
         raise HTTPException(
@@ -2507,6 +2537,8 @@ def _list_findings_impl(
     finding_class: str | None = None,
     kev: bool | None = None,
     include_facets: bool = False,
+    framework: str | None = None,
+    control: str | None = None,
 ) -> dict:
     """Synchronous body of :func:`list_findings` (runs in a worker thread).
 
@@ -2632,7 +2664,9 @@ def _list_findings_impl(
     # returns that scan's rows verbatim.
     from agent_bom.api.findings_current import current_scan_findings
 
-    scope_filters = _canonical_scope_filters(provider, account, environment, domain, finding_class, q, kev=kev)
+    scope_filters = _canonical_scope_filters(
+        provider, account, environment, domain, finding_class, q, kev=kev, framework=framework, control=control
+    )
 
     store = get_compliance_hub_store()
     bulk_list = getattr(store, "list_current_page", None) or getattr(store, "list_page", None)
@@ -2930,6 +2964,8 @@ def _list_findings_impl(
             for key, value in {
                 "finding_class": finding_class,
                 "q": q.strip() if q and q.strip() else None,
+                "framework": framework.strip() if framework and framework.strip() else None,
+                "control": control.strip() if control and control.strip() else None,
             }.items()
             if value is not None
         },

--- a/src/agent_bom/cli/_findings_group.py
+++ b/src/agent_bom/cli/_findings_group.py
@@ -188,6 +188,8 @@ def push_findings_cmd(
 
 @findings_cmd.command("list")
 @click.option("--severity", help="Filter findings by severity.")
+@click.option("--framework", help="Compliance framework drill-through (e.g. soc2, nist-csf).")
+@click.option("--control", help="Framework control code; narrows within --framework (e.g. CC6.1).")
 @click.option("--sort", default="effective_reach", show_default=True, help="Sort field used by the API.")
 @click.option("--limit", default=500, show_default=True, type=click.IntRange(min=1, max=1000), help="Maximum rows to return.")
 @click.option("--offset", default=0, show_default=True, type=click.IntRange(min=0), help="Rows to skip.")
@@ -199,6 +201,8 @@ def list_findings_cmd(
     bearer_token: str | None,
     tenant_id: str | None,
     severity: str | None,
+    framework: str | None,
+    control: str | None,
     sort: str,
     limit: int,
     offset: int,
@@ -207,7 +211,10 @@ def list_findings_cmd(
     """List findings with the same filters as the REST API."""
 
     client = _make_client(api_url, api_key, bearer_token, tenant_id)
-    payload = _run_request(client, lambda api: api.list_findings(severity=severity, sort=sort, limit=limit, offset=offset))
+    payload = _run_request(
+        client,
+        lambda api: api.list_findings(severity=severity, sort=sort, limit=limit, offset=offset, framework=framework, control=control),
+    )
     if output_format == "json":
         _emit_json(payload)
     else:

--- a/src/agent_bom/client.py
+++ b/src/agent_bom/client.py
@@ -167,8 +167,15 @@ class AgentBomClient:
         sort: str = "effective_reach",
         limit: int = 500,
         offset: int = 0,
+        framework: str | None = None,
+        control: str | None = None,
     ) -> JsonObject:
-        """List normalized findings from scan jobs and bulk ingests."""
+        """List normalized findings from scan jobs and bulk ingests.
+
+        ``framework`` / ``control`` are the compliance drill-through filters
+        (epic #4790): a framework section id (e.g. ``soc2`` / ``nist-csf``) and,
+        optionally, a control code that narrows within it.
+        """
 
         return self._request(
             "GET",
@@ -179,6 +186,8 @@ class AgentBomClient:
                     "sort": sort,
                     "limit": limit,
                     "offset": offset,
+                    "framework": framework,
+                    "control": control,
                 }
             ),
         )

--- a/src/agent_bom/compliance_coverage.py
+++ b/src/agent_bom/compliance_coverage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 
@@ -350,6 +351,45 @@ def normalize_framework_slug(slug: str) -> str:
     """Normalize API/ingest framework slugs to canonical hyphenated form."""
     normalized = slug.strip().lower().replace("_", "-")
     return FRAMEWORK_SLUG_ALIASES.get(normalized, normalized)
+
+
+_FRAMEWORK_IDENT_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _normalize_framework_ident(value: str) -> str:
+    """Lowercase and strip every non-alphanumeric character.
+
+    Collapses the small representational differences between the compliance
+    UI's section id, the metadata ``slug``, its ``output_key`` and its
+    ``tag_field`` so all three forms of one framework compare equal
+    (``nist-csf`` == ``nist_csf`` == ``nistcsf``).
+    """
+    return _FRAMEWORK_IDENT_RE.sub("", value.strip().lower())
+
+
+def resolve_framework_filter(value: str) -> ComplianceFrameworkMetadata | None:
+    """Resolve a UI/API framework identifier to its tag-mapped metadata.
+
+    The compliance drill-through links to ``/findings?framework=<section id>``
+    where the section id is the UI slug (``nist-csf``, ``iso27001``,
+    ``nist-ai-rmf`` …). Those do not always equal the metadata ``slug`` /
+    ``output_key`` / ``tag_field`` (``nist-ai-rmf`` maps to slug ``nist``,
+    ``iso27001`` to ``iso-27001``), so match tolerantly against all three,
+    normalized. Returns ``None`` for an unrecognized identifier so the caller
+    can return an honest empty result rather than raising.
+    """
+    key = _normalize_framework_ident(value)
+    if not key:
+        return None
+    for meta in TAG_MAPPED_FRAMEWORKS:
+        candidates = {
+            _normalize_framework_ident(meta.slug),
+            _normalize_framework_ident(meta.output_key),
+            _normalize_framework_ident(meta.tag_field.removesuffix("_tags")),
+        }
+        if key in candidates:
+            return meta
+    return None
 
 
 AISVS_BENCHMARK = ComplianceBenchmarkMetadata(

--- a/src/agent_bom/finding_scope.py
+++ b/src/agent_bom/finding_scope.py
@@ -760,6 +760,76 @@ def row_matches_search(row: Mapping[str, object], query: str | None) -> bool:
     return False
 
 
+def _framework_control_codes(row: Mapping[str, Any], tag_field: str, framework_key: str) -> set[str]:
+    """Collect one framework's control codes from every representation on a row.
+
+    A scan finding may carry its framework controls three ways: the per-framework
+    tag list (``soc2_tags``), the structured ``controls`` list, and the flattened
+    ``framework_tags`` (``"soc2:CC6.1"``). All are read, but strictly scoped to
+    ``framework_key`` so a code is never matched against another framework's
+    namespace — the flat ``compliance_tags`` union is deliberately NOT consulted.
+    """
+    codes: set[str] = set()
+    raw = row.get(tag_field)
+    if isinstance(raw, (list, tuple, set)):
+        codes.update(str(tag) for tag in raw)
+    controls = row.get("controls")
+    if isinstance(controls, list):
+        for control in controls:
+            if isinstance(control, dict) and str(control.get("framework") or "") == framework_key:
+                code = control.get("control") or control.get("id")
+                if code:
+                    codes.add(str(code))
+    framework_tags = row.get("framework_tags")
+    if isinstance(framework_tags, list):
+        prefix = f"{framework_key}:"
+        for tag in framework_tags:
+            text = str(tag)
+            if text.startswith(prefix):
+                codes.add(text[len(prefix) :])
+    return codes
+
+
+def _row_matches_framework(row: Mapping[str, Any], filters: Mapping[str, str]) -> bool:
+    """Framework / control drill-through predicate (compliance → findings).
+
+    The framework identifier is resolved once in the route to ``framework_tag_field``
+    (e.g. ``soc2_tags``) plus the canonical ``framework_slug``. When it does not
+    resolve the route stores the raw value under ``framework`` and nothing can
+    match it — an honest empty result rather than a silent widening.
+
+    With a ``control`` code the match is exact containment in the framework's
+    control codes, mirroring the compliance per-control count (``code in tags``)
+    so the drilled queue reconciles with the badge the user clicked. Without a
+    control it is a framework-level match: any control tagged for the framework,
+    or — for bulk-ingested rows whose per-framework tags are redacted at rest —
+    the framework slug present in ``applicable_frameworks``.
+    """
+    tag_field = filters.get("framework_tag_field")
+    if tag_field is None:
+        # Unresolved framework identifier: match nothing (honest empty).
+        return False
+
+    control = filters.get("control")
+    control = control.strip() if isinstance(control, str) else None
+    framework_key = tag_field[:-5] if tag_field.endswith("_tags") else tag_field
+    codes = _framework_control_codes(row, tag_field, framework_key)
+
+    if control:
+        return control in codes
+    if codes:
+        return True
+    slug = filters.get("framework_slug")
+    if slug:
+        from agent_bom.compliance_coverage import normalize_framework_slug
+
+        wanted = normalize_framework_slug(slug)
+        applicable = row.get("applicable_frameworks")
+        if isinstance(applicable, (list, tuple, set)):
+            return any(normalize_framework_slug(str(item)) == wanted for item in applicable)
+    return False
+
+
 def row_matches_scope(row: dict, filters: Mapping[str, str]) -> bool:
     """Return True when a finding row matches every active scope filter.
 
@@ -771,8 +841,10 @@ def row_matches_scope(row: dict, filters: Mapping[str, str]) -> bool:
     equality checks. ``domain`` matches membership in the finding's overlapping
     coverage-lens set (:func:`lenses_for_row`), so ``domain=aspm`` returns
     SAST + secrets + repo dependencies + IaC and ``domain=vuln`` returns every
-    CVE. The caller is responsible for pre-canonicalizing the filter values
-    (lowercased/trimmed, ``appsec_sca`` -> ``aspm`` legacy alias applied).
+    CVE. ``framework`` / ``control`` power the compliance drill-through
+    (:func:`_row_matches_framework`). The caller is responsible for
+    pre-canonicalizing the filter values (lowercased/trimmed, ``appsec_sca`` ->
+    ``aspm`` legacy alias applied, framework resolved to its tag field).
     """
     for key in ("provider", "account_ref", "environment"):
         wanted = filters.get(key)
@@ -786,6 +858,12 @@ def row_matches_scope(row: dict, filters: Mapping[str, str]) -> bool:
     wanted_class = filters.get("finding_class")
     if wanted_class is not None and finding_class_for_row(row) != wanted_class:
         return False
+    # Compliance drill-through: framework (resolved to its tag field) + optional
+    # control code. ``framework`` (raw) is present only when the identifier did
+    # not resolve, in which case the match is an honest empty.
+    if filters.get("framework_tag_field") is not None or filters.get("framework") is not None:
+        if not _row_matches_framework(row, filters):
+            return False
     # KEV leads the executive headline — "actively exploited, fix these first" —
     # so the list has to be able to answer it. An absent verdict is not a match:
     # a row nobody checked must never be presented as known-exploited.

--- a/tests/test_cli_findings.py
+++ b/tests/test_cli_findings.py
@@ -151,7 +151,23 @@ def test_findings_list_outputs_json_and_passes_filters(monkeypatch) -> None:
     assert fake.init_kwargs["tenant_id"] == "tenant-a"
     assert fake.calls[0] == (
         "list_findings",
-        {"severity": "high", "sort": "effective_reach", "limit": 10, "offset": 0},
+        {"severity": "high", "sort": "effective_reach", "limit": 10, "offset": 0, "framework": None, "control": None},
+    )
+
+
+def test_findings_list_passes_framework_and_control_filters(monkeypatch) -> None:
+    """CLI parity for the compliance drill-through (epic #4790)."""
+    fake = _install_fake_client(monkeypatch)
+
+    result = CliRunner().invoke(
+        main,
+        ["findings", "list", "--framework", "soc2", "--control", "CC6.1", "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake.calls[0] == (
+        "list_findings",
+        {"severity": None, "sort": "effective_reach", "limit": 500, "offset": 0, "framework": "soc2", "control": "CC6.1"},
     )
 
 

--- a/tests/test_findings_framework_control_filter.py
+++ b/tests/test_findings_framework_control_filter.py
@@ -1,0 +1,231 @@
+"""Compliance drill-through filter on GET /v1/findings (epic #4790, ws 3a).
+
+The Compliance view links a control's non-zero finding count to
+``/findings?framework=<section id>&control=<code>``. Until now neither the API
+nor the UI honoured those params, so the link landed on an UNFILTERED queue. The
+per-control count on the badge is derived from the scan ``blast_radius`` entries
+via ``br.get(tag_field)`` (``code in tags``), so the drilled queue has to filter
+on the SAME per-framework control tags to reconcile with the number the user
+clicked.
+
+The predicate lives in ``row_matches_scope`` — the single source of truth shared
+by the route's in-memory scan findings and the hub store's bulk-ingested rows —
+so the two paths cannot diverge. The framework identifier is resolved once, in
+the route, to the finding's ``*_tags`` field and canonical slug.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore, set_compliance_hub_store
+from agent_bom.api.models import JobStatus
+from agent_bom.api.server import ScanJob, ScanRequest, app, set_job_store
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import _get_store
+from agent_bom.compliance_coverage import resolve_framework_filter
+from agent_bom.finding_scope import row_matches_scope
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+_AUTH = proxy_headers(tenant="default")
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+    set_job_store(InMemoryJobStore())
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+
+
+# ── Resolver: UI section id → finding tag field ──────────────────────────────
+
+
+def test_resolver_maps_every_ui_section_id() -> None:
+    """The compliance page's section ids must all resolve to a tag field.
+
+    Two ids do not equal the metadata slug (``nist-ai-rmf`` → ``nist``,
+    ``iso27001`` → ``iso-27001``); the resolver strips separators so both land.
+    """
+    cases = {
+        "owasp-llm": "owasp_tags",
+        "owasp-mcp": "owasp_mcp_tags",
+        "atlas": "atlas_tags",
+        "nist-ai-rmf": "nist_ai_rmf_tags",
+        "owasp-agentic": "owasp_agentic_tags",
+        "eu-ai-act": "eu_ai_act_tags",
+        "nist-csf": "nist_csf_tags",
+        "iso27001": "iso_27001_tags",
+        "soc2": "soc2_tags",
+        "cis": "cis_tags",
+        "cmmc": "cmmc_tags",
+        "nist-800-53": "nist_800_53_tags",
+        "pci-dss": "pci_dss_tags",
+        "fedramp": "fedramp_tags",
+    }
+    for section_id, tag_field in cases.items():
+        meta = resolve_framework_filter(section_id)
+        assert meta is not None, section_id
+        assert meta.tag_field == tag_field, section_id
+
+
+def test_resolver_returns_none_for_unknown_framework() -> None:
+    assert resolve_framework_filter("not-a-framework") is None
+    assert resolve_framework_filter("") is None
+
+
+# ── Predicate: row_matches_scope with pre-resolved filters ───────────────────
+
+
+def _row(**overrides: object) -> dict:
+    base: dict = {"id": "f", "severity": "high", "title": "t"}
+    base.update(overrides)
+    return base
+
+
+def test_control_filter_is_exact_containment_in_the_tag_field() -> None:
+    filters = {"framework_tag_field": "soc2_tags", "framework_slug": "soc2", "control": "CC6.1"}
+    assert row_matches_scope(_row(soc2_tags=["CC6.1", "CC7.2"]), filters) is True
+    assert row_matches_scope(_row(soc2_tags=["CC7.2"]), filters) is False
+    assert row_matches_scope(_row(), filters) is False
+
+
+def test_control_matching_never_crosses_frameworks() -> None:
+    """A CIS code must not match a SOC 2 drill even via the flattened tags."""
+    filters = {"framework_tag_field": "soc2_tags", "framework_slug": "soc2", "control": "4.1"}
+    row = _row(cis_tags=["4.1"], framework_tags=["cis:4.1"], applicable_frameworks=["cis", "soc2"])
+    assert row_matches_scope(row, filters) is False
+
+
+def test_framework_only_matches_any_control_or_the_slug() -> None:
+    resolved = {"framework_tag_field": "cis_tags", "framework_slug": "cis"}
+    # A row carrying a CIS control tag matches.
+    assert row_matches_scope(_row(cis_tags=["4.1"]), resolved) is True
+    # A bulk-ingested row whose per-framework tags were redacted at rest still
+    # matches on the retained applicable_frameworks slug.
+    assert row_matches_scope(_row(applicable_frameworks=["cis"]), resolved) is True
+    # A row for a different framework does not.
+    assert row_matches_scope(_row(soc2_tags=["CC6.1"], applicable_frameworks=["soc2"]), resolved) is False
+
+
+def test_unresolved_framework_filter_matches_nothing() -> None:
+    """An unknown framework returns an honest empty match, never everything."""
+    assert row_matches_scope(_row(soc2_tags=["CC6.1"]), {"framework": "bogus"}) is False
+
+
+def test_framework_control_composes_with_other_scope_filters() -> None:
+    filters = {"framework_tag_field": "soc2_tags", "framework_slug": "soc2", "control": "CC6.1", "provider": "aws"}
+    row = _row(soc2_tags=["CC6.1"], provider="aws")
+    assert row_matches_scope(row, filters) is True
+    assert row_matches_scope(_row(soc2_tags=["CC6.1"], provider="gcp"), filters) is False
+
+
+# ── Route: GET /v1/findings?framework=&control= ──────────────────────────────
+
+
+def _seed() -> None:
+    set_job_store(InMemoryJobStore())
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+    observed_at = datetime.now(timezone.utc).isoformat()
+    job = ScanJob(job_id="fw-job", tenant_id="default", created_at=observed_at, request=ScanRequest())
+    job.status = JobStatus.DONE
+    job.completed_at = observed_at
+    job.result = {
+        "agents": [],
+        "scan_sources": ["cloud"],
+        "findings": [
+            {
+                "id": "f-soc2-cis",
+                "severity": "high",
+                "title": "soc2 CC6.1 + cis 4.1",
+                "soc2_tags": ["CC6.1"],
+                "cis_tags": ["4.1"],
+                "applicable_frameworks": ["soc2", "cis"],
+            },
+            {
+                "id": "f-soc2-only",
+                "severity": "medium",
+                "title": "soc2 CC7.2",
+                "soc2_tags": ["CC7.2"],
+                "applicable_frameworks": ["soc2"],
+            },
+            {
+                "id": "f-nistcsf",
+                "severity": "critical",
+                "title": "nist csf PR.AC-1",
+                "nist_csf_tags": ["PR.AC-1"],
+                "applicable_frameworks": ["nist-csf"],
+            },
+            {
+                "id": "f-cis-slug-only",
+                "severity": "low",
+                "title": "cis by slug, tags redacted",
+                "applicable_frameworks": ["cis"],
+            },
+        ],
+    }
+    _get_store().put(job)
+
+
+def _ids(resp) -> set[str]:
+    return {f.get("id") for f in resp.json()["findings"]}
+
+
+def test_route_framework_filter_narrows_to_that_framework() -> None:
+    _seed()
+    resp = TestClient(app).get("/v1/findings?framework=soc2", headers=_AUTH)
+    assert resp.status_code == 200
+    assert _ids(resp) == {"f-soc2-cis", "f-soc2-only"}
+
+
+def test_route_control_filter_narrows_within_framework() -> None:
+    _seed()
+    resp = TestClient(app).get("/v1/findings?framework=soc2&control=CC6.1", headers=_AUTH)
+    assert resp.status_code == 200
+    assert _ids(resp) == {"f-soc2-cis"}
+
+
+def test_route_control_reconciles_with_the_drill_link() -> None:
+    _seed()
+    resp = TestClient(app).get("/v1/findings?framework=soc2&control=CC7.2", headers=_AUTH)
+    assert resp.status_code == 200
+    assert _ids(resp) == {"f-soc2-only"}
+
+
+def test_route_framework_includes_slug_only_rows_but_control_does_not() -> None:
+    _seed()
+    fw = TestClient(app).get("/v1/findings?framework=cis", headers=_AUTH)
+    assert _ids(fw) == {"f-soc2-cis", "f-cis-slug-only"}
+    ctrl = TestClient(app).get("/v1/findings?framework=cis&control=4.1", headers=_AUTH)
+    assert _ids(ctrl) == {"f-soc2-cis"}
+
+
+def test_route_hyphenated_ui_slug_resolves() -> None:
+    _seed()
+    resp = TestClient(app).get("/v1/findings?framework=nist-csf&control=PR.AC-1", headers=_AUTH)
+    assert resp.status_code == 200
+    assert _ids(resp) == {"f-nistcsf"}
+
+
+def test_route_unknown_framework_returns_empty_not_everything() -> None:
+    _seed()
+    resp = TestClient(app).get("/v1/findings?framework=not-a-framework", headers=_AUTH)
+    assert resp.status_code == 200
+    assert resp.json()["findings"] == []
+
+
+def test_route_echoes_framework_and_control_filters() -> None:
+    _seed()
+    resp = TestClient(app).get("/v1/findings?framework=soc2&control=CC6.1", headers=_AUTH)
+    assert resp.json()["filters"] == {"framework": "soc2", "control": "CC6.1"}
+
+
+def test_route_no_framework_filter_is_backward_compatible() -> None:
+    _seed()
+    resp = TestClient(app).get("/v1/findings", headers=_AUTH)
+    assert resp.status_code == 200
+    assert len(resp.json()["findings"]) == 4

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -259,6 +259,10 @@ function FindingsPage() {
   const paramProvider = searchParams.get("provider");
   const paramAccount = searchParams.get("account");
   const paramEnvironment = searchParams.get("environment");
+  // Compliance drill-through (epic #4790): a framework section id + optional
+  // control code linked from the Compliance view's per-control finding count.
+  const paramFramework = searchParams.get("framework");
+  const paramControl = searchParams.get("control");
   const { lens, selectLens, lenses, label: lensLabel, hint: lensHint } = useFindingsLens(paramLens);
 
   const [vulns, setVulns] = useState<EnrichedVuln[]>([]);
@@ -285,6 +289,9 @@ function FindingsPage() {
   const [providerFilter, setProviderFilter] = useState<string>(paramProvider ?? "");
   const [accountFilter, setAccountFilter] = useState<string>(paramAccount ?? "");
   const [environmentFilter, setEnvironmentFilter] = useState<string>(paramEnvironment ?? "");
+  const [frameworkFilter, setFrameworkFilter] = useState<string>(paramFramework ?? "");
+  // A control code is only meaningful alongside a framework; it is cleared with it.
+  const [controlFilter, setControlFilter] = useState<string>(paramFramework ? (paramControl ?? "") : "");
   const [sortKey, setSortKey] = useState<SortKey>("severity");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
   // Default read-window (#4009): findings default to the last ~90 days so the
@@ -388,6 +395,11 @@ function FindingsPage() {
   }, [paramEnvironment]);
 
   useEffect(() => {
+    setFrameworkFilter(paramFramework ?? "");
+    setControlFilter(paramFramework ? (paramControl ?? "") : "");
+  }, [paramFramework, paramControl]);
+
+  useEffect(() => {
     const parsed = Number(paramWindow);
     setWindowDays(
       paramWindow != null && Number.isFinite(parsed) && parsed >= 0
@@ -410,6 +422,9 @@ function FindingsPage() {
     if (providerFilter.trim()) params.set("provider", providerFilter.trim());
     if (accountFilter.trim()) params.set("account", accountFilter.trim());
     if (environmentFilter.trim()) params.set("environment", environmentFilter.trim());
+    if (frameworkFilter.trim()) params.set("framework", frameworkFilter.trim());
+    // A control code without a framework is meaningless — only sync it alongside.
+    if (frameworkFilter.trim() && controlFilter.trim()) params.set("control", controlFilter.trim());
     if (windowDays !== DEFAULT_FINDINGS_WINDOW_DAYS) params.set("window", String(windowDays));
     if (page > 1) params.set("page", String(page));
     if (paramScan) params.set("scan", paramScan);
@@ -424,6 +439,8 @@ function FindingsPage() {
     providerFilter,
     accountFilter,
     environmentFilter,
+    frameworkFilter,
+    controlFilter,
     windowDays,
     page,
     paramScope,
@@ -540,6 +557,8 @@ function FindingsPage() {
           ...(providerFilter.trim() ? { provider: providerFilter.trim() } : {}),
           ...(accountFilter.trim() ? { account: accountFilter.trim() } : {}),
           ...(environmentFilter.trim() ? { environment: environmentFilter.trim() } : {}),
+          ...(frameworkFilter.trim() ? { framework: frameworkFilter.trim() } : {}),
+          ...(frameworkFilter.trim() && controlFilter.trim() ? { control: controlFilter.trim() } : {}),
           ...(issueTypeFilter !== "all" ? { findingClass: issueTypeFilter } : {}),
           sort: serverFindingsSort(sortKey),
           limit: PAGE_SIZE,
@@ -577,6 +596,8 @@ function FindingsPage() {
     providerFilter,
     accountFilter,
     environmentFilter,
+    frameworkFilter,
+    controlFilter,
     issueTypeFilter,
     windowDays,
     sortKey,
@@ -665,6 +686,21 @@ function FindingsPage() {
     environmentFilter.trim()
       ? { key: "environment", label: `Env: ${environmentFilter.trim()}`, onClear: () => setEnvironmentFilter("") }
       : null,
+    // Compliance drill-through chips. Clearing the framework also clears the
+    // control, since a control code without its framework is meaningless.
+    frameworkFilter.trim()
+      ? {
+          key: "framework",
+          label: `Framework: ${frameworkFilter.trim().toUpperCase()}`,
+          onClear: () => {
+            setFrameworkFilter("");
+            setControlFilter("");
+          },
+        }
+      : null,
+    frameworkFilter.trim() && controlFilter.trim()
+      ? { key: "control", label: `Control: ${controlFilter.trim()}`, onClear: () => setControlFilter("") }
+      : null,
   ].filter((chip): chip is { key: string; label: string; onClear: () => void } => chip !== null);
   const activeFilterCount = activeFilterChips.length;
   const clearAdvancedFilters = () => {
@@ -672,6 +708,8 @@ function FindingsPage() {
     setProviderFilter("");
     setAccountFilter("");
     setEnvironmentFilter("");
+    setFrameworkFilter("");
+    setControlFilter("");
   };
 
   const FILTERS: { key: SeverityFilter; label: string; color: string }[] = [

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -1436,6 +1436,10 @@ export const api = {
     account?: string;
     environment?: string;
     domain?: string;
+    // Compliance drill-through (epic #4790): a framework section id (e.g. `soc2`
+    // / `nist-csf`) and, optionally, a control code that narrows within it.
+    framework?: string;
+    control?: string;
     findingClass?: "vulnerability" | "misconfiguration" | "secret" | "identity" | "unclassified";
     status?: "open" | "resolved" | "all";
     // Known-exploited only, or explicitly everything else. Omit for no filter —
@@ -1459,6 +1463,8 @@ export const api = {
     if (filters?.account) params.set("account", filters.account);
     if (filters?.environment) params.set("environment", filters.environment);
     if (filters?.domain) params.set("domain", filters.domain);
+    if (filters?.framework) params.set("framework", filters.framework);
+    if (filters?.control) params.set("control", filters.control);
     if (filters?.findingClass) params.set("finding_class", filters.findingClass);
     if (filters?.kev != null) params.set("kev", String(filters.kev));
     if (filters?.status) params.set("status", filters.status);

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -254,6 +254,18 @@ describe('api.listFindings', () => {
       expect.objectContaining({ credentials: 'include' }),
     )
   })
+
+  it('serializes the compliance drill-through framework and control filters', async () => {
+    const fetchMock = mockFetch({ findings: [], total: 0 })
+    global.fetch = fetchMock
+
+    await api.listFindings({ framework: 'soc2', control: 'CC6.1', limit: 25 })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/v1/findings?limit=25&framework=soc2&control=CC6.1',
+      expect.objectContaining({ credentials: 'include' }),
+    )
+  })
 })
 
 describe('api.getCompliance', () => {

--- a/ui/tests/findings-page.test.tsx
+++ b/ui/tests/findings-page.test.tsx
@@ -264,6 +264,38 @@ describe("FindingsPage", () => {
     expect(screen.getByTestId("findings-filters-toggle")).not.toHaveTextContent("(1)");
   });
 
+  it("honours the compliance drill-through framework/control URL and surfaces removable chips", async () => {
+    navigationState.query = "framework=soc2&control=CC6.1";
+    render(<FindingsPage />);
+    expect(await screen.findByText("Findings queue")).toBeInTheDocument();
+
+    // The drill-through params are forwarded to the findings API.
+    await waitFor(() =>
+      expect(apiMock.listFindings).toHaveBeenLastCalledWith(
+        expect.objectContaining({ framework: "soc2", control: "CC6.1" }),
+      ),
+    );
+
+    // Both facets surface as removable chips.
+    const frameworkChip = screen.getByTestId("findings-chip-framework");
+    expect(frameworkChip).toHaveTextContent("Framework: SOC2");
+    const controlChip = screen.getByTestId("findings-chip-control");
+    expect(controlChip).toHaveTextContent("Control: CC6.1");
+
+    // Clearing the framework drops the control too (a control without its
+    // framework is meaningless) and re-queries without either param.
+    fireEvent.click(frameworkChip);
+    await waitFor(() =>
+      expect(screen.queryByTestId("findings-chip-framework")).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("findings-chip-control")).not.toBeInTheDocument();
+    await waitFor(() => {
+      const lastCall = apiMock.listFindings.mock.calls.at(-1)?.[0] ?? {};
+      expect(lastCall).not.toHaveProperty("framework");
+      expect(lastCall).not.toHaveProperty("control");
+    });
+  });
+
   it("sends the selected issue class to the paginated findings API", async () => {
     render(<FindingsPage />);
     expect(await screen.findByText("Findings queue")).toBeInTheDocument();


### PR DESCRIPTION
Epic #4790 workstream 3a. Completes the drill-through dependency flagged in #4791: the compliance finding-count links now actually filter the Findings queue and reconcile with the badge count.

## What
- **API** `GET /findings` gains `framework` + `control` params, filtering on the finding's real per-framework control tags (`soc2_tags`/`cis_tags`/… + flattened `framework_tags` + structured `controls`) — the same basis the compliance per-control count derives from, so the filtered list reconciles with the badge. `control` = exact tag containment (framework-scoped, no cross-framework contamination); `framework`-only also includes bulk rows via `applicable_frameworks`.
- **UI** `ui/app/findings/page.tsx` parses `framework`/`control` from the URL, forwards them, and renders removable filter chips (clearing framework clears control).
- **CLI parity** `agent-bom findings list --framework --control` (Consistent bar).
- Single source of truth: `finding_scope.row_matches_scope` (scan + hub-store paths); UI-section-id → tag-field mapping in `compliance_coverage.resolve_framework_filter` (handles `nist-ai-rmf`→`nist`, `iso27001`→`iso-27001`).

## Honest boundary
Bulk-ingested findings aren't counted per-control by Compliance (their framework tags are redacted at rest by SAFE_TO_STORE), so `control`-level drill won't surface them — consistent with the badge, not a drift. `framework`-only is a broader "all findings mapped to this framework" view with no contradicting badge.

## Verified
- New `test_findings_framework_control_filter.py` (15) — resolver, predicate, `?framework=X` filters, `&control=Y` narrows, reconciliation, honest-empty; broad sweep 134 passed
- `mypy` / `ruff check` / `ruff format --check` clean; OpenAPI `--check` OK; `check-counts` + `product_metrics --check` consistent
- UI: typecheck clean, vitest 65 passed, `npm run build` + `NEXT_EXPORT=1 build` pass