### PR TITLE
#4790 parity round 2: framework/control filter + ticketing/export CLI + triage MCP

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -115,7 +115,7 @@ helm upgrade --install agent-bom deploy/helm/agent-bom \
 - **Blast radius + attack-path fusion** — multi-hop exposure paths over one `UnifiedGraph`, from package → finding → MCP server → credentials → connected agents
 - **CWE-aware impact** — RCE shows credential exposure, DoS does not; symbol-level CVE reachability joins CWE/CVE/CPE advisory context when OSV/GHSA carry affected symbols (Python, npm, Go)
 - **Portable outputs** — SARIF, CycloneDX, SPDX, OCSF, HTML, graph, JSON, ZIP evidence bundles, and more
-- **MCP server mode** — 78 MCP tools, 6 resources, and 8 workflow prompts exposed to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
+- **MCP server mode** — 79 MCP tools, 6 resources, and 8 workflow prompts exposed to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
 - **Skill bundle identity** — stable bundle hashes for skill and instruction file review
 - **Dependency confusion detection** — flags internal naming patterns
 - **VEX generation** — auto-triage with CWE/CVE/CPE-aware reachability (package + function-level when advisory symbols exist)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center"><b>Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.</b></p>
 
 <p align="center">
-  <b>15</b> package ecosystems · <b>16</b> compliance surfaces · <b>77</b> MCP tools · no account required<br />
+  <b>15</b> package ecosystems · <b>16</b> compliance surfaces · <b>79</b> MCP tools · no account required<br />
   <a href="#quick-start"><b>Quick start</b></a> ·
   <a href="https://agent-bom-demo-82102570041.us-central1.run.app">Live demo</a> ·
   <a href="https://msaad00.github.io/agent-bom/">Docs</a>
@@ -184,10 +184,10 @@ real identity, TLS, PostgreSQL, encryption, and audit keys before exposing it.
 | GitHub CI | `uses: msaad00/agent-bom@v0.100.0` | SARIF, PR summary, and a policy exit code |
 | Cloud evidence | `agent-bom connect aws` | Stored connection reference; run scans from the control plane |
 | Runtime gateway | `agent-bom gateway serve --from-control-plane http://127.0.0.1:8422 --bind 127.0.0.1:8090` | Allow, warn, and block audit events |
-| Agent interface | `agent-bom mcp server` | 78 MCP tools, 6 resources, and 8 workflow prompts |
+| Agent interface | `agent-bom mcp server` | 79 MCP tools, 6 resources, and 8 workflow prompts |
 | Agent distribution | [Smithery manifest](integrations/smithery.yaml) · [Glama](glama.json) · [MCP registry](integrations/mcp-registry) · [Docker MCP](integrations/docker-mcp-registry) | Registry-specific installation metadata |
 
-MCP server mode exposes 78 MCP tools, 6 resources, and 8 workflow prompts, all
+MCP server mode exposes 79 MCP tools, 6 resources, and 8 workflow prompts, all
 read-first: discovery and analysis never mutate a scanned target.
 
 Set `YDC_API_KEY` to enable the optional `youcom_search` MCP tool for live web

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -1,6 +1,6 @@
 # MCP Server — Streamable HTTP transport for remote clients.
 #
-# Exposes agent-bom's 78 MCP tools over streamable HTTP so that Smithery, Claude
+# Exposes agent-bom's 79 MCP tools over streamable HTTP so that Smithery, Claude
 # Desktop (remote mode), and any other MCP client can connect via public URL.
 #
 # Build:   docker build -f deploy/docker/Dockerfile.sse -t agent-bom-sse .

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -22,7 +22,7 @@ the caller wants to explore or to invoke — not by whether it is human.
 
 | Area | Shipped today |
 |---|---|
-| MCP security tools | 78 tools, 6 resources, 8 workflow prompts |
+| MCP security tools | 79 tools, 6 resources, 8 workflow prompts |
 | REST API | 382 operations across 45 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -465,7 +465,7 @@ graph TB
 | Output | `src/agent_bom/output/__init__.py` | JSON, CycloneDX, SARIF, SPDX, console |
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine (17 conditions) |
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
-| MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (78 tools across core, operator, runtime-catalog, and specialized modules) |
+| MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (79 tools across core, operator, runtime-catalog, and specialized modules) |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse estate inventory; CIS posture where published and Databricks security best practices |
 | Cloud side-scan | `src/agent_bom/cloud/side_scan.py`, `src/agent_bom/cloud/side_scan_targets.py`, `src/agent_bom/cloud/side_scan_lifecycle.py`, `src/agent_bom/cloud/side_scan_provider_adapters.py` | Agentless workload side-scan (CWPP) — AWS EBS CLI executor; injected-SDK Azure Managed Disk and GCP Persistent Disk lifecycle adapters with durable ownership/cleanup state; Azure/GCP scheduler/CLI wiring and live credentialed proof are not shipped |
 | Registry sweep | `src/agent_bom/cloud/registry_sweep.py` | Registry-wide image enumeration + scan (ECR/ACR/GAR), digest-deduped, capped |

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -59,7 +59,7 @@ claude mcp add agent-bom -- uvx agent-bom mcp server
 
 ## What users get inside Claude
 
-`agent-bom mcp server` exposes 78 MCP tools for:
+`agent-bom mcp server` exposes 79 MCP tools for:
 
 - agent and MCP discovery
 - package and registry checks

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -237,7 +237,7 @@ For cross-agent correlation, use the broader runtime protection engine (`agent-b
 agent-bom mcp server
 ```
 
-Exposes 78 tools to any MCP-compatible AI assistant. Your agent can run scans,
+Exposes 79 tools to any MCP-compatible AI assistant. Your agent can run scans,
 check packages, query ExposurePaths, ask for deploy decisions, query threat
 intel, inspect runtime posture, run admin-gated Shield actions, and generate
 compliance reports without leaving the chat:

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,6 +1,6 @@
 # MCP Server — Connect agent-bom to AI Assistants
 
-agent-bom exposes 78 MCP tools as an MCP server. Any MCP-compatible client can
+agent-bom exposes 79 MCP tools as an MCP server. Any MCP-compatible client can
 connect and get vulnerability scanning, blast radius analysis, compliance
 checks, runtime posture, and supply-chain verification through natural
 conversation.
@@ -202,7 +202,8 @@ agent-bom proxy-bootstrap \
 `model_provenance_scan`, `prompt_scan`, `model_file_scan`, `ai_inventory_scan`,
 `license_compliance_scan`, `ingest_external_scan`, `runtime_evidence_ingest`,
 `cost_forecast`, `cost_allocation`, `credential_expiry`, `nhi_discover`,
-`cloud_inventory`, `access_review`, `create_ticket`, `sync_ticket_status`.
+`cloud_inventory`, `access_review`, `create_ticket`, `sync_ticket_status`,
+`findings_triage`.
 
 </details>
 
@@ -240,9 +241,9 @@ live runtime traffic rather than static reachability.
 ## Security Model
 
 - **Read-mostly**: scanner, graph, audit, and posture tools are read-only.
-  The 14 write-annotated tools cover scan-history diff, Shield, identity,
-  external ingest, CWPP runtime-evidence ingest, access review, and ticket
-  workflows. They require an
+  The 15 write-annotated tools cover scan-history diff, Shield, identity,
+  external ingest, CWPP runtime-evidence ingest, access review, finding
+  triage, and ticket workflows. They require an
   authenticated MCP operator token plus admin role, their specific write
   scope (`findings:write`, `identity:write`, `shield:write`, or
   `ticketing:write`), and an audit reason; stdio cannot invoke them.

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -165,7 +165,7 @@ agent-bom proxy-bootstrap \
 
 `proxy-configure` is best for JSON MCP clients such as Claude Desktop, Cursor, Windsurf, and Cortex CoCo. TOML-based clients like Codex CLI need manual proxy wrapping.
 
-## Tool Categories (78 tools)
+## Tool Categories (79 tools)
 
 | Category | Tools | What They Do |
 |----------|-------|-------------|
@@ -182,7 +182,7 @@ agent-bom proxy-bootstrap \
 | **AI supply chain** | `dataset_card_scan`, `training_pipeline_scan`, `browser_extension_scan`, `model_provenance_scan`, `prompt_scan`, `model_file_scan`, `ingest_external_scan`, `runtime_evidence_ingest` | Scan AI artifacts, prompts, model files, and browser extensions; import tool-agnostic SARIF/SBOM/scanner evidence without executing its producer; merge CWPP runtime signals |
 
 <details>
-<summary>Complete current catalog (78 tools)</summary>
+<summary>Complete current catalog (79 tools)</summary>
 
 `scan`, `check`, `intel_lookup`, `intel_match`, `intel_sources`,
 `intel_daily_brief`, `youcom_search`, `blast_radius`, `exposure_paths`, `should_i_deploy`,

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -131,7 +131,7 @@ notes discuss agent-native product direction.
 | Area | Shipped today | Not yet shipped |
 |---|---|---|
 | Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
-| Agent interface | 78 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated write actions | long-lived posture subscription tool, autonomous remediation actions |
+| Agent interface | 79 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated write actions | long-lived posture subscription tool, autonomous remediation actions |
 | Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, Python/Go/TypeScript control-plane clients, TypeScript runtime detector package | full scanner SDKs |
 | Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions, **webhook outbox** for posture events | Kafka connectors, cloud-log ingestion connectors, Kinesis/Firehose adapter, and MCP posture subscriptions |
 | Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -4,7 +4,7 @@
   "metrics": [
     {
       "name": "MCP tools",
-      "value": 78,
+      "value": 79,
       "source": "src/agent_bom/mcp_server_metadata.py",
       "notes": "Counted from the advertised server-card tools."
     },
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 844,
+      "value": 847,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -10,13 +10,13 @@ Keep counts out of public positioning copy and update this file from the repo in
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |
-| MCP tools | 78 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
+| MCP tools | 79 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 844 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 847 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 
 ## AI / agent developers (MCP · clients · tools)
 
-- [`MCP_SERVER.md`](MCP_SERVER.md) — run the MCP server, 78 tools
+- [`MCP_SERVER.md`](MCP_SERVER.md) — run the MCP server, 79 tools
 - [`MCP_CLIENT_GUIDES.md`](MCP_CLIENT_GUIDES.md) — connect MCP clients
 - [`PYTHON_API.md`](PYTHON_API.md) — Python control-plane client
 - [`PLUGIN_ENTRYPOINTS.md`](PLUGIN_ENTRYPOINTS.md) — opt-in plugin entry-point loader and author contract

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -102,12 +102,12 @@ scan a repo by URL.
 
 ```bash
 pip install 'agent-bom[mcp-server]'
-agent-bom mcp server                      # stdio MCP server: 78 tools, 6 resources, 8 prompts
+agent-bom mcp server                      # stdio MCP server: 79 tools, 6 resources, 8 prompts
 ```
 
 - MCP server setup + client guides: [`MCP_SERVER.md`](MCP_SERVER.md),
   [`MCP_CLIENT_GUIDES.md`](MCP_CLIENT_GUIDES.md)
-- Tool catalog (78 tools; sensitive writes remain admin-gated): see the
+- Tool catalog (79 tools; sensitive writes remain admin-gated): see the
   `Tools (77)` block in
   [`../src/agent_bom/mcp_server.py`](../src/agent_bom/mcp_server.py)
 - Typed control-plane clients: [`PYTHON_API.md`](PYTHON_API.md),

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -91,7 +91,7 @@
 <rect x="488" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="496" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
 <text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">MCP server</text>
-<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">78 tools</text>
+<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">79 tools</text>
 <rect x="706" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="714" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(718,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
 <text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Fleet jobs</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -91,7 +91,7 @@
 <rect x="488" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="496" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
 <text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">MCP server</text>
-<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">78 tools</text>
+<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">79 tools</text>
 <rect x="706" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="714" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(718,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
 <text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Fleet jobs</text>

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -18,7 +18,7 @@
 <rect x="35" y="126" width="378" height="52" rx="8" fill="none" stroke="#fb7185" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#fb7185"/>
 <text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">382 API ops · 78 MCP tools · SARIF</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">382 API ops · 79 MCP tools · SARIF</text>
 <rect x="439" y="18" width="402" height="174" rx="12" fill="#2dd4bf"/>
 <rect x="439" y="22" width="402" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="453" y="32" width="40" height="40" rx="11" fill="#2dd4bf" opacity="0.16"/><g transform="translate(457,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#2dd4bf"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#2dd4bf"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#2dd4bf"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#2dd4bf" stroke-width="1.05"/></g></g>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -18,7 +18,7 @@
 <rect x="35" y="126" width="378" height="52" rx="8" fill="none" stroke="#e11d48" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#e11d48"/>
 <text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#18181b">Agent-native surface</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">382 API ops · 78 MCP tools · SARIF</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">382 API ops · 79 MCP tools · SARIF</text>
 <rect x="439" y="18" width="402" height="174" rx="12" fill="#0d9488"/>
 <rect x="439" y="22" width="402" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="453" y="32" width="40" height="40" rx="11" fill="#0d9488" opacity="0.10"/><g transform="translate(457,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0d9488"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0d9488"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0d9488"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#ffffff" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#0d9488" stroke-width="1.05"/></g></g>

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -17183,6 +17183,44 @@
             }
           },
           {
+            "description": "Compliance framework drill-through, e.g. soc2 / nist-csf (compliance section id)",
+            "in": "query",
+            "name": "framework",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 64,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Compliance framework drill-through, e.g. soc2 / nist-csf (compliance section id)",
+              "title": "Framework"
+            }
+          },
+          {
+            "description": "Framework control code, narrows within framework (e.g. CC6.1)",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 64,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Framework control code, narrows within framework (e.g. CC6.1)",
+              "title": "Control"
+            }
+          },
+          {
             "in": "query",
             "name": "include_facets",
             "required": false,

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -11554,6 +11554,30 @@ paths:
           - type: 'null'
           description: Only known-exploited (KEV) findings, or only non-KEV when false
           title: Kev
+      - description: Compliance framework drill-through, e.g. soc2 / nist-csf (compliance
+          section id)
+        in: query
+        name: framework
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          description: Compliance framework drill-through, e.g. soc2 / nist-csf (compliance
+            section id)
+          title: Framework
+      - description: Framework control code, narrows within framework (e.g. CC6.1)
+        in: query
+        name: control
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          description: Framework control code, narrows within framework (e.g. CC6.1)
+          title: Control
       - in: query
         name: include_facets
         required: false

--- a/glama.json
+++ b/glama.json
@@ -5,7 +5,7 @@
   ],
   "name": "agent-bom",
   "title": "agent-bom",
