### PR TITLE
fix(release): enforce exact MCP deployment inventory

### DIFF
--- a/.github/workflows/deploy-mcp-sse.yml
+++ b/.github/workflows/deploy-mcp-sse.yml
@@ -51,6 +51,7 @@ jobs:
           EXPECTED_TAG: ${{ steps.tag.outputs.ref }}
           EXPECTED_VERSION: ${{ steps.tag.outputs.version }}
         run: |
+          set -euo pipefail
           git fetch --force --tags origin "refs/tags/$EXPECTED_TAG:refs/tags/$EXPECTED_TAG"
           TAG_SHA=$(git rev-list -n 1 "$EXPECTED_TAG^{commit}")
           HEAD_SHA=$(git rev-parse HEAD)
@@ -68,8 +69,20 @@ jobs:
             echo "::error::Checked-out version $REPO_VERSION does not match release tag $EXPECTED_TAG"
             exit 1
           fi
+          METRICS_JSON=$(git show "HEAD:docs/PRODUCT_METRICS.json")
+          METRICS_VERSION=$(echo "$METRICS_JSON" | jq -er '.version')
+          TOOL_COUNT=$(echo "$METRICS_JSON" | jq -er 'first(.metrics[] | select(.name == "MCP tools") | .value)')
+          if [ "$METRICS_VERSION" != "$REPO_VERSION" ]; then
+            echo "::error::Release metrics version $METRICS_VERSION does not match $REPO_VERSION"
+            exit 1
+          fi
+          if ! echo "$TOOL_COUNT" | grep -qE '^[1-9][0-9]*$'; then
+            echo "::error::Release metrics do not declare a positive MCP tool count"
+            exit 1
+          fi
           echo "Checked-out version: $REPO_VERSION"
           echo "repo_version=$REPO_VERSION" >> "$GITHUB_ENV"
+          echo "repo_tool_count=$TOOL_COUNT" >> "$GITHUB_ENV"
 
       - name: Install Railway CLI
         run: npm install -g @railway/cli@4.30.5  # pinned — update periodically
@@ -89,44 +102,24 @@ jobs:
             railway up --detach
           fi
 
-      - name: Post-deploy version check
+      - name: Post-deploy exact release contract check
         shell: bash
         env:
           RAILWAY_MCP_URL: ${{ vars.RAILWAY_MCP_URL }}
           RAILWAY_MCP_BEARER_TOKEN: ${{ secrets.RAILWAY_MCP_BEARER_TOKEN }}
         run: |
+          set -euo pipefail
           echo "Waiting 60s for Railway to rebuild and start..."
           sleep 60
           DEPLOY_URL="${RAILWAY_MCP_URL:-https://agent-bom-mcp.up.railway.app}"
-          HEALTH_URL=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe --base-url "$DEPLOY_URL" --resolve-only)
-          echo "Checking $HEALTH_URL"
-          RESPONSE=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe \
+          echo "Checking the public server card at $DEPLOY_URL"
+          PYTHONPATH=src python3 -m agent_bom.deployment_probe \
             --base-url "$DEPLOY_URL" \
             --bearer-token "${RAILWAY_MCP_BEARER_TOKEN:-}" \
+            --server-card \
+            --expected-version "$repo_version" \
+            --expected-tool-count "$repo_tool_count" \
             --attempts 5 \
             --backoff-seconds 30 \
