### PR TITLE
fix(evidence): make counts, scope, and public product truth consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center"><b>Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.</b></p>
 
 <p align="center">
-  <b>15</b> package ecosystems · <b>16</b> compliance surfaces · <b>79</b> MCP tools · no account required<br />
+  <b>15</b> package ecosystems · <b>16</b> compliance surfaces · <b>80</b> MCP tools · no account required<br />
   <a href="#quick-start"><b>Quick start</b></a> ·
   <a href="https://agent-bom-demo-82102570041.us-central1.run.app">Live demo</a> ·
   <a href="https://msaad00.github.io/agent-bom/">Docs</a>

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -54,7 +54,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
 | `docs/openapi/v1.json` | paths | 326 |
-| `docs/openapi/v1.json` | component schemas | 139 |
+| `docs/openapi/v1.json` | component schemas | 140 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -70,5 +70,5 @@
 <rect x="459" y="330" width="3" height="14" rx="1.5" fill="#38bdf8"/>
 <text x="469" y="338" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#e9e9ec">One correlated view</text>
 <text x="469" y="358" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">material risk · trend · explicit gaps</text>
-<rect x="24" y="402" width="1232" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="640" y="422" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<rect x="24" y="402" width="1232" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="640" y="422" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="600" fill="#4ade80">SCAN + CI · CENTRALIZE EVIDENCE · ENFORCE AT RUNTIME — one Finding + UnifiedGraph</text>
 </svg>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -70,5 +70,5 @@
 <rect x="459" y="330" width="3" height="14" rx="1.5" fill="#0284c7"/>
 <text x="469" y="338" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#18181b">One correlated view</text>
 <text x="469" y="358" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">material risk · trend · explicit gaps</text>
-<rect x="24" y="402" width="1232" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="640" y="422" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<rect x="24" y="402" width="1232" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="640" y="422" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="600" fill="#15803d">SCAN + CI · CENTRALIZE EVIDENCE · ENFORCE AT RUNTIME — one Finding + UnifiedGraph</text>
 </svg>

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -2765,6 +2765,66 @@
         "title": "EnterpriseDemoBounds",
         "type": "object"
       },
+      "EnterpriseDemoCountMetadata": {
+        "additionalProperties": false,
+        "description": "Definition and completeness carried beside an ambiguous demo count.",
+        "properties": {
+          "completeness": {
+            "enum": [
+              "complete",
+              "partial",
+              "unknown"
+            ],
+            "title": "Completeness",
+            "type": "string"
+          },
+          "definition": {
+            "title": "Definition",
+            "type": "string"
+          },
+          "filters": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Filters",
+            "type": "array"
+          },
+          "returned": {
+            "minimum": 0.0,
+            "title": "Returned",
+            "type": "integer"
+          },
+          "scope": {
+            "title": "Scope",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0.0,
+            "title": "Total",
+            "type": "integer"
+          },
+          "window": {
+            "title": "Window",
+            "type": "string"
+          }
+        },
+        "required": [
+          "definition",
+          "source",
+          "scope",
+          "window",
+          "returned",
+          "total",
+          "completeness"
+        ],
+        "title": "EnterpriseDemoCountMetadata",
+        "type": "object"
+      },
       "EnterpriseDemoListBound": {
         "additionalProperties": false,
         "description": "What one truncated list holds, and what it was truncated out of.",
@@ -2818,6 +2878,13 @@
             },
             "title": "Correlations",
             "type": "array"
+          },
+          "count_metadata": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/EnterpriseDemoCountMetadata"
+            },
+            "title": "Count Metadata",
+            "type": "object"
           },
           "disclosure": {
             "title": "Disclosure",
@@ -2901,6 +2968,7 @@
           "story_content_hash",
           "summary",
           "bounds",
+          "count_metadata",
           "primary_correlation",
           "events",
           "correlations",
@@ -21757,6 +21825,10 @@
                         "type": "object"
                       },
                       "type": "array"