-  "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 78 read-first MCP tools for headless security agents.",
+  "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 79 read-first MCP tools for headless security agents.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/integrations/docker-mcp-registry/SUBMISSION.md
+++ b/integrations/docker-mcp-registry/SUBMISSION.md
@@ -5,7 +5,7 @@ Submission files for listing agent-bom in the Docker Desktop MCP Toolkit catalog
 ## Files
 
 - `server.yaml` — server metadata, image, allowed hosts, optional secrets
-- `tools.json` — all 78 MCP tools with descriptions and parameters
+- `tools.json` — all 79 MCP tools with descriptions and parameters
 - `readme.md` — Docker MCP Toolkit detail page content
 
 ## How to submit

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -1434,5 +1434,24 @@
       {"name": "reason", "type": "string", "desc": "Human audit reason"},
       {"name": "tenant_id", "type": "string", "desc": "Tenant scope"}
     ]
+  },
+  {
+    "name": "findings_triage",
+    "description": "Record a tenant-scoped finding triage decision (queue state, VEX decision + justification, assignee) to the exception store; no per-action credential.",
+    "arguments": [
+      {"name": "vulnerability_id", "type": "string", "desc": "Vulnerability/advisory id being triaged"},
+      {"name": "package", "type": "string", "desc": "Affected package name, or '*' for all"},
+      {"name": "server_name", "type": "string", "desc": "Optional MCP server / asset scope"},
+      {"name": "assignee", "type": "string", "desc": "Owner recorded for the triage entry"},
+      {"name": "queue_state", "type": "string", "desc": "open, assigned, reviewing, or decided"},
+      {"name": "decision", "type": "string", "desc": "under_investigation, affected, or not_affected"},
+      {"name": "justification", "type": "string", "desc": "OpenVEX justification (required for not_affected)"},
+      {"name": "decision_reason", "type": "string", "desc": "Free-text rationale for the decision"},
+      {"name": "expires_at", "type": "string", "desc": "Optional ISO-8601 expiry"},
+      {"name": "operator_role", "type": "string", "desc": "Authenticated operator role"},
+      {"name": "operator_scopes", "type": "string", "desc": "Comma-separated operator scopes"},
+      {"name": "reason", "type": "string", "desc": "Human audit reason"},
+      {"name": "tenant_id", "type": "string", "desc": "Tenant scope"}
+    ]
   }
 ]

--- a/integrations/smithery.yaml
+++ b/integrations/smithery.yaml
@@ -3,7 +3,7 @@
 # The startCommand / configSchema / commandFunction block below is the runtime
 # contract Smithery executes — do not change its shape.
 name: agent-bom
-description: "Open security scanner and self-hosted control plane for AI/MCP infrastructure — agents, MCP servers, runtime, and blast radius. Exposes 78 MCP tools for scanning, compliance, and graph analysis."
+description: "Open security scanner and self-hosted control plane for AI/MCP infrastructure — agents, MCP servers, runtime, and blast radius. Exposes 79 MCP tools for scanning, compliance, and graph analysis."
 homepage: "https://github.com/msaad00/agent-bom"
 
 runtime: "python"

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -546,7 +546,7 @@ def main() -> int:
     tools = len(tool_names)
     resources = len(resource_uris)
     prompts = len(prompt_names)
-    if (tools, resources, prompts) != (78, 6, 8):
+    if (tools, resources, prompts) != (79, 6, 8):
         _fail(f"MCP server card count changed unexpectedly: tools={tools}, resources={resources}, prompts={prompts}")
     docker_mcp_tool_names = [str(tool["name"]) for tool in json.loads(DOCKER_MCP_TOOLS.read_text())]
     if docker_mcp_tool_names != tool_names:

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,11 +1,11 @@
 # MCP Server Setup
 
-agent-bom runs as an MCP server, exposing 78 MCP tools to any MCP client.
+agent-bom runs as an MCP server, exposing 79 MCP tools to any MCP client.
 The server card also advertises 6 resources and 8 workflow prompts so agents can
 choose structured playbooks instead of guessing tool order.
-Most tools are read-only. Fourteen write-annotated tools cover scan-history
+Most tools are read-only. 15 write-annotated tools cover scan-history
 diff, Shield, identity, external ingest, CWPP runtime-evidence ingest, access
-review, and ticket workflows.
+review, finding triage, and ticket workflows.
 Each requires `operator_role=admin`, its tool-specific write scope, and an audit
 reason. The registered scope families are `findings:write`, `identity:write`,
 `shield:write`, and `ticketing:write`.

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -73,7 +73,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|---|
 | **CLI / CI** | developers and pipelines | local scans, SARIF/SBOM/HTML/JSON, graph exports, deterministic gates |
 | **REST API** | security platforms, SIEM jobs, custom services | self-hosted control-plane routes for scans, normalized bulk findings, dataset versions, evaluation runs, graph evidence, audit, and governance |
-| **MCP tools** | AI agents and coding assistants | 78 tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture, audited write actions |
+| **MCP tools** | AI agents and coding assistants | 79 tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture, audited write actions |
 | **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
 | **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |
 | **UI cockpit** | security teams and auditors | graph cockpit, compliance, audit, and evidence review over the same backend data |

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -134,6 +134,8 @@ metadata or environment defaults.
 |---------|-------------|
 | `policy` | Policy templates, application, and install-guard checks |
 | `campaigns` | List remediation campaigns and record verification (owner, SLA, priority, status) |
+| `ticket` | File and sync ITSM tickets for findings through a stored connect-once connection (no per-action credential) |
+| `export` | Manage connect-once findings-export destinations and cron schedules (`destinations list/create/run`, `schedules list/create`) |
 | `firewall` | Inter-agent firewall policy validate / list / check |
 | `trust` | Show data access, network, auth, and storage boundaries |
 | `auth` | Configure dashboard authentication — guided browser SSO / OIDC setup |

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -3,9 +3,9 @@
 agent-bom exposes MCP tools for scanning, blast radius, trust, compliance,
 runtime, and remediation. The tools are read-only by default: agent consumers
 can request evidence and deploy guidance without mutating repos, cloud
-resources, or runtime targets. Fourteen write-annotated tools cover scan-history
+resources, or runtime targets. 15 write-annotated tools cover scan-history
 diff, Shield, identity, external ingest, CWPP runtime-evidence ingest, access
-review, and ticket workflows.
+review, finding triage, and ticket workflows.
 They fail closed unless a remote caller uses the operator token and supplies an
 admin role, the tool-specific write scope, and an audit reason; stdio cannot
 invoke them.
@@ -31,7 +31,8 @@ invoke them.
 `model_provenance_scan`, `prompt_scan`, `model_file_scan`, `ai_inventory_scan`,
 `license_compliance_scan`, `ingest_external_scan`, `runtime_evidence_ingest`,
 `cost_forecast`, `cost_allocation`, `credential_expiry`, `nhi_discover`,
-`cloud_inventory`, `access_review`, `create_ticket`, `sync_ticket_status`.
+`cloud_inventory`, `access_review`, `create_ticket`, `sync_ticket_status`,
+`findings_triage`.
 
 </details>
 

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -11,7 +11,7 @@ admin role, the tool-specific write scope, and an audit reason; stdio cannot
 invoke them.
 
 <details>
-<summary>Complete current catalog (78 tools)</summary>
+<summary>Complete current catalog (79 tools)</summary>
 
 `scan`, `check`, `intel_lookup`, `intel_match`, `intel_sources`,
 `intel_daily_brief`, `youcom_search`, `blast_radius`, `exposure_paths`, `should_i_deploy`,

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -2503,15 +2503,18 @@ async def list_finding_feedback(request: Request, state: str | None = None) -> d
     return {"feedback": entries, "total": len(entries)}
 
 
-@router.post("/findings/triage", tags=["enterprise"], status_code=201)
-async def create_finding_triage(request: Request, req: FindingTriageRequest) -> dict:
-    """Create a tenant-scoped finding triage queue item."""
+def record_finding_triage(*, tenant_id: str, actor: str, req: FindingTriageRequest) -> dict[str, Any]:
+    """Persist a tenant-scoped triage decision to the exception store.
+
+    Shared by ``POST /v1/findings/triage`` and the MCP ``findings_triage`` write
+    tool so both surfaces write identical entries to the one exception store.
+    Raises ``HTTPException(400)`` when a ``not_affected`` decision omits its
+    required OpenVEX justification.
+    """
     from agent_bom.api.audit_log import log_action
     from agent_bom.api.exception_store import ExceptionStatus, VulnException
 
     _validate_triage_decision(req.decision, req.justification)
-    tenant_id = require_request_tenant_id(request)
-    actor = _request_actor(request)
     now = datetime.now(timezone.utc).isoformat()
     queue_state = "decided" if req.decision in {"affected", "not_affected"} else req.queue_state
     reviewed_at = now if queue_state == "decided" else ""
@@ -2548,6 +2551,14 @@ async def create_finding_triage(request: Request, req: FindingTriageRequest) -> 
         decision=req.decision,
     )
     return _triage_response(exc)
+
+
+@router.post("/findings/triage", tags=["enterprise"], status_code=201)
+async def create_finding_triage(request: Request, req: FindingTriageRequest) -> dict:
+    """Create a tenant-scoped finding triage queue item."""
+    tenant_id = require_request_tenant_id(request)
+    actor = _request_actor(request)
+    return record_finding_triage(tenant_id=tenant_id, actor=actor, req=req)
 
 
 @router.get("/findings/triage", tags=["enterprise"])

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -2150,6 +2150,8 @@ def _canonical_scope_filters(
     finding_class: str | None = None,
     q: str | None = None,
     kev: bool | None = None,
+    framework: str | None = None,
+    control: str | None = None,
 ) -> dict[str, str]:
     """Normalize the optional scope/domain filters into an active-filter map.
 
@@ -2157,8 +2159,26 @@ def _canonical_scope_filters(
     and empty inputs dropped. Unknown values are kept (not rejected) so the
     endpoint never raises on ad-hoc input — an unmatched value simply returns no
     findings. ``account`` maps to the finding's ``account_ref``.
+
+    ``framework`` / ``control`` power the compliance drill-through (epic #4790):
+    the framework identifier (a UI section id such as ``nist-csf`` / ``iso27001``)
+    is resolved once here to the finding's ``*_tags`` field and canonical slug so
+    the per-row predicate stays a cheap containment check. An unresolved
+    framework is stored raw so the predicate returns an honest empty match.
+    ``control`` is only meaningful alongside a framework and is dropped otherwise.
     """
     filters: dict[str, str] = {}
+    if framework and framework.strip():
+        from agent_bom.compliance_coverage import resolve_framework_filter
+
+        meta = resolve_framework_filter(framework)
+        if meta is not None:
+            filters["framework_tag_field"] = meta.tag_field
+            filters["framework_slug"] = meta.slug
+        else:
+            filters["framework"] = framework.strip().lower()
+        if control and control.strip():
+            filters["control"] = control.strip()
     if provider and provider.strip():
         filters["provider"] = provider.strip().lower()
     if account and account.strip():