-            --timeout 15 2>/dev/null || true)
-          if [ -n "$RESPONSE" ]; then
-            echo "Health response: $RESPONSE"
-            DEPLOYED_VERSION=$(echo "$RESPONSE" | python3 -c "
-          import sys, json
-          try:
-              data = json.load(sys.stdin)
-              print(data.get('version', 'unknown'))
-          except Exception:
-              print('unknown')
-          " 2>/dev/null || echo "unknown")
-            echo "Deployed version: $DEPLOYED_VERSION"
-            echo "Expected version: $repo_version"
-            if [ "$DEPLOYED_VERSION" = "$repo_version" ]; then
-              echo "✅ Version match confirmed"
-              exit 0
-            elif [ "$DEPLOYED_VERSION" = "unknown" ]; then
-              echo "⚠️ Could not extract version from health endpoint — auth or startup may still be incomplete"
-            else
-              echo "::warning::Version mismatch — deployed=$DEPLOYED_VERSION expected=$repo_version"
-            fi
-          else
-            echo "::warning::Health endpoint not ready after retries"
-          fi
-          echo "::warning::Could not verify deployed version — check Railway manually"
+            --timeout 15 >/dev/null
+          echo "Exact release contract confirmed: v${repo_version}, ${repo_tool_count} MCP tool schemas"

--- a/.github/workflows/deployment-freshness.yml
+++ b/.github/workflows/deployment-freshness.yml
@@ -1,6 +1,7 @@
 name: Deployment Freshness
 
-# Checks that the protected Railway surface serves the latest release and that
+# Checks that the protected Railway surface serves the exact latest release
+# version and MCP tool-schema inventory, and that
 # the Smithery catalog listing is live with a non-empty tool inventory. Runs
 # daily and on-demand. Opens an issue if stale or misconfigured.
 #
@@ -29,18 +30,42 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Get expected version from repo
+      - name: Get expected contract from latest published release
         id: expected
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION=$(python3 -c "
-          import re, pathlib
-          text = pathlib.Path('pyproject.toml').read_text()
-          m = re.search(r'version\s*=\s*\"([^\"]+)\"', text)
-          print(m.group(1))
-          ")
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Expected version: $VERSION"
+          set -euo pipefail
+          RELEASE_JSON=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest")
+          RELEASE_TAG=$(echo "$RELEASE_JSON" | jq -er '.tag_name')
+          if [ "$(echo "$RELEASE_JSON" | jq -r '.draft != false')" = "true" ]; then
+            echo "::error::Latest GitHub release is a draft"
+            exit 1
+          fi
+          git fetch --force --no-tags origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          RELEASE_SHA=$(git rev-list -n 1 "refs/tags/${RELEASE_TAG}")
+          VERSION="${RELEASE_TAG#v}"
+          METRICS_JSON=$(git show "${RELEASE_SHA}:docs/PRODUCT_METRICS.json")
+          METRICS_VERSION=$(echo "$METRICS_JSON" | jq -er '.version')
+          TOOL_COUNT=$(echo "$METRICS_JSON" | jq -er 'first(.metrics[] | select(.name == "MCP tools") | .value)')
+          if [ "$METRICS_VERSION" != "$VERSION" ]; then
+            echo "::error::Published release metrics version $METRICS_VERSION does not match $VERSION"
+            exit 1
+          fi
+          if ! echo "$TOOL_COUNT" | grep -qE '^[1-9][0-9]*$'; then
+            echo "::error::Published release metrics do not declare a positive MCP tool count"
+            exit 1
+          fi
+          {
+            echo "version=$VERSION"
+            echo "tool_count=$TOOL_COUNT"
+            echo "release_sha=$RELEASE_SHA"
+          } >> "$GITHUB_OUTPUT"
+          echo "Expected published contract: v${VERSION}, ${TOOL_COUNT} MCP tools"
 
       - name: Check Railway deployment
         shell: bash
@@ -50,31 +75,33 @@ jobs:
           RAILWAY_MCP_URL: ${{ vars.RAILWAY_MCP_URL }}
           RAILWAY_MCP_BEARER_TOKEN: ${{ secrets.RAILWAY_MCP_BEARER_TOKEN }}
         run: |
+          set -euo pipefail
           DEPLOY_URL="${RAILWAY_MCP_URL:-https://agent-bom-mcp.up.railway.app}"
-          HEALTH_URL=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe --base-url "$DEPLOY_URL" --resolve-only)
-          echo "Checking $HEALTH_URL ..."
-          RESPONSE=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe \
+          if RESPONSE=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe \
             --base-url "$DEPLOY_URL" \
             --bearer-token "${RAILWAY_MCP_BEARER_TOKEN:-}" \
+            --server-card \
+            --expected-version "${{ steps.expected.outputs.version }}" \
+            --expected-tool-count "${{ steps.expected.outputs.tool_count }}" \
             --attempts 3 \
             --backoff-seconds 5 \
-            --timeout 15 2>/dev/null || echo '{}')
-          DEPLOYED=$(echo "$RESPONSE" | python3 -c "
-          import sys, json
-          try:
-              data = json.load(sys.stdin)
-              print(data.get('version', 'unknown'))
-          except Exception:
-              print('unreachable')
-          ")
-          echo "railway_version=$DEPLOYED" >> "$GITHUB_OUTPUT"
-          echo "Railway version: $DEPLOYED (expected: ${{ steps.expected.outputs.version }})"
-          if [ "$DEPLOYED" = "unknown" ] || [ "$DEPLOYED" = "unreachable" ]; then
-            echo "probe_failed=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Could not verify Railway version from $HEALTH_URL"
-          elif [ "$DEPLOYED" != "${{ steps.expected.outputs.version }}" ]; then
-            echo "stale=true" >> "$GITHUB_OUTPUT"
+            --timeout 15); then
+            DEPLOYED=$(echo "$RESPONSE" | jq -er '.serverInfo.version')
+            TOOL_COUNT=$(echo "$RESPONSE" | jq -er '.tools | length')
+          else
+            {
+              echo "railway_version=unreachable"
+              echo "tool_count=unknown"
+              echo "probe_failed=true"
+            } >> "$GITHUB_OUTPUT"
+            echo "::warning::Railway server card does not match the latest published release contract"
+            exit 0
           fi
