### PR TITLE
Make docker-mcp pin test robust to CI dubious-ownership (post-#4813)

### DIFF
--- a/tests/test_docker_mcp_pin.py
+++ b/tests/test_docker_mcp_pin.py
@@ -39,13 +39,19 @@ def test_shipped_pin_is_a_full_sha_reachable_in_this_repository() -> None:
     current = pin.read_pin(SERVER_YAML.read_text(encoding="utf-8"))
     assert current is not None, "server.yaml lost its source.commit pin"
     assert re.fullmatch(r"[0-9a-f]{40}", current), f"source.commit must be a full SHA, not a prefix or a branch: {current!r}"
+    # ``-c safe.directory=*`` so these read-only queries work when the repo is
+    # checked out under a different UID than the process (git's dubious-ownership
+    # guard otherwise makes cat-file exit 128 — indistinguishable from a missing
+    # object — and blanks the is-shallow-repository probe below so its skip never
+    # fires). This surfaced on the musl CI container's newer git. Reachability is
+    # still enforced: a genuinely absent commit exits 1 and fails the assert.
     resolved = subprocess.run(
-        ["git", "cat-file", "-e", f"{current}^{{commit}}"],
+        ["git", "-c", "safe.directory=*", "cat-file", "-e", f"{current}^{{commit}}"],
         cwd=ROOT,
         capture_output=True,
     )
     shallow = subprocess.run(
-        ["git", "rev-parse", "--is-shallow-repository"],
+        ["git", "-c", "safe.directory=*", "rev-parse", "--is-shallow-repository"],
         cwd=ROOT,
         capture_output=True,
         text=True,


### PR DESCRIPTION
Follow-up to #4813, which merged before this could land on its branch.

**What #4813 surfaced:** the base image bump to `3.14.7-alpine3.23` ships a newer git. In the `Test (Alpine/musl)` container the repo is checked out under a different UID than the test process, so git's dubious-ownership guard makes `git cat-file -e <pin>^{commit}` exit **128** — which `test_docker_mcp_pin.py::test_shipped_pin_is_a_full_sha_reachable_in_this_repository` could not distinguish from a missing object — and also blanks its `--is-shallow-repository` probe so the intended skip never fired. The pin commit is genuinely reachable; the failure was environmental (returncode 128 + git's "detected dubious ownership … add safe.directory" message).

**Fix:** run both read-only git queries with `-c safe.directory=*`, so they work regardless of checkout ownership. Reachability is still enforced — a truly absent commit exits 1 and fails the assert.

Verified: `pytest tests/test_docker_mcp_pin.py` (4 passed), ruff clean. Prevents the intermittent Alpine failure from recurring on future PRs now that the base bump is on main.