+                    },
+                    "count_metadata": {
+                      "additionalProperties": true,
+                      "type": "object"
                     },
                     "created_at": {
                       "type": "string"

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -1909,6 +1909,53 @@ components:
       - findings
       title: EnterpriseDemoBounds
       type: object
+    EnterpriseDemoCountMetadata:
+      additionalProperties: false
+      description: Definition and completeness carried beside an ambiguous demo count.
+      properties:
+        completeness:
+          enum:
+          - complete
+          - partial
+          - unknown
+          title: Completeness
+          type: string
+        definition:
+          title: Definition
+          type: string
+        filters:
+          default: []
+          items:
+            type: string
+          title: Filters
+          type: array
+        returned:
+          minimum: 0.0
+          title: Returned
+          type: integer
+        scope:
+          title: Scope
+          type: string
+        source:
+          title: Source
+          type: string
+        total:
+          minimum: 0.0
+          title: Total
+          type: integer
+        window:
+          title: Window
+          type: string
+      required:
+      - definition
+      - source
+      - scope
+      - window
+      - returned
+      - total
+      - completeness
+      title: EnterpriseDemoCountMetadata
+      type: object
     EnterpriseDemoListBound:
       additionalProperties: false
       description: What one truncated list holds, and what it was truncated out of.
@@ -1951,6 +1998,11 @@ components:
             $ref: '#/components/schemas/EnterpriseCorrelation'
           title: Correlations
           type: array
+        count_metadata:
+          additionalProperties:
+            $ref: '#/components/schemas/EnterpriseDemoCountMetadata'
+          title: Count Metadata
+          type: object
         disclosure:
           title: Disclosure
           type: string
@@ -2018,6 +2070,7 @@ components:
       - story_content_hash
       - summary
       - bounds
+      - count_metadata
       - primary_correlation
       - events
       - correlations
@@ -14519,6 +14572,9 @@ paths:
                           type: array
                       type: object
                     type: array
+                  count_metadata:
+                    additionalProperties: true
+                    type: object
                   created_at:
                     type: string
                   edges:

--- a/scripts/check_published_counts.py
+++ b/scripts/check_published_counts.py
@@ -123,7 +123,8 @@ RULES: tuple[CountRule, ...] = (
     CountRule(
         "MCP tools",
         (
-            re.compile(rf"{_NUMBER}\s+MCP\s+tools\b", re.I),
+            # Inline HTML is presentation, not a shield from count drift.
+            re.compile(rf"(?:<[^>]+>\s*)*{_NUMBER}(?:\s*</[^>]+>)*\s+MCP\s+tools\b", re.I),
             re.compile(rf"Tool\s+Categories\s*\(\s*{_NUMBER}\s+tools\s*\)", re.I),
         ),
     ),

--- a/scripts/cve_matching_accuracy.py
+++ b/scripts/cve_matching_accuracy.py
@@ -139,6 +139,10 @@ def _sound_negatives(block: dict) -> list[str]:
     declared = {str(v) for v in (block.get("versions") or [])}
     negatives: set[str] = set()
     for rng in block.get("ranges") or []:
+        # Commit fixes are only ordered inside the repository's graph. They are
+        # not released package versions and cannot label an ecosystem oracle.
+        if (rng.get("type") or "") not in _ECOSYSTEM_RANGE_TYPES:
+            continue
         for event in rng.get("events") or []:
             fixed = event.get("fixed")
             if fixed and str(fixed) not in declared:

--- a/scripts/generate_doc_architecture_svgs.py
+++ b/scripts/generate_doc_architecture_svgs.py
@@ -1705,7 +1705,7 @@ def persona_value(theme: str) -> str:
             w,
             h,
             t,
-            "LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph",
+            "SCAN + CI · CENTRALIZE EVIDENCE · ENFORCE AT RUNTIME — one Finding + UnifiedGraph",
         )
     )
     parts.append("</svg>")

--- a/src/agent_bom/api/finding_list_envelope.py
+++ b/src/agent_bom/api/finding_list_envelope.py
@@ -45,6 +45,7 @@ FINDING_LIST_ENVELOPE_KEYS: tuple[str, ...] = (
     "has_more",
     "filters",
     "warnings",
+    "count_metadata",
 )
 
 
@@ -61,6 +62,9 @@ def finding_list_envelope(
     filters: dict[str, Any] | None = None,
     warnings: list[str] | None = None,
     total_approximate: bool = False,
+    source: str = "unified_findings",
+    scope: str = "tenant-scoped current findings",
+    window: dict[str, Any] | None = None,
     schema_version: str = FINDING_LIST_SCHEMA_VERSION,
 ) -> dict[str, Any]:
     """Build the canonical finding-list envelope shared by every list surface.
@@ -68,6 +72,17 @@ def finding_list_envelope(
     ``count`` and ``has_more`` are derived so callers cannot drift them out of
     sync with ``findings`` and ``next_cursor``.
     """
+    applied_filters = filters if filters is not None else {}
+    has_more = bool(next_cursor)
+    if total is None:
+        completeness = {"status": "unknown", "reason": "total_unavailable"}
+    elif total_approximate:
+        completeness = {"status": "partial", "reason": "total_is_lower_bound"}
+    elif offset > 0 or has_more or len(findings) < total:
+        completeness = {"status": "partial", "reason": "paginated_result"}
+    else:
+        completeness = {"status": "complete", "reason": ""}
+
     envelope: dict[str, Any] = {
         "schema_version": schema_version,
         "findings": findings,
@@ -79,9 +94,20 @@ def finding_list_envelope(
         "scan_id": scan_id,
         "cursor": cursor,
         "next_cursor": next_cursor,
-        "has_more": bool(next_cursor),
-        "filters": filters if filters is not None else {},
+        "has_more": has_more,
+        "filters": applied_filters,
         "warnings": warnings if warnings is not None else [],
+        "count_metadata": {
+            "definition": "Findings matching this endpoint's tenant, source, window, and filters.",
+            "source": source,
+            "scope": scope,
+            "window": window,
+            "filters": applied_filters,
+            "returned": len(findings),
+            "total": total,
+            "total_kind": "unknown" if total is None else "lower_bound" if total_approximate else "exact",
+            "completeness": completeness,
+        },
     }
     if total_approximate:
         envelope["total_approximate"] = True

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -2821,6 +2821,8 @@ def _list_hub_findings_impl(request: Request, limit: int, offset: int, cursor: s
         sort=sort,
         cursor=cursor or "",
         next_cursor=next_cursor,
+        source="native_and_compliance_hub_findings",
+        scope="tenant compliance-hub current findings",
     )
 
 

--- a/src/agent_bom/api/routes/governance.py
+++ b/src/agent_bom/api/routes/governance.py
@@ -133,7 +133,11 @@ async def governance_findings(
             total=total,
             limit=safe_limit,
             offset=safe_offset,
+            filters={key: value for key, value in {"severity": severity, "category": category}.items() if value},
             warnings=list(report.warnings),
+            source="snowflake_governance_discovery",
+            scope="requested Snowflake governance discovery",
+            window={"days": days},
         )
 
     try:

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -276,6 +276,7 @@ _ATTACK_PATHS_OPENAPI_RESPONSE: dict[str, Any] = {
                         "additionalProperties": True,
                     },
                     "pagination": {"type": "object", "additionalProperties": True},
+                    "count_metadata": {"type": "object", "additionalProperties": True},
                 },
             }
         }
