### PR TITLE
Compliance: explain why a control is Not evaluated + next-step CTA

### DIFF
--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -33,6 +33,9 @@ import {
 } from "lucide-react";
 import { ComplianceControlDrawer } from "@/components/compliance-control-drawer";
 import {
+  controlStatusLabel,
+  evidenceReasonLabel,
+  isControlUnscored,
   isNotEvaluated,
   postureLabel,
   statusColor,
@@ -73,12 +76,6 @@ function downloadBlobToFile(blob: Blob, filename: string) {
   a.click();
   URL.revokeObjectURL(url);
 }
-
-const CONTROL_STATUS_LABEL: Record<string, string> = {
-  pass: "Pass",
-  warning: "Warn",
-  fail: "Fail",
-};
 
 function statusToAccent(status: string): StatAccent {
   if (isNotEvaluated(status)) return "neutral";
@@ -540,15 +537,32 @@ function CompliancePageContent() {
     {
       key: "status",
       header: "Status",
-      width: "6rem",
-      cell: (c) => (
-        <span className="inline-flex items-center gap-1.5">
-          <StatusIcon status={c.status} className="h-3.5 w-3.5" />
-          <span className={`text-xs font-medium ${statusColor(c.status)}`}>
-            {CONTROL_STATUS_LABEL[c.status] ?? c.status}
-          </span>
-        </span>
-      ),
+      width: "9rem",
+      cell: (c) => {
+        // Surface the provenance behind an unscored control: instead of a bare
+        // "Not evaluated", show WHY (e.g. "No completed scan"). The full CTA
+        // lives in the drawer; here it's a dense, honest one-liner.
+        const reason = isControlUnscored(c.status) ? evidenceReasonLabel(c.evidence_reason) : null;
+        return (
+          <div className="min-w-0">
+            <span className="inline-flex items-center gap-1.5">
+              <StatusIcon status={c.status} className="h-3.5 w-3.5" />
+              <span className={`text-xs font-medium ${statusColor(c.status)}`}>
+                {controlStatusLabel(c.status)}
+              </span>
+            </span>
+            {reason ? (
+              <span
+                className="mt-0.5 block truncate text-[10px] text-[color:var(--text-tertiary)]"
+                title={reason}
+                data-testid="control-evidence-reason"
+              >
+                {reason}
+              </span>
+            ) : null}
+          </div>
+        );
+      },
     },
     {
       key: "findings",

--- a/ui/components/compliance-control-drawer.tsx
+++ b/ui/components/compliance-control-drawer.tsx
@@ -4,19 +4,14 @@ import Link from "next/link";
 import { Package, Server, X } from "lucide-react";
 
 import { useEscToClose } from "@/hooks/use-esc-to-close";
+import {
+  controlStatusLabel,
+  evidenceReasonCta,
+  evidenceReasonLabel,
+  isControlUnscored,
+} from "@/components/compliance-status";
 import type { ComplianceControl } from "@/lib/api";
 import { findingsHref, remediationHref, securityGraphHref } from "@/lib/page-links";
-
-function statusLabel(status: ComplianceControl["status"]): string {
-  switch (status) {
-    case "pass":
-      return "Pass";
-    case "warning":
-      return "Needs attention";
-    default:
-      return "Fail";
-  }
-}
 
 export function ComplianceControlDrawer({
   control,
@@ -32,6 +27,9 @@ export function ComplianceControlDrawer({
   useEscToClose(true, onClose);
   const name = catalogName ?? control.name;
   const sev = control.severity_breakdown;
+  const unscored = isControlUnscored(control.status);
+  const reasonLabel = evidenceReasonLabel(control.evidence_reason);
+  const reasonCta = unscored ? evidenceReasonCta(control.evidence_reason) : null;
 
   return (
     <div
@@ -62,18 +60,41 @@ export function ComplianceControlDrawer({
                     ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300"
                     : control.status === "warning"
                       ? "bg-yellow-500/15 text-yellow-700 dark:text-yellow-300"
-                      : "bg-red-500/15 text-red-700 dark:text-red-300"
+                      : unscored
+                        ? "bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]"
+                        : "bg-red-500/15 text-red-700 dark:text-red-300"
                 }`}
               >
-                {statusLabel(control.status)}
+                {controlStatusLabel(control.status)}
               </span>
             </div>
             <h2 className="mt-2 text-base font-medium leading-snug text-[color:var(--foreground)]">
               {name}
             </h2>
-            <p className="mt-2 text-sm text-[color:var(--text-secondary)]">
-              {control.findings} finding{control.findings === 1 ? "" : "s"} mapped to this control.
-            </p>
+            {unscored ? (
+              // Provenance for a control the scan couldn't grade: state WHY, and
+              // (when a missing input is implied) offer the next step. Never
+              // imply a source is connected/disconnected — "no observed signal"
+              // is an honest statement of absence.
+              <div className="mt-2" data-testid="control-unscored-provenance">
+                <p className="text-sm text-[color:var(--text-secondary)]">
+                  Not evaluated{reasonLabel ? ` — ${reasonLabel.toLowerCase()}` : ""}.
+                </p>
+                {reasonCta ? (
+                  <Link
+                    href={reasonCta.href}
+                    className="mt-2 inline-flex items-center rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-1.5 text-xs font-medium text-[color:var(--accent)] transition hover:bg-[color:var(--accent-soft-hover)]"
+                    data-testid="control-evidence-cta"
+                  >
+                    {reasonCta.label}
+                  </Link>
+                ) : null}
+              </div>
+            ) : (
+              <p className="mt-2 text-sm text-[color:var(--text-secondary)]">
+                {control.findings} finding{control.findings === 1 ? "" : "s"} mapped to this control.
+              </p>
+            )}
           </div>
           <button
             type="button"

--- a/ui/components/compliance-status.tsx
+++ b/ui/components/compliance-status.tsx
@@ -62,3 +62,85 @@ export function postureLabel(status: string): string {
       return "No data";
   }
 }
+
+// A control is "unscored" when its status is anything other than a graded
+// pass/warning/fail. The API expresses this as not_evaluated / not_assessed
+// (corrective + detective with no usable evidence) or applicable /
+// not_applicable (overlay techniques). These never read as green or red — they
+// carry an evidence_reason explaining WHY, surfaced beside the status.
+const GRADED_STATUSES = new Set(["pass", "warning", "fail"]);
+
+export function isControlUnscored(status: string): boolean {
+  return !GRADED_STATUSES.has(status);
+}
+
+// Per-control status label (denser than postureLabel, which speaks to the
+// framework/estate headline). Keeps the raw code out of the UI.
+export function controlStatusLabel(status: string): string {
+  switch (status) {
+    case "pass":
+      return "Pass";
+    case "warning":
+      return "Warn";
+    case "fail":
+      return "Fail";
+    case "not_assessed":
+      return "Not assessed";
+    case "not_applicable":
+      return "Not applicable";
+    case "applicable":
+      return "Applicable";
+    case "not_evaluated":
+    case "no_data":
+      return "Not evaluated";
+    default:
+      return "Not evaluated";
+  }
+}
+
+// Human labels for the backend's per-control `evidence_reason` codes
+// (api/routes/compliance.py + evidence/control_modes.py). This is the single
+// map from reason code → concise provenance the UI shows next to an unscored
+// control, so a bare "Not evaluated" explains itself.
+const EVIDENCE_REASON_LABEL: Record<string, string> = {
+  // Detective controls (the scan itself is the evidence).
+  no_completed_scan: "No completed scan",
+  scan_evidence_age_unknown: "Scan age unknown",
+  fresh_scan_evidence: "Fresh scan evidence",
+  stale_scan_evidence: "Stale scan evidence",
+  future_scan_evidence: "Scan timestamp in the future",
+  // Corrective controls (attested by the absence of an open finding).
+  no_mapped_finding: "No mapped finding",
+  unrated_severity_finding: "Unrated-severity finding",
+  open_finding: "Open finding",
+  // Overlay techniques (made applicable by an observed weakness, or not).
+  no_observed_signal: "No observed signal",
+  technique_observed: "Technique observed",
+};
+
+export function evidenceReasonLabel(reason: string | null | undefined): string | null {
+  if (!reason) return null;
+  return EVIDENCE_REASON_LABEL[reason] ?? null;
+}
+
+export interface EvidenceReasonCta {
+  label: string;
+  href: string;
+}
+
+// Only reasons that imply a MISSING input get a next-step CTA. "No mapped
+// finding" / "unrated severity" mean a scan ran but nothing graded this control
+// — there is no honest single action to suggest, so they get none. We never
+// imply a source is connected or disconnected; "no observed signal" is a
+// statement of absence, and the CTA is the honest way to add coverage.
+export function evidenceReasonCta(reason: string | null | undefined): EvidenceReasonCta | null {
+  switch (reason) {
+    case "no_completed_scan":
+    case "scan_evidence_age_unknown":
+      return { label: "New Scan", href: "/scan" };
+    case "no_observed_signal":
+      return { label: "Connect a source", href: "/connections" };
+    default:
+      return null;
+  }
+}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2113,7 +2113,17 @@ export interface ComplianceControl {
   code: string;
   name: string;
   findings: number;
+  // The API also emits the unscored statuses "not_evaluated", "not_assessed",
+  // "not_applicable", and "applicable" (api/routes/compliance.py:_build_controls).
+  // They are handled as strings through the compliance-status helpers rather than
+  // widening this union — the matrix/heatmap row types mirror it narrowly.
   status: "pass" | "warning" | "fail";
+  // Provenance for the status: WHY a control landed where it did (e.g.
+  // "no_completed_scan", "no_mapped_finding", "no_observed_signal"). Drives the
+  // "Not evaluated — <reason>" label and the next-step CTA in the UI.
+  evidence_reason?: string | undefined;
+  // Evaluation mode that produced the status: "detective" | "corrective" | "overlay".
+  evaluation_mode?: string | undefined;
   severity_breakdown: Record<string, number>;
   affected_packages: string[];
   affected_agents: string[];

--- a/ui/tests/compliance-page.test.tsx
+++ b/ui/tests/compliance-page.test.tsx
@@ -40,13 +40,15 @@ const { compliance } = vi.hoisted(() => {
   const control = (
     code: string,
     name: string,
-    status: "pass" | "warning" | "fail",
+    status: string,
     findings: number,
+    evidence_reason?: string,
   ) => ({
     code,
     name,
     findings,
     status,
+    evidence_reason,
     severity_breakdown: {},
     affected_packages: [],
     affected_agents: [],
@@ -87,6 +89,7 @@ const { compliance } = vi.hoisted(() => {
       owasp_llm_top10: [
         control("LLM01", "Prompt Injection", "fail", 4),
         control("LLM02", "Insecure Output Handling", "pass", 0),
+        control("LLM03", "Training Data Poisoning", "not_evaluated", 0, "no_completed_scan"),
       ],
       owasp_mcp_top10: [control("MCP01", "Tool Poisoning", "warning", 1)],
       mitre_atlas: [],
@@ -180,6 +183,35 @@ describe("CompliancePage (dense restyle)", () => {
     expect(
       screen.queryByRole("link", { name: /findings for LLM02/i }),
     ).toBeNull();
+  });
+
+  it("surfaces WHY a not-evaluated control was not scored in the dense list", async () => {
+    render(<CompliancePage />);
+    await screen.findByTestId("compliance-kpi-strip");
+    // LLM03 is not_evaluated with reason no_completed_scan → the row shows the
+    // provenance, not a bare "Not evaluated".
+    await screen.findByText("Training Data Poisoning");
+    const reasons = screen.getAllByTestId("control-evidence-reason");
+    expect(reasons.some((el) => el.textContent === "No completed scan")).toBe(true);
+  });
+
+  it("offers a next-step CTA in the drawer for a not-evaluated control", async () => {
+    render(<CompliancePage />);
+    await screen.findByTestId("compliance-kpi-strip");
+
+    const poisoning = await screen.findByText("Training Data Poisoning");
+    fireEvent.click(poisoning);
+
+    const drawer = await screen.findByRole("dialog", {
+      name: /Control details for LLM03/i,
+    });
+    // Honest provenance line + an actionable "New Scan" link into /scan.
+    expect(within(drawer).getByTestId("control-unscored-provenance")).toHaveTextContent(
+      /not evaluated — no completed scan/i,
+    );
+    const cta = within(drawer).getByTestId("control-evidence-cta");
+    expect(cta).toHaveAttribute("href", "/scan");
+    expect(cta).toHaveTextContent("New Scan");
   });
 
   it("opens the control drawer when a control row is clicked", async () => {

--- a/ui/tests/compliance-status.test.ts
+++ b/ui/tests/compliance-status.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { isNotEvaluated, postureLabel } from "@/components/compliance-status";
+import {
+  controlStatusLabel,
+  evidenceReasonCta,
+  evidenceReasonLabel,
+  isControlUnscored,
+  isNotEvaluated,
+  postureLabel,
+} from "@/components/compliance-status";
 
 describe("compliance status honesty", () => {
   it("treats no-evidence statuses as not evaluated", () => {
@@ -15,5 +22,50 @@ describe("compliance status honesty", () => {
     expect(postureLabel("not_evaluated")).toBe("Not evaluated");
     expect(postureLabel("pass")).toBe("Compliant");
     expect(postureLabel("fail")).toBe("Non-compliant");
+  });
+});
+
+describe("compliance control provenance", () => {
+  it("treats anything other than graded pass/warn/fail as unscored", () => {
+    for (const s of ["pass", "warning", "fail"]) {
+      expect(isControlUnscored(s)).toBe(false);
+    }
+    for (const s of ["not_evaluated", "not_assessed", "not_applicable", "applicable"]) {
+      expect(isControlUnscored(s)).toBe(true);
+    }
+  });
+
+  it("gives every control status a human label, never a raw code", () => {
+    expect(controlStatusLabel("pass")).toBe("Pass");
+    expect(controlStatusLabel("not_assessed")).toBe("Not assessed");
+    expect(controlStatusLabel("not_applicable")).toBe("Not applicable");
+    expect(controlStatusLabel("applicable")).toBe("Applicable");
+    expect(controlStatusLabel("not_evaluated")).toBe("Not evaluated");
+    // An unknown status still reads honestly, never as a raw code.
+    expect(controlStatusLabel("something_new")).toBe("Not evaluated");
+  });
+
+  it("maps every backend evidence_reason code to a concise label", () => {
+    expect(evidenceReasonLabel("no_completed_scan")).toBe("No completed scan");
+    expect(evidenceReasonLabel("no_mapped_finding")).toBe("No mapped finding");
+    expect(evidenceReasonLabel("unrated_severity_finding")).toBe("Unrated-severity finding");
+    expect(evidenceReasonLabel("no_observed_signal")).toBe("No observed signal");
+    expect(evidenceReasonLabel("scan_evidence_age_unknown")).toBe("Scan age unknown");
+    expect(evidenceReasonLabel(undefined)).toBeNull();
+    expect(evidenceReasonLabel("mystery_code")).toBeNull();
+  });
+
+  it("offers a next-step CTA only where a missing input is implied", () => {
+    expect(evidenceReasonCta("no_completed_scan")).toEqual({ label: "New Scan", href: "/scan" });
+    expect(evidenceReasonCta("scan_evidence_age_unknown")).toEqual({ label: "New Scan", href: "/scan" });
+    expect(evidenceReasonCta("no_observed_signal")).toEqual({
+      label: "Connect a source",
+      href: "/connections",
+    });
+    // A scan ran but nothing graded the control — no honest single action.
+    expect(evidenceReasonCta("no_mapped_finding")).toBeNull();
+    expect(evidenceReasonCta("unrated_severity_finding")).toBeNull();
+    expect(evidenceReasonCta("open_finding")).toBeNull();
+    expect(evidenceReasonCta(undefined)).toBeNull();
   });
 });


### PR DESCRIPTION
Epic #4790 workstream 3c (provenance / "connected vs not"). UI-only — the reason code was already in the `GET /v1/compliance` response (`evidence_reason`), just never rendered.

## What
- Not-evaluated controls now show **why**, not a bare "Not evaluated": reason code → human label + a next-step CTA where a missing input is implied.
  - `no_completed_scan` / `scan_evidence_age_unknown` → "New Scan" (`/scan`)
  - `no_observed_signal` → "Connect a source" (`/connections`)
  - `no_mapped_finding` / `unrated_severity_finding` → labeled, no CTA (a scan ran but nothing graded the control — no honest single action)
- Surfaced in the dense control list (muted reason line) and the control drawer (provenance block + CTA button).
- **Honesty fix:** the drawer previously defaulted every non-pass/warn control to a red **"Fail"** chip — including not-evaluated ones. Unscored controls now get a token-neutral chip. (This was mislabeling absence-of-evidence as failure.)
- Single mapping home: `ui/components/compliance-status.tsx`. CTAs reuse the canonical `/scan` and `/connections` surfaces.

## Honest boundary (deferred)
Per-control "is source X connected?" (joining live connection state onto controls) is a larger correlation effort — connection state lives in `cloud_connections.py`/`connectors.py`/`sources.py`, not joined onto controls. Linking to Scan/Connect by reason is the honest smallest cut; the join is deferred.

## Verified
- typecheck clean; vitest touched 16 + regression 25 passed; eslint clean; `npm run build` + `NEXT_EXPORT=1 build` pass. No Python change (reason code already serialized) → no count/API gates affected.