+          {
+            echo "railway_version=$DEPLOYED"
+            echo "tool_count=$TOOL_COUNT"
+          } >> "$GITHUB_OUTPUT"
+          echo "Railway contract: v${DEPLOYED}, ${TOOL_COUNT} tools"
 
       - name: Check Smithery catalog listing
         shell: bash
@@ -117,10 +144,12 @@ jobs:
           }, separators=(",", ":")))
           PY
           ) || {
-            echo "public_version=unreachable" >> "$GITHUB_OUTPUT"
-            echo "tool_count=unknown" >> "$GITHUB_OUTPUT"
-            echo "auth_required=smithery-oauth" >> "$GITHUB_OUTPUT"
-            echo "probe_failed=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "public_version=unreachable"
+              echo "tool_count=unknown"
+              echo "auth_required=smithery-oauth"
+              echo "probe_failed=true"
+            } >> "$GITHUB_OUTPUT"
             echo "::warning::Could not verify Smithery catalog listing"
             exit 0
           }
@@ -134,9 +163,11 @@ jobs:
           ")
           TOOL_COUNT=$(echo "$RESPONSE" | python3 -c "import json, sys; print(json.load(sys.stdin).get('tool_count', 'unknown'))")
           DEPLOY_URL=$(echo "$RESPONSE" | python3 -c "import json, sys; print(json.load(sys.stdin).get('deployment_url', 'unknown'))")
-          echo "public_version=$STATE" >> "$GITHUB_OUTPUT"
-          echo "tool_count=$TOOL_COUNT" >> "$GITHUB_OUTPUT"
-          echo "auth_required=smithery-oauth" >> "$GITHUB_OUTPUT"
+          {
+            echo "public_version=$STATE"
+            echo "tool_count=$TOOL_COUNT"
+            echo "auth_required=smithery-oauth"
+          } >> "$GITHUB_OUTPUT"
           echo "Smithery catalog state: $STATE"
           echo "Smithery deployment URL: $DEPLOY_URL"
           echo "Smithery tool count: $TOOL_COUNT"
@@ -147,12 +178,13 @@ jobs:
 
       - name: Open issue if deployment surfaces drift or public endpoint is misconfigured
         shell: bash
-        if: steps.railway.outputs.stale == 'true' || steps.public.outputs.stale == 'true' || steps.public.outputs.auth_gate == 'true' || steps.public.outputs.probe_failed == 'true'
+        if: steps.railway.outputs.stale == 'true' || steps.railway.outputs.probe_failed == 'true' || steps.public.outputs.stale == 'true' || steps.public.outputs.auth_gate == 'true' || steps.public.outputs.probe_failed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           EXPECTED="${{ steps.expected.outputs.version }}"
           RAILWAY="${{ steps.railway.outputs.railway_version }}"