@@ -2433,6 +2453,14 @@ async def list_findings(
     status: Annotated[str, Query(max_length=16)] = _DEFAULT_FINDING_STATUS,
     finding_class: FindingClass | None = None,
     kev: Annotated[bool | None, Query(description="Only known-exploited (KEV) findings, or only non-KEV when false")] = None,
+    framework: Annotated[
+        str | None,
+        Query(max_length=64, description="Compliance framework drill-through, e.g. soc2 / nist-csf (compliance section id)"),
+    ] = None,
+    control: Annotated[
+        str | None,
+        Query(max_length=64, description="Framework control code, narrows within framework (e.g. CC6.1)"),
+    ] = None,
     include_facets: bool = False,
 ) -> dict:
     """List unified findings aggregated from completed scan results.
@@ -2479,6 +2507,8 @@ async def list_findings(
                 finding_class,
                 kev,
                 include_facets,
+                framework,
+                control,
             )
     except BackpressureRejectedError as exc:
         raise HTTPException(
@@ -2507,6 +2537,8 @@ def _list_findings_impl(
     finding_class: str | None = None,
     kev: bool | None = None,
     include_facets: bool = False,
+    framework: str | None = None,
+    control: str | None = None,
 ) -> dict:
     """Synchronous body of :func:`list_findings` (runs in a worker thread).
 
@@ -2632,7 +2664,9 @@ def _list_findings_impl(
     # returns that scan's rows verbatim.
     from agent_bom.api.findings_current import current_scan_findings
 
-    scope_filters = _canonical_scope_filters(provider, account, environment, domain, finding_class, q, kev=kev)
+    scope_filters = _canonical_scope_filters(
+        provider, account, environment, domain, finding_class, q, kev=kev, framework=framework, control=control
+    )
 
     store = get_compliance_hub_store()
     bulk_list = getattr(store, "list_current_page", None) or getattr(store, "list_page", None)
@@ -2930,6 +2964,8 @@ def _list_findings_impl(
             for key, value in {
                 "finding_class": finding_class,
                 "q": q.strip() if q and q.strip() else None,
+                "framework": framework.strip() if framework and framework.strip() else None,
+                "control": control.strip() if control and control.strip() else None,
             }.items()
             if value is not None
         },

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -319,6 +319,16 @@ from agent_bom.cli._compliance_group import compliance_cmd  # noqa: E402
 main.add_command(campaigns_cmd, "campaigns")
 main.add_command(compliance_cmd, "compliance")
 
+# ---------------------------------------------------------------------------
+# Ticketing + export groups — headless parity for the connect-once ITSM
+# ticketing plane and the scheduled findings-export plane (API-only until now).
+# ---------------------------------------------------------------------------
+from agent_bom.cli._exports_group import export_cmd  # noqa: E402
+from agent_bom.cli._ticketing_group import ticket_cmd  # noqa: E402
+
+main.add_command(ticket_cmd, "ticket")
+main.add_command(export_cmd, "export")
+
 from agent_bom.cli._db import db_cmd  # noqa: E402
 
 main.add_command(db_cmd, "db")

--- a/src/agent_bom/cli/_exports_group.py
+++ b/src/agent_bom/cli/_exports_group.py
@@ -1,0 +1,249 @@
+"""CLI commands for scheduled findings exports (destinations + schedules).
+
+Thin surface over ``/v1/exports/destinations`` and ``/v1/exports/schedules`` —
+the connect-once security-data-lake export plane. All logic (encryption at rest,
+off-event-loop run, cron scheduling) lives in ``agent_bom.export`` and the
+destination/schedule stores; the CLI only renders what the API returns.
+
+Connect-once: a destination is configured with its stored, encrypted config and
+every ``run`` streams findings **through** it — no per-action credential is ever
+passed to these commands. Secret-bearing destinations (e.g. Snowflake) are
+provisioned through the connect-once API/hub, not by handing a credential to the
+CLI; ``destinations create`` here carries only non-secret config.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from agent_bom.cli._findings_group import (
+    _common_api_options,
+    _emit_json,
+    _make_client,
+    _run_request,
+    _string,
+)
+from agent_bom.client import JsonObject, JsonValue
+
+
+def _emit_json_rows(rows: list[JsonObject]) -> None:
+    click.echo(json.dumps(rows, indent=2, sort_keys=True))
+
+
+def _print_destinations_table(rows: list[JsonObject]) -> None:
+    noun = "destination" if len(rows) == 1 else "destinations"
+    click.echo(f"{len(rows)} export {noun}")
+    click.echo("id\tkind\tdisplay_name\tstatus\thas_secret\tlast_run_status\tlast_run_at")
+    for item in rows:
+        if not isinstance(item, dict):
+            continue
+        click.echo(
+            "\t".join(
+                [
+                    _string(item.get("id")),
+                    _string(item.get("kind")),
+                    _string(item.get("display_name")),
+                    _string(item.get("status")),
+                    _string(item.get("has_secret")),
+                    _string(item.get("last_run_status")) or "-",
+                    _string(item.get("last_run_at")) or "-",
+                ]
+            )
+        )
+
+
+def _print_schedules_table(rows: list[JsonObject]) -> None:
+    noun = "schedule" if len(rows) == 1 else "schedules"
+    click.echo(f"{len(rows)} export {noun}")
+    click.echo("id\tname\tcron\tdestination\tenabled\tnext_run")
+    for item in rows:
+        if not isinstance(item, dict):
+            continue
+        click.echo(
+            "\t".join(
+                [
+                    _string(item.get("schedule_id") or item.get("id")),
+                    _string(item.get("name")),
+                    _string(item.get("cron_expression")),
+                    _string(item.get("destination_id")),
+                    _string(item.get("enabled")),
+                    _string(item.get("next_run")) or "-",
+                ]
+            )
+        )
+
+
+def _parse_config(config: str | None) -> dict[str, JsonValue]:
+    if not config:
+        return {}
+    try:
+        parsed = json.loads(config)
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(f"--config must be a JSON object: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise click.ClickException("--config must be a JSON object.")
+    return parsed
+
+
+@click.group(name="export")
+def export_cmd() -> None:
+    """Manage connect-once findings-export destinations and schedules.
+
+    No per-action credential is passed to these commands; a run operates over a
+    stored destination. Requires the API server.
+    """
+
+
+@export_cmd.group("destinations")
+def destinations_group() -> None:
+    """List, create, and run connect-once export destinations."""
+
+
+@destinations_group.command("list")
+@click.option("--format", "output_format", type=click.Choice(["table", "json"]), default="table", show_default=True)
+@_common_api_options
+def list_destinations_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    output_format: str,
+) -> None:
+    """List the tenant's export destinations and their last-run status."""
+
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    rows = _run_request(client, lambda api: api.list_export_destinations())
+    if output_format == "json":
+        _emit_json_rows(rows)
+    else:
+        _print_destinations_table(rows)
+
+
+@destinations_group.command("create")
+@click.option("--kind", required=True, help="Destination kind: s3, azure-blob, gcs, clickhouse, snowflake, bigquery, or databricks.")
+@click.option("--display-name", "display_name", required=True, help="Human-readable name for the destination.")
+@click.option(
+    "--config",
+    default="",
+    help="Non-secret destination config as a JSON object (bucket/prefix/region, warehouse coordinates, etc.).",
+)
+@click.option("--format", "output_format", type=click.Choice(["json"]), default="json", show_default=True)
+@_common_api_options
+def create_destination_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    kind: str,
+    display_name: str,
+    config: str,
+    output_format: str,
+) -> None:
+    """Create a connect-once export destination (non-secret config only).
+
+    Secret-bearing destinations (Snowflake / Databricks) are provisioned through
+    the connect-once API/hub so no credential is passed here; this command
+    surfaces the API's guidance if a secret is required.
+    """
+
+    parsed_config = _parse_config(config)
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    payload = _run_request(
+        client,
+        lambda api: api.create_export_destination(kind=kind, display_name=display_name, config=parsed_config),
+    )
+    if output_format == "json":
+        _emit_json(payload)
+
+
+@destinations_group.command("run")
+@click.argument("destination_id")
+@click.option("--format", "output_format", type=click.Choice(["json"]), default="json", show_default=True)
+@_common_api_options
+def run_destination_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    destination_id: str,
+    output_format: str,
+) -> None:
+    """Fire a one-off findings export to a stored destination now."""
+
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    payload = _run_request(client, lambda api: api.run_export_destination(destination_id))
+    if output_format == "json":
+        _emit_json(payload)
+
+
+@export_cmd.group("schedules")
+def schedules_group() -> None:
+    """List and create cron export schedules bound to a destination."""
+
+
+@schedules_group.command("list")
+@click.option("--format", "output_format", type=click.Choice(["table", "json"]), default="table", show_default=True)
+@_common_api_options
+def list_schedules_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    output_format: str,
+) -> None:
+    """List the tenant's export schedules."""
+
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    rows = _run_request(client, lambda api: api.list_export_schedules())
+    if output_format == "json":
+        _emit_json_rows(rows)
+    else:
+        _print_schedules_table(rows)
+
+
+@schedules_group.command("create")
+@click.option("--name", required=True, help="Human-readable schedule name.")
+@click.option("--cron", "cron_expression", required=True, help="Five-field cron expression.")
+@click.option("--destination-id", "destination_id", required=True, help="Stored destination id to export to.")
+@click.option("--sort", default="effective_reach", show_default=True, help="Findings sort applied to each export.")
+@click.option("--severity", default=None, help="Optional minimum severity filter.")
+@click.option("--since-days", "since_days", default=None, type=click.IntRange(min=1, max=3650), help="Optional lookback window in days.")
+@click.option("--disabled", is_flag=True, help="Create the schedule disabled (default: enabled).")
+@click.option("--format", "output_format", type=click.Choice(["json"]), default="json", show_default=True)
+@_common_api_options
+def create_schedule_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    name: str,
+    cron_expression: str,
+    destination_id: str,
+    sort: str,
+    severity: str | None,
+    since_days: int | None,
+    disabled: bool,
+    output_format: str,
+) -> None:
+    """Create a cron export schedule bound to a stored destination."""
+
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    payload = _run_request(
+        client,
+        lambda api: api.create_export_schedule(
+            name=name,
+            cron_expression=cron_expression,
+            destination_id=destination_id,
+            sort=sort,
+            severity=severity,
+            since_days=since_days,
+            enabled=not disabled,
+        ),
+    )
+    if output_format == "json":
+        _emit_json(payload)
+
+
+__all__ = ["export_cmd"]

