### PR TITLE
feat(workflow): close the finding-to-verification loop

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -115,7 +115,7 @@ helm upgrade --install agent-bom deploy/helm/agent-bom \
 - **Blast radius + attack-path fusion** — multi-hop exposure paths over one `UnifiedGraph`, from package → finding → MCP server → credentials → connected agents
 - **CWE-aware impact** — RCE shows credential exposure, DoS does not; symbol-level CVE reachability joins CWE/CVE/CPE advisory context when OSV/GHSA carry affected symbols (Python, npm, Go)
 - **Portable outputs** — SARIF, CycloneDX, SPDX, OCSF, HTML, graph, JSON, ZIP evidence bundles, and more
-- **MCP server mode** — 80 MCP tools, 6 resources, and 8 workflow prompts exposed to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
+- **MCP server mode** — 81 MCP tools, 6 resources, and 8 workflow prompts exposed to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
 - **Skill bundle identity** — stable bundle hashes for skill and instruction file review
 - **Dependency confusion detection** — flags internal naming patterns
 - **VEX generation** — auto-triage with CWE/CVE/CPE-aware reachability (package + function-level when advisory symbols exist)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center"><b>Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.</b></p>
 
 <p align="center">
-  <b>15</b> package ecosystems · <b>16</b> compliance surfaces · <b>80</b> MCP tools · no account required<br />
+  <b>15</b> package ecosystems · <b>16</b> compliance surfaces · <b>81</b> MCP tools · no account required<br />
   <a href="#quick-start"><b>Quick start</b></a> ·
   <a href="https://agent-bom-demo-82102570041.us-central1.run.app">Live demo</a> ·
   <a href="https://msaad00.github.io/agent-bom/">Docs</a>
@@ -184,10 +184,10 @@ real identity, TLS, PostgreSQL, encryption, and audit keys before exposing it.
 | GitHub CI | `uses: msaad00/agent-bom@v0.100.0` | SARIF, PR summary, and a policy exit code |
 | Cloud evidence | `agent-bom connect aws` | Stored connection reference; run scans from the control plane |
 | Runtime gateway | `agent-bom gateway serve --from-control-plane http://127.0.0.1:8422 --bind 127.0.0.1:8090` | Allow, warn, and block audit events |
-| Agent interface | `agent-bom mcp server` | 80 MCP tools, 6 resources, and 8 workflow prompts |
+| Agent interface | `agent-bom mcp server` | 81 MCP tools, 6 resources, and 8 workflow prompts |
 | Agent distribution | [Smithery manifest](integrations/smithery.yaml) · [Glama](glama.json) · [MCP registry](integrations/mcp-registry) · [Docker MCP](integrations/docker-mcp-registry) | Registry-specific installation metadata |
 
-MCP server mode exposes 80 MCP tools, 6 resources, and 8 workflow prompts, all
+MCP server mode exposes 81 MCP tools, 6 resources, and 8 workflow prompts, all
 read-first: discovery and analysis never mutate a scanned target.
 
 Set `YDC_API_KEY` to enable the optional `youcom_search` MCP tool for live web

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -1,6 +1,6 @@
 # MCP Server — Streamable HTTP transport for remote clients.
 #
-# Exposes agent-bom's 80 MCP tools over streamable HTTP so that Smithery, Claude
+# Exposes agent-bom's 81 MCP tools over streamable HTTP so that Smithery, Claude
 # Desktop (remote mode), and any other MCP client can connect via public URL.
 #
 # Build:   docker build -f deploy/docker/Dockerfile.sse -t agent-bom-sse .

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -22,7 +22,7 @@ the caller wants to explore or to invoke — not by whether it is human.
 
 | Area | Shipped today |
 |---|---|
-| MCP security tools | 80 tools, 6 resources, 8 workflow prompts |
+| MCP security tools | 81 tools, 6 resources, 8 workflow prompts |
 | REST API | 387 operations across 46 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -465,7 +465,7 @@ graph TB
 | Output | `src/agent_bom/output/__init__.py` | JSON, CycloneDX, SARIF, SPDX, console |
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine (17 conditions) |
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
-| MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (80 tools across core, operator, runtime-catalog, and specialized modules) |
+| MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (81 tools across core, operator, runtime-catalog, and specialized modules) |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse estate inventory; CIS posture where published and Databricks security best practices |
 | Cloud side-scan | `src/agent_bom/cloud/side_scan.py`, `src/agent_bom/cloud/side_scan_targets.py`, `src/agent_bom/cloud/side_scan_lifecycle.py`, `src/agent_bom/cloud/side_scan_provider_adapters.py` | Agentless workload side-scan (CWPP) — AWS EBS, plus injected-SDK Azure Managed Disk and GCP Persistent Disk lifecycle adapters with durable ownership/cleanup state, all three shipping a CLI executor (`run_provider_side_scan`); Azure/GCP scheduler + execution API/MCP wiring and live credentialed proof are not shipped |
 | Registry sweep | `src/agent_bom/cloud/registry_sweep.py` | Registry-wide image enumeration + scan (ECR/ACR/GAR), digest-deduped, capped |

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -59,7 +59,7 @@ claude mcp add agent-bom -- uvx agent-bom mcp server
 
 ## What users get inside Claude
 