+          RAILWAY_TOOLS="${{ steps.railway.outputs.tool_count }}"
           PUBLIC="${{ steps.public.outputs.public_version }}"
           PUBLIC_TOOLS="${{ steps.public.outputs.tool_count }}"
           PUBLIC_AUTH="${{ steps.public.outputs.auth_required }}"
@@ -176,7 +208,7 @@ jobs:
 
           | Surface | Version | Expected | Auth Required | Tool Count |
           |---------|---------|----------|---------------|------------|
-          | Railway (protected) | $RAILWAY | $EXPECTED | true | — |
+          | Railway (protected) | $RAILWAY | $EXPECTED | true | $RAILWAY_TOOLS |
           | Public marketplace | $PUBLIC | $EXPECTED | $PUBLIC_AUTH | $PUBLIC_TOOLS |
 
           **Action**: Ensure the protected Railway deployment is fresh and the Smithery catalog API lists a remote deployment with tools, then re-run this workflow.
@@ -195,7 +227,7 @@ jobs:
 
           | Surface | Version | Expected | Auth Required | Tool Count |
           |---------|---------|----------|---------------|------------|
-          | Railway (protected) | $RAILWAY | $EXPECTED | true | — |
+          | Railway (protected) | $RAILWAY | $EXPECTED | true | $RAILWAY_TOOLS |
           | Public marketplace | $PUBLIC | $EXPECTED | $PUBLIC_AUTH | $PUBLIC_TOOLS |
 
           **Action**: Ensure the protected Railway deployment is fresh and the Smithery catalog API lists a remote deployment with tools, then re-run this workflow.

--- a/src/agent_bom/deployment_probe.py
+++ b/src/agent_bom/deployment_probe.py
@@ -42,6 +42,58 @@ def resolve_health_url(base_url: str | None) -> str:
     return urlunsplit((parts.scheme, parts.netloc, path, "", ""))
 
 