--- a/src/agent_bom/cli/_findings_group.py
+++ b/src/agent_bom/cli/_findings_group.py
@@ -188,6 +188,8 @@ def push_findings_cmd(
 
 @findings_cmd.command("list")
 @click.option("--severity", help="Filter findings by severity.")
+@click.option("--framework", help="Compliance framework drill-through (e.g. soc2, nist-csf).")
+@click.option("--control", help="Framework control code; narrows within --framework (e.g. CC6.1).")
 @click.option("--sort", default="effective_reach", show_default=True, help="Sort field used by the API.")
 @click.option("--limit", default=500, show_default=True, type=click.IntRange(min=1, max=1000), help="Maximum rows to return.")
 @click.option("--offset", default=0, show_default=True, type=click.IntRange(min=0), help="Rows to skip.")
@@ -199,6 +201,8 @@ def list_findings_cmd(
     bearer_token: str | None,
     tenant_id: str | None,
     severity: str | None,
+    framework: str | None,
+    control: str | None,
     sort: str,
     limit: int,
     offset: int,
@@ -207,7 +211,10 @@ def list_findings_cmd(
     """List findings with the same filters as the REST API."""
 
     client = _make_client(api_url, api_key, bearer_token, tenant_id)
-    payload = _run_request(client, lambda api: api.list_findings(severity=severity, sort=sort, limit=limit, offset=offset))
+    payload = _run_request(
+        client,
+        lambda api: api.list_findings(severity=severity, sort=sort, limit=limit, offset=offset, framework=framework, control=control),
+    )
     if output_format == "json":
         _emit_json(payload)
     else:

--- a/src/agent_bom/cli/_findings_group.py
+++ b/src/agent_bom/cli/_findings_group.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 import click
 
 from agent_bom.client import AgentBomApiError, AgentBomClient, JsonObject
+
+_RequestResult = TypeVar("_RequestResult")
 
 
 def _make_client(api_url: str | None, api_key: str | None, bearer_token: str | None, tenant_id: str | None) -> AgentBomClient:
@@ -119,7 +121,7 @@ def _print_triage_table(payload: JsonObject) -> None:
         )
 
 
-def _run_request(client: AgentBomClient, callback: Any) -> JsonObject:
+def _run_request(client: AgentBomClient, callback: Callable[[AgentBomClient], _RequestResult]) -> _RequestResult:
     import httpx
 
     try:

--- a/src/agent_bom/cli/_grouped_help.py
+++ b/src/agent_bom/cli/_grouped_help.py
@@ -46,6 +46,8 @@ COMMAND_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
                 "teardown",
                 "findings",
                 "campaigns",
+                "ticket",
+                "export",
                 "attest",
                 "audit-drain-dlq",
             ],

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -1075,7 +1075,7 @@ def mcp_server_cmd(
       docs/MCP_WORKFLOWS.md
 
     \b
-    Exposes 78 security tools via MCP protocol, organized behind 8 workflow
+    Exposes 79 security tools via MCP protocol, organized behind 8 workflow
     prompts. Advanced direct tools include skill_scan, skill_verify,
     compliance, and remediate.
 

--- a/src/agent_bom/cli/_ticketing_group.py
+++ b/src/agent_bom/cli/_ticketing_group.py
@@ -1,0 +1,161 @@
+"""CLI commands for the connect-once ITSM ticketing plane.
+
+Thin surface over ``/v1/ticketing/tickets`` — the same connect-once actions the
+REST API and the MCP ``create_ticket`` / ``sync_ticket_status`` tools expose. All
+logic (connection resolution, idempotent filing, ITSM transport) lives in
+``agent_bom.ticketing.service``; the CLI only renders what the API returns.
+
+No credential, token, or base URL is ever passed here: auth and endpoint come
+only from the stored, encrypted, tenant-scoped connection configured once in the
+Connections hub. Filing a ticket therefore requires the API server plus a
+ticketing connection for the tenant.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+import click
+
+from agent_bom.cli._findings_group import (
+    _common_api_options,
+    _emit_json,
+    _make_client,
+    _run_request,
+    _string,
+)
+
+
+def _print_tickets_table(payload: Mapping[str, object]) -> None:
+    rows = payload.get("tickets")
+    if not isinstance(rows, list):
+        rows = []
+    tenant = _string(payload.get("tenant_id")) or "-"
+    noun = "ticket" if len(rows) == 1 else "tickets"
+    click.echo(f"{len(rows)} {noun} (tenant {tenant})")
+    click.echo("id\tprovider\tstatus\tkey\texternal_id\tconnection\turl")
+    for item in rows:
+        if not isinstance(item, dict):
+            continue
+        click.echo(
+            "\t".join(
+                [
+                    _string(item.get("id")),
+                    _string(item.get("provider")),
+                    _string(item.get("status")),
+                    _string(item.get("key")) or "-",
+                    _string(item.get("external_id")) or "-",
+                    _string(item.get("connection_id")) or "-",
+                    _string(item.get("url")) or "-",
+                ]
+            )
+        )
+
+
+@click.group(name="ticket")
+def ticket_cmd() -> None:
+    """File and sync ITSM tickets for findings through a stored connection.
+
+    Connect-once: configure a ticketing connection first (Connections hub / the
+    ticketing API). These commands carry no credentials and require the API
+    server.
+    """
+
+
+@ticket_cmd.command("list")
+@click.option("--format", "output_format", type=click.Choice(["table", "json"]), default="table", show_default=True)
+@_common_api_options
+def list_tickets_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    output_format: str,
+) -> None:
+    """List filed finding→ticket links with their last-known ITSM status."""
+
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    payload = _run_request(client, lambda api: api.list_tickets())
+    if output_format == "json":
+        _emit_json(payload)
+    else:
+        _print_tickets_table(payload)
+
+
+@ticket_cmd.command("create")
+@click.option(
+    "--finding-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Path to a JSON file with the finding/issue object to file.",
+)
+@click.option(
+    "--connection-id", "connection_id", default="", help="Stored ticketing connection id (uses the tenant's only one if omitted)."
+)
+@click.option("--project", default="", help="Target ITSM project/queue key (uses the connection default if omitted).")
+@click.option("--finding-id", "finding_id", default="", help="Stable finding id for idempotency (derived from finding if omitted).")
+@click.option("--issue-type", "issue_type", default="", help="ITSM issue type (provider default if omitted).")
+@click.option("--source-url", "source_url", default="", help="Optional deep link back into agent-bom for provenance.")
+@click.option("--format", "output_format", type=click.Choice(["json"]), default="json", show_default=True)
+@_common_api_options
+def create_ticket_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    finding_file: Path,
+    connection_id: str,
+    project: str,
+    finding_id: str,
+    issue_type: str,
+    source_url: str,
+    output_format: str,
+) -> None:
+    """File a ticket for a finding through the stored connection (idempotent)."""
+
+    try:
+        finding = json.loads(finding_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise click.ClickException(f"Could not read finding JSON from {finding_file}: {exc}") from exc
+    if not isinstance(finding, dict):
+        raise click.ClickException("The finding file must contain a single JSON object.")
+
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    payload = _run_request(
+        client,
+        lambda api: api.create_ticket(
+            finding=finding,
+            connection_id=connection_id,
+            project=project,
+            finding_id=finding_id,
+            issue_type=issue_type,
+            source_url=source_url,
+        ),
+    )
+    if output_format == "json":
+        _emit_json(payload)
+
+
+@ticket_cmd.command("sync")
+@click.argument("ticket_id")
+@click.option("--format", "output_format", type=click.Choice(["json"]), default="json", show_default=True)
+@_common_api_options
+def sync_ticket_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    ticket_id: str,
+    output_format: str,
+) -> None:
+    """Refresh a filed ticket's status from its ITSM through the connection."""
+
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    payload = _run_request(client, lambda api: api.sync_ticket(ticket_id))
+    if output_format == "json":
+        _emit_json(payload)
+
+
+__all__ = ["ticket_cmd"]

--- a/src/agent_bom/client.py
+++ b/src/agent_bom/client.py
@@ -137,6 +137,113 @@ class AgentBomClient:
 
         return self._request("GET", f"/v1/compliance/{_quote_path(framework)}")
 
+    # ── Ticketing (connect-once ITSM) ───────────────────────────────────────
+    def list_tickets(self) -> JsonObject:
+        """List the tenant's filed finding→ticket links."""
+
+        return self._request("GET", "/v1/ticketing/tickets")
+
+    def create_ticket(
+        self,
+        *,
+        finding: Mapping[str, JsonValue],
+        connection_id: str = "",
+        project: str = "",
+        finding_id: str = "",
+        issue_type: str = "",
+        source_url: str = "",
+    ) -> JsonObject:
+        """File an ITSM ticket for a finding through a stored connection.
+
+        Carries no credential or base URL: auth and endpoint are resolved from
+        the stored, encrypted ticketing connection (connect-once).
+        """
+
+        return self._request(
+            "POST",
+            "/v1/ticketing/tickets",
+            json=_strip_none(
+                {
+                    "finding": dict(finding),
+                    "connection_id": connection_id,
+                    "project": project,
+                    "finding_id": finding_id,
+                    "issue_type": issue_type,
+                    "source_url": source_url,
+                }
+            ),
+        )
+
+    def sync_ticket(self, ticket_id: str) -> JsonObject:
+        """Refresh a filed ticket's status from its ITSM through the connection."""
+
+        return self._request("POST", f"/v1/ticketing/tickets/{_quote_path(ticket_id)}/sync")
+
+    # ── Scheduled findings exports (connect-once destinations) ──────────────
+    def list_export_destinations(self) -> list[JsonObject]:
+        """List the tenant's connect-once export destinations."""
+
+        return self._request_list("GET", "/v1/exports/destinations")
+
+    def create_export_destination(
+        self,
+        *,
+        kind: str,
+        display_name: str,
+        config: Mapping[str, JsonValue] | None = None,
+    ) -> JsonObject:
+        """Create a connect-once export destination (no per-action credential).
+
+        Only non-secret ``config`` is sent; a secret-bearing destination
+        (e.g. Snowflake) is provisioned through the connect-once API/hub, not by
+        passing a credential to this command.
+        """
+
+        return self._request(
+            "POST",
+            "/v1/exports/destinations",
+            json={"kind": kind, "display_name": display_name, "config": dict(config or {})},
+        )
+
+    def run_export_destination(self, destination_id: str) -> JsonObject:
+        """Fire a one-off findings export to a stored destination now."""
+
+        return self._request("POST", f"/v1/exports/destinations/{_quote_path(destination_id)}/run")
+
+    def list_export_schedules(self) -> list[JsonObject]:
+        """List the tenant's export schedules."""
+
+        return self._request_list("GET", "/v1/exports/schedules")
+
+    def create_export_schedule(
+        self,
+        *,
+        name: str,
+        cron_expression: str,
+        destination_id: str,
+        sort: str = "effective_reach",
+        severity: str | None = None,
+        since_days: int | None = None,
+        enabled: bool = True,
+    ) -> JsonObject:
+        """Create a cron export schedule bound to a stored destination."""
+
+        return self._request(
+            "POST",
+            "/v1/exports/schedules",
+            json=_strip_none(
+                {
+                    "name": name,
+                    "cron_expression": cron_expression,
+                    "destination_id": destination_id,
+                    "sort": sort,
+                    "severity": severity,
+                    "since_days": since_days,
+                    "enabled": enabled,
+                }
+            ),
+        )
+
     def should_i_deploy(
         self,
         candidate: str | Mapping[str, JsonValue],
@@ -681,6 +788,34 @@ class AgentBomClient:
         if not isinstance(data, dict):
             raise AgentBomApiError("agent-bom response was not a JSON object", status_code=response.status_code, body=text)
         return data
+
+    def _request_list(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Mapping[str, QueryValue] | None = None,
+        json: Mapping[str, JsonValue] | None = None,
+        extra_headers: Mapping[str, str] | None = None,
+    ) -> list[JsonObject]:
+        """Like :meth:`_request` but for endpoints returning a JSON array."""
+        headers = self._headers(json is not None)
+        if extra_headers:
+            headers.update(extra_headers)
+        response = self._client.request(method, self._url(path), params=params, json=json, headers=headers)
+        text = response.text
+        if response.status_code < 200 or response.status_code >= 300:
+            raise AgentBomApiError(
+                f"agent-bom request failed: {response.status_code}",
+                status_code=response.status_code,
+                body=text,
+            )
+        if not text:
+            return []
+        data = response.json()
+        if not isinstance(data, list):
+            raise AgentBomApiError("agent-bom response was not a JSON array", status_code=response.status_code, body=text)
+        return [item for item in data if isinstance(item, dict)]
 
     def _url(self, path: str) -> str:
         if path.startswith(("http://", "https://")):

--- a/src/agent_bom/client.py
+++ b/src/agent_bom/client.py
@@ -167,8 +167,15 @@ class AgentBomClient:
         sort: str = "effective_reach",
         limit: int = 500,
         offset: int = 0,
+        framework: str | None = None,
+        control: str | None = None,
     ) -> JsonObject:
-        """List normalized findings from scan jobs and bulk ingests."""
+        """List normalized findings from scan jobs and bulk ingests.
+
+        ``framework`` / ``control`` are the compliance drill-through filters
+        (epic #4790): a framework section id (e.g. ``soc2`` / ``nist-csf``) and,
+        optionally, a control code that narrows within it.
+        """
 
         return self._request(
             "GET",
@@ -179,6 +186,8 @@ class AgentBomClient:
                     "sort": sort,
                     "limit": limit,
                     "offset": offset,
+                    "framework": framework,
+                    "control": control,
                 }
             ),
         )

--- a/src/agent_bom/compliance_coverage.py
+++ b/src/agent_bom/compliance_coverage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 
@@ -350,6 +351,45 @@ def normalize_framework_slug(slug: str) -> str:
     """Normalize API/ingest framework slugs to canonical hyphenated form."""
     normalized = slug.strip().lower().replace("_", "-")
     return FRAMEWORK_SLUG_ALIASES.get(normalized, normalized)
