### PR TITLE
fix(ci): give Python coverage lane bounded headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -898,9 +898,11 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    # Observed worst case is ~17.6 minutes on the slowest matrix leg; 25 keeps
-    # real headroom while surfacing a hung suite well before a 35-minute burn.
-    timeout-minutes: 25
+    # The Python 3.11 main-push lane also collects coverage and reached the
+    # former 25-minute ceiling twice at cd43aadee while 3.13/3.14 completed.
+    # Keep a bounded 35-minute budget so normal suite growth can finish while
+    # a genuinely hung run still releases the hosted runner promptly.
+    timeout-minutes: 35
     permissions:
       contents: read
     needs: changes

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -121,12 +121,13 @@ def test_path_gated_jobs_remain_cancellable() -> None:
 
 
 def test_test_job_timeout_leaves_margin_over_observed_worst_case() -> None:
-    """25 minutes keeps ~40% headroom over the ~17.6 min worst case seen on main.
+    """Keep bounded headroom over the Python 3.11 coverage lane on main.
 
-    A 35-minute ceiling let a hung suite burn a runner for another quarter hour
-    before anyone saw it.
+    The coverage lane reached the former 25-minute ceiling twice at
+    ``cd43aadee`` while the 3.13 and 3.14 lanes completed successfully. A
+    35-minute ceiling preserves a hard bound while allowing normal suite growth.
     """
-    assert _ci()["jobs"]["test"]["timeout-minutes"] == 25
+    assert _ci()["jobs"]["test"]["timeout-minutes"] == 35
 
 
 def test_alpine_full_suite_timeout_leaves_musl_headroom() -> None:


### PR DESCRIPTION
## Summary

- raise the bounded Python test-matrix timeout from 25 to 35 minutes after the Python 3.11 coverage lane reached the former ceiling twice on main SHA `cd43aadee`
- update the workflow regression contract with the observed failure mode while retaining a hard runner limit

## Verification

- `uv run pytest -q tests/test_ci_workflow_contract.py tests/test_ci_path_classifier.py tests/test_audit_round2.py::test_stuck_job_timeout_defined` — 23 passed
- `uv run python scripts/check_workflow_timeouts.py`
- `uv run ruff check tests/test_ci_workflow_contract.py`
- `actionlint .github/workflows/ci.yml`
- `make preflight`
- `git diff --check`

## Notes

- Python 3.13, Python 3.14, Alpine/musl, security, lint, version-alignment, Helm, and docs jobs completed successfully on the same main run; only the coverage-bearing Python 3.11 lane reached the job timeout.
- The prior Alpine failure that opened #4815 was corrected by #4816 and passes on current main.

Closes #4815