-`agent-bom mcp server` exposes 80 MCP tools for:
+`agent-bom mcp server` exposes 81 MCP tools for:
 
 - agent and MCP discovery
 - package and registry checks

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -237,7 +237,7 @@ For cross-agent correlation, use the broader runtime protection engine (`agent-b
 agent-bom mcp server
 ```
 
-Exposes 80 tools to any MCP-compatible AI assistant. Your agent can run scans,
+Exposes 81 tools to any MCP-compatible AI assistant. Your agent can run scans,
 check packages, query ExposurePaths, ask for deploy decisions, query threat
 intel, inspect runtime posture, run admin-gated Shield actions, and generate
 compliance reports without leaving the chat:

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,6 +1,6 @@
 # MCP Server — Connect agent-bom to AI Assistants
 
-agent-bom exposes 80 MCP tools as an MCP server. Any MCP-compatible client can
+agent-bom exposes 81 MCP tools as an MCP server. Any MCP-compatible client can
 connect and get vulnerability scanning, blast radius analysis, compliance
 checks, runtime posture, and supply-chain verification through natural
 conversation.
@@ -165,7 +165,7 @@ agent-bom proxy-bootstrap \
 
 `proxy-configure` is best for JSON MCP clients such as Claude Desktop, Cursor, Windsurf, and Cortex CoCo. TOML-based clients like Codex CLI need manual proxy wrapping.
 
-## Tool Categories (80 tools)
+## Tool Categories (81 tools)
 
 | Category | Tools | What They Do |
 |----------|-------|-------------|
@@ -182,7 +182,7 @@ agent-bom proxy-bootstrap \
 | **AI supply chain** | `dataset_card_scan`, `training_pipeline_scan`, `browser_extension_scan`, `model_provenance_scan`, `prompt_scan`, `model_file_scan`, `ingest_external_scan`, `runtime_evidence_ingest` | Scan AI artifacts, prompts, model files, and browser extensions; import tool-agnostic SARIF/SBOM/scanner evidence without executing its producer; merge CWPP runtime signals |
 
 <details>
-<summary>Complete current catalog (80 tools)</summary>
+<summary>Complete current catalog (81 tools)</summary>
 
 `scan`, `check`, `intel_lookup`, `intel_match`, `intel_sources`,
 `intel_daily_brief`, `youcom_search`, `blast_radius`, `exposure_paths`, `should_i_deploy`,
@@ -203,7 +203,7 @@ agent-bom proxy-bootstrap \
 `license_compliance_scan`, `ingest_external_scan`, `runtime_evidence_ingest`,
 `cost_forecast`, `cost_allocation`, `credential_expiry`, `nhi_discover`,
 `cloud_inventory`, `access_review`, `create_ticket`, `sync_ticket_status`,
-`findings_triage`, `cloud_side_scan`.
+`findings_triage`, `risk_campaign_workflow`, `cloud_side_scan`.
 
 </details>
 
@@ -241,9 +241,9 @@ live runtime traffic rather than static reachability.
 ## Security Model
 
 - **Read-mostly**: scanner, graph, audit, and posture tools are read-only.
-  The 16 write-annotated tools cover scan-history diff, Shield, identity,
+  The 17 write-annotated tools cover scan-history diff, Shield, identity,
   external ingest, CWPP runtime-evidence ingest, access review, finding
-  triage, and ticket workflows. They require an
+  triage, remediation campaigns, and ticket workflows. They require an
   authenticated MCP operator token plus admin role, their specific write
   scope (`cloud:write`, `findings:write`, `identity:write`, `shield:write`,
   or `ticketing:write`), and an audit reason; stdio cannot invoke them.

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -131,7 +131,7 @@ notes discuss agent-native product direction.
 | Area | Shipped today | Not yet shipped |
 |---|---|---|
 | Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
-| Agent interface | 80 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated write actions | long-lived posture subscription tool, autonomous remediation actions |
+| Agent interface | 81 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated write actions | long-lived posture subscription tool, autonomous remediation actions |
 | Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, Python/Go/TypeScript control-plane clients, TypeScript runtime detector package | full scanner SDKs |
 | Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions, **webhook outbox** for posture events | Kafka connectors, cloud-log ingestion connectors, Kinesis/Firehose adapter, and MCP posture subscriptions |
 | Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,10 +1,10 @@
 {
-  "generated_on": "2026-08-13",
+  "generated_on": "2026-08-14",
   "version": "0.100.0",
   "metrics": [
     {
       "name": "MCP tools",
-      "value": 80,
+      "value": 81,
       "source": "src/agent_bom/mcp_server_metadata.py",
       "notes": "Counted from the advertised server-card tools."
     },
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 851,
+      "value": 852,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,18 +5,18 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-13`
+- Generated on: `2026-08-14`
 - Version: `0.100.0`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |
-| MCP tools | 80 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
+| MCP tools | 81 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 47 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 851 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 852 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -91,7 +91,7 @@
 <rect x="488" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="496" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
 <text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">MCP server</text>
-<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">80 tools</text>
+<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">81 tools</text>
 <rect x="706" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="714" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(718,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
 <text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Fleet jobs</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -91,7 +91,7 @@
 <rect x="488" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="496" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
 <text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">MCP server</text>
-<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">80 tools</text>
+<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">81 tools</text>
 <rect x="706" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="714" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(718,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
 <text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Fleet jobs</text>

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -18,7 +18,7 @@
 <rect x="35" y="126" width="378" height="52" rx="8" fill="none" stroke="#fb7185" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#fb7185"/>
 <text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">387 API ops · 80 MCP tools · SARIF</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">387 API ops · 81 MCP tools · SARIF</text>
 <rect x="439" y="18" width="402" height="174" rx="12" fill="#2dd4bf"/>
 <rect x="439" y="22" width="402" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="453" y="32" width="40" height="40" rx="11" fill="#2dd4bf" opacity="0.16"/><g transform="translate(457,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#2dd4bf"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#2dd4bf"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#2dd4bf"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#2dd4bf" stroke-width="1.05"/></g></g>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -18,7 +18,7 @@
 <rect x="35" y="126" width="378" height="52" rx="8" fill="none" stroke="#e11d48" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#e11d48"/>
 <text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#18181b">Agent-native surface</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">387 API ops · 80 MCP tools · SARIF</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">387 API ops · 81 MCP tools · SARIF</text>
 <rect x="439" y="18" width="402" height="174" rx="12" fill="#0d9488"/>
 <rect x="439" y="22" width="402" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="453" y="32" width="40" height="40" rx="11" fill="#0d9488" opacity="0.10"/><g transform="translate(457,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0d9488"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0d9488"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0d9488"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#ffffff" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#0d9488" stroke-width="1.05"/></g></g>

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -1188,6 +1188,14 @@
             "title": "Original Member Count",
             "type": "integer"
           },
+          "outcome": {
+            "enum": [
+              "verified_fixed",
+              "still_affected"
+            ],
+            "title": "Outcome",
+            "type": "string"
+          },
           "remaining_count": {
             "title": "Remaining Count",
             "type": "integer"
@@ -1198,6 +1206,14 @@
             },
             "title": "Remaining Finding Ids",
             "type": "array"
+          },
+          "retry_state": {
+            "enum": [
+              "complete",
+              "ready_after_rescan"
+            ],
+            "title": "Retry State",
+            "type": "string"
           },
           "schema_version": {
             "const": "risk-campaign-verification.v1",
@@ -1229,6 +1245,8 @@
           "schema_version",
           "campaign_id",
           "verification_status",
+          "outcome",
+          "retry_state",
           "state",
           "remaining_finding_ids",
           "remaining_count",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -841,6 +841,12 @@ components:
         original_member_count:
           title: Original Member Count
           type: integer
+        outcome:
+          enum:
+          - verified_fixed
+          - still_affected
+          title: Outcome
+          type: string
         remaining_count:
           title: Remaining Count
           type: integer
@@ -849,6 +855,12 @@ components:
             type: string
           title: Remaining Finding Ids
           type: array
+        retry_state:
+          enum:
+          - complete
+          - ready_after_rescan
+          title: Retry State
+          type: string
         schema_version:
           const: risk-campaign-verification.v1
           title: Schema Version
@@ -872,6 +884,8 @@ components:
       - schema_version
       - campaign_id
       - verification_status
+      - outcome
+      - retry_state
       - state
       - remaining_finding_ids
       - remaining_count

--- a/glama.json
+++ b/glama.json
@@ -5,7 +5,7 @@
   ],
   "name": "agent-bom",
   "title": "agent-bom",
-  "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 80 read-first MCP tools for headless security agents.",
+  "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 81 read-first MCP tools for headless security agents.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/integrations/docker-mcp-registry/SUBMISSION.md
+++ b/integrations/docker-mcp-registry/SUBMISSION.md
@@ -5,7 +5,7 @@ Submission files for listing agent-bom in the Docker Desktop MCP Toolkit catalog
 ## Files
 
 - `server.yaml` — server metadata, image, allowed hosts, optional secrets
-- `tools.json` — all 80 MCP tools with descriptions and parameters
+- `tools.json` — all 81 MCP tools with descriptions and parameters
 - `readme.md` — Docker MCP Toolkit detail page content
 
 ## How to submit

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -1455,6 +1455,27 @@
     ]
   },
   {
+    "name": "risk_campaign_workflow",
+    "description": "List, assign, ticket, and verify tenant-scoped remediation campaigns through the shared persisted workflow.",
+    "arguments": [
+      {"name": "action", "type": "string", "desc": "list, update, verify, verification_queue, ticket_create, or ticket_sync"},
+      {"name": "campaign_id", "type": "string", "desc": "Campaign id for update, verify, or ticket actions"},
+      {"name": "version", "type": "integer", "desc": "Current optimistic-lock version for update or verify"},
+      {"name": "owner", "type": "string", "desc": "Owner to assign during update"},
+      {"name": "sla_due_at", "type": "string", "desc": "Timezone-aware ISO-8601 SLA deadline"},
+      {"name": "state", "type": "string", "desc": "open, in_progress, blocked, or done"},
+      {"name": "connection_id", "type": "string", "desc": "Stored ticketing connection id for ticket_create"},
+      {"name": "project", "type": "string", "desc": "Optional ticketing project override"},
+      {"name": "issue_type", "type": "string", "desc": "Optional ticketing issue type override"},
+      {"name": "cursor", "type": "string", "desc": "Continuation cursor for bounded queue or ticket actions"},
+      {"name": "limit", "type": "integer", "desc": "Bounded queue or ticket action page size"},
+      {"name": "idempotency_key", "type": "string", "desc": "Retry key for verify"},
+      {"name": "operator_role", "type": "string", "desc": "Authenticated operator role"},
+      {"name": "operator_scopes", "type": "string", "desc": "Comma-separated operator scopes"},
+      {"name": "tenant_id", "type": "string", "desc": "Requested tenant; server binding is authoritative"}
+    ]
+  },
+  {
     "name": "cloud_side_scan",
     "description": "Trigger one agentless Azure/GCP disk side-scan (snapshot + read-only mount, SBOM + CVE + secret metadata) through the shared executor; admin-gated, no per-action credential.",
     "arguments": [

--- a/integrations/smithery.yaml
+++ b/integrations/smithery.yaml
@@ -3,7 +3,7 @@
 # The startCommand / configSchema / commandFunction block below is the runtime
 # contract Smithery executes — do not change its shape.
 name: agent-bom
-description: "Open security scanner and self-hosted control plane for AI/MCP infrastructure — agents, MCP servers, runtime, and blast radius. Exposes 80 MCP tools for scanning, compliance, and graph analysis."
+description: "Open security scanner and self-hosted control plane for AI/MCP infrastructure — agents, MCP servers, runtime, and blast radius. Exposes 81 MCP tools for scanning, compliance, and graph analysis."
 homepage: "https://github.com/msaad00/agent-bom"
 
 runtime: "python"

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -546,7 +546,7 @@ def main() -> int:
     tools = len(tool_names)
     resources = len(resource_uris)
     prompts = len(prompt_names)
-    if (tools, resources, prompts) != (80, 6, 8):
+    if (tools, resources, prompts) != (81, 6, 8):
         _fail(f"MCP server card count changed unexpectedly: tools={tools}, resources={resources}, prompts={prompts}")
     docker_mcp_tool_names = [str(tool["name"]) for tool in json.loads(DOCKER_MCP_TOOLS.read_text())]
     if docker_mcp_tool_names != tool_names:

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,11 +1,11 @@
 # MCP Server Setup
 
-agent-bom runs as an MCP server, exposing 80 MCP tools to any MCP client.
+agent-bom runs as an MCP server, exposing 81 MCP tools to any MCP client.
 The server card also advertises 6 resources and 8 workflow prompts so agents can
 choose structured playbooks instead of guessing tool order.
-Most tools are read-only. 16 write-annotated tools cover scan-history
+Most tools are read-only. 17 write-annotated tools cover scan-history
 diff, Shield, identity, external ingest, CWPP runtime-evidence ingest, access
-review, finding triage, and ticket workflows.
+review, finding triage, remediation campaigns, and ticket workflows.
 Each requires `operator_role=admin`, its tool-specific write scope, and an audit
 reason. The registered scope families are `cloud:write`, `findings:write`,
 `identity:write`, `shield:write`, and `ticketing:write`.

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -73,7 +73,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|---|
 | **CLI / CI** | developers and pipelines | local scans, SARIF/SBOM/HTML/JSON, graph exports, deterministic gates |
 | **REST API** | security platforms, SIEM jobs, custom services | self-hosted control-plane routes for scans, normalized bulk findings, dataset versions, evaluation runs, graph evidence, audit, and governance |
-| **MCP tools** | AI agents and coding assistants | 80 tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture, audited write actions |
+| **MCP tools** | AI agents and coding assistants | 81 tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture, audited write actions |
 | **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
 | **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |
 | **UI cockpit** | security teams and auditors | graph cockpit, compliance, audit, and evidence review over the same backend data |

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -3,15 +3,15 @@
 agent-bom exposes MCP tools for scanning, blast radius, trust, compliance,
 runtime, and remediation. The tools are read-only by default: agent consumers
 can request evidence and deploy guidance without mutating repos, cloud
-resources, or runtime targets. 16 write-annotated tools cover scan-history
+resources, or runtime targets. 17 write-annotated tools cover scan-history
 diff, Shield, identity, external ingest, CWPP runtime-evidence ingest, access
-review, finding triage, and ticket workflows.
+review, finding triage, remediation campaigns, and ticket workflows.
 They fail closed unless a remote caller uses the operator token and supplies an
 admin role, the tool-specific write scope, and an audit reason; stdio cannot
 invoke them.
 
 <details>
-<summary>Complete current catalog (80 tools)</summary>
+<summary>Complete current catalog (81 tools)</summary>
 
 `scan`, `check`, `intel_lookup`, `intel_match`, `intel_sources`,
 `intel_daily_brief`, `youcom_search`, `blast_radius`, `exposure_paths`, `should_i_deploy`,
@@ -32,7 +32,7 @@ invoke them.
 `license_compliance_scan`, `ingest_external_scan`, `runtime_evidence_ingest`,
 `cost_forecast`, `cost_allocation`, `credential_expiry`, `nhi_discover`,
 `cloud_inventory`, `access_review`, `create_ticket`, `sync_ticket_status`,
-`findings_triage`, `cloud_side_scan`.
+`findings_triage`, `risk_campaign_workflow`, `cloud_side_scan`.
 
 </details>
 

--- a/src/agent_bom/api/routes/campaigns.py
+++ b/src/agent_bom/api/routes/campaigns.py
@@ -16,7 +16,9 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from agent_bom.api.audit_log import log_action
 from agent_bom.api.campaign_store import MembershipEvidence, get_campaign_store
+from agent_bom.api.idempotency_store import IdempotencyConflictError, idempotency_request_fingerprint
 from agent_bom.api.risk_campaigns import derive_campaigns
+from agent_bom.api.stores import _get_idempotency_store
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.rbac import require_authenticated_permission
 from agent_bom.ticketing.service import TicketingError, create_ticket_for_finding, sync_ticket_status
@@ -258,6 +260,8 @@ class CampaignVerificationResponse(BaseModel):
     schema_version: Literal["risk-campaign-verification.v1"]
     campaign_id: str
     verification_status: Literal["verified", "failed"]
+    outcome: Literal["verified_fixed", "still_affected"]
+    retry_state: Literal["complete", "ready_after_rescan"]
     state: str
     remaining_finding_ids: list[str]
     remaining_count: int
@@ -441,16 +445,148 @@ def _require_complete_membership(campaign: dict[str, Any]) -> None:
 
 
 def _audit(action: str, request: Request, campaign_id: str, **details: Any) -> None:
+    _audit_for_actor(action, tenant_id=_tenant(request), actor=_actor(request), campaign_id=campaign_id, **details)
+
+
+def _audit_for_actor(action: str, *, tenant_id: str, actor: str, campaign_id: str, **details: Any) -> None:
     try:
         log_action(
             action,
-            actor=_actor(request),
+            actor=actor,
             resource=f"risk-campaign/{campaign_id}",
-            tenant_id=_tenant(request),
+            tenant_id=tenant_id,
             **details,
         )
     except Exception:  # noqa: BLE001 - audit failure must not corrupt workflow state
         _logger.warning("risk campaign audit append failed")
+
+
+def verify_campaign_workflow(
+    *,
+    tenant_id: str,
+    campaign_id: str,
+    version: int,
+    source: dict[str, Any],
+    actor: str,
+    idempotency_key: str = "",
+) -> dict[str, Any]:
+    """Verify a campaign through the shared persisted workflow service."""
+    if len(idempotency_key) > 200:
+        raise HTTPException(status_code=422, detail="Idempotency-Key must be 200 characters or fewer.")
+    if _source_incomplete(source):
+        _audit_for_actor(
+            "risk_campaign.verify_unavailable",
+            tenant_id=tenant_id,
+            actor=actor,
+            campaign_id=campaign_id,
+            outcome="unavailable_evidence",
+            retry_state="awaiting_complete_snapshot",
+        )
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "outcome": "unavailable_evidence",
+                "retry_state": "awaiting_complete_snapshot",
+                "reason": "Campaign verification requires a complete findings snapshot.",
+            },
+        )
+
+    endpoint = f"/v1/campaigns/{campaign_id}/verify"
+    request_hash = idempotency_request_fingerprint({"campaign_id": campaign_id, "version": version})
+    if idempotency_key:
+        cached = _get_idempotency_store().get(
+            endpoint,
+            tenant_id,
+            "risk-campaign",
+            idempotency_key,
+            request_hash=request_hash,
+        )
+        if cached is not None:
+            return cast("dict[str, Any]", cached)
+
+    store = get_campaign_store()
+    stored = store.get(tenant_id, campaign_id)
+    if stored is None or not stored.member_ids:
+        raise HTTPException(status_code=404, detail="Campaign membership evidence was not found for this tenant.")
+    current_campaigns = derive_campaigns(
+        source["findings"],
+        tenant_id=tenant_id,
+        workflow_by_id={},
+        window_days=90,
+        finding_limit=1000,
+        truncated=False,
+    )
+    current = next((item for item in current_campaigns if item["id"] == campaign_id), None)
+    remaining = tuple(sorted(str(value) for value in current["finding_ids"])) if current else ()
+    verified = store.verify(tenant_id, campaign_id, expected_version=version, remaining_ids=remaining)
+    if verified is None:
+        raise HTTPException(status_code=409, detail="Campaign changed; refresh and retry with the current version.")
+
+    outcome = "verified_fixed" if verified.verification_status == "verified" else "still_affected"
+    retry_state = "complete" if outcome == "verified_fixed" else "ready_after_rescan"
+    result: dict[str, Any] = {
+        "schema_version": "risk-campaign-verification.v1",
+        "campaign_id": campaign_id,
+        "verification_status": verified.verification_status,
+        "outcome": outcome,
+        "retry_state": retry_state,
+        "state": verified.state,
+        "remaining_finding_ids": list(remaining),
+        "remaining_count": len(remaining),
+        "original_member_count": len(stored.member_ids),
+        "evidence_scope": {
+            "source": "canonical_findings_spine",
+            "finding_window_days": 90,
+            "finding_limit": 1000,
+            "membership_complete": True,
+        },
+        "version": verified.version,
+        "verified_at": verified.updated_at,
+    }
+    _audit_for_actor(
+        "risk_campaign.verify",
+        tenant_id=tenant_id,
+        actor=actor,
+        campaign_id=campaign_id,
+        verification_status=verified.verification_status,
+        outcome=outcome,
+        retry_state=retry_state,
+        remaining_count=len(remaining),
+    )
+    if idempotency_key:
+        _get_idempotency_store().put(
+            endpoint,
+            tenant_id,
+            "risk-campaign",
+            idempotency_key,
+            result,
+            request_hash=request_hash,
+        )
+    return result
+
+
+def update_campaign_workflow(
+    *,
+    request: Request,
+    campaign_id: str,
+    body: CampaignUpdate,
+    source: dict[str, Any],
+) -> dict[str, Any]:
+    """Update owner, SLA, or state through one REST/MCP workflow service."""
+    tenant_id = _tenant(request)
+    campaign = _find_campaign(_campaigns(request, source), campaign_id)
+    _require_complete_membership(campaign)
+    fields = body.model_dump(exclude_unset=True, exclude={"version"})
+    if not fields:
+        raise HTTPException(status_code=422, detail="At least one campaign workflow field is required.")
+    if "owner" in fields:
+        fields["owner"] = body.owner.strip() if body.owner else None
+    workflow = get_campaign_store().patch(tenant_id, campaign_id, expected_version=body.version, fields=fields)
+    if workflow is None:
+        raise HTTPException(status_code=409, detail="Campaign changed; refresh and retry with the current version.")
+    campaign.update(workflow.to_dict())
+    _audit("risk_campaign.update", request, campaign_id, state=workflow.state, verification_status=workflow.verification_status)
+    return campaign
 
 
 @router.get("/campaigns", response_model=CampaignListResponse)
@@ -514,68 +650,25 @@ async def campaign_verification_queue(
 
 @router.patch("/campaigns/{campaign_id}", response_model=CampaignResponse)
 async def update_campaign(request: Request, campaign_id: str, body: CampaignUpdate, _role: Any = _WRITE) -> dict[str, Any]:
-    tenant_id = _tenant(request)
     source = _source_payload(await anyio.to_thread.run_sync(_load_findings, request))
-    campaign = _find_campaign(_campaigns(request, source), campaign_id)
-    _require_complete_membership(campaign)
-    fields = body.model_dump(exclude_unset=True, exclude={"version"})
-    if "owner" in fields:
-        fields["owner"] = body.owner.strip() if body.owner else None
-    workflow = get_campaign_store().patch(tenant_id, campaign_id, expected_version=body.version, fields=fields)
-    if workflow is None:
-        raise HTTPException(status_code=409, detail="Campaign changed; refresh and retry with the current version.")
-    campaign.update(workflow.to_dict())
-    _audit("risk_campaign.update", request, campaign_id, state=workflow.state, verification_status=workflow.verification_status)
-    return campaign
+    return update_campaign_workflow(request=request, campaign_id=campaign_id, body=body, source=source)
 
 
 @router.post("/campaigns/{campaign_id}/verify", response_model=CampaignVerificationResponse)
 async def verify_campaign(request: Request, campaign_id: str, body: CampaignVerificationRequest, _role: Any = _WRITE) -> dict[str, Any]:
     tenant_id = _tenant(request)
     source = _source_payload(await anyio.to_thread.run_sync(_load_findings, request))
-    if _source_incomplete(source):
-        raise HTTPException(status_code=409, detail="Campaign verification requires a complete findings snapshot.")
-    store = get_campaign_store()
-    stored = store.get(tenant_id, campaign_id)
-    if stored is None or not stored.member_ids:
-        raise HTTPException(status_code=404, detail="Campaign membership evidence was not found for this tenant.")
-    current_campaigns = derive_campaigns(
-        source["findings"],
-        tenant_id=tenant_id,
-        workflow_by_id={},
-        window_days=90,
-        finding_limit=1000,
-        truncated=False,
-    )
-    current = next((item for item in current_campaigns if item["id"] == campaign_id), None)
-    remaining = tuple(sorted(str(value) for value in current["finding_ids"])) if current else ()
-    verified = store.verify(tenant_id, campaign_id, expected_version=body.version, remaining_ids=remaining)
-    if verified is None:
-        raise HTTPException(status_code=409, detail="Campaign changed; refresh and retry with the current version.")
-    _audit(
-        "risk_campaign.verify",
-        request,
-        campaign_id,
-        verification_status=verified.verification_status,
-        remaining_count=len(remaining),
-    )
-    return {
-        "schema_version": "risk-campaign-verification.v1",
-        "campaign_id": campaign_id,
-        "verification_status": verified.verification_status,
-        "state": verified.state,
-        "remaining_finding_ids": list(remaining),
-        "remaining_count": len(remaining),
-        "original_member_count": len(stored.member_ids),
-        "evidence_scope": {
-            "source": "canonical_findings_spine",
-            "finding_window_days": 90,
-            "finding_limit": 1000,
-            "membership_complete": True,
-        },
-        "version": verified.version,
-        "verified_at": verified.updated_at,
-    }
+    try:
+        return verify_campaign_workflow(
+            tenant_id=tenant_id,
+            campaign_id=campaign_id,
+            version=body.version,
+            source=source,
+            actor=_actor(request),
+            idempotency_key=(request.headers.get("Idempotency-Key") or "").strip(),
+        )
+    except IdempotencyConflictError as exc:
+        raise HTTPException(status_code=409, detail="Idempotency key was reused with a different verification request.") from exc
 
 
 @router.post(

--- a/src/agent_bom/cli/_campaigns_group.py
+++ b/src/agent_bom/cli/_campaigns_group.py
@@ -57,7 +57,7 @@ def _print_campaigns_table(payload: Mapping[str, object]) -> None:
 
 @click.group(name="campaigns")
 def campaigns_cmd() -> None:
-    """Inspect and verify risk/remediation campaigns from the control plane."""
+    """Assign, ticket, verify, and inspect remediation campaigns."""
 
 
 @campaigns_cmd.command("list")
@@ -104,6 +104,112 @@ def verify_campaign_cmd(
 
     client = _make_client(api_url, api_key, bearer_token, tenant_id)
     payload = _run_request(client, lambda api: api.verify_campaign(campaign_id, version=version))
+    if output_format == "json":
+        _emit_json(payload)
+
+
+@campaigns_cmd.command("update")
+@click.argument("campaign_id")
+@click.option("--version", type=int, required=True, help="Current campaign version for optimistic concurrency.")
+@click.option("--owner", default=None, help="Team or operator responsible for the campaign.")
+@click.option("--sla-due-at", default=None, help="Timezone-aware ISO-8601 SLA deadline.")
+@click.option("--state", type=click.Choice(["open", "in_progress", "blocked", "done"]), default=None)
+@click.option("--format", "output_format", type=click.Choice(["json"]), default="json", show_default=True)
+@_common_api_options
+def update_campaign_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    campaign_id: str,
+    version: int,
+    owner: str | None,
+    sla_due_at: str | None,
+    state: str | None,
+    output_format: str,
+) -> None:
+    """Assign owner, SLA, and state through the canonical workflow."""
+
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    payload = _run_request(
+        client,
+        lambda api: api.update_campaign(
+            campaign_id,
+            version=version,
+            owner=owner,
+            sla_due_at=sla_due_at,
+            state=state,
+        ),
+    )
+    if output_format == "json":
+        _emit_json(payload)
+
+
+@campaigns_cmd.group("tickets")
+def campaign_tickets_cmd() -> None:
+    """Create or synchronize tickets linked to campaign findings."""
+
+
+@campaign_tickets_cmd.command("create")
+@click.argument("campaign_id")
+@click.option("--connection-id", required=True, help="Stored connect-once ticketing connection id.")
+@click.option("--project", default="", help="Provider project override.")
+@click.option("--issue-type", default="", help="Provider issue type override.")
+@click.option("--cursor", default=None, help="Continuation cursor from the previous bounded action.")
+@click.option("--limit", type=click.IntRange(1, 25), default=25, show_default=True)
+@click.option("--format", "output_format", type=click.Choice(["json"]), default="json", show_default=True)
+@_common_api_options
+def create_campaign_tickets_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    campaign_id: str,
+    connection_id: str,
+    project: str,
+    issue_type: str,
+    cursor: str | None,
+    limit: int,
+    output_format: str,
+) -> None:
+    """Create one bounded page of tickets for campaign findings."""
+
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    payload = _run_request(
+        client,
+        lambda api: api.create_campaign_tickets(
+            campaign_id,
+            connection_id=connection_id,
+            project=project,
+            issue_type=issue_type,
+            cursor=cursor,
+            limit=limit,
+        ),
+    )
+    if output_format == "json":
+        _emit_json(payload)
+
+
+@campaign_tickets_cmd.command("sync")
+@click.argument("campaign_id")
+@click.option("--cursor", default=None, help="Continuation cursor from the previous bounded action.")
+@click.option("--limit", type=click.IntRange(1, 25), default=25, show_default=True)
+@click.option("--format", "output_format", type=click.Choice(["json"]), default="json", show_default=True)
+@_common_api_options
+def sync_campaign_tickets_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    campaign_id: str,
+    cursor: str | None,
+    limit: int,
+    output_format: str,
+) -> None:
+    """Refresh one bounded page of linked ticket states."""
+
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    payload = _run_request(client, lambda api: api.sync_campaign_tickets(campaign_id, cursor=cursor, limit=limit))
     if output_format == "json":
         _emit_json(payload)
 

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -1108,7 +1108,7 @@ def mcp_server_cmd(
       docs/MCP_WORKFLOWS.md
 
     \b
-    Exposes 80 security tools via MCP protocol, organized behind 8 workflow
+    Exposes 81 security tools via MCP protocol, organized behind 8 workflow
     prompts. Advanced direct tools include skill_scan, skill_verify,
     compliance, and remediate.
 

--- a/src/agent_bom/client.py
+++ b/src/agent_bom/client.py
@@ -123,13 +123,66 @@ class AgentBomClient:
 
         return self._request("GET", "/v1/campaigns")
 
-    def verify_campaign(self, campaign_id: str, *, version: int) -> JsonObject:
+    def update_campaign(
+        self,
+        campaign_id: str,
+        *,
+        version: int,
+        owner: str | None = None,
+        sla_due_at: str | None = None,
+        state: str | None = None,
+    ) -> JsonObject:
+        """Assign a campaign owner/SLA/state using optimistic concurrency."""
+
+        return self._request(
+            "PATCH",
+            f"/v1/campaigns/{_quote_path(campaign_id)}",
+            json=_strip_none({"version": version, "owner": owner, "sla_due_at": sla_due_at, "state": state}),
+        )
+
+    def verify_campaign(self, campaign_id: str, *, version: int, idempotency_key: str = "") -> JsonObject:
         """Verify a campaign against the current findings spine (optimistic lock)."""
 
         return self._request(
             "POST",
             f"/v1/campaigns/{_quote_path(campaign_id)}/verify",
             json={"version": version},
+            extra_headers={"Idempotency-Key": idempotency_key} if idempotency_key else None,
+        )
+
+    def create_campaign_tickets(
+        self,
+        campaign_id: str,
+        *,
+        connection_id: str,
+        project: str = "",
+        issue_type: str = "",
+        cursor: str | None = None,
+        limit: int = 25,
+    ) -> JsonObject:
+        """Create one bounded page of tickets for campaign findings."""
+
+        return self._request(
+            "POST",
+            f"/v1/campaigns/{_quote_path(campaign_id)}/tickets",
+            json=_strip_none(
+                {
+                    "connection_id": connection_id,
+                    "project": project,
+                    "issue_type": issue_type,
+                    "cursor": cursor,
+                    "limit": limit,
+                }
+            ),
+        )
+
+    def sync_campaign_tickets(self, campaign_id: str, *, cursor: str | None = None, limit: int = 25) -> JsonObject:
+        """Sync one bounded page of the campaign's linked tickets."""
+
+        return self._request(
+            "POST",
+            f"/v1/campaigns/{_quote_path(campaign_id)}/tickets/sync",
+            params=_strip_query_none({"cursor": cursor, "limit": limit}),
         )
 
     def compliance_framework(self, framework: str) -> JsonObject:

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -5,7 +5,7 @@ Start with:
     agent-bom mcp server --transport sse          # SSE transport (for remote clients)
     agent-bom mcp server --transport streamable-http
 
-Tools (80):
+Tools (81):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
     intel_lookup        — Look up a CVE, GHSA, or OSV advisory from local threat intel

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -409,6 +409,11 @@ _SERVER_CARD_TOOLS = [
         "annotations": {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
     },
     {
+        "name": "risk_campaign_workflow",
+        "description": "List, assign, ticket, and verify tenant-scoped remediation campaigns through the shared persisted workflow",
+        "annotations": {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True},
+    },
+    {
         "name": "cloud_side_scan",
         "description": "Trigger one agentless Azure/GCP disk side-scan — metadata-only SBOM/CVE/secret evidence; admin-gated write",
         "annotations": {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
@@ -496,6 +501,7 @@ _TOOL_CAPABILITY_CLASSES = {
     "create_ticket": ["WRITE", "NETWORK", "INTEGRATION"],
     "sync_ticket_status": ["WRITE", "NETWORK", "INTEGRATION"],
     "findings_triage": ["WRITE", "GOVERNANCE", "AUDIT"],
+    "risk_campaign_workflow": ["WRITE", "GOVERNANCE", "AUDIT"],
     "cloud_side_scan": ["WRITE", "NETWORK", "CLOUD", "CWPP", "AUDIT"],
 }
 

--- a/src/agent_bom/mcp_server_operator_tools.py
+++ b/src/agent_bom/mcp_server_operator_tools.py
@@ -49,6 +49,7 @@ def register_operator_tools(
         nhi_discover_impl,
     )
     from agent_bom.mcp_tools.registry import fleet_scan_impl, marketplace_check_impl
+    from agent_bom.mcp_tools.risk_campaigns import risk_campaign_workflow_impl
     from agent_bom.mcp_tools.runtime import (
         anomaly_scan_impl,
         audit_integrity_impl,
@@ -150,6 +151,58 @@ def register_operator_tools(
             operator_role=operator_role,
             operator_scopes=operator_scopes,
             reason=reason,
+            tenant_id=tenant_id,
+            _truncate_response=truncate_response,
+        )
+
+    # ── risk_campaign_workflow ───────────────────────────────────
+    # Headless parity for the persisted owner/SLA/verification lifecycle.
+
+    @mcp.tool(annotations=write_action, title="Manage Remediation Campaign Workflow")
+    async def risk_campaign_workflow(
+        action: Annotated[
+            str,
+            Field(description="Workflow action: list, update, verify, verification_queue, ticket_create, or ticket_sync."),
+        ] = "list",
+        campaign_id: Annotated[str, Field(description="Campaign id for update or verify.")] = "",
+        version: Annotated[int, Field(description="Current optimistic-lock version for update or verify.", ge=0)] = 0,
+        owner: Annotated[str, Field(description="Owner to assign during update.")] = "",
+        sla_due_at: Annotated[str, Field(description="Timezone-aware ISO-8601 SLA deadline during update.")] = "",
+        state: Annotated[str, Field(description="Workflow state: open, in_progress, blocked, or done.")] = "",
+        connection_id: Annotated[str, Field(description="Stored ticketing connection id for ticket_create.")] = "",
+        project: Annotated[str, Field(description="Optional ticketing project override.")] = "",
+        issue_type: Annotated[str, Field(description="Optional ticketing issue type override.")] = "",
+        cursor: Annotated[str, Field(description="Continuation cursor for bounded queue or ticket actions.")] = "",
+        limit: Annotated[int, Field(description="Bounded queue or ticket action page size.", ge=1, le=25)] = 25,
+        idempotency_key: Annotated[str, Field(description="Retry key for verify; replays return the original result.")] = "",
+        operator_role: Annotated[str, Field(description="Operator role for this write action (audit).")] = "viewer",
+        operator_scopes: Annotated[str, Field(description="Comma-separated operator scopes (audit).")] = "",
+        tenant_id: Annotated[str, Field(description="Requested tenant; the MCP server binding remains authoritative.")] = "default",
+    ) -> str:
+        """List, assign, ticket, or verify a tenant-scoped remediation campaign.
+
+        Uses the same campaign store and verification service as REST and CLI.
+        Writes require an authenticated admin operator with ``findings:write``.
+        """
+        return await execute_tool_async(
+            "risk_campaign_workflow",
+            risk_campaign_workflow_impl,
+            destructive=True,
+            required_scope="findings:write",
+            action=action,
+            campaign_id=campaign_id,
+            version=version,
+            owner=owner,
+            sla_due_at=sla_due_at,
+            state=state,
+            connection_id=connection_id,
+            project=project,
+            issue_type=issue_type,
+            cursor=cursor,
+            limit=limit,
+            idempotency_key=idempotency_key,
+            operator_role=operator_role,
+            operator_scopes=operator_scopes,
             tenant_id=tenant_id,
             _truncate_response=truncate_response,
         )

--- a/src/agent_bom/mcp_tools/risk_campaigns.py
+++ b/src/agent_bom/mcp_tools/risk_campaigns.py
@@ -7,7 +7,6 @@ import logging
 from types import SimpleNamespace
 from typing import Any
 
-from fastapi import HTTPException, Response
 from pydantic import ValidationError
 
 from agent_bom.api.idempotency_store import IdempotencyConflictError
@@ -49,6 +48,12 @@ async def risk_campaign_workflow_impl(
     _authenticated_actor: str = "",
 ) -> str:
     """List, assign, ticket, and verify tenant-scoped remediation campaigns."""
+    # Imported lazily: the campaign workflow runs against the FastAPI route layer,
+    # so fastapi is only needed when this write tool is invoked — never at MCP
+    # import/boot. Keeps the stdio MCP server importable in the clean (no-api-extra)
+    # wheel, which the packaging smoke exercises.
+    from fastapi import HTTPException, Response
+
     from agent_bom.api.routes.campaigns import (
         CampaignTicketAction,
         CampaignUpdate,

--- a/src/agent_bom/mcp_tools/risk_campaigns.py
+++ b/src/agent_bom/mcp_tools/risk_campaigns.py
@@ -1,0 +1,166 @@
+"""MCP parity surface for the canonical risk-campaign workflow."""
+
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+from fastapi import HTTPException, Response
+from pydantic import ValidationError
+
+from agent_bom.api.idempotency_store import IdempotencyConflictError
+from agent_bom.mcp_tenant import resolve_mcp_tool_tenant_id
+from agent_bom.security import sanitize_error
+
+logger = logging.getLogger(__name__)
+
+
+def _request_for_tenant(tenant_id: str, actor: str) -> Any:
+    return SimpleNamespace(
+        state=SimpleNamespace(tenant_id=tenant_id, api_key_name=actor, auth_method="mcp"),
+        headers={},
+    )
+
+
+def _load_source(tenant_id: str) -> dict[str, Any]:
+    from agent_bom.api.routes.campaigns import _load_findings, _source_payload
+
+    return _source_payload(_load_findings(_request_for_tenant(tenant_id, "mcp-operator")))
+
+
+async def risk_campaign_workflow_impl(
+    *,
+    action: str = "list",
+    campaign_id: str = "",
+    version: int = 0,
+    owner: str = "",
+    sla_due_at: str = "",
+    state: str = "",
+    connection_id: str = "",
+    project: str = "",
+    issue_type: str = "",
+    cursor: str = "",
+    limit: int = 25,
+    idempotency_key: str = "",
+    tenant_id: str = "default",
+    _truncate_response,
+    _authenticated_actor: str = "",
+) -> str:
+    """List, assign, ticket, and verify tenant-scoped remediation campaigns."""
+    from agent_bom.api.routes.campaigns import (
+        CampaignTicketAction,
+        CampaignUpdate,
+        _campaigns,
+        _source_incomplete,
+        campaign_verification_queue,
+        create_campaign_tickets,
+        sync_campaign_tickets,
+        update_campaign_workflow,
+        verify_campaign_workflow,
+    )
+
+    resolved_tenant = resolve_mcp_tool_tenant_id(tenant_id)
+    actor = (_authenticated_actor or "mcp-operator").strip()
+    normalized_action = action.strip().lower()
+    request = _request_for_tenant(resolved_tenant, actor)
+    try:
+        source = _load_source(resolved_tenant)
+        if normalized_action == "list":
+            campaigns = _campaigns(request, source)
+            result: dict[str, Any] = {
+                "schema_version": "risk-campaigns.v1",
+                "tenant_id": resolved_tenant,
+                "campaigns": campaigns,
+                "count": len(campaigns),
+                "membership_complete": not _source_incomplete(source),
+            }
+        elif normalized_action == "update":
+            if not campaign_id.strip() or version < 1:
+                return json.dumps({"status": "rejected", "error": "campaign_id and version are required for update."})
+            update_values: dict[str, Any] = {"version": version}
+            if owner:
+                update_values["owner"] = owner
+            if sla_due_at:
+                update_values["sla_due_at"] = sla_due_at
+            if state:
+                update_values["state"] = state
+            result = update_campaign_workflow(
+                request=request,
+                campaign_id=campaign_id.strip(),
+                body=CampaignUpdate.model_validate(update_values),
+                source=source,
+            )
+        elif normalized_action == "verify":
+            if not campaign_id.strip() or version < 1:
+                return json.dumps({"status": "rejected", "error": "campaign_id and version are required for verify."})
+            result = verify_campaign_workflow(
+                tenant_id=resolved_tenant,
+                campaign_id=campaign_id.strip(),
+                version=version,
+                source=source,
+                actor=actor,
+                idempotency_key=idempotency_key.strip(),
+            )
+        elif normalized_action == "verification_queue":
+            result = await campaign_verification_queue(
+                request,
+                cursor=cursor.strip() or None,
+                limit=limit,
+                _role=None,
+            )
+        elif normalized_action == "ticket_create":
+            if not campaign_id.strip() or not connection_id.strip():
+                return json.dumps({"status": "rejected", "error": "campaign_id and connection_id are required."})
+            result = await create_campaign_tickets(
+                request,
+                campaign_id.strip(),
+                CampaignTicketAction(
+                    connection_id=connection_id,
+                    project=project,
+                    issue_type=issue_type,
+                    cursor=cursor.strip() or None,
+                    limit=limit,
+                ),
+                Response(),
+                _role=None,
+            )
+        elif normalized_action == "ticket_sync":
+            if not campaign_id.strip():
+                return json.dumps({"status": "rejected", "error": "campaign_id is required."})
+            result = await sync_campaign_tickets(
+                request,
+                campaign_id.strip(),
+                Response(),
+                cursor=cursor.strip() or None,
+                limit=limit,
+                _role=None,
+            )
+        else:
+            return json.dumps(
+                {
+                    "status": "rejected",
+                    "error": "Unsupported action. Use list, update, verify, verification_queue, ticket_create, or ticket_sync.",
+                }
+            )
+    except ValidationError as exc:
+        return json.dumps({"status": "rejected", "error": exc.errors(include_url=False)})
+    except HTTPException as exc:
+        detail = exc.detail if isinstance(exc.detail, dict) else {"reason": str(exc.detail)}
+        return json.dumps({"status": "rejected", "http_status": exc.status_code, **detail})
+    except IdempotencyConflictError:
+        return json.dumps(
+            {
+                "status": "rejected",
+                "http_status": 409,
+                "reason": "Idempotency key was reused with a different verification request.",
+            }
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("MCP risk campaign workflow failed")
+        return json.dumps({"status": "error", "error": sanitize_error(exc)})
+    return _truncate_response(json.dumps(result, indent=2, default=str))
+
+
+__all__ = ["risk_campaign_workflow_impl"]

--- a/tests/test_cli_campaigns.py
+++ b/tests/test_cli_campaigns.py
@@ -54,6 +54,18 @@ class FakeCampaignsClient:
             "version": 4,
         }
 
+    def update_campaign(self, campaign_id: str, **kwargs: Any) -> dict[str, Any]:
+        self.__class__.calls.append(("update_campaign", {"campaign_id": campaign_id, **kwargs}))
+        return {"id": campaign_id, **kwargs}
+
+    def create_campaign_tickets(self, campaign_id: str, **kwargs: Any) -> dict[str, Any]:
+        self.__class__.calls.append(("create_campaign_tickets", {"campaign_id": campaign_id, **kwargs}))
+        return {"campaign_id": campaign_id, "created": 1, "failed": 0}
+
+    def sync_campaign_tickets(self, campaign_id: str, **kwargs: Any) -> dict[str, Any]:
+        self.__class__.calls.append(("sync_campaign_tickets", {"campaign_id": campaign_id, **kwargs}))
+        return {"campaign_id": campaign_id, "synced": 1, "failed": 0}
+
 
 def _install_fake(monkeypatch) -> type[FakeCampaignsClient]:
     FakeCampaignsClient.calls = []
@@ -66,7 +78,6 @@ def test_campaigns_list_table_has_owner_sla_priority_status(monkeypatch) -> None
     _install_fake(monkeypatch)
     result = CliRunner().invoke(main, ["campaigns", "list"])
     assert result.exit_code == 0, result.output
-    # Leads with a summary line (dense, cloud-CLI readability pattern).
     assert "1 campaign" in result.output
     lines = result.output.strip().splitlines()
     header = next(line for line in lines if line.startswith("id\t"))
@@ -112,6 +123,27 @@ def test_campaigns_verify_posts_version(monkeypatch) -> None:
     assert result.exit_code == 0, result.output
     assert json.loads(result.output)["verification_status"] == "verified"
     assert fake.calls[0] == ("verify_campaign", {"campaign_id": "camp-1", "version": 3})
+
+
+def test_campaign_cli_update_and_ticket_actions_use_canonical_api(monkeypatch) -> None:
+    fake = _install_fake(monkeypatch)
+    runner = CliRunner()
+
+    updated = runner.invoke(main, ["campaigns", "update", "campaign-a", "--version", "3", "--owner", "payments", "--state", "in_progress"])
+    created = runner.invoke(
+        main,
+        ["campaigns", "tickets", "create", "campaign-a", "--connection-id", "jira", "--project", "SEC"],
+    )
+    synced = runner.invoke(main, ["campaigns", "tickets", "sync", "campaign-a", "--limit", "10"])
+
+    assert updated.exit_code == created.exit_code == synced.exit_code == 0
+    assert json.loads(updated.output)["owner"] == "payments"
+    assert fake.calls[0] == (
+        "update_campaign",
+        {"campaign_id": "campaign-a", "version": 3, "owner": "payments", "sla_due_at": None, "state": "in_progress"},
+    )
+    assert fake.calls[2][0] == "create_campaign_tickets"
+    assert fake.calls[4] == ("sync_campaign_tickets", {"campaign_id": "campaign-a", "cursor": None, "limit": 10})
 
 
 class ConnRefusedClient:

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -121,7 +121,7 @@ class TestAgentBom:
         assert "quick-audit" in r.output
         assert "gateway-fleet-live-demo" in r.output
         assert "full tool catalog" in r.output
-        assert "Exposes 80 security tools via MCP protocol" in r.output
+        assert "Exposes 81 security tools via MCP protocol" in r.output
         assert "organized behind 8 workflow" in r.output
 
     def test_secrets_help_has_common_output_flags(self):

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -298,6 +298,8 @@ def test_server_card_tools_expose_capability_classes():
         # Records a triage decision to the exception store (can suppress a
         # finding); admin-gated findings:write.
         "findings_triage",
+        # Assigns, tickets, and verifies persisted remediation campaigns.
+        "risk_campaign_workflow",
     }
     # Writes that tear down or invalidate state advertise destructiveHint; issuing
     # an identity or granting access creates state and is non-destructive.
@@ -315,6 +317,7 @@ def test_server_card_tools_expose_capability_classes():
         "create_ticket",
         "sync_ticket_status",
         "findings_triage",
+        "risk_campaign_workflow",
         "cloud_side_scan",
     }
     card = build_server_card()
@@ -384,6 +387,7 @@ def test_mcp_docs_match_resource_and_prompt_catalog():
         "identity_revoke_jit",
         "identity_rotate",
         "ingest_external_scan",
+        "risk_campaign_workflow",
         "runtime_evidence_ingest",
         "shield_break_glass",
         "shield_start",

--- a/tests/test_mcp_risk_campaign_workflow.py
+++ b/tests/test_mcp_risk_campaign_workflow.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+from agent_bom.api.campaign_store import InMemoryCampaignStore, set_campaign_store
+from agent_bom.api.idempotency_store import InMemoryIdempotencyStore
+from agent_bom.api.risk_campaigns import derive_campaigns
+from agent_bom.api.stores import set_idempotency_store
+from agent_bom.mcp_tools.risk_campaigns import risk_campaign_workflow_impl
+
+
+def _truncate(value: str) -> str:
+    return value
+
+
+def test_mcp_risk_campaign_verification_uses_shared_outcome_and_tenant(monkeypatch) -> None:
+    findings = [{"id": "finding-a", "severity": "high"}]
+    campaign = derive_campaigns(findings, tenant_id="tenant-alpha", workflow_by_id={})[0]
+    campaign_id = campaign["id"]
+    store = InMemoryCampaignStore()
+    store.reconcile_memberships(
+        "tenant-alpha",
+        {campaign_id: (campaign["membership_fingerprint"], ("finding-a",), campaign["title"])},
+    )
+    set_campaign_store(store)
+    set_idempotency_store(InMemoryIdempotencyStore())
+    monkeypatch.setenv("AGENT_BOM_MCP_TENANT_ID", "tenant-alpha")
+    monkeypatch.setattr(
+        "agent_bom.mcp_tools.risk_campaigns._load_source",
+        lambda tenant_id: {"findings": findings, "total": 1, "has_more": False},
+    )
+    try:
+        result = json.loads(
+            asyncio.run(
+                risk_campaign_workflow_impl(
+                    action="verify",
+                    campaign_id=campaign_id,
+                    version=1,
+                    idempotency_key="mcp-verify-once",
+                    tenant_id="tenant-alpha",
+                    _authenticated_actor="mcp-admin",
+                    _truncate_response=_truncate,
+                )
+            )
+        )
+    finally:
+        set_campaign_store(None)
+        set_idempotency_store(None)
+
+    assert result["outcome"] == "still_affected"
+    assert result["campaign_id"] == campaign_id
+    assert store.get("tenant-alpha", campaign_id).verification_status == "failed"
+    assert store.get("default", campaign_id) is None
+
+
+def test_risk_campaign_workflow_is_advertised_and_write_gated() -> None:
+    from agent_bom.mcp_server_metadata import _TOOL_CAPABILITY_CLASSES, registered_mcp_tool_decorator_names, server_card_tool_names
+
+    assert "risk_campaign_workflow" in server_card_tool_names()
+    assert "risk_campaign_workflow" in registered_mcp_tool_decorator_names()
+    assert "WRITE" in _TOOL_CAPABILITY_CLASSES["risk_campaign_workflow"]

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -166,7 +166,7 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert "Scan repositories, images, and cloud accounts" not in hero
     assert "<b>15</b> package ecosystems" in hero
     assert "<b>16</b> compliance surfaces" in hero
-    assert "<b>80</b> MCP tools" in hero
+    assert "<b>81</b> MCP tools" in hero
     assert '<a href="#quick-start"><b>Quick start</b></a>' in hero
     assert '<a href="https://msaad00.github.io/agent-bom/">Docs</a>' in hero
     # The hero links the live demo. This project operates that Cloud Run service

--- a/tests/test_python_client.py
+++ b/tests/test_python_client.py
@@ -141,6 +141,31 @@ def test_client_exposes_findings_and_dataset_loop() -> None:
     ]
 
 
+def test_client_exposes_complete_campaign_workflow() -> None:
+    seen: list[tuple[str, str, dict[str, object], dict[str, str]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8")) if request.content else {}
+        seen.append((request.method, str(request.url), body, dict(request.headers)))
+        return httpx.Response(200, json={"ok": True})
+
+    client = _client(handler)
+    client.update_campaign("campaign/a", version=2, owner="payments", state="in_progress")
+    client.verify_campaign("campaign/a", version=3, idempotency_key="verify-once")
+    client.create_campaign_tickets("campaign/a", connection_id="jira", project="SEC", limit=10)
+    client.sync_campaign_tickets("campaign/a", cursor="next", limit=5)
+
+    assert [(method, url) for method, url, _, _ in seen] == [
+        ("PATCH", "https://agent-bom.example.com/v1/campaigns/campaign%2Fa"),
+        ("POST", "https://agent-bom.example.com/v1/campaigns/campaign%2Fa/verify"),
+        ("POST", "https://agent-bom.example.com/v1/campaigns/campaign%2Fa/tickets"),
+        ("POST", "https://agent-bom.example.com/v1/campaigns/campaign%2Fa/tickets/sync?cursor=next&limit=5"),
+    ]
+    assert seen[0][2] == {"version": 2, "owner": "payments", "state": "in_progress"}
+    assert seen[1][3]["idempotency-key"] == "verify-once"
+    assert seen[2][2] == {"connection_id": "jira", "project": "SEC", "issue_type": "", "limit": 10}
+
+
 def test_client_exposes_runtime_event_sessions() -> None:
     seen: list[tuple[str, str]] = []
     bodies: list[dict[str, object]] = []

--- a/tests/test_risk_campaigns.py
+++ b/tests/test_risk_campaigns.py
@@ -14,10 +14,11 @@ from starlette.testclient import TestClient
 
 from agent_bom.api.campaign_store import InMemoryCampaignStore, SQLiteCampaignStore, get_campaign_store, set_campaign_store
 from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore, set_compliance_hub_store
+from agent_bom.api.idempotency_store import InMemoryIdempotencyStore
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.risk_campaigns import derive_campaigns
 from agent_bom.api.store import InMemoryJobStore
-from agent_bom.api.stores import set_job_store
+from agent_bom.api.stores import set_idempotency_store, set_job_store
 from agent_bom.ticketing.connection_store import InMemoryTicketingStore, TicketLink, get_ticketing_store, set_ticketing_store
 from agent_bom.ticketing.service import TicketingError
 
@@ -43,6 +44,7 @@ def _stores() -> Iterator[None]:
     os.environ["AGENT_BOM_TRUST_PROXY_AUTH"] = "1"
     os.environ["AGENT_BOM_TRUST_PROXY_AUTH_SECRET"] = PROXY_SECRET
     set_campaign_store(InMemoryCampaignStore())
+    set_idempotency_store(InMemoryIdempotencyStore())
     set_compliance_hub_store(InMemoryComplianceHubStore())
     set_ticketing_store(InMemoryTicketingStore())
     set_job_store(InMemoryJobStore())
@@ -50,6 +52,7 @@ def _stores() -> Iterator[None]:
         yield
     finally:
         set_campaign_store(None)
+        set_idempotency_store(None)
         set_compliance_hub_store(None)
         set_ticketing_store(None)
         for key, value in prior.items():
@@ -679,6 +682,42 @@ def test_campaign_verify_fails_with_remaining_members_and_is_cas_safe(monkeypatc
     assert first.json()["evidence_scope"]["membership_complete"] is True
     stale = client.post(f"/v1/campaigns/{campaign['id']}/verify", json={"version": campaign["version"]}, headers=_headers())
     assert stale.status_code == 409
+
+
+def test_campaign_verify_returns_honest_outcome_and_replays_idempotently(monkeypatch) -> None:
+    from agent_bom.api.server import app
+
+    monkeypatch.setattr("agent_bom.api.routes.campaigns._load_findings", lambda request: _findings())
+    client = TestClient(app)
+    campaign = next(item for item in client.get("/v1/campaigns", headers=_headers()).json()["campaigns"] if item["finding_count"] == 2)
+    headers = {**_headers(), "Idempotency-Key": "verify-campaign-once"}
+
+    first = client.post(f"/v1/campaigns/{campaign['id']}/verify", json={"version": campaign["version"]}, headers=headers)
+    replay = client.post(f"/v1/campaigns/{campaign['id']}/verify", json={"version": campaign["version"]}, headers=headers)
+
+    assert first.status_code == 200 and replay.status_code == 200
+    assert replay.json() == first.json()
+    assert first.json()["outcome"] == "still_affected"
+    assert first.json()["retry_state"] == "ready_after_rescan"
+
+
+def test_campaign_verify_reports_unavailable_evidence_without_mutating(monkeypatch) -> None:
+    from agent_bom.api.server import app
+
+    monkeypatch.setattr("agent_bom.api.routes.campaigns._load_findings", lambda request: _findings())
+    client = TestClient(app)
+    campaign = client.get("/v1/campaigns", headers=_headers()).json()["campaigns"][0]
+    monkeypatch.setattr(
+        "agent_bom.api.routes.campaigns._load_findings",
+        lambda request: {"findings": _findings(), "total": 4, "total_approximate": False, "has_more": True},
+    )
+
+    response = client.post(f"/v1/campaigns/{campaign['id']}/verify", json={"version": campaign["version"]}, headers=_headers())
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["outcome"] == "unavailable_evidence"
+    assert response.json()["detail"]["retry_state"] == "awaiting_complete_snapshot"
+    assert get_campaign_store().get("tenant-alpha", campaign["id"]).version == campaign["version"]
 
 
 def test_campaign_verify_survives_restart_and_disappeared_campaign(monkeypatch, tmp_path) -> None:

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -2809,7 +2809,7 @@ function CodingAgentDrawer({ open, onClose }: { open: boolean; onClose: () => vo
       }
       headerAside={
         <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 dark:border-emerald-900/60 bg-emerald-500/10 dark:bg-emerald-950/30 px-2.5 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
-          <Bot className="h-3 w-3" /> 80 MCP tools
+          <Bot className="h-3 w-3" /> 81 MCP tools
         </span>
       }
     >

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -839,7 +839,7 @@ describe("ConnectionsPage — Connect segment", () => {
 
     const drawer = await screen.findByRole("dialog", { name: /Connect a coding agent/ });
     expect(within(drawer).getByText("agent-bom mcp-server")).toBeInTheDocument();
-    expect(within(drawer).getByText(/80 MCP tools/)).toBeInTheDocument();
+    expect(within(drawer).getByText(/81 MCP tools/)).toBeInTheDocument();
   });
 
   it("syncs the segmented tab to the URL", async () => {


### PR DESCRIPTION
## Summary

- make campaign verification return explicit `verified_fixed`, `still_affected`, and unavailable-evidence retry states with tenant-scoped idempotent replay
- expose the existing persisted owner/SLA/ticket/rescan workflow through the typed client, CLI, REST, and one authenticated MCP workflow tool
- regenerate OpenAPI, product metrics, documentation SVGs, registry catalogs, and every public MCP count for the 81-tool surface

## Verification

- `make preflight`
- `uv run ruff check src tests scripts`
- `uv run mypy src/agent_bom`
- `uv run python scripts/check_exception_sanitization.py`
- `uv run pytest -q tests/test_risk_campaigns.py tests/test_mcp_risk_campaign_workflow.py` (66 passed)
- `uv run pytest -q tests/test_deployment.py tests/test_stats_alignment.py` (93 passed, 2 skipped)
- supported Node 24: `npm run verify:toolchain`, `npm run typecheck`, `npm test -- --run` (1,169 passed), `npm run build`

## Notes

- campaign writes remain authenticated and tenant-scoped; MCP uses the server-bound tenant and requires `findings:write`
- existing fields/routes remain compatible; verification response fields are additive
- incomplete findings snapshots never mutate verification state