@@ -1787,9 +1788,16 @@ def _serialize_attack_path_queue(
     offset: int,
     limit: int,
     stats: dict[str, Any],
+    path_source: str,
 ) -> dict[str, Any]:
     nodes_by_id = {node.id: node for node in nodes}
     stats = _sync_attack_path_stats(stats, total=total, paths=paths)
+    completeness = graph_completeness(
+        returned=len(paths),
+        total=total,
+        truncated=offset + len(paths) < total,
+        reason="path_page_limit" if offset + len(paths) < total else "",
+    )
     return {
         "scan_id": scan_id,
         "tenant_id": tenant,
@@ -1803,12 +1811,17 @@ def _serialize_attack_path_queue(
         "interaction_risks": [],
         "stats": stats,
         "pagination": _page_meta(total, offset, limit),
-        "completeness": graph_completeness(
-            returned=len(paths),
-            total=total,
-            truncated=offset + len(paths) < total,
-            reason="path_page_limit" if offset + len(paths) < total else "",
-        ),
+        "completeness": completeness,
+        "count_metadata": {
+            "definition": "Ranked persisted attack paths when available, otherwise paths derived from traversable graph topology.",
+            "source": path_source,
+            "scope": "tenant graph snapshot",
+            "window": {"snapshot_created_at": created_at},
+            "filters": {"scan_id": scan_id, "offset": offset, "limit": limit},
+            "returned": len(paths),
+            "total": total,
+            "completeness": completeness,
+        },
     }
 
 
@@ -2488,6 +2501,7 @@ async def get_graph_attack_paths(
         offset=offset,
         limit=limit,
     )
+    path_source = "persisted_graph_paths"
     if total == 0:
         graph = await _load_graph_for_investigation(
             graph_store,
@@ -2500,6 +2514,7 @@ async def get_graph_attack_paths(
             offset=offset,
             limit=limit,
         )
+        path_source = "derived_graph_paths"
     hop_ids = {hop for path in paths for hop in path.hops}
     nodes = await _graph_store_call(
         graph_store.nodes_by_ids,
@@ -2530,6 +2545,7 @@ async def get_graph_attack_paths(
         offset=offset,
         limit=limit,
         stats=stats,
+        path_source=path_source,
     )
 
 

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -2971,10 +2971,13 @@ def _list_findings_impl(
         },
         warnings=warnings,
         total_approximate=total_approximate,
+        source="scan_and_current_ingest_findings",
+        scope="tenant current-state findings",
     )
     # Echo the applied read-window so clients label counts honestly as
     # "last Nd" rather than "all" (#4009).
     envelope["window"] = time_window.window_metadata(resolved_window)
+    envelope["count_metadata"]["window"] = envelope["window"]
     if scope_completeness is not None:
         envelope["scope_completeness"] = scope_completeness
     if facets is not None:

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -8,6 +8,7 @@ import os
 import secrets
 import ssl
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any, Optional
 
@@ -224,6 +225,36 @@ def _enforce_database_role_posture(command: str) -> None:
             f"Postgres role preflight failed before {command} could bind. Verify the distinct "
             "application and maintenance credentials, database reachability, migrations, and "
             "agent_bom_rls_maintenance membership."
+        ) from exc
+
+
+def _enforce_writable_control_plane_state(command: str) -> None:
+    """Fail once, before app import, when durable SQLite state is unwritable."""
+    from agent_bom.api.durable_store import select_backend, sqlite_path
+
+    if select_backend() != "sqlite":
+        return
+    raw_path = sqlite_path(create_parent=False)
+    if raw_path == ":memory:":
+        return
+
+    database_path = Path(raw_path).expanduser()
+    directory = database_path.parent
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        # SQLite may create journal, WAL, and shared-memory sidecars even when
+        # the database file already exists, so the parent must always be
+        # writable as well as the file itself.
+        with tempfile.NamedTemporaryFile(prefix=".agent-bom-write-probe-", dir=directory):
+            pass
+        if database_path.exists():
+            descriptor = os.open(database_path, os.O_WRONLY | os.O_APPEND)
+            os.close(descriptor)
+    except OSError as exc:
+        raise click.ClickException(
+            "Control-plane state is not writable. Set a writable state directory and retry:\n"
+            f"  AGENT_BOM_STATE_DIR=/writable/path agent-bom {command}\n"
+            "Or choose an explicit database with --persist /writable/path/control-plane.db."
         ) from exc
 
 
@@ -665,6 +696,7 @@ def serve_cmd(
     _enforce_auth_defaults("serve", host, api_key, allow_insecure_no_auth)
     _enforce_control_plane_listener_posture(host)
     _enforce_database_role_posture("serve")
+    _enforce_writable_control_plane_state("serve")
     tls_kwargs = _uvicorn_tls_kwargs()
 
     seeded_connection_key = _maybe_seed_local_connection_key(host=host, allow_insecure_no_auth=allow_insecure_no_auth)
@@ -945,6 +977,7 @@ def api_cmd(
     _enforce_auth_defaults("api", host, api_key, allow_insecure_no_auth)
     _enforce_control_plane_listener_posture(host)
     _enforce_database_role_posture("api")
+    _enforce_writable_control_plane_state("api")
     tls_kwargs = _uvicorn_tls_kwargs()
 
     seeded_connection_key = _maybe_seed_local_connection_key(host=host, allow_insecure_no_auth=allow_insecure_no_auth)

--- a/src/agent_bom/demo_estate/presentation.py
+++ b/src/agent_bom/demo_estate/presentation.py
@@ -84,6 +84,21 @@ class EnterpriseDemoBounds(BaseModel):
     findings: EnterpriseDemoListBound
 
 
+class EnterpriseDemoCountMetadata(BaseModel):
+    """Definition and completeness carried beside an ambiguous demo count."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    definition: str
+    source: str
+    scope: str
+    window: str
+    filters: tuple[str, ...] = ()
+    returned: int = Field(ge=0)
+    total: int = Field(ge=0)
+    completeness: Literal["complete", "partial", "unknown"]
+
+
 class EnterpriseDemoStory(BaseModel):
     """One read model for every operator-facing synthetic-demo surface."""
 
@@ -101,6 +116,7 @@ class EnterpriseDemoStory(BaseModel):
     story_content_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
     summary: EnterpriseDemoSummary
     bounds: EnterpriseDemoBounds
+    count_metadata: dict[str, EnterpriseDemoCountMetadata]
     primary_correlation: EnterpriseCorrelation
     events: tuple[NormalizedEnterpriseEvent, ...]
     correlations: tuple[EnterpriseCorrelation, ...]
@@ -159,6 +175,28 @@ def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> Enterprise
     def _bound(returned: int, total: int, limit: int) -> EnterpriseDemoListBound:
         return EnterpriseDemoListBound(returned=returned, total=total, limit=limit, truncated=returned < total)
 
+    def _count(
+        *,
+        definition: str,
+        source: str,
+        returned: int,
+        total: int,
+        filters: tuple[str, ...] = (),
+    ) -> EnterpriseDemoCountMetadata:
+        return EnterpriseDemoCountMetadata(
+            definition=definition,
+            source=source,
+            scope="whole bundled fictional estate",
+            window="bundled synthetic snapshot",
+            filters=filters,
+            returned=returned,
+            total=total,
+            completeness="partial" if returned < total else "complete",
+        )
+
+    cross_source_total = sum(1 for row in result.correlations if len(set(row.sources)) >= 2)
+    evidence_link_total = finding_summary.attack_paths_evidenced
+
     return EnterpriseDemoStory(
         disclosure=estate.disclosure,
         estate_id=estate.estate_id,
@@ -173,7 +211,7 @@ def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> Enterprise
             complete_sources=result.complete_source_count,
             partial_sources=result.partial_source_count,
             correlations=len(result.correlations),
-            cross_source_correlations=sum(1 for row in result.correlations if len(set(row.sources)) >= 2),
+            cross_source_correlations=cross_source_total,
             snapshots=len(estate.snapshots),
             findings=finding_summary.total,
         ),
@@ -182,6 +220,36 @@ def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> Enterprise
             correlations=_bound(len(correlations), len(result.correlations), _STORY_CORRELATION_LIMIT),
             findings=_bound(len(findings), finding_summary.total, _STORY_FINDING_LIMIT),
         ),
+        count_metadata={
+            "findings": _count(
+                definition="Synthetic findings across the fictional estate; not current persisted control-plane findings.",
+                source="synthetic_estate_findings",
+                returned=len(findings),
+                total=finding_summary.total,
+                filters=("ranked worst-first", "primary incident first"),
+            ),
+            "correlations": _count(
+                definition="Synthetic trace-group correlations; a row may contain evidence from only one source.",
+                source="synthetic_estate_correlations",
+                returned=len(correlations),
+                total=len(result.correlations),
+                filters=("primary incident first", "newest remainder first"),
+            ),
+            "cross_source_correlations": _count(
+                definition="Synthetic correlation rows joining evidence from at least two distinct sources.",
+                source="synthetic_estate_correlations",
+                returned=cross_source_total,
+                total=cross_source_total,
+                filters=("distinct source count >= 2",),
+            ),
+            "attack_paths_evidenced": _count(
+                definition="Unique correlation identifiers referenced by synthetic finding evidence; not persisted or derived graph paths.",
+                source="synthetic_finding_evidence",
+                returned=evidence_link_total,
+                total=evidence_link_total,
+                filters=("finding evidence has correlation_id",),
+            ),
+        },
         primary_correlation=primary,
         events=events,
         correlations=correlations,

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -36,8 +36,18 @@ SHOWCASE_BASELINE_SCAN_ID = "showcase-baseline"
 # ``Remediation`` object frozen to its Python repr, and a running demo would have
 # served that snapshot forever. The seven-day gap is the drift lens's window and
 # is preserved on every bump.
-SHOWCASE_BASELINE_CREATED_AT = "2026-08-08T12:00:00+00:00"
-SHOWCASE_CURRENT_CREATED_AT = "2026-08-15T12:00:00+00:00"
+_SHOWCASE_CURRENT_TARGET = datetime(2026, 8, 15, 12, 0, 0, tzinfo=timezone.utc)
+_SHOWCASE_IMPORT_NOW = datetime.now(timezone.utc)
+# Preserve the deterministic target once it is in the past. Before then, clamp
+# to the current UTC day's start so a release candidate never presents a
+# snapshot from tomorrow. The seven-day baseline window remains intact.
+_SHOWCASE_CURRENT_STAMP = (
+    _SHOWCASE_CURRENT_TARGET
+    if _SHOWCASE_CURRENT_TARGET <= _SHOWCASE_IMPORT_NOW
+    else _SHOWCASE_IMPORT_NOW.replace(hour=0, minute=0, second=0, microsecond=0)
+)
+SHOWCASE_CURRENT_CREATED_AT = _SHOWCASE_CURRENT_STAMP.isoformat()
+SHOWCASE_BASELINE_CREATED_AT = (_SHOWCASE_CURRENT_STAMP - timedelta(days=7)).isoformat()
 
 # The estate's containment root, once projected, becomes the graph's single
 # top-level container. The hand-built showcase org hangs off it so the demo reads

--- a/tests/api/test_findings_contract_envelope.py
+++ b/tests/api/test_findings_contract_envelope.py
@@ -65,6 +65,15 @@ def _assert_canonical_envelope(body: dict) -> None:
     assert isinstance(body["filters"], dict)
     assert isinstance(body["warnings"], list)
     assert body["schema_version"] == "v1"
+    metadata = body["count_metadata"]
+    assert metadata["definition"]
+    assert metadata["source"]
+    assert metadata["scope"]
+    assert "window" in metadata
+    assert metadata["filters"] == body["filters"]
+    assert metadata["returned"] == body["count"]
+    assert metadata["total"] == body["total"]
+    assert metadata["completeness"]["status"] in {"complete", "partial", "unknown"}
 
 
 def _ingest_csv(client: TestClient, rows: int) -> None:

--- a/tests/test_cve_matching_accuracy_gate.py
+++ b/tests/test_cve_matching_accuracy_gate.py
@@ -151,6 +151,21 @@ def test_a_git_range_alone_does_not_disqualify_an_advisory() -> None:
     assert out.true_positive == 2
 
 
+def test_git_commit_fixes_are_not_pypi_negative_oracles() -> None:
+    """A Git commit cannot be replayed as though it were a released PyPI version."""
+    harness = _load_harness()
+    block = {
+        "package": {"name": "requests", "ecosystem": "PyPI"},
+        "ranges": [
+            {"type": "GIT", "events": [{"introduced": "0"}, {"fixed": "c45d7c49ea75133e52ab22a8e9e13173938e36ff"}]},
+            {"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "2.20.0"}]},
+        ],
+        "versions": ["2.19.1"],
+    }
+
+    assert harness._sound_negatives(block) == ["2.20.0"]
+
+
 # Every advisory the corpus cannot label, named rather than counted, so a new
 # skip is visible as an identity and not just as a number moving. All of them
 # are PYSEC records whose GIT range from ``introduced: 0`` enumerates git tags

--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -71,6 +71,8 @@ def test_persona_value_renders_buyer_lanes() -> None:
     assert "Agent-native surface" in svg
     assert "Triage by reachability" in svg
     assert "Audit-ready exports" in svg
+    assert "SCAN + CI · CENTRALIZE EVIDENCE · ENFORCE AT RUNTIME — one Finding + UnifiedGraph" in svg
+    assert "LOCAL SCAN · CONTROL PLANE · RUNTIME" not in svg
     assert _audit_layout(svg) == []
 
 

--- a/tests/test_enterprise_demo_surfaces.py
+++ b/tests/test_enterprise_demo_surfaces.py
@@ -136,6 +136,32 @@ def test_story_artifact_states_the_bound_on_every_list_it_truncates() -> None:
     assert all(bounds[name]["truncated"] for name in bounds)
 
 
+def test_story_defines_count_scope_source_and_completeness() -> None:
+    """Synthetic totals must not masquerade as persisted or derived graph counts."""
+    story = build_enterprise_demo_story(tenant_id="tenant-count-truth")
+    payload = json.loads(story.model_dump_json())
+
+    metadata = payload["count_metadata"]
+    findings = metadata["findings"]
+    assert findings["source"] == "synthetic_estate_findings"
+    assert findings["scope"] == "whole bundled fictional estate"
+    assert findings["returned"] == len(story.findings)
+    assert findings["total"] == story.summary.findings
+    assert findings["completeness"] == "partial"
+
+    correlations = metadata["correlations"]
+    assert correlations["source"] == "synthetic_estate_correlations"
+    assert correlations["returned"] == len(story.correlations)
+    assert correlations["total"] == story.summary.correlations
+    assert correlations["completeness"] == "partial"
+
+    evidence_links = metadata["attack_paths_evidenced"]
+    assert evidence_links["source"] == "synthetic_finding_evidence"
+    assert "not persisted or derived graph paths" in evidence_links["definition"]
+    assert evidence_links["returned"] == evidence_links["total"] == story.finding_summary.attack_paths_evidenced
+    assert evidence_links["completeness"] == "complete"
+
+
 def test_demo_story_help_does_not_promise_the_complete_evidence() -> None:
     """The artifact carries a bounded view, so the help cannot say "complete"."""
     result = CliRunner().invoke(main, ["demo", "story", "--help"])

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -1859,6 +1859,14 @@ class TestGraphStoreBackendSelection:
 
         queue = client.get("/v1/graph/attack-paths", params={"scan_id": "store-scan", "limit": 5}).json()
         assert queue["pagination"]["total"] == 1
+        count_metadata = queue["count_metadata"]
+        assert count_metadata["definition"]
+        assert count_metadata["source"] == "derived_graph_paths"
+        assert count_metadata["scope"] == "tenant graph snapshot"
+        assert count_metadata["filters"] == {"scan_id": "store-scan", "offset": 0, "limit": 5}
+        assert count_metadata["returned"] == len(queue["attack_paths"])
+        assert count_metadata["total"] == queue["pagination"]["total"]
+        assert count_metadata["completeness"] == queue["completeness"]
         assert queue["stats"]["attack_path_count"] == 1
         assert queue["attack_paths"][0]["hops"] == ["agent:a", "server:a:fs", "pkg:npm:form-data", "vuln:cve"]
         assert queue["attack_paths"][0]["edges"] == ["uses", "depends_on", "vulnerable_to"]

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -166,7 +166,7 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert "Scan repositories, images, and cloud accounts" not in hero
     assert "<b>15</b> package ecosystems" in hero
     assert "<b>16</b> compliance surfaces" in hero
-    assert "<b>79</b> MCP tools" in hero
+    assert "<b>80</b> MCP tools" in hero
     assert '<a href="#quick-start"><b>Quick start</b></a>' in hero
     assert '<a href="https://msaad00.github.io/agent-bom/">Docs</a>' in hero
     # The hero links the live demo. This project operates that Cloud Run service

--- a/tests/test_published_counts_gate.py
+++ b/tests/test_published_counts_gate.py
@@ -83,6 +83,11 @@ class TestStaleClaimsAreCaught:
         problems = self._sweep(tmp_path, monkeypatch, svg, suffix=".svg")
         assert any("999" in p for p in problems)
 
+    def test_html_wrapped_readme_badge_count_is_swept(self, tmp_path, monkeypatch):
+        """Inline markup must not hide a stale headline count from the gate."""
+        problems = self._sweep(tmp_path, monkeypatch, "<b>999</b> MCP tools\n")
+        assert any("999" in p and "MCP tools" in p for p in problems)
+
     def test_shipped_python_prose_is_swept(self, tmp_path, monkeypatch):
         """Two of the six real stale claims were runtime strings, not docs."""
         source = '"""Browse the 999-entry server security metadata registry."""\n'

--- a/tests/test_serve_command.py
+++ b/tests/test_serve_command.py
@@ -1,6 +1,7 @@
 """Tests for the rewritten `agent-bom serve` command (API-based, no Streamlit)."""
 
 import builtins
+import tempfile
 
 from click.testing import CliRunner
 
@@ -75,3 +76,52 @@ def test_serve_no_ui_sets_rest_only_env(monkeypatch):
     assert result.exit_code == 0, result.output
     assert seen.get("no_ui_env") == "1"
     assert "Disabled (--no-ui" in result.output
+
+
+def test_serve_reports_one_sanitized_state_directory_recovery(monkeypatch, tmp_path):
+    """An unwritable durable default is one actionable CLI error, never a traceback."""
+    import uvicorn
+
+    state_dir = tmp_path / "blocked-state"
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(state_dir))
+    monkeypatch.delenv("AGENT_BOM_DB", raising=False)
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
+    monkeypatch.delenv("AGENT_BOM_EPHEMERAL_STORE", raising=False)
+
+    def deny_probe(*args, **kwargs):
+        raise PermissionError("private host path and secret detail")
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", deny_probe)
+    monkeypatch.setattr(uvicorn, "run", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not bind")))
+
+    result = CliRunner().invoke(main, ["serve", "--no-ui"])
+    combined = (result.output or "") + str(result.exception or "")
+    assert result.exit_code != 0
+    assert "Control-plane state is not writable" in combined
+    assert "AGENT_BOM_STATE_DIR=/writable/path agent-bom serve" in combined
+    assert "private host path" not in combined
+    assert "Traceback" not in combined
+
+
+def test_serve_checks_parent_directory_for_existing_sqlite_database(monkeypatch, tmp_path):
+    """An existing SQLite file still needs a writable directory for WAL sidecars."""
+    import uvicorn
+
+    database_path = tmp_path / "existing.db"
+    database_path.touch()
+    monkeypatch.setenv("AGENT_BOM_DB", str(database_path))
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
+    monkeypatch.delenv("AGENT_BOM_EPHEMERAL_STORE", raising=False)
+
+    def deny_directory_probe(*args, **kwargs):
+        raise PermissionError("private WAL directory detail")
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", deny_directory_probe)
+    monkeypatch.setattr(uvicorn, "run", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not bind")))
+
+    result = CliRunner().invoke(main, ["serve", "--no-ui"])
+    combined = (result.output or "") + str(result.exception or "")
+    assert result.exit_code != 0
+    assert "Control-plane state is not writable" in combined
+    assert "private WAL directory" not in combined
+    assert "Traceback" not in combined

--- a/tests/test_showcase_graph_seeding.py
+++ b/tests/test_showcase_graph_seeding.py
@@ -7,6 +7,7 @@ seed must be refreshed on ``--demo-estate`` boot instead of early-returning.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -46,6 +47,15 @@ def test_seeds_when_empty(store: SQLiteGraphStore) -> None:
     assert created.get(SHOWCASE_SCAN_ID) == SHOWCASE_CURRENT_CREATED_AT
     assert SHOWCASE_BASELINE_SCAN_ID in created
     assert store.latest_snapshot_id(tenant_id=SHOWCASE_TENANT) == SHOWCASE_SCAN_ID
+
+
+def test_showcase_snapshot_stamps_are_never_future_dated() -> None:
+    """A seeded demo must not present tomorrow's snapshot as observed evidence."""
+    from agent_bom.demo_estate.showcase_graph import SHOWCASE_BASELINE_CREATED_AT
+
+    now = datetime.now(timezone.utc)
+    assert datetime.fromisoformat(SHOWCASE_BASELINE_CREATED_AT) <= now
+    assert datetime.fromisoformat(SHOWCASE_CURRENT_CREATED_AT) <= now
 
 
 def test_persisted_finding_nodes_serve_prose_not_a_python_repr(store: SQLiteGraphStore) -> None:

--- a/ui/app/demo-estate/page.tsx
+++ b/ui/app/demo-estate/page.tsx
@@ -165,8 +165,8 @@ export default function DemoEstatePage() {
           { label: "Assets", value: story.summary.assets, icon: Database },
           { label: "Observations", value: story.summary.observations, icon: Clock3 },
           { label: "Evidence sources", value: story.summary.evidence_sources, hint: `${story.summary.complete_sources} complete` },
-          { label: "Correlations", value: story.summary.correlations, icon: Network, hint: `${story.summary.cross_source_correlations} cross-source` },
-          { label: "Findings", value: story.summary.findings, icon: TriangleAlert },
+          { label: "Correlations", value: story.summary.correlations, icon: Network, hint: `${story.bounds.correlations.returned} returned · ${story.summary.cross_source_correlations} cross-source` },
+          { label: "Demo findings", value: story.summary.findings, icon: TriangleAlert, hint: `${story.bounds.findings.returned} returned · fictional estate` },
           { label: "Snapshots", value: story.summary.snapshots, icon: GitBranch },
           { label: "Partial sources", value: story.summary.partial_sources, accent: "warn", icon: TriangleAlert },
         ]}
@@ -219,7 +219,7 @@ export default function DemoEstatePage() {
           <dl className="grid shrink-0 grid-cols-3 gap-x-5 gap-y-1 text-xs sm:text-right">
             <div><dt className="text-[color:var(--text-tertiary)]">Assets affected</dt><dd className="font-semibold text-[color:var(--foreground)]">{posture.assets_affected} / {posture.assets_total}</dd></div>
             <div><dt className="text-[color:var(--text-tertiary)]">Controls</dt><dd className="font-semibold text-[color:var(--foreground)]">{posture.controls_evidenced}</dd></div>
-            <div><dt className="text-[color:var(--text-tertiary)]">Attack paths</dt><dd className="font-semibold text-[color:var(--foreground)]">{posture.attack_paths_evidenced}</dd></div>
+            <div title={story.count_metadata.attack_paths_evidenced?.definition}><dt className="text-[color:var(--text-tertiary)]">Evidence-linked correlations</dt><dd className="font-semibold text-[color:var(--foreground)]">{posture.attack_paths_evidenced}</dd></div>
           </dl>
         </div>
 

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1147,6 +1147,20 @@ export interface FindingListEnvelope<T> {
   next_cursor: string;
   has_more: boolean;
   warnings: string[];
+  count_metadata: {
+    definition: string;
+    source: string;
+    scope: string;
+    window: ReadWindow | { days: number } | null;
+    filters: Record<string, unknown>;
+    returned: number;
+    total: number | null;
+    total_kind: "exact" | "lower_bound" | "unknown";
+    completeness: {
+      status: "complete" | "partial" | "unknown";
+      reason: string;
+    };
+  };
   /** Applied default read-window (#4009); present on `/v1/findings`. */
   window?: ReadWindow | undefined;
   /** Canonical server-applied facets echoed for pagination/debugging. */
@@ -2993,6 +3007,18 @@ export interface EnterpriseDemoBounds {
   findings: EnterpriseDemoListBound;
 }
 
+/** Definition and completeness carried beside an otherwise ambiguous count. */
+export interface EnterpriseDemoCountMetadata {
+  definition: string;
+  source: string;
+  scope: string;
+  window: string;
+  filters: string[];
+  returned: number;
+  total: number;
+  completeness: "complete" | "partial" | "unknown";
+}
+
 /** GET /v1/demo-estate/story — normalized, fictional enterprise evidence. */
 export interface EnterpriseDemoStory {
   schema_version: string;
@@ -3008,6 +3034,7 @@ export interface EnterpriseDemoStory {
   summary: EnterpriseDemoSummary;
   /** Limit + true total for each bounded list below. */
   bounds: EnterpriseDemoBounds;
+  count_metadata: Record<string, EnterpriseDemoCountMetadata>;
   primary_correlation: EnterpriseDemoCorrelation;
   events: EnterpriseDemoEvent[];
   correlations: EnterpriseDemoCorrelation[];

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -89,7 +89,13 @@ const BUDGETS = {
   // Code-splitting the one consumer was tried first and does not help — this
   // budget totals every chunk, so moving bytes between them changes nothing.
   // Restore ~21 KiB of headroom on the same terms as every raise above.
-  totalClientJsBytes: 3_850_240,
+  // The evidence-truth surfacing (explicit definition/source/scope/filters/
+  // returned-total/completeness provenance on the demo-estate page) measures
+  // 3760.2 KiB in Linux CI — 0.2 KiB over the 3760 KiB line with no headroom.
+  // Legitimate feature copy, not bloat (the api-types additions are erased at
+  // compile). Restore ~16 KiB to 3776 KiB on the same terms as every raise
+  // above; largest-chunk and shared-runtime budgets are unchanged.
+  totalClientJsBytes: 3_866_624,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };

--- a/ui/tests/demo-estate-page.test.tsx
+++ b/ui/tests/demo-estate-page.test.tsx
@@ -56,6 +56,18 @@ const story: EnterpriseDemoStory = {
     correlations: { returned: 1, total: 4, limit: 50, truncated: true },
     findings: { returned: 1, total: 439, limit: 100, truncated: true },
   },
+  count_metadata: {
+    attack_paths_evidenced: {
+      definition: "Unique correlation identifiers referenced by synthetic finding evidence; not persisted or derived graph paths.",
+      source: "synthetic_finding_evidence",
+      scope: "whole bundled fictional estate",
+      window: "bundled synthetic snapshot",
+      filters: ["finding evidence has correlation_id"],
+      returned: 4,
+      total: 4,
+      completeness: "complete",
+    },
+  },
   primary_correlation: correlation,
   events: [
     {
@@ -168,6 +180,9 @@ describe("DemoEstatePage", () => {
     expect(screen.getByText("2 records · google-cloud-audit-log")).toBeInTheDocument();
     expect(screen.getByText("workflow_run")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open security graph/ })).toHaveAttribute("href", "/security-graph");
+    expect(screen.getByText("Demo findings")).toBeInTheDocument();
+    expect(screen.getByText("Evidence-linked correlations")).toBeInTheDocument();
+    expect(screen.queryByText("Attack paths")).not.toBeInTheDocument();
   });
 
   it("renders each finding as a chain, with counts that reconcile", async () => {


### PR DESCRIPTION
## Summary

- add explicit definition, source, scope, filters, returned/total, and completeness metadata to finding lists, graph attack paths, and the synthetic enterprise demo
- align the public 80-tool count and persona message across README/generated SVGs, prevent future-dated demo snapshots, and exclude Git commit hashes from package-version accuracy oracles
- fail early with one sanitized recovery command when durable SQLite state or its WAL directory is unwritable
- clarify the demo dashboard's synthetic findings and evidence-linked correlation counts while preserving existing response fields

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check src tests scripts`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom`
- focused pytest contracts for findings envelopes, filters, graph paths, demo surfaces, timestamp normalization, published counts, accuracy, SVGs, and server startup
- `uv run python scripts/check_exception_sanitization.py`
- Node 24.18 / npm 10.9.7: `npm run verify:toolchain`, `npm run typecheck`, `npm test -- --run` (185 files, 1,169 tests), `npm run build`
- bundled demo browser walkthrough: dark/light, desktop/mobile, real story and graph APIs

## Notes

- API changes are additive; existing count and pagination fields remain intact.
- Synthetic demo counts are explicitly distinguished from persisted findings and persisted/derived graph paths.
- This PR does not change the package version or publish a release.