+
+
+_FRAMEWORK_IDENT_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _normalize_framework_ident(value: str) -> str:
+    """Lowercase and strip every non-alphanumeric character.
+
+    Collapses the small representational differences between the compliance
+    UI's section id, the metadata ``slug``, its ``output_key`` and its
+    ``tag_field`` so all three forms of one framework compare equal
+    (``nist-csf`` == ``nist_csf`` == ``nistcsf``).
+    """
+    return _FRAMEWORK_IDENT_RE.sub("", value.strip().lower())
+
+
+def resolve_framework_filter(value: str) -> ComplianceFrameworkMetadata | None:
+    """Resolve a UI/API framework identifier to its tag-mapped metadata.
+
+    The compliance drill-through links to ``/findings?framework=<section id>``
+    where the section id is the UI slug (``nist-csf``, ``iso27001``,
+    ``nist-ai-rmf`` …). Those do not always equal the metadata ``slug`` /
+    ``output_key`` / ``tag_field`` (``nist-ai-rmf`` maps to slug ``nist``,
+    ``iso27001`` to ``iso-27001``), so match tolerantly against all three,
+    normalized. Returns ``None`` for an unrecognized identifier so the caller
+    can return an honest empty result rather than raising.
+    """
+    key = _normalize_framework_ident(value)
+    if not key:
+        return None
+    for meta in TAG_MAPPED_FRAMEWORKS:
+        candidates = {
+            _normalize_framework_ident(meta.slug),
+            _normalize_framework_ident(meta.output_key),
+            _normalize_framework_ident(meta.tag_field.removesuffix("_tags")),
+        }
+        if key in candidates:
+            return meta
+    return None
 
 
 AISVS_BENCHMARK = ComplianceBenchmarkMetadata(

--- a/src/agent_bom/finding_scope.py
+++ b/src/agent_bom/finding_scope.py
@@ -760,6 +760,76 @@ def row_matches_search(row: Mapping[str, object], query: str | None) -> bool:
     return False
 
 
+def _framework_control_codes(row: Mapping[str, Any], tag_field: str, framework_key: str) -> set[str]:
+    """Collect one framework's control codes from every representation on a row.
+
+    A scan finding may carry its framework controls three ways: the per-framework
+    tag list (``soc2_tags``), the structured ``controls`` list, and the flattened
+    ``framework_tags`` (``"soc2:CC6.1"``). All are read, but strictly scoped to
+    ``framework_key`` so a code is never matched against another framework's
+    namespace — the flat ``compliance_tags`` union is deliberately NOT consulted.
+    """
+    codes: set[str] = set()
+    raw = row.get(tag_field)
+    if isinstance(raw, (list, tuple, set)):
+        codes.update(str(tag) for tag in raw)
+    controls = row.get("controls")
+    if isinstance(controls, list):
+        for control in controls:
+            if isinstance(control, dict) and str(control.get("framework") or "") == framework_key:
+                code = control.get("control") or control.get("id")
+                if code:
+                    codes.add(str(code))
+    framework_tags = row.get("framework_tags")
+    if isinstance(framework_tags, list):
+        prefix = f"{framework_key}:"
+        for tag in framework_tags:
+            text = str(tag)
+            if text.startswith(prefix):
+                codes.add(text[len(prefix) :])
+    return codes
+
+
+def _row_matches_framework(row: Mapping[str, Any], filters: Mapping[str, str]) -> bool:
+    """Framework / control drill-through predicate (compliance → findings).
+
+    The framework identifier is resolved once in the route to ``framework_tag_field``
+    (e.g. ``soc2_tags``) plus the canonical ``framework_slug``. When it does not
+    resolve the route stores the raw value under ``framework`` and nothing can
+    match it — an honest empty result rather than a silent widening.
+
+    With a ``control`` code the match is exact containment in the framework's
+    control codes, mirroring the compliance per-control count (``code in tags``)
+    so the drilled queue reconciles with the badge the user clicked. Without a
+    control it is a framework-level match: any control tagged for the framework,
+    or — for bulk-ingested rows whose per-framework tags are redacted at rest —
+    the framework slug present in ``applicable_frameworks``.
+    """
+    tag_field = filters.get("framework_tag_field")
+    if tag_field is None:
+        # Unresolved framework identifier: match nothing (honest empty).
+        return False
+
+    control = filters.get("control")
+    control = control.strip() if isinstance(control, str) else None
+    framework_key = tag_field[:-5] if tag_field.endswith("_tags") else tag_field
+    codes = _framework_control_codes(row, tag_field, framework_key)
+
+    if control:
+        return control in codes
+    if codes:
+        return True
+    slug = filters.get("framework_slug")
+    if slug:
+        from agent_bom.compliance_coverage import normalize_framework_slug
+
+        wanted = normalize_framework_slug(slug)
+        applicable = row.get("applicable_frameworks")
+        if isinstance(applicable, (list, tuple, set)):
+            return any(normalize_framework_slug(str(item)) == wanted for item in applicable)
+    return False
+
+
 def row_matches_scope(row: dict, filters: Mapping[str, str]) -> bool:
     """Return True when a finding row matches every active scope filter.
 
@@ -771,8 +841,10 @@ def row_matches_scope(row: dict, filters: Mapping[str, str]) -> bool:
     equality checks. ``domain`` matches membership in the finding's overlapping
     coverage-lens set (:func:`lenses_for_row`), so ``domain=aspm`` returns
     SAST + secrets + repo dependencies + IaC and ``domain=vuln`` returns every
-    CVE. The caller is responsible for pre-canonicalizing the filter values
-    (lowercased/trimmed, ``appsec_sca`` -> ``aspm`` legacy alias applied).
+    CVE. ``framework`` / ``control`` power the compliance drill-through
+    (:func:`_row_matches_framework`). The caller is responsible for
+    pre-canonicalizing the filter values (lowercased/trimmed, ``appsec_sca`` ->
+    ``aspm`` legacy alias applied, framework resolved to its tag field).
     """
     for key in ("provider", "account_ref", "environment"):
         wanted = filters.get(key)
@@ -786,6 +858,12 @@ def row_matches_scope(row: dict, filters: Mapping[str, str]) -> bool:
     wanted_class = filters.get("finding_class")
     if wanted_class is not None and finding_class_for_row(row) != wanted_class:
         return False
+    # Compliance drill-through: framework (resolved to its tag field) + optional
+    # control code. ``framework`` (raw) is present only when the identifier did
+    # not resolve, in which case the match is an honest empty.
+    if filters.get("framework_tag_field") is not None or filters.get("framework") is not None:
+        if not _row_matches_framework(row, filters):
+            return False
     # KEV leads the executive headline — "actively exploited, fix these first" —
     # so the list has to be able to answer it. An absent verdict is not a match:
     # a row nobody checked must never be presented as known-exploited.

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -5,7 +5,7 @@ Start with:
     agent-bom mcp server --transport sse          # SSE transport (for remote clients)
     agent-bom mcp server --transport streamable-http
 
-Tools (78):
+Tools (79):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
     intel_lookup        — Look up a CVE, GHSA, or OSV advisory from local threat intel

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -403,6 +403,11 @@ _SERVER_CARD_TOOLS = [
         "description": "Refresh a filed ITSM ticket's status through the stored ticketing connection",
         "annotations": {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
     },
+    {
+        "name": "findings_triage",
+        "description": "Record a tenant-scoped finding triage decision (queue state, VEX decision + justification) to the exception store",
+        "annotations": {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
+    },
 ]
 
 _TOOL_CAPABILITY_CLASSES = {
@@ -485,6 +490,7 @@ _TOOL_CAPABILITY_CLASSES = {
     "cost_allocation": ["READ", "RUNTIME", "OBSERVABILITY"],
     "create_ticket": ["WRITE", "NETWORK", "INTEGRATION"],
     "sync_ticket_status": ["WRITE", "NETWORK", "INTEGRATION"],
+    "findings_triage": ["WRITE", "GOVERNANCE", "AUDIT"],
 }
 
 for _tool in _SERVER_CARD_TOOLS:

--- a/src/agent_bom/mcp_server_operator_tools.py
+++ b/src/agent_bom/mcp_server_operator_tools.py
@@ -70,6 +70,7 @@ def register_operator_tools(
     )
     from agent_bom.mcp_tools.sbom import diff_impl
     from agent_bom.mcp_tools.scanning import code_scan_impl
+    from agent_bom.mcp_tools.triage import findings_triage_impl
 
     # ── Tool 13: diff ─────────────────────────────────────────────
 
@@ -99,6 +100,56 @@ def register_operator_tools(
             required_scope="findings:write",
             baseline=baseline,
             _run_scan_pipeline=run_scan_pipeline,
+            _truncate_response=truncate_response,
+        )
+
+    # ── findings_triage ──────────────────────────────────────────
+    # Headless MCP surface over POST /v1/findings/triage. Writes a triage
+    # decision to the shared exception store via ``record_finding_triage`` — no
+    # new business logic, no per-action credential. Admin-gated write.
+
+    @mcp.tool(annotations=write_action, title="Record Finding Triage Decision")
+    async def findings_triage(
+        vulnerability_id: Annotated[str, Field(description="Vulnerability/advisory id being triaged (e.g. CVE-2024-1234).")] = "",
+        package: Annotated[str, Field(description="Affected package name, or '*' for all packages (default).")] = "*",
+        server_name: Annotated[str, Field(description="Optional MCP server / asset scope for the decision.")] = "",
+        assignee: Annotated[str, Field(description="Owner recorded for the triage entry.")] = "",
+        queue_state: Annotated[str, Field(description="Queue state: open, assigned, reviewing, or decided.")] = "open",
+        decision: Annotated[str, Field(description="Decision: under_investigation, affected, or not_affected.")] = "under_investigation",
+        justification: Annotated[
+            str, Field(description="OpenVEX justification (required for not_affected), e.g. vulnerable_code_not_present.")
+        ] = "",
+        decision_reason: Annotated[str, Field(description="Free-text rationale for the decision.")] = "",
+        expires_at: Annotated[str, Field(description="Optional ISO-8601 expiry for the triage entry.")] = "",
+        operator_role: Annotated[str, Field(description="Operator role for this write action (audit).")] = "viewer",
+        operator_scopes: Annotated[str, Field(description="Comma-separated operator scopes (audit).")] = "",
+        reason: Annotated[str, Field(description="Human audit reason for recording the decision.")] = "",
+        tenant_id: Annotated[str, Field(description="Tenant scope for the triage entry and audit logging.")] = "default",
+    ) -> str:
+        """Record a tenant-scoped finding triage decision to the exception store.
+
+        Writes the same entry as the REST ``POST /v1/findings/triage`` endpoint.
+        Requires an admin operator + ``findings:write`` scope. A ``not_affected``
+        decision requires an OpenVEX ``justification``.
+        """
+        return await execute_tool_async(
+            "findings_triage",
+            findings_triage_impl,
+            destructive=True,
+            required_scope="findings:write",
+            vulnerability_id=vulnerability_id,
+            package=package,
+            server_name=server_name,
+            assignee=assignee,
+            queue_state=queue_state,
+            decision=decision,
+            justification=justification,
+            decision_reason=decision_reason,
+            expires_at=expires_at,
+            operator_role=operator_role,
+            operator_scopes=operator_scopes,
+            reason=reason,
+            tenant_id=tenant_id,
             _truncate_response=truncate_response,
         )
 

--- a/src/agent_bom/mcp_tools/triage.py
+++ b/src/agent_bom/mcp_tools/triage.py
@@ -1,0 +1,78 @@
+"""MCP findings-triage tool — record a triage decision to the exception store.
+
+Exposes the same write the REST ``POST /v1/findings/triage`` endpoint and the
+CLI ``findings triage`` command perform: it persists a tenant-scoped triage
+decision (queue state, VEX-eligible decision + justification, assignee) to the
+one exception store via the shared ``record_finding_triage`` helper. No new
+business logic lives here — this is the headless MCP surface over the existing
+store write.
+
+The tool is a ``destructiveHint`` write, gated at the dispatch layer by an
+authenticated admin operator + ``findings:write`` scope, and audit-logged by the
+shared helper.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from agent_bom.mcp_tenant import resolve_mcp_tool_tenant_id
+from agent_bom.security import sanitize_error
+
+logger = logging.getLogger(__name__)
+
+
+async def findings_triage_impl(
+    *,
+    vulnerability_id: str = "",
+    package: str = "*",
+    server_name: str = "",
+    assignee: str = "",
+    queue_state: str = "open",
+    decision: str = "under_investigation",
+    justification: str = "",
+    decision_reason: str = "",
+    expires_at: str = "",
+    operator_role: str = "viewer",
+    operator_scopes: str = "",
+    reason: str = "",
+    tenant_id: str = "default",
+    _truncate_response,
+    _authenticated_actor: str = "",
+) -> str:
+    """Record a tenant-scoped finding triage decision through the shared store."""
+    from fastapi import HTTPException
+    from pydantic import ValidationError
+
+    from agent_bom.api.models import FindingTriageRequest
+    from agent_bom.api.routes.enterprise import record_finding_triage
+
+    if not vulnerability_id.strip():
+        return json.dumps({"error": "A 'vulnerability_id' is required to record a triage decision.", "status": "rejected"})
+
+    resolved_tenant = resolve_mcp_tool_tenant_id(tenant_id)
+    actor = (_authenticated_actor or "mcp-operator").strip()
+    try:
+        req = FindingTriageRequest(
+            vulnerability_id=vulnerability_id.strip(),
+            package=(package.strip() or "*"),
+            server_name=server_name.strip(),
+            assignee=assignee.strip(),
+            queue_state=queue_state.strip() or "open",  # type: ignore[arg-type]
+            decision=decision.strip() or "under_investigation",  # type: ignore[arg-type]
+            justification=(justification.strip() or None),  # type: ignore[arg-type]
+            decision_reason=decision_reason.strip(),
+            expires_at=expires_at.strip(),
+        )
+    except ValidationError as exc:
+        return json.dumps({"error": exc.errors(include_url=False), "status": "rejected"})
+
+    try:
+        result = record_finding_triage(tenant_id=resolved_tenant, actor=actor, req=req)
+    except HTTPException as exc:
+        return json.dumps({"error": str(exc.detail), "status": "rejected"})
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("MCP findings_triage failed")
+        return json.dumps({"error": sanitize_error(exc), "status": "error"})
+    return _truncate_response(json.dumps(result, indent=2, default=str))

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -121,7 +121,7 @@ class TestAgentBom:
         assert "quick-audit" in r.output
         assert "gateway-fleet-live-demo" in r.output
         assert "full tool catalog" in r.output
-        assert "Exposes 78 security tools via MCP protocol" in r.output
+        assert "Exposes 79 security tools via MCP protocol" in r.output
         assert "organized behind 8 workflow" in r.output
 
     def test_secrets_help_has_common_output_flags(self):

--- a/tests/test_cli_exports.py
+++ b/tests/test_cli_exports.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+
+
+class FakeExportClient:
+    calls: list[tuple[str, dict[str, Any]]] = []
+    init_kwargs: dict[str, Any] = {}
+    base_url = "http://127.0.0.1:8422"
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.__class__.init_kwargs = kwargs
+
+    def close(self) -> None:
+        self.__class__.calls.append(("close", {}))
+
+    def list_export_destinations(self, **kwargs: Any) -> list[dict[str, object]]:
+        self.__class__.calls.append(("list_export_destinations", kwargs))
+        return [
+            {
+                "id": "dest-1",
+                "kind": "s3",
+                "display_name": "Lake",
+                "status": "active",
+                "has_secret": False,
+                "last_run_status": "success",
+                "last_run_at": "2026-08-13T00:00:00+00:00",
+            }
+        ]
+
+    def create_export_destination(self, **kwargs: Any) -> dict[str, object]:
+        self.__class__.calls.append(("create_export_destination", kwargs))
+        return {"id": "dest-1", "kind": kwargs.get("kind"), "status": "pending", "has_secret": False}
+
+    def run_export_destination(self, destination_id: str, **kwargs: Any) -> dict[str, object]:
+        self.__class__.calls.append(("run_export_destination", {"destination_id": destination_id, **kwargs}))
+        return {"status": "accepted", "destination_id": destination_id, "run_id": "run-1"}
+
+    def list_export_schedules(self, **kwargs: Any) -> list[dict[str, object]]:
+        self.__class__.calls.append(("list_export_schedules", kwargs))
+        return [
+            {
+                "schedule_id": "sch-1",
+                "name": "Nightly",
+                "cron_expression": "0 3 * * *",
+                "destination_id": "dest-1",
+                "enabled": True,
+                "next_run": "2026-08-14T03:00:00+00:00",
+            }
+        ]
+
+    def create_export_schedule(self, **kwargs: Any) -> dict[str, object]:
+        self.__class__.calls.append(("create_export_schedule", kwargs))
+        return {"schedule_id": "sch-1", "name": kwargs.get("name"), "enabled": kwargs.get("enabled")}
+
+
+def _install_fake(monkeypatch) -> type[FakeExportClient]:
+    FakeExportClient.calls = []
+    FakeExportClient.init_kwargs = {}
+    monkeypatch.setattr("agent_bom.cli._findings_group.AgentBomClient", FakeExportClient)
+    return FakeExportClient
+
+
+def test_export_destinations_list_table(monkeypatch) -> None:
+    _install_fake(monkeypatch)
+    result = CliRunner().invoke(main, ["export", "destinations", "list"])
+    assert result.exit_code == 0, result.output
+    assert "1 export destination" in result.output
+    lines = result.output.strip().splitlines()
+    header = next(line for line in lines if line.startswith("id\t"))
+    assert header == "id\tkind\tdisplay_name\tstatus\thas_secret\tlast_run_status\tlast_run_at"
+    row = next(line for line in lines if line.startswith("dest-1\t"))
+    assert "s3" in row
+    assert "active" in row
+
+
+def test_export_destinations_list_json_is_array(monkeypatch) -> None:
+    _install_fake(monkeypatch)
+    result = CliRunner().invoke(main, ["export", "destinations", "list", "--format", "json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert data[0]["id"] == "dest-1"
+
+
+def test_export_destinations_create_sends_config_no_secret(monkeypatch) -> None:
+    fake = _install_fake(monkeypatch)
+    result = CliRunner().invoke(
+        main,
+        [
+            "export",
+            "destinations",
+            "create",
+            "--kind",
+            "s3",
+            "--display-name",
+            "Lake",
+            "--config",
+            json.dumps({"bucket": "b", "region": "us-east-1"}),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    name, kwargs = fake.calls[0]
+    assert name == "create_export_destination"
+    assert kwargs["kind"] == "s3"
+    assert kwargs["config"] == {"bucket": "b", "region": "us-east-1"}
+    # No per-action credential is accepted by the command.
+    assert "secret" not in kwargs
+
+
+def test_export_destinations_create_rejects_bad_config(monkeypatch) -> None:
+    _install_fake(monkeypatch)
+    result = CliRunner().invoke(main, ["export", "destinations", "create", "--kind", "s3", "--display-name", "Lake", "--config", "[1,2]"])
+    assert result.exit_code != 0
+    assert "must be a JSON object" in result.output
+
+
+def test_export_destinations_run_posts_destination_id(monkeypatch) -> None:
+    fake = _install_fake(monkeypatch)
+    result = CliRunner().invoke(main, ["export", "destinations", "run", "dest-1"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["run_id"] == "run-1"
+    assert fake.calls[0] == ("run_export_destination", {"destination_id": "dest-1"})
+
+
+def test_export_schedules_list_table(monkeypatch) -> None:
+    _install_fake(monkeypatch)
+    result = CliRunner().invoke(main, ["export", "schedules", "list"])
+    assert result.exit_code == 0, result.output
+    assert "1 export schedule" in result.output
+    row = next(line for line in result.output.strip().splitlines() if line.startswith("sch-1\t"))
+    assert "0 3 * * *" in row
+    assert "dest-1" in row
+
+
+def test_export_schedules_create_passes_cron_and_enabled(monkeypatch) -> None:
+    fake = _install_fake(monkeypatch)
+    result = CliRunner().invoke(
+        main,
+        ["export", "schedules", "create", "--name", "Nightly", "--cron", "0 3 * * *", "--destination-id", "dest-1"],
+    )
+    assert result.exit_code == 0, result.output
+    name, kwargs = fake.calls[0]
+    assert name == "create_export_schedule"
+    assert kwargs["cron_expression"] == "0 3 * * *"
+    assert kwargs["destination_id"] == "dest-1"
+    assert kwargs["enabled"] is True
+
+
+def test_export_schedules_create_disabled_flag(monkeypatch) -> None:
+    fake = _install_fake(monkeypatch)
+    result = CliRunner().invoke(
+        main,
+        ["export", "schedules", "create", "--name", "N", "--cron", "0 3 * * *", "--destination-id", "dest-1", "--disabled"],
+    )
+    assert result.exit_code == 0, result.output
+    assert fake.calls[0][1]["enabled"] is False
+
+
+class ConnRefusedClient:
+    base_url = "http://127.0.0.1:8422"
+
+    def __init__(self, **kwargs: Any) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def _refuse(self, *args: Any, **kwargs: Any):
+        import httpx
+
+        raise httpx.ConnectError("[Errno 61] Connection refused")
+
+    list_export_destinations = _refuse
+    list_export_schedules = _refuse
+
+
+def test_export_destinations_list_connection_refused_is_friendly(monkeypatch) -> None:
+    monkeypatch.setattr("agent_bom.cli._findings_group.AgentBomClient", ConnRefusedClient)
+    result = CliRunner().invoke(main, ["export", "destinations", "list"])
+    assert result.exit_code != 0
+    assert "Connection refused" not in result.output
+    assert "requires the API server" in result.output

--- a/tests/test_cli_findings.py
+++ b/tests/test_cli_findings.py
@@ -151,7 +151,23 @@ def test_findings_list_outputs_json_and_passes_filters(monkeypatch) -> None:
     assert fake.init_kwargs["tenant_id"] == "tenant-a"
     assert fake.calls[0] == (
         "list_findings",
-        {"severity": "high", "sort": "effective_reach", "limit": 10, "offset": 0},
+        {"severity": "high", "sort": "effective_reach", "limit": 10, "offset": 0, "framework": None, "control": None},
+    )
+
+
+def test_findings_list_passes_framework_and_control_filters(monkeypatch) -> None:
+    """CLI parity for the compliance drill-through (epic #4790)."""
+    fake = _install_fake_client(monkeypatch)
+
+    result = CliRunner().invoke(
+        main,
+        ["findings", "list", "--framework", "soc2", "--control", "CC6.1", "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake.calls[0] == (
+        "list_findings",
+        {"severity": None, "sort": "effective_reach", "limit": 500, "offset": 0, "framework": "soc2", "control": "CC6.1"},
     )
 
 

--- a/tests/test_cli_ticketing.py
+++ b/tests/test_cli_ticketing.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+
+
+class FakeTicketClient:
+    calls: list[tuple[str, dict[str, Any]]] = []
+    init_kwargs: dict[str, Any] = {}
+    base_url = "http://127.0.0.1:8422"
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.__class__.init_kwargs = kwargs
+
+    def close(self) -> None:
+        self.__class__.calls.append(("close", {}))
+
+    def list_tickets(self, **kwargs: Any) -> dict[str, object]:
+        self.__class__.calls.append(("list_tickets", kwargs))
+        return {
+            "schema_version": "ticketing.tickets.v1",
+            "tenant_id": "tenant-a",
+            "count": 1,
+            "tickets": [
+                {
+                    "id": "tl-1",
+                    "provider": "jira",
+                    "status": "open",
+                    "key": "SEC-42",
+                    "external_id": "10042",
+                    "connection_id": "conn-1",
+                    "url": "https://jira.example.com/browse/SEC-42",
+                }
+            ],
+        }
+
+    def create_ticket(self, **kwargs: Any) -> dict[str, object]:
+        self.__class__.calls.append(("create_ticket", kwargs))
+        return {"id": "tl-1", "provider": "jira", "key": "SEC-42", "status": "open"}
+
+    def sync_ticket(self, ticket_id: str, **kwargs: Any) -> dict[str, object]:
+        self.__class__.calls.append(("sync_ticket", {"ticket_id": ticket_id, **kwargs}))
+        return {"id": ticket_id, "status": "in_progress"}
+
+
+def _install_fake(monkeypatch) -> type[FakeTicketClient]:
+    FakeTicketClient.calls = []
+    FakeTicketClient.init_kwargs = {}
+    monkeypatch.setattr("agent_bom.cli._findings_group.AgentBomClient", FakeTicketClient)
+    return FakeTicketClient
+
+
+def test_ticket_list_table_has_provider_status_key(monkeypatch) -> None:
+    _install_fake(monkeypatch)
+    result = CliRunner().invoke(main, ["ticket", "list"])
+    assert result.exit_code == 0, result.output
+    assert "1 ticket (tenant tenant-a)" in result.output
+    lines = result.output.strip().splitlines()
+    header = next(line for line in lines if line.startswith("id\t"))
+    assert header == "id\tprovider\tstatus\tkey\texternal_id\tconnection\turl"
+    row = next(line for line in lines if line.startswith("tl-1\t"))
+    assert "jira" in row
+    assert "open" in row
+    assert "SEC-42" in row
+    assert "conn-1" in row
+
+
+def test_ticket_list_json_passes_client_args(monkeypatch) -> None:
+    fake = _install_fake(monkeypatch)
+    result = CliRunner().invoke(
+        main,
+        ["ticket", "list", "--api-url", "https://abom.example.com", "--api-key", "key", "--tenant", "tenant-a", "--format", "json"],
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["tickets"][0]["id"] == "tl-1"
+    assert fake.init_kwargs["base_url"] == "https://abom.example.com"
+    assert fake.init_kwargs["api_key"] == "key"
+    assert fake.init_kwargs["tenant_id"] == "tenant-a"
+    assert fake.calls[0][0] == "list_tickets"
+
+
+def test_ticket_create_reads_finding_file_and_passes_no_credential(monkeypatch, tmp_path) -> None:
+    fake = _install_fake(monkeypatch)
+    finding_file = tmp_path / "finding.json"
+    finding_file.write_text(json.dumps({"vulnerability_id": "CVE-2024-1", "package": "left-pad", "severity": "high"}))
+    result = CliRunner().invoke(
+        main,
+        ["ticket", "create", "--finding-file", str(finding_file), "--connection-id", "conn-1", "--project", "SEC"],
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["key"] == "SEC-42"
+    name, kwargs = fake.calls[0]
+    assert name == "create_ticket"
+    assert kwargs["finding"]["vulnerability_id"] == "CVE-2024-1"
+    assert kwargs["connection_id"] == "conn-1"
+    assert kwargs["project"] == "SEC"
+    # Connect-once: no credential/token/base-URL is ever an argument.
+    assert not any(k in kwargs for k in ("secret", "token", "api_token", "endpoint", "url"))
+
+
+def test_ticket_create_rejects_non_object_finding(monkeypatch, tmp_path) -> None:
+    _install_fake(monkeypatch)
+    finding_file = tmp_path / "finding.json"
+    finding_file.write_text(json.dumps(["not", "an", "object"]))
+    result = CliRunner().invoke(main, ["ticket", "create", "--finding-file", str(finding_file)])
+    assert result.exit_code != 0
+    assert "single JSON object" in result.output
+
+
+def test_ticket_sync_posts_ticket_id(monkeypatch) -> None:
+    fake = _install_fake(monkeypatch)
+    result = CliRunner().invoke(main, ["ticket", "sync", "tl-1"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["status"] == "in_progress"
+    assert fake.calls[0] == ("sync_ticket", {"ticket_id": "tl-1"})
+
+
+class ConnRefusedClient:
+    base_url = "http://127.0.0.1:8422"
+
+    def __init__(self, **kwargs: Any) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def _refuse(self, *args: Any, **kwargs: Any):
+        import httpx
+
+        raise httpx.ConnectError("[Errno 61] Connection refused")
+
+    list_tickets = _refuse
+    create_ticket = _refuse
+    sync_ticket = _refuse
+
+
+def test_ticket_list_connection_refused_is_friendly(monkeypatch) -> None:
+    monkeypatch.setattr("agent_bom.cli._findings_group.AgentBomClient", ConnRefusedClient)
+    result = CliRunner().invoke(main, ["ticket", "list"])
+    assert result.exit_code != 0
+    assert "Connection refused" not in result.output
+    assert "requires the API server" in result.output

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -292,6 +292,9 @@ def test_server_card_tools_expose_capability_classes():
         # through a stored connection (no per-action credential).
         "create_ticket",
         "sync_ticket_status",
+        # Records a triage decision to the exception store (can suppress a
+        # finding); admin-gated findings:write.
+        "findings_triage",
     }
     # Writes that tear down or invalidate state advertise destructiveHint; issuing
     # an identity or granting access creates state and is non-destructive.
@@ -308,6 +311,7 @@ def test_server_card_tools_expose_capability_classes():
         "diff",
         "create_ticket",
         "sync_ticket_status",
+        "findings_triage",
     }
     card = build_server_card()
     for tool in card["tools"]:
@@ -368,6 +372,7 @@ def test_mcp_docs_match_resource_and_prompt_catalog():
         "access_review",
         "create_ticket",
         "diff",
+        "findings_triage",
         "identity_grant_jit",
         "identity_issue",
         "identity_revoke",

--- a/tests/test_findings_framework_control_filter.py
+++ b/tests/test_findings_framework_control_filter.py
@@ -1,0 +1,231 @@
+"""Compliance drill-through filter on GET /v1/findings (epic #4790, ws 3a).
+
+The Compliance view links a control's non-zero finding count to
+``/findings?framework=<section id>&control=<code>``. Until now neither the API
+nor the UI honoured those params, so the link landed on an UNFILTERED queue. The
+per-control count on the badge is derived from the scan ``blast_radius`` entries
+via ``br.get(tag_field)`` (``code in tags``), so the drilled queue has to filter
+on the SAME per-framework control tags to reconcile with the number the user
+clicked.
+
+The predicate lives in ``row_matches_scope`` — the single source of truth shared
+by the route's in-memory scan findings and the hub store's bulk-ingested rows —
+so the two paths cannot diverge. The framework identifier is resolved once, in
+the route, to the finding's ``*_tags`` field and canonical slug.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore, set_compliance_hub_store
+from agent_bom.api.models import JobStatus
+from agent_bom.api.server import ScanJob, ScanRequest, app, set_job_store
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import _get_store
+from agent_bom.compliance_coverage import resolve_framework_filter
+from agent_bom.finding_scope import row_matches_scope
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+_AUTH = proxy_headers(tenant="default")
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+    set_job_store(InMemoryJobStore())
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+
+
+# ── Resolver: UI section id → finding tag field ──────────────────────────────
+
+
+def test_resolver_maps_every_ui_section_id() -> None:
+    """The compliance page's section ids must all resolve to a tag field.
+
+    Two ids do not equal the metadata slug (``nist-ai-rmf`` → ``nist``,
+    ``iso27001`` → ``iso-27001``); the resolver strips separators so both land.
+    """
+    cases = {
+        "owasp-llm": "owasp_tags",
+        "owasp-mcp": "owasp_mcp_tags",
+        "atlas": "atlas_tags",
+        "nist-ai-rmf": "nist_ai_rmf_tags",
+        "owasp-agentic": "owasp_agentic_tags",
+        "eu-ai-act": "eu_ai_act_tags",
+        "nist-csf": "nist_csf_tags",
+        "iso27001": "iso_27001_tags",
+        "soc2": "soc2_tags",
+        "cis": "cis_tags",
+        "cmmc": "cmmc_tags",
+        "nist-800-53": "nist_800_53_tags",
+        "pci-dss": "pci_dss_tags",
+        "fedramp": "fedramp_tags",
+    }
+    for section_id, tag_field in cases.items():
+        meta = resolve_framework_filter(section_id)
+        assert meta is not None, section_id
+        assert meta.tag_field == tag_field, section_id
+
+
+def test_resolver_returns_none_for_unknown_framework() -> None:
+    assert resolve_framework_filter("not-a-framework") is None
+    assert resolve_framework_filter("") is None
+
+
+# ── Predicate: row_matches_scope with pre-resolved filters ───────────────────
+
+
+def _row(**overrides: object) -> dict:
+    base: dict = {"id": "f", "severity": "high", "title": "t"}
+    base.update(overrides)
+    return base
+
+
+def test_control_filter_is_exact_containment_in_the_tag_field() -> None:
+    filters = {"framework_tag_field": "soc2_tags", "framework_slug": "soc2", "control": "CC6.1"}
+    assert row_matches_scope(_row(soc2_tags=["CC6.1", "CC7.2"]), filters) is True
+    assert row_matches_scope(_row(soc2_tags=["CC7.2"]), filters) is False
+    assert row_matches_scope(_row(), filters) is False
+
+
+def test_control_matching_never_crosses_frameworks() -> None:
+    """A CIS code must not match a SOC 2 drill even via the flattened tags."""
+    filters = {"framework_tag_field": "soc2_tags", "framework_slug": "soc2", "control": "4.1"}
+    row = _row(cis_tags=["4.1"], framework_tags=["cis:4.1"], applicable_frameworks=["cis", "soc2"])
+    assert row_matches_scope(row, filters) is False
+
+
+def test_framework_only_matches_any_control_or_the_slug() -> None:
+    resolved = {"framework_tag_field": "cis_tags", "framework_slug": "cis"}
+    # A row carrying a CIS control tag matches.
+    assert row_matches_scope(_row(cis_tags=["4.1"]), resolved) is True
+    # A bulk-ingested row whose per-framework tags were redacted at rest still
+    # matches on the retained applicable_frameworks slug.
+    assert row_matches_scope(_row(applicable_frameworks=["cis"]), resolved) is True
+    # A row for a different framework does not.
+    assert row_matches_scope(_row(soc2_tags=["CC6.1"], applicable_frameworks=["soc2"]), resolved) is False
+
+
+def test_unresolved_framework_filter_matches_nothing() -> None:
+    """An unknown framework returns an honest empty match, never everything."""
+    assert row_matches_scope(_row(soc2_tags=["CC6.1"]), {"framework": "bogus"}) is False
+
+
+def test_framework_control_composes_with_other_scope_filters() -> None:
+    filters = {"framework_tag_field": "soc2_tags", "framework_slug": "soc2", "control": "CC6.1", "provider": "aws"}
+    row = _row(soc2_tags=["CC6.1"], provider="aws")
+    assert row_matches_scope(row, filters) is True
+    assert row_matches_scope(_row(soc2_tags=["CC6.1"], provider="gcp"), filters) is False
+
+
+# ── Route: GET /v1/findings?framework=&control= ──────────────────────────────
+
+
+def _seed() -> None:
+    set_job_store(InMemoryJobStore())
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+    observed_at = datetime.now(timezone.utc).isoformat()
+    job = ScanJob(job_id="fw-job", tenant_id="default", created_at=observed_at, request=ScanRequest())
+    job.status = JobStatus.DONE
+    job.completed_at = observed_at
+    job.result = {
+        "agents": [],
+        "scan_sources": ["cloud"],
+        "findings": [
+            {
+                "id": "f-soc2-cis",
+                "severity": "high",
+                "title": "soc2 CC6.1 + cis 4.1",
+                "soc2_tags": ["CC6.1"],
+                "cis_tags": ["4.1"],
+                "applicable_frameworks": ["soc2", "cis"],
+            },
+            {
+                "id": "f-soc2-only",
+                "severity": "medium",
+                "title": "soc2 CC7.2",
+                "soc2_tags": ["CC7.2"],
+                "applicable_frameworks": ["soc2"],
+            },
+            {
+                "id": "f-nistcsf",
+                "severity": "critical",
+                "title": "nist csf PR.AC-1",
+                "nist_csf_tags": ["PR.AC-1"],
+                "applicable_frameworks": ["nist-csf"],
+            },
+            {
+                "id": "f-cis-slug-only",
+                "severity": "low",
+                "title": "cis by slug, tags redacted",
+                "applicable_frameworks": ["cis"],
+            },
+        ],
+    }
+    _get_store().put(job)
+
+
+def _ids(resp) -> set[str]:
+    return {f.get("id") for f in resp.json()["findings"]}
+
+
+def test_route_framework_filter_narrows_to_that_framework() -> None:
+    _seed()
+    resp = TestClient(app).get("/v1/findings?framework=soc2", headers=_AUTH)
+    assert resp.status_code == 200
+    assert _ids(resp) == {"f-soc2-cis", "f-soc2-only"}
+
+
+def test_route_control_filter_narrows_within_framework() -> None:
+    _seed()
+    resp = TestClient(app).get("/v1/findings?framework=soc2&control=CC6.1", headers=_AUTH)
+    assert resp.status_code == 200
+    assert _ids(resp) == {"f-soc2-cis"}
+
+
+def test_route_control_reconciles_with_the_drill_link() -> None:
+    _seed()
+    resp = TestClient(app).get("/v1/findings?framework=soc2&control=CC7.2", headers=_AUTH)
+    assert resp.status_code == 200
+    assert _ids(resp) == {"f-soc2-only"}
+
+
+def test_route_framework_includes_slug_only_rows_but_control_does_not() -> None:
+    _seed()
+    fw = TestClient(app).get("/v1/findings?framework=cis", headers=_AUTH)
+    assert _ids(fw) == {"f-soc2-cis", "f-cis-slug-only"}
+    ctrl = TestClient(app).get("/v1/findings?framework=cis&control=4.1", headers=_AUTH)
+    assert _ids(ctrl) == {"f-soc2-cis"}
+
+
+def test_route_hyphenated_ui_slug_resolves() -> None:
+    _seed()
+    resp = TestClient(app).get("/v1/findings?framework=nist-csf&control=PR.AC-1", headers=_AUTH)
+    assert resp.status_code == 200
+    assert _ids(resp) == {"f-nistcsf"}
+
+
+def test_route_unknown_framework_returns_empty_not_everything() -> None:
+    _seed()
+    resp = TestClient(app).get("/v1/findings?framework=not-a-framework", headers=_AUTH)
+    assert resp.status_code == 200
+    assert resp.json()["findings"] == []
+
+
+def test_route_echoes_framework_and_control_filters() -> None:
+    _seed()
+    resp = TestClient(app).get("/v1/findings?framework=soc2&control=CC6.1", headers=_AUTH)
+    assert resp.json()["filters"] == {"framework": "soc2", "control": "CC6.1"}
+
+
+def test_route_no_framework_filter_is_backward_compatible() -> None:
+    _seed()
+    resp = TestClient(app).get("/v1/findings", headers=_AUTH)
+    assert resp.status_code == 200
+    assert len(resp.json()["findings"]) == 4

--- a/tests/test_mcp_findings_triage.py
+++ b/tests/test_mcp_findings_triage.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+import agent_bom.api.routes.enterprise as enterprise
+from agent_bom.api.exception_store import InMemoryExceptionStore
+from agent_bom.mcp_tools.triage import findings_triage_impl
+
+
+def _truncate(text: str) -> str:
+    return text
+
+
+@pytest.fixture
+def isolated_store(monkeypatch) -> InMemoryExceptionStore:
+    store = InMemoryExceptionStore()
+    monkeypatch.setattr(enterprise, "_get_exception_store", lambda: store)
+    return store
+
+
+def _run(**kwargs) -> dict:
+    out = asyncio.run(findings_triage_impl(_truncate_response=_truncate, **kwargs))
+    return json.loads(out)
+
+
+def test_findings_triage_records_decision_to_store(isolated_store, monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_MCP_TENANT_ID", "tenant-a")
+    result = _run(
+        vulnerability_id="CVE-2024-9",
+        package="left-pad",
+        assignee="secops@example.com",
+        queue_state="assigned",
+        decision="under_investigation",
+        _authenticated_actor="operator-1",
+    )
+    assert result["vulnerability_id"] == "CVE-2024-9"
+    assert result["package"] == "left-pad"
+    assert result["queue_state"] == "assigned"
+    assert result["assignee"] == "secops@example.com"
+    # The entry is durably in the exception store, tenant-scoped.
+    entries = isolated_store.list_all(tenant_id="tenant-a")
+    assert len(entries) == 1
+    assert entries[0].vuln_id == "CVE-2024-9"
+    assert entries[0].requested_by == "operator-1"
+
+
+def test_findings_triage_not_affected_requires_justification(isolated_store, monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_MCP_TENANT_ID", "tenant-a")
+    result = _run(vulnerability_id="CVE-2024-9", decision="not_affected")
+    assert result["status"] == "rejected"
+    assert "justification" in json.dumps(result).lower()
+    assert isolated_store.list_all(tenant_id="tenant-a") == []
+
+
+def test_findings_triage_not_affected_with_justification_is_vex_eligible(isolated_store, monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_MCP_TENANT_ID", "tenant-a")
+    result = _run(
+        vulnerability_id="CVE-2024-9",
+        decision="not_affected",
+        justification="vulnerable_code_not_present",
+    )
+    assert result["decision"] == "not_affected"
+    assert result["vex_eligible"] is True
+    assert result["queue_state"] == "decided"
+
+
+def test_findings_triage_requires_vulnerability_id(isolated_store) -> None:
+    result = _run(vulnerability_id="")
+    assert result["status"] == "rejected"
+    assert isolated_store.list_all(tenant_id="default") == []
+
+
+def test_findings_triage_rejects_invalid_decision(isolated_store, monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_MCP_TENANT_ID", "tenant-a")
+    result = _run(vulnerability_id="CVE-2024-9", decision="totally_bogus")
+    assert result["status"] == "rejected"
+    assert isolated_store.list_all(tenant_id="tenant-a") == []
+
+
+def test_findings_triage_advertised_on_server_card_and_registered() -> None:
+    from agent_bom.mcp_server_metadata import (
+        _TOOL_CAPABILITY_CLASSES,
+        registered_mcp_tool_decorator_names,
+        server_card_tool_names,
+    )
+
+    assert "findings_triage" in server_card_tool_names()
+    assert "findings_triage" in registered_mcp_tool_decorator_names()
+    assert "findings_triage" in _TOOL_CAPABILITY_CLASSES

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -166,7 +166,7 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert "Scan repositories, images, and cloud accounts" not in hero
     assert "<b>15</b> package ecosystems" in hero
     assert "<b>16</b> compliance surfaces" in hero
-    assert "<b>77</b> MCP tools" in hero
+    assert "<b>79</b> MCP tools" in hero
     assert '<a href="#quick-start"><b>Quick start</b></a>' in hero
     assert '<a href="https://msaad00.github.io/agent-bom/">Docs</a>' in hero
     # The hero links the live demo. This project operates that Cloud Run service

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -2809,7 +2809,7 @@ function CodingAgentDrawer({ open, onClose }: { open: boolean; onClose: () => vo
       }
       headerAside={
         <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 dark:border-emerald-900/60 bg-emerald-500/10 dark:bg-emerald-950/30 px-2.5 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
-          <Bot className="h-3 w-3" /> 78 MCP tools
+          <Bot className="h-3 w-3" /> 79 MCP tools
         </span>
       }
     >

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -259,6 +259,10 @@ function FindingsPage() {
   const paramProvider = searchParams.get("provider");
   const paramAccount = searchParams.get("account");
   const paramEnvironment = searchParams.get("environment");
+  // Compliance drill-through (epic #4790): a framework section id + optional
+  // control code linked from the Compliance view's per-control finding count.
+  const paramFramework = searchParams.get("framework");
+  const paramControl = searchParams.get("control");
   const { lens, selectLens, lenses, label: lensLabel, hint: lensHint } = useFindingsLens(paramLens);
 
   const [vulns, setVulns] = useState<EnrichedVuln[]>([]);
@@ -285,6 +289,9 @@ function FindingsPage() {
   const [providerFilter, setProviderFilter] = useState<string>(paramProvider ?? "");
   const [accountFilter, setAccountFilter] = useState<string>(paramAccount ?? "");
   const [environmentFilter, setEnvironmentFilter] = useState<string>(paramEnvironment ?? "");
+  const [frameworkFilter, setFrameworkFilter] = useState<string>(paramFramework ?? "");
+  // A control code is only meaningful alongside a framework; it is cleared with it.
+  const [controlFilter, setControlFilter] = useState<string>(paramFramework ? (paramControl ?? "") : "");
   const [sortKey, setSortKey] = useState<SortKey>("severity");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
   // Default read-window (#4009): findings default to the last ~90 days so the
@@ -388,6 +395,11 @@ function FindingsPage() {
   }, [paramEnvironment]);
 
   useEffect(() => {
+    setFrameworkFilter(paramFramework ?? "");
+    setControlFilter(paramFramework ? (paramControl ?? "") : "");
+  }, [paramFramework, paramControl]);
+
+  useEffect(() => {
     const parsed = Number(paramWindow);
     setWindowDays(
       paramWindow != null && Number.isFinite(parsed) && parsed >= 0
@@ -410,6 +422,9 @@ function FindingsPage() {
     if (providerFilter.trim()) params.set("provider", providerFilter.trim());
     if (accountFilter.trim()) params.set("account", accountFilter.trim());
     if (environmentFilter.trim()) params.set("environment", environmentFilter.trim());
+    if (frameworkFilter.trim()) params.set("framework", frameworkFilter.trim());
+    // A control code without a framework is meaningless — only sync it alongside.
+    if (frameworkFilter.trim() && controlFilter.trim()) params.set("control", controlFilter.trim());
     if (windowDays !== DEFAULT_FINDINGS_WINDOW_DAYS) params.set("window", String(windowDays));
     if (page > 1) params.set("page", String(page));
     if (paramScan) params.set("scan", paramScan);
@@ -424,6 +439,8 @@ function FindingsPage() {
     providerFilter,
     accountFilter,
     environmentFilter,
+    frameworkFilter,
+    controlFilter,
     windowDays,
     page,
     paramScope,
@@ -540,6 +557,8 @@ function FindingsPage() {
           ...(providerFilter.trim() ? { provider: providerFilter.trim() } : {}),
           ...(accountFilter.trim() ? { account: accountFilter.trim() } : {}),
           ...(environmentFilter.trim() ? { environment: environmentFilter.trim() } : {}),
+          ...(frameworkFilter.trim() ? { framework: frameworkFilter.trim() } : {}),
+          ...(frameworkFilter.trim() && controlFilter.trim() ? { control: controlFilter.trim() } : {}),
           ...(issueTypeFilter !== "all" ? { findingClass: issueTypeFilter } : {}),
           sort: serverFindingsSort(sortKey),
           limit: PAGE_SIZE,
@@ -577,6 +596,8 @@ function FindingsPage() {
     providerFilter,
     accountFilter,
     environmentFilter,
+    frameworkFilter,
+    controlFilter,
     issueTypeFilter,
     windowDays,
     sortKey,
@@ -665,6 +686,21 @@ function FindingsPage() {
     environmentFilter.trim()
       ? { key: "environment", label: `Env: ${environmentFilter.trim()}`, onClear: () => setEnvironmentFilter("") }
       : null,
+    // Compliance drill-through chips. Clearing the framework also clears the
+    // control, since a control code without its framework is meaningless.
+    frameworkFilter.trim()
+      ? {
+          key: "framework",
+          label: `Framework: ${frameworkFilter.trim().toUpperCase()}`,
+          onClear: () => {
+            setFrameworkFilter("");
+            setControlFilter("");
+          },
+        }
+      : null,
+    frameworkFilter.trim() && controlFilter.trim()
+      ? { key: "control", label: `Control: ${controlFilter.trim()}`, onClear: () => setControlFilter("") }
+      : null,
   ].filter((chip): chip is { key: string; label: string; onClear: () => void } => chip !== null);
   const activeFilterCount = activeFilterChips.length;
   const clearAdvancedFilters = () => {
@@ -672,6 +708,8 @@ function FindingsPage() {
     setProviderFilter("");
     setAccountFilter("");
     setEnvironmentFilter("");
+    setFrameworkFilter("");
+    setControlFilter("");
   };
 
   const FILTERS: { key: SeverityFilter; label: string; color: string }[] = [

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -1436,6 +1436,10 @@ export const api = {
     account?: string;
     environment?: string;
     domain?: string;
+    // Compliance drill-through (epic #4790): a framework section id (e.g. `soc2`
+    // / `nist-csf`) and, optionally, a control code that narrows within it.
+    framework?: string;
+    control?: string;
     findingClass?: "vulnerability" | "misconfiguration" | "secret" | "identity" | "unclassified";
     status?: "open" | "resolved" | "all";
     // Known-exploited only, or explicitly everything else. Omit for no filter —
@@ -1459,6 +1463,8 @@ export const api = {
     if (filters?.account) params.set("account", filters.account);
     if (filters?.environment) params.set("environment", filters.environment);
     if (filters?.domain) params.set("domain", filters.domain);
+    if (filters?.framework) params.set("framework", filters.framework);
+    if (filters?.control) params.set("control", filters.control);
     if (filters?.findingClass) params.set("finding_class", filters.findingClass);
     if (filters?.kev != null) params.set("kev", String(filters.kev));
     if (filters?.status) params.set("status", filters.status);

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -254,6 +254,18 @@ describe('api.listFindings', () => {
       expect.objectContaining({ credentials: 'include' }),
     )
   })
+
+  it('serializes the compliance drill-through framework and control filters', async () => {
+    const fetchMock = mockFetch({ findings: [], total: 0 })
+    global.fetch = fetchMock
+
+    await api.listFindings({ framework: 'soc2', control: 'CC6.1', limit: 25 })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/v1/findings?limit=25&framework=soc2&control=CC6.1',
+      expect.objectContaining({ credentials: 'include' }),
+    )
+  })
 })
 
 describe('api.getCompliance', () => {

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -839,7 +839,7 @@ describe("ConnectionsPage — Connect segment", () => {
 
     const drawer = await screen.findByRole("dialog", { name: /Connect a coding agent/ });
     expect(within(drawer).getByText("agent-bom mcp-server")).toBeInTheDocument();
-    expect(within(drawer).getByText(/78 MCP tools/)).toBeInTheDocument();
+    expect(within(drawer).getByText(/79 MCP tools/)).toBeInTheDocument();
   });
 
   it("syncs the segmented tab to the URL", async () => {

--- a/ui/tests/findings-page.test.tsx
+++ b/ui/tests/findings-page.test.tsx
@@ -264,6 +264,38 @@ describe("FindingsPage", () => {
     expect(screen.getByTestId("findings-filters-toggle")).not.toHaveTextContent("(1)");
   });
 
+  it("honours the compliance drill-through framework/control URL and surfaces removable chips", async () => {
+    navigationState.query = "framework=soc2&control=CC6.1";
+    render(<FindingsPage />);
+    expect(await screen.findByText("Findings queue")).toBeInTheDocument();
+
+    // The drill-through params are forwarded to the findings API.
+    await waitFor(() =>
+      expect(apiMock.listFindings).toHaveBeenLastCalledWith(
+        expect.objectContaining({ framework: "soc2", control: "CC6.1" }),
+      ),
+    );
+
+    // Both facets surface as removable chips.
+    const frameworkChip = screen.getByTestId("findings-chip-framework");
+    expect(frameworkChip).toHaveTextContent("Framework: SOC2");
+    const controlChip = screen.getByTestId("findings-chip-control");
+    expect(controlChip).toHaveTextContent("Control: CC6.1");
+
+    // Clearing the framework drops the control too (a control without its
+    // framework is meaningless) and re-queries without either param.
+    fireEvent.click(frameworkChip);
+    await waitFor(() =>
+      expect(screen.queryByTestId("findings-chip-framework")).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("findings-chip-control")).not.toBeInTheDocument();
+    await waitFor(() => {
+      const lastCall = apiMock.listFindings.mock.calls.at(-1)?.[0] ?? {};
+      expect(lastCall).not.toHaveProperty("framework");
+      expect(lastCall).not.toHaveProperty("control");
+    });
+  });
+
   it("sends the selected issue class to the paginated findings API", async () => {
     render(<FindingsPage />);
     expect(await screen.findByText("Findings queue")).toBeInTheDocument();


### PR DESCRIPTION
Epic #4790 workstream 3 — combines two independently-verified branches (finding drill-through filter + CLI/MCP surface parity) into one coherent PR. Supersedes #4801. Merged clean (zero conflicts); full gate set re-run on the merged result.

## What
**Drill-through filter (3a)** — `GET /findings` gains `framework`/`control` params filtering on the finding's real per-framework control tags (reconciles with the compliance badge count); UI parses the params with removable chips; `agent-bom findings list --framework --control` for CLI parity. Completes #4791's drill-through dependency.

**Surface parity (3b)** — each a thin surface over existing backend, no new business logic:
- **Ticketing CLI** `agent-bom ticket list|create|sync` over `api/routes/ticketing.py` (connect-once; no credential flags).
- **Export destinations/schedules CLI** `agent-bom export destinations|schedules …` over `api/routes/exports.py` (no `--secret`; secret-bearing destinations stay in the connect-once hub).
- **findings-triage MCP write tool** `findings_triage` — shares a `record_finding_triage` helper with `POST /findings/triage`, so REST and MCP write identical entries to one exception store; admin-gated, fail-closed. MCP tools 78→79.

## Consistency (the Codex bar)
Every count surface regenerated: `PRODUCT_METRICS` (modules 844→847, tools 78→79), `site-docs/reference/cli.md` (ticket/export rows), README/PYPI/glama/smithery/docs/SVGs, OpenAPI (+2 params). Two frozen tests updated to the true new values.

## Verified on the MERGED result
- Python: `product_metrics --check`, `check_cli_reference_alignment`, `export_openapi --check`, `check-counts`, `check_package_layout`, `ruff check` + `ruff format --check`, `mypy` — all clean; new suites (framework/control filter, cli ticketing/exports, mcp triage, cli findings) 44 passed
- UI: `npm ci`, typecheck clean, vitest 83 passed, `npm run build` + `NEXT_EXPORT=1 build` both pass

Closes #4801