### PR TITLE
feat(ui): guide the blast-radius journey by persona

### DIFF
--- a/ui/app/demo-estate/page.tsx
+++ b/ui/app/demo-estate/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 
 import { StatStrip } from "@/components/stat-strip";
+import { PersonaStartRoutes } from "@/components/persona-start-routes";
 import { PageErrorState, PageLoadingState } from "@/components/states/page-state";
 import { api, type EnterpriseDemoStory } from "@/lib/api";
 
@@ -189,7 +190,7 @@ export default function DemoEstatePage() {
           {primary.asset_path.map((asset, index) => (
             <div className="contents" key={asset}>
               {index > 0 ? <ArrowRight className="h-4 w-4 shrink-0 text-[color:var(--text-tertiary)]" aria-hidden="true" /> : null}
-              <span className="max-w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 font-mono text-xs text-[color:var(--foreground)]" title={asset}>
+              <span className="min-w-0 max-w-full break-all rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 font-mono text-xs text-[color:var(--foreground)]" title={asset}>
                 {asset}
               </span>
             </div>
@@ -200,6 +201,8 @@ export default function DemoEstatePage() {
           {primary.data_classifications.map((classification) => <span key={classification} className="rounded-full border border-rose-500/30 bg-rose-500/10 px-2.5 py-1 font-semibold uppercase text-rose-700 dark:text-rose-200">{classification}</span>)}
         </div>
       </section>
+
+      <PersonaStartRoutes />
 
       <section
         className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 elev-1"

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -149,7 +149,7 @@ function SecurityGraphPageContent() {
       setCompletedSteps((current) => ({ ...current, [next]: true }));
       if (next === "fix") {
         setPathView("path");
-      } else if (next === "expand" || next === "impact") {
+      } else if (next === "impact") {
         setPathView("graph");
         setInvestigationFocusMode(true);
       } else {
@@ -171,9 +171,10 @@ function SecurityGraphPageContent() {
 
   const handleStepHint = useCallback(
     (step: "expand" | "impact" | "fix") => {
-      setCompletedSteps((current) => ({ ...current, path: true, [step]: true }));
-      if (investigationStep === "path" && step === "expand") {
-        setInvestigationStep("expand");
+      const lifecycleStep: InvestigationStep = step === "expand" ? "impact" : step;
+      setCompletedSteps((current) => ({ ...current, path: true, [lifecycleStep]: true }));
+      if (investigationStep === "path" && lifecycleStep === "impact") {
+        setInvestigationStep("impact");
       }
     },
     [investigationStep, setInvestigationStep],
@@ -669,6 +670,11 @@ function SecurityGraphPageContent() {
             step={investigationStep}
             onStepChange={setInvestigationStep}
             completed={completedSteps}
+            stepHrefs={{
+              owner: "/remediation#campaigns",
+              fix: "/remediation#campaigns",
+              verify: "/remediation#verification",
+            }}
           />
           {pinnedNodeId ? (
             <span className="text-xs text-[color:var(--text-tertiary)]">

--- a/ui/components/findings-queue.tsx
+++ b/ui/components/findings-queue.tsx
@@ -506,7 +506,7 @@ function EngineeringCells({
             {vuln.fixed_version ? `Upgrade ${vuln.fixed_version}` : "Fix unavailable"}
           </span>
           <span className="max-w-[14rem] truncate font-mono text-[11px] text-[var(--text-tertiary)]" title={verifyCommand ?? undefined}>
-            {verifyCommand ? `Verify: ${verifyCommand}` : "Verify unavailable"}
+            {verifyCommand ? `Verify: ${verifyCommand}` : "No scanner-provided verification command"}
           </span>
         </div>
       </td>

--- a/ui/components/investigation-step-strip.tsx
+++ b/ui/components/investigation-step-strip.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { CheckCircle2, Focus, Network, Radar, Wrench } from "lucide-react";
+import Link from "next/link";
+import { CheckCircle2, Focus, Radar, ShieldCheck, UserRound, Wrench } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
-export type InvestigationStep = "path" | "expand" | "impact" | "fix";
+export type InvestigationStep = "path" | "impact" | "owner" | "fix" | "verify";
 
 const STEPS: {
   key: InvestigationStep;
@@ -12,13 +13,17 @@ const STEPS: {
   hint: string;
 }[] = [
   { key: "path", label: "Path", icon: Focus, hint: "Select a ranked exposure path" },
-  { key: "expand", label: "Expand", icon: Network, hint: "Pin a node and load neighbors" },
-  { key: "impact", label: "Impact", icon: Radar, hint: "Compute blast radius for the pin" },
+  { key: "impact", label: "Impact", icon: Radar, hint: "Review blast radius and affected assets" },
+  { key: "owner", label: "Owner", icon: UserRound, hint: "Assign an owner and remediation SLA" },
   { key: "fix", label: "Fix", icon: Wrench, hint: "Open the recommended remediation" },
+  { key: "verify", label: "Verify", icon: ShieldCheck, hint: "Rescan and record the evidence-backed result" },
 ];
 
 export function parseInvestigationStep(raw: string | null | undefined): InvestigationStep {
-  if (raw === "expand" || raw === "impact" || raw === "fix" || raw === "path") return raw;
+  // Preserve old graph links while presenting the product lifecycle rather
+  // than an implementation-specific graph expansion step.
+  if (raw === "expand") return "impact";
+  if (raw === "impact" || raw === "owner" || raw === "fix" || raw === "verify" || raw === "path") return raw;
   return "path";
 }
 
@@ -30,45 +35,68 @@ export function InvestigationStepStrip({
   step,
   onStepChange,
   completed,
+  stepHrefs,
 }: {
   step: InvestigationStep;
   onStepChange: (next: InvestigationStep) => void;
   /** Steps the operator has already completed in this session. */
   completed?: Partial<Record<InvestigationStep, boolean>> | undefined;
+  /** Continue on an existing product surface instead of duplicating it here. */
+  stepHrefs?: Partial<Record<InvestigationStep, string>> | undefined;
 }) {
   const activeIndex = STEPS.findIndex((item) => item.key === step);
 
   return (
-    <nav
-      aria-label="Investigation steps"
-      data-testid="investigation-step-strip"
-      className="flex flex-wrap gap-2"
-    >
-      {STEPS.map((item, index) => {
-        const active = item.key === step;
-        const done = Boolean(completed?.[item.key]) || index < activeIndex;
-        const Icon = done && !active ? CheckCircle2 : item.icon;
-        return (
-          <button
-            key={item.key}
-            type="button"
-            aria-current={active ? "step" : undefined}
-            title={item.hint}
-            onClick={() => onStepChange(item.key)}
-            className={`inline-flex items-center gap-2 rounded-lg border px-3 py-1.5 text-xs font-medium transition ${
-              active
-                ? "border-emerald-600/50 bg-emerald-500/10 text-emerald-800 dark:text-emerald-200"
-                : done
-                  ? "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]"
-                  : "border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-[color:var(--text-tertiary)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
-            }`}
-          >
-            <span className="font-mono text-[10px] opacity-70">{index + 1}</span>
-            <Icon className="h-3.5 w-3.5" />
-            {item.label}
-          </button>
-        );
-      })}
+    <nav aria-label="Investigation steps" data-testid="investigation-step-strip" className="min-w-0">
+      <ol className="flex min-w-0 flex-wrap gap-2">
+        {STEPS.map((item, index) => {
+          const active = item.key === step;
+          const done = Boolean(completed?.[item.key]) || index < activeIndex;
+          const Icon = done && !active ? CheckCircle2 : item.icon;
+          const descriptionId = `investigation-step-${item.key}-hint`;
+          const className = `inline-flex items-center gap-2 rounded-lg border px-3 py-1.5 text-xs font-medium transition motion-reduce:transition-none ${
+            active
+              ? "border-emerald-600/50 bg-emerald-500/10 text-emerald-800 dark:text-emerald-200"
+              : done
+                ? "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]"
+                : "border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-[color:var(--text-tertiary)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
+          }`;
+          const content = (
+            <>
+              <span className="font-mono text-[10px] opacity-70">{index + 1}</span>
+              <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+              {item.label}
+              <span id={descriptionId} className="sr-only">{item.hint}</span>
+            </>
+          );
+          return (
+            <li key={item.key}>
+              {stepHrefs?.[item.key] ? (
+                <Link
+                  href={stepHrefs[item.key]!}
+                  aria-current={active ? "step" : undefined}
+                  aria-describedby={descriptionId}
+                  title={item.hint}
+                  className={className}
+                >
+                  {content}
+                </Link>
+              ) : (
+                <button
+                  type="button"
+                  aria-current={active ? "step" : undefined}
+                  aria-describedby={descriptionId}
+                  title={item.hint}
+                  onClick={() => onStepChange(item.key)}
+                  className={className}
+                >
+                  {content}
+                </button>
+              )}
+            </li>
+          );
+        })}
+      </ol>
     </nav>
   );
 }

--- a/ui/components/persona-start-routes.tsx
+++ b/ui/components/persona-start-routes.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link";
+
+type PersonaStart = {
+  label: string;
+  persona: string;
+  command: string;
+  artifact: string;
+  href: string;
+};
+
+const STARTS: PersonaStart[] = [
+  {
+    label: "CLI scan",
+    persona: "Developer / agent builder",
+    command: "agent-bom scan .",
+    artifact: "Inventory, prioritized findings, and exportable evidence",
+    href: "/scan",
+  },
+  {
+    label: "Docker scan",
+    persona: "Developer / evaluator",
+    command: "docker run --rm agentbom/agent-bom:latest agents --demo",
+    artifact: "An isolated synthetic scan without a local install",
+    href: "/scan",
+  },
+  {
+    label: "GitHub Action",
+    persona: "AppSec / SecOps",
+    command: "uses: msaad00/agent-bom@v0.100.0",
+    artifact: "SARIF, pull-request summary, and policy exit code",
+    href: "/findings",
+  },
+  {
+    label: "Control plane",
+    persona: "Platform operator",
+    command: "agent-bom serve --host 127.0.0.1",
+    artifact: "Centralized fleet, findings, graph, and audit evidence",
+    href: "/connections",
+  },
+  {
+    label: "Compliance evidence",
+    persona: "GRC / audit",
+    command: "agent-bom scan . --compliance",
+    artifact: "Control mappings and signed evidence paths",
+    href: "/compliance",
+  },
+  {
+    label: "Runtime enforcement",
+    persona: "Security / platform",
+    command: "agent-bom gateway serve --from-control-plane http://127.0.0.1:8422",
+    artifact: "Allow, warn, block, and auditable tool-call decisions",
+    href: "/runtime",
+  },
+];
+
+export function PersonaStartRoutes() {
+  return (
+    <section
+      role="region"
+      aria-label="Start by workflow"
+      className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] elev-1"
+    >
+      <details className="group">
+        <summary className="flex cursor-pointer list-none items-start justify-between gap-4 p-5 [&::-webkit-details-marker]:hidden">
+          <span>
+            <span className="block text-sm font-semibold text-[color:var(--foreground)]">Start with the workflow you already use</span>
+            <span className="mt-1 block text-xs text-[color:var(--text-tertiary)]">First command → artifact → existing product surface. Local scan is one entry point, not the product boundary.</span>
+          </span>
+          <span className="shrink-0 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--text-tertiary)] group-open:hidden">Show 6 starts</span>
+          <span className="hidden shrink-0 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--text-tertiary)] group-open:inline">Hide starts</span>
+        </summary>
+        <div className="grid gap-3 border-t border-[color:var(--border-subtle)] p-5 md:grid-cols-2 xl:grid-cols-3">
+          {STARTS.map((start) => (
+            <article key={start.label} className="min-w-0 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-4">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">{start.persona}</p>
+              <h3 className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">{start.label}</h3>
+              <code className="mt-3 block overflow-x-auto rounded-md bg-[color:var(--background)] px-2.5 py-2 text-[11px] text-emerald-700 dark:text-emerald-200">{start.command}</code>
+              <p className="mt-3 text-xs leading-5 text-[color:var(--text-secondary)]">{start.artifact}</p>
+              <Link href={start.href} className="mt-3 inline-flex text-xs font-medium text-emerald-700 hover:underline dark:text-emerald-300">
+                Continue in product
+              </Link>
+            </article>
+          ))}
+        </div>
+      </details>
+    </section>
+  );
+}

--- a/ui/components/risk-campaign-command-center.tsx
+++ b/ui/components/risk-campaign-command-center.tsx
@@ -98,17 +98,20 @@ type TicketProgress = {
 };
 
 const ACTION_BATCH_LIMIT = 25;
+const CAMPAIGN_PAGE_SIZE = 10;
 
 function CampaignCard({
   campaign,
   onChanged,
   connections,
   onReload,
+  defaultOpen,
 }: {
   campaign: RiskCampaign;
   onChanged: (campaign: RiskCampaign) => void;
   connections: TicketingConnection[];
   onReload: () => void;
+  defaultOpen: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -247,7 +250,7 @@ function CampaignCard({
   >;
 
   return (
-    <details className="group risk-campaign-card">
+    <details className="group risk-campaign-card" open={defaultOpen || undefined}>
       <summary className="risk-campaign-summary">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
@@ -490,6 +493,7 @@ function VerificationQueue() {
 
   return (
     <details
+      id="verification"
       className="group risk-campaign-queue"
       open={entries.length > 0 || Boolean(error)}
     >
@@ -569,6 +573,7 @@ export function RiskCampaignCommandCenter() {
   const [connections, setConnections] = useState<TicketingConnection[]>([]);
   const [totalFindings, setTotalFindings] = useState<number | null>(null);
   const [totalApproximate, setTotalApproximate] = useState(false);
+  const [visibleCampaignCount, setVisibleCampaignCount] = useState(CAMPAIGN_PAGE_SIZE);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -580,6 +585,7 @@ export function RiskCampaignCommandCenter() {
       setWindowDays(response.finding_window_days);
       setTotalFindings(response.total_findings);
       setTotalApproximate(response.total_approximate);
+      setVisibleCampaignCount(CAMPAIGN_PAGE_SIZE);
       try {
         const ticketing = await api.listTicketingConnections();
         setConnections(ticketing.connections.filter((connection) => connection.status === "active"));
@@ -596,12 +602,16 @@ export function RiskCampaignCommandCenter() {
   useEffect(() => { void load(); }, [load]);
 
   const campaignFindingCount = useMemo(() => campaigns.reduce((sum, campaign) => sum + campaign.finding_count, 0), [campaigns]);
+  const visibleCampaigns = useMemo(
+    () => campaigns.slice(0, visibleCampaignCount),
+    [campaigns, visibleCampaignCount],
+  );
   const updateCampaign = useCallback((updated: RiskCampaign) => {
     setCampaigns((current) => current.map((campaign) => campaign.id === updated.id ? updated : campaign));
   }, []);
 
   return (
-    <section aria-labelledby="risk-campaigns-title" className="space-y-4">
+    <section id="campaigns" aria-labelledby="risk-campaigns-title" className="space-y-4 scroll-mt-24">
       {loading ? (
         <PageLoadingState title="Loading prioritized campaigns" detail="Reading server-authored risk priorities and workflow state." />
       ) : error ? (
@@ -612,7 +622,7 @@ export function RiskCampaignCommandCenter() {
         <div>
           <div className="risk-campaign-kicker">Prioritized remediation</div>
           <h2 id="risk-campaigns-title" className="risk-page-title">Risk campaigns</h2>
-          <p className="risk-page-copy">{campaigns.length} campaigns cluster {campaignFindingCount} finding{campaignFindingCount === 1 ? "" : "s"} into owner-ready work.</p>
+          <p className="risk-page-copy">{campaigns.length} campaigns cluster {campaignFindingCount} finding{campaignFindingCount === 1 ? "" : "s"} into owner-ready work. Start with the highest-priority campaign, opened below.</p>
         </div>
         <div className="flex flex-wrap gap-2 text-xs">
           <Link href="/security-graph" className="risk-campaign-investigate">Open investigation</Link>
@@ -632,8 +642,22 @@ export function RiskCampaignCommandCenter() {
       {!loading && !error && campaigns.length > 0 ? (
         <>
           <div className="grid gap-1.5">
-            {campaigns.map((campaign) => <CampaignCard key={campaign.id} campaign={campaign} onChanged={updateCampaign} connections={connections} onReload={() => void load()} />)}
+            {visibleCampaigns.map((campaign, index) => <CampaignCard key={campaign.id} campaign={campaign} onChanged={updateCampaign} connections={connections} onReload={() => void load()} defaultOpen={index === 0} />)}
           </div>
+          {visibleCampaignCount < campaigns.length ? (
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3 text-xs text-[color:var(--text-tertiary)]">
+              <span>Showing {visibleCampaigns.length} of {campaigns.length} prioritized campaigns.</span>
+              <button
+                type="button"
+                onClick={() => setVisibleCampaignCount((count) => Math.min(count + CAMPAIGN_PAGE_SIZE, campaigns.length))}
+                className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-1.5 font-medium text-[color:var(--foreground)] hover:border-[color:var(--border-strong)]"
+              >
+                Show {Math.min(CAMPAIGN_PAGE_SIZE, campaigns.length - visibleCampaignCount)} more campaigns
+              </button>
+            </div>
+          ) : campaigns.length > CAMPAIGN_PAGE_SIZE ? (
+            <p className="text-xs text-[color:var(--text-tertiary)]">Showing all {campaigns.length} prioritized campaigns.</p>
+          ) : null}
           <div className="risk-proof-note">
             <CheckCircle2 className="h-3.5 w-3.5" /> Priority is supplied by the server; modeled reduction appears only with its server-authored basis. Ticket actions use stored connections.
           </div>

--- a/ui/e2e/workspace-actions.spec.ts
+++ b/ui/e2e/workspace-actions.spec.ts
@@ -174,9 +174,10 @@ test("remediation compact rows disclose detail and durable re-verification", asy
 
   const campaignSummary = page.getByText(campaign.title, { exact: true });
   await expect(campaignSummary).toBeVisible();
-  await expect(page.getByRole("button", { name: /Why this priority/i })).toBeHidden();
-  await campaignSummary.click();
-  await page.getByRole("button", { name: /Why this priority/i }).click();
+  const priorityDisclosure = page.getByRole("button", { name: /Why this priority/i });
+  await expect(priorityDisclosure).toBeVisible();
+  await expect(priorityDisclosure).toHaveAttribute("aria-expanded", "false");
+  await priorityDisclosure.click();
   await expect(page.getByText("Observed priority evidence", { exact: true })).toBeVisible();
 
   await page.getByRole("button", { name: "Details", exact: true }).click();

--- a/ui/tests/demo-estate-page.test.tsx
+++ b/ui/tests/demo-estate-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import DemoEstatePage from "@/app/demo-estate/page";
@@ -183,6 +183,19 @@ describe("DemoEstatePage", () => {
     expect(screen.getByText("Demo findings")).toBeInTheDocument();
     expect(screen.getByText("Evidence-linked correlations")).toBeInTheDocument();
     expect(screen.queryByText("Attack paths")).not.toBeInTheDocument();
+    const incident = screen.getByRole("heading", { name: /Sensitive-data path stopped/i }).closest("section");
+    expect(within(incident!).getByTitle(story.primary_correlation.asset_path[0]!)).toHaveClass("break-all");
+    const starts = screen.getByRole("region", { name: /Start by workflow/i });
+    for (const label of [
+      "CLI scan",
+      "Docker scan",
+      "GitHub Action",
+      "Control plane",
+      "Compliance evidence",
+      "Runtime enforcement",
+    ]) {
+      expect(within(starts).getByText(label)).toBeInTheDocument();
+    }
   });
 
   it("renders each finding as a chain, with counts that reconcile", async () => {

--- a/ui/tests/investigation-step-strip.test.tsx
+++ b/ui/tests/investigation-step-strip.test.tsx
@@ -9,19 +9,36 @@ import {
 
 describe("InvestigationStepStrip", () => {
   it("parses step query values with a safe default", () => {
-    expect(parseInvestigationStep("expand")).toBe("expand");
+    expect(parseInvestigationStep("expand")).toBe("impact");
     expect(parseInvestigationStep("impact")).toBe("impact");
+    expect(parseInvestigationStep("owner")).toBe("owner");
     expect(parseInvestigationStep("fix")).toBe("fix");
+    expect(parseInvestigationStep("verify")).toBe("verify");
     expect(parseInvestigationStep(null)).toBe("path");
     expect(parseInvestigationStep("nope")).toBe("path");
+  });
+
+  it("guides the complete finding lifecycle in order", () => {
+    render(<InvestigationStepStrip step="impact" onStepChange={vi.fn()} />);
+
+    const steps = screen.getAllByRole("listitem");
+    expect(steps).toHaveLength(5);
+    expect(steps.map((item) => item.textContent)).toEqual([
+      expect.stringMatching(/1Path/),
+      expect.stringMatching(/2Impact/),
+      expect.stringMatching(/3Owner/),
+      expect.stringMatching(/4Fix/),
+      expect.stringMatching(/5Verify/),
+    ]);
+    expect(screen.queryByRole("button", { name: /Expand/i })).not.toBeInTheDocument();
   });
 
   it("notifies when the operator advances a step", async () => {
     const user = userEvent.setup();
     const onStepChange = vi.fn();
     render(<InvestigationStepStrip step="path" onStepChange={onStepChange} />);
-    await user.click(screen.getByRole("button", { name: /Expand/i }));
-    expect(onStepChange).toHaveBeenCalledWith("expand");
+    await user.click(screen.getByRole("button", { name: /Impact/i }));
+    expect(onStepChange).toHaveBeenCalledWith("impact");
   });
 
   it("marks the active step for assistive tech", () => {
@@ -29,6 +46,28 @@ describe("InvestigationStepStrip", () => {
     expect(screen.getByRole("button", { name: /Impact/i })).toHaveAttribute(
       "aria-current",
       "step",
+    );
+    expect(screen.getByRole("button", { name: /Impact/i })).toHaveAccessibleDescription(
+      /blast radius/i,
+    );
+  });
+
+  it("uses continuation links without creating another workflow surface", () => {
+    render(
+      <InvestigationStepStrip
+        step="impact"
+        onStepChange={vi.fn()}
+        stepHrefs={{ owner: "/remediation#campaigns", fix: "/remediation#campaigns", verify: "/remediation#verification" }}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: /Owner/i })).toHaveAttribute(
+      "href",
+      "/remediation#campaigns",
+    );
+    expect(screen.getByRole("link", { name: /Verify/i })).toHaveAttribute(
+      "href",
+      "/remediation#verification",
     );
   });
 });

--- a/ui/tests/product-proof-contract.test.ts
+++ b/ui/tests/product-proof-contract.test.ts
@@ -97,4 +97,9 @@ describe("product proof capture contract", () => {
     expect(findingsQueue).toMatch(/getOsvVulnerabilityUrl\((?:v|vuln)\.id\)/);
     expect(findingsQueue).not.toContain("https://osv.dev/vulnerability/${v.id}");
   });
+
+  it("explains why a finding cannot be verified", () => {
+    expect(findingsQueue).not.toContain('"Verify unavailable"');
+    expect(findingsQueue).toContain("No scanner-provided verification command");
+  });
 });

--- a/ui/tests/risk-campaign-command-center.test.tsx
+++ b/ui/tests/risk-campaign-command-center.test.tsx
@@ -137,6 +137,39 @@ describe("RiskCampaignCommandCenter", () => {
     expect(screen.getAllByText("Unknown").length).toBeGreaterThan(0);
   });
 
+  it("opens the highest-priority campaign as the default guided work item", async () => {
+    render(<RiskCampaignCommandCenter />);
+
+    const title = await screen.findByText(response.campaigns[0]!.title);
+    expect(title.closest("details")).toHaveAttribute("open");
+    expect(screen.getByText(/Start with the highest-priority campaign/i)).toBeInTheDocument();
+  });
+
+  it("progressively discloses large campaign queues", async () => {
+    const campaigns = Array.from({ length: 12 }, (_, index) => ({
+      ...response.campaigns[0]!,
+      id: `campaign-${index + 1}`,
+      title: `Campaign ${index + 1}`,
+      priority_score: 10 - index / 10,
+    }));
+    vi.mocked(api.listRiskCampaigns).mockResolvedValue({
+      ...response,
+      campaigns,
+      count: campaigns.length,
+      truncated: false,
+      total_findings: campaigns.length,
+      total_approximate: false,
+    });
+
+    const { container } = render(<RiskCampaignCommandCenter />);
+    await screen.findByText("Campaign 1");
+
+    expect(container.querySelectorAll(".risk-campaign-card")).toHaveLength(10);
+    expect(screen.getByText(/Showing 10 of 12 prioritized campaigns/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Show 2 more campaigns/i }));
+    expect(container.querySelectorAll(".risk-campaign-card")).toHaveLength(12);
+  });
+
   it("renders generic finding campaigns without assuming a CVE workflow", async () => {
     vi.mocked(api.listRiskCampaigns).mockResolvedValue({
       ...response,


### PR DESCRIPTION
## Summary

- guide graph investigations through Path → Impact → Owner → Fix → Verify while continuing into the existing remediation surface
- open the highest-priority campaign by default, bound large campaign queues to 10 rendered cards, and disclose additional campaigns on demand
- add six first-command → artifact persona starts to the synthetic enterprise demo and explain unavailable verification evidence
- prevent long correlated asset identifiers from overflowing the mobile demo

## Verification

- `npm run verify:toolchain` (Node 24.19.0 / npm 10.9.7)
- `npm run lint -- <changed UI and test files>`
- `npm run typecheck`
- `npm test -- --run` — 185 files, 1,174 tests
- `npm run build`
- `uv run ruff check src tests`
- `uv run mypy src/agent_bom`
- `make preflight`
- authenticated browser walkthrough against the seeded estate: dark/light desktop, 390px mobile, graph lifecycle handoff, campaign-first remediation, and console error review

## Notes

- existing graph, findings, remediation, compliance, connections, and runtime pages remain the product surfaces; this change adds guided continuity rather than a parallel workflow
- the API remains authoritative for campaign priority and completeness; partial membership continues to block workflow writes