+def resolve_server_card_url(base_url: str | None) -> str:
+    """Return the public MCP server-card URL for a deployment origin."""
+
+    raw = (base_url or DEFAULT_BASE_URL).strip()
+    if not raw:
+        raw = DEFAULT_BASE_URL
+
+    parts = urlsplit(raw)
+    if not parts.scheme or not parts.netloc:
+        raise ValueError(f"invalid base URL: {base_url!r}")
+    if parts.scheme not in {"http", "https"}:
+        raise ValueError(f"unsupported URL scheme for deployment probe: {parts.scheme!r}")
+
+    return urlunsplit((parts.scheme, parts.netloc, "/.well-known/mcp/server-card.json", "", ""))
+
+
+def _fetch_json(
+    url: str,
+    *,
+    bearer_token: str | None,
+    attempts: int,
+    backoff_seconds: float,
+    timeout: float,
+) -> dict[str, Any]:
+    if attempts < 1:
+        raise ValueError("attempts must be >= 1")
+
+    headers = {"Accept": "application/json", "User-Agent": _USER_AGENT}
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:  # nosec B310 - URL resolvers enforce http/https only
+                payload = json.loads(response.read())
+            if not isinstance(payload, dict):
+                raise ValueError("deployment response must be a JSON object")
+            return payload
+        except (ValueError, json.JSONDecodeError, OSError, urllib.error.URLError) as exc:
+            last_error = exc
+            if attempt == attempts:
+                break
+            sleep_seconds = max(backoff_seconds, 0.0) * attempt
+            if sleep_seconds:
+                sys.stderr.write(f"Attempt {attempt}/{attempts} failed for {url}. Retrying in {sleep_seconds:.0f}s...\n")
+                time.sleep(sleep_seconds)
+
+    raise RuntimeError(f"unable to fetch deployment metadata from {url}: {last_error}")
+
+
 def fetch_health(
     base_url: str | None,
     *,
@@ -52,33 +104,36 @@ def fetch_health(
 ) -> tuple[str, dict[str, Any]]:
     """Fetch and parse the MCP health payload with retry support."""
 
-    if attempts < 1:
-        raise ValueError("attempts must be >= 1")
-
     health_url = resolve_health_url(base_url)
-    headers = {"User-Agent": _USER_AGENT}
-    if bearer_token:
-        headers["Authorization"] = f"Bearer {bearer_token}"
+    payload = _fetch_json(
+        health_url,
+        bearer_token=bearer_token,
+        attempts=attempts,
+        backoff_seconds=backoff_seconds,
+        timeout=timeout,
+    )
+    return health_url, payload
 
-    last_error: Exception | None = None
-    for attempt in range(1, attempts + 1):
-        request = urllib.request.Request(health_url, headers=headers)
-        try:
-            with urllib.request.urlopen(request, timeout=timeout) as response:  # nosec B310 - resolve_health_url enforces http/https only
-                payload = json.loads(response.read())
-            if not isinstance(payload, dict):
-                raise ValueError("health response must be a JSON object")
-            return health_url, payload
-        except (ValueError, json.JSONDecodeError, OSError, urllib.error.URLError) as exc:
-            last_error = exc
-            if attempt == attempts:
-                break
-            sleep_seconds = max(backoff_seconds, 0.0) * attempt
-            if sleep_seconds:
-                sys.stderr.write(f"Attempt {attempt}/{attempts} failed for {health_url}: {exc}. Retrying in {sleep_seconds:.0f}s...\n")
-                time.sleep(sleep_seconds)
 
-    raise RuntimeError(f"unable to fetch MCP health from {health_url}: {last_error}")
+def fetch_server_card(
+    base_url: str | None,
+    *,
+    bearer_token: str | None = None,
+    attempts: int = 1,
+    backoff_seconds: float = 0.0,
+    timeout: float = 15.0,
+) -> tuple[str, dict[str, Any]]:
+    """Fetch the public MCP server card with bounded retries."""
+
+    server_card_url = resolve_server_card_url(base_url)
+    payload = _fetch_json(
+        server_card_url,
+        bearer_token=bearer_token,
+        attempts=attempts,
+        backoff_seconds=backoff_seconds,
+        timeout=timeout,
+    )
+    return server_card_url, payload
 
 
 def validate_health_payload(
@@ -92,6 +147,36 @@ def validate_health_payload(
         raise ValueError("health response must be a JSON object")
     if forbid_auth_required and bool(payload.get("auth_required")):
         raise ValueError("deployment surface requires auth and is not suitable for public registry publishing")
+    return payload
+
+
+def validate_server_card_release(
+    payload: dict[str, Any],
+    *,
+    expected_version: str,
+    expected_tool_count: int,
+) -> dict[str, Any]:
+    """Require exact version, inventory, and usable schemas for a release."""
+
+    server_info = payload.get("serverInfo")
+    if not isinstance(server_info, dict) or server_info.get("version") != expected_version:
+        deployed = server_info.get("version") if isinstance(server_info, dict) else None
+        raise ValueError(f"server-card version mismatch: deployed={deployed!r} expected={expected_version!r}")
+
+    tools = payload.get("tools")
+    if not isinstance(tools, list) or len(tools) != expected_tool_count:
+        actual = len(tools) if isinstance(tools, list) else None
+        raise ValueError(f"server-card tool count mismatch: deployed={actual!r} expected={expected_tool_count}")
+
+    names: list[str] = []
+    for tool in tools:
+        if not isinstance(tool, dict) or not isinstance(tool.get("name"), str) or not tool["name"].strip():
+            raise ValueError("server-card tool schema is missing a non-empty name")
+        if not isinstance(tool.get("inputSchema"), dict):
+            raise ValueError(f"server-card tool schema is missing inputSchema for {tool['name']!r}")
+        names.append(tool["name"])
+    if len(set(names)) != len(names):
+        raise ValueError("server-card tool schema contains duplicate tool names")
     return payload
 
 
@@ -117,6 +202,13 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Fail if the health payload reports auth_required=true.",
     )
+    parser.add_argument(
+        "--server-card",
+        action="store_true",
+        help="Probe the public MCP server card instead of /health.",
+    )
+    parser.add_argument("--expected-version", default=None, help="Exact release version required from the server card.")
+    parser.add_argument("--expected-tool-count", type=int, default=None, help="Exact released MCP tool count required.")
     return parser
 
 
@@ -129,17 +221,33 @@ def main(argv: list[str] | None = None) -> int:
             sys.stdout.write(f"{resolve_health_url(args.base_url)}\n")
             return 0
 
-        _, payload = fetch_health(
-            args.base_url,
-            bearer_token=args.bearer_token,
-            attempts=args.attempts,
-            backoff_seconds=args.backoff_seconds,
-            timeout=args.timeout,
-        )
-        payload = validate_health_payload(
-            payload,
-            forbid_auth_required=args.forbid_auth_required,
-        )
+        if args.server_card:
+            if not args.expected_version or args.expected_tool_count is None:
+                raise ValueError("--server-card requires --expected-version and --expected-tool-count")
+            _, payload = fetch_server_card(
+                args.base_url,
+                bearer_token=args.bearer_token,
+                attempts=args.attempts,
+                backoff_seconds=args.backoff_seconds,
+                timeout=args.timeout,
+            )
+            payload = validate_server_card_release(
+                payload,
+                expected_version=args.expected_version,
+                expected_tool_count=args.expected_tool_count,
+            )
+        else:
+            _, payload = fetch_health(
+                args.base_url,
+                bearer_token=args.bearer_token,
+                attempts=args.attempts,
+                backoff_seconds=args.backoff_seconds,
+                timeout=args.timeout,
+            )
+            payload = validate_health_payload(
+                payload,
+                forbid_auth_required=args.forbid_auth_required,
+            )
     except (RuntimeError, ValueError) as exc:
         sys.stderr.write(f"{exc}\n")
         return 1

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -804,7 +804,7 @@ def test_deploy_mcp_sse_fails_closed_on_exact_release_server_card_drift():
 
     assert 'METRICS_JSON=$(git show "HEAD:docs/PRODUCT_METRICS.json")' in workflow
     assert 'select(.name == "MCP tools")' in workflow
-    assert 'repo_tool_count=$TOOL_COUNT' in workflow
+    assert "repo_tool_count=$TOOL_COUNT" in workflow
     assert "--server-card" in workflow
     assert '--expected-version "$repo_version"' in workflow
     assert '--expected-tool-count "$repo_tool_count"' in workflow

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -516,7 +516,21 @@ def test_deployment_freshness_workflow_uses_bearer_token_and_parses_tool_count()
     assert "smithery-oauth" in workflow
     assert "probe_failed=true" in workflow
     assert "steps.railway.outputs.probe_failed != 'true'" in workflow
-    assert "--resolve-only" in workflow
+    assert "--server-card" in workflow
+
+
+def test_deployment_freshness_targets_exact_published_server_card_contract():
+    """Unreleased main and same-version tool drift must not blur deployment truth."""
+    workflow = (ROOT / ".github" / "workflows" / "deployment-freshness.yml").read_text()
+
+    assert "Get expected contract from latest published release" in workflow
+    assert "repos/$GITHUB_REPOSITORY/releases/latest" in workflow
+    assert 'git show "${RELEASE_SHA}:docs/PRODUCT_METRICS.json"' in workflow
+    assert 'select(.name == "MCP tools")' in workflow
+    assert "--server-card" in workflow
+    assert '--expected-version "${{ steps.expected.outputs.version }}"' in workflow
+    assert '--expected-tool-count "${{ steps.expected.outputs.tool_count }}"' in workflow
+    assert "steps.railway.outputs.probe_failed == 'true'" in workflow
 
 
 def test_deployment_freshness_uses_a_version_stable_issue_identity():
@@ -782,6 +796,19 @@ def test_deploy_mcp_sse_workflow_uses_bearer_token_for_health_check():
     assert "RAILWAY_MCP_BEARER_TOKEN" in workflow
     assert "python3 -m agent_bom.deployment_probe" in workflow
     assert "--attempts 5" in workflow
+
+
+def test_deploy_mcp_sse_fails_closed_on_exact_release_server_card_drift():
+    """A release deploy is green only when version, tool count, and schemas match."""
+    workflow = (ROOT / ".github" / "workflows" / "deploy-mcp-sse.yml").read_text()
+
+    assert 'METRICS_JSON=$(git show "HEAD:docs/PRODUCT_METRICS.json")' in workflow
+    assert 'select(.name == "MCP tools")' in workflow
+    assert 'repo_tool_count=$TOOL_COUNT' in workflow
+    assert "--server-card" in workflow
+    assert '--expected-version "$repo_version"' in workflow
+    assert '--expected-tool-count "$repo_tool_count"' in workflow
+    assert "Could not verify deployed version" not in workflow
 
 
 def test_dockerfiles_support_proxy_and_ca_contract():

--- a/tests/test_deployment_probe.py
+++ b/tests/test_deployment_probe.py
@@ -6,7 +6,13 @@ import urllib.error
 
 import pytest
 
-from agent_bom.deployment_probe import fetch_health, resolve_health_url, validate_health_payload
+from agent_bom.deployment_probe import (
+    fetch_health,
+    resolve_health_url,
+    resolve_server_card_url,
+    validate_health_payload,
+    validate_server_card_release,
+)
 
 
 class _Response:
@@ -31,6 +37,12 @@ def test_resolve_health_url_accepts_root_base_url():
 def test_resolve_health_url_strips_mcp_suffix():
     assert resolve_health_url("https://agent-bom-mcp.up.railway.app/mcp") == "https://agent-bom-mcp.up.railway.app/health"
     assert resolve_health_url("https://agent-bom-mcp.up.railway.app/nested/mcp") == "https://agent-bom-mcp.up.railway.app/nested/health"
+
+
+def test_resolve_server_card_url_uses_public_well_known_route():
+    expected = "https://agent-bom-mcp.up.railway.app/.well-known/mcp/server-card.json"
+    assert resolve_server_card_url("https://agent-bom-mcp.up.railway.app") == expected
+    assert resolve_server_card_url("https://agent-bom-mcp.up.railway.app/mcp") == expected
 
 
 def test_fetch_health_retries_normalized_url(monkeypatch):
@@ -70,3 +82,25 @@ def test_validate_health_payload_rejects_auth_required_for_public_registry():
 def test_validate_health_payload_allows_public_surface():
     payload = validate_health_payload({"version": "0.76.0", "auth_required": False}, forbid_auth_required=True)
     assert payload["version"] == "0.76.0"
+
+
+def test_validate_server_card_release_requires_exact_version_tools_and_schemas():
+    payload = {
+        "serverInfo": {"version": "0.100.0"},
+        "tools": [
+            {"name": "scan", "inputSchema": {"type": "object"}},
+            {"name": "generate_sbom", "inputSchema": {"type": "object"}},
+        ],
+    }
+
+    validated = validate_server_card_release(payload, expected_version="0.100.0", expected_tool_count=2)
+    assert validated is payload
+
+    with pytest.raises(ValueError, match="version mismatch"):
+        validate_server_card_release(payload, expected_version="0.101.0", expected_tool_count=2)
+    with pytest.raises(ValueError, match="tool count mismatch"):
+        validate_server_card_release(payload, expected_version="0.100.0", expected_tool_count=3)
+
+    payload["tools"][1].pop("inputSchema")
+    with pytest.raises(ValueError, match="tool schema"):
+        validate_server_card_release(payload, expected_version="0.100.0", expected_tool_count=2)


### PR DESCRIPTION
## Summary

- validate the exact published version, MCP tool count, and tool schemas after Railway deployments
- derive daily freshness expectations from the latest published tag instead of unreleased `main`
- fail closed and open drift evidence when the live server card cannot prove the release contract

## Verification

- `uv run pytest -q tests/test_deployment_probe.py tests/test_deployment.py` (70 passed)
- `uv run ruff check src/agent_bom/deployment_probe.py tests/test_deployment.py tests/test_deployment_probe.py`
- `uv run mypy src/agent_bom/deployment_probe.py`
- `actionlint .github/workflows/deploy-mcp-sse.yml .github/workflows/deployment-freshness.yml`
- `make preflight`
- live Railway probe: v0.100.0 with 78 unique MCP tool schemas

## Notes

Railway branch auto-deploy was disabled so unreleased `main` cannot overwrite the signed release deployment. The exact `v0.100.0` workflow redeploy completed successfully before the live server-card verification.