### PR TITLE
feat(storage): expose portable Postgres contract

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -54,7 +54,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
 | `docs/openapi/v1.json` | paths | 328 |
-| `docs/openapi/v1.json` | component schemas | 141 |
+| `docs/openapi/v1.json` | component schemas | 142 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-15",
+  "generated_on": "2026-08-16",
   "version": "0.100.0",
   "metrics": [
     {
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 855,
+      "value": 856,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-15`
+- Generated on: `2026-08-16`
 - Version: `0.100.0`
 
 | Metric | Value | Source | Notes |
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 48 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 855 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 856 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -5727,6 +5727,47 @@
         "title": "PolicyUpdate",
         "type": "object"
       },
+      "PostgresPortabilityHealth": {
+        "description": "Non-secret, operator-declared PostgreSQL compatibility posture.",
+        "properties": {
+          "contract": {
+            "default": "postgresql",
+            "title": "Contract",
+            "type": "string"
+          },
+          "declared_hint": {
+            "title": "Declared Hint",
+            "type": "string"
+          },
+          "evidence": {
+            "default": "provider_unverified",
+            "title": "Evidence",
+            "type": "string"
+          },
+          "next_action": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "agent-bom doctor",
+            "title": "Next Action"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider",
+          "declared_hint"
+        ],
+        "title": "PostgresPortabilityHealth",
+        "type": "object"
+      },
       "PresetCreate": {
         "additionalProperties": false,
         "properties": {
@@ -7348,6 +7389,16 @@
             "default": "inmemory",
             "title": "Policy Store",
             "type": "string"
+          },
+          "postgres": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PostgresPortabilityHealth"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "schedule_store": {
             "default": "inmemory",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -4070,6 +4070,34 @@ components:
           title: Rules
       title: PolicyUpdate
       type: object
+    PostgresPortabilityHealth:
+      description: Non-secret, operator-declared PostgreSQL compatibility posture.
+      properties:
+        contract:
+          default: postgresql
+          title: Contract
+          type: string
+        declared_hint:
+          title: Declared Hint
+          type: string
+        evidence:
+          default: provider_unverified
+          title: Evidence
+          type: string
+        next_action:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: agent-bom doctor
+          title: Next Action
+        provider:
+          title: Provider
+          type: string
+      required:
+      - provider
+      - declared_hint
+      title: PostgresPortabilityHealth
+      type: object
     PresetCreate:
       additionalProperties: false
       properties:
@@ -5158,6 +5186,10 @@ components:
           default: inmemory
           title: Policy Store
           type: string
+        postgres:
+          anyOf:
+          - $ref: '#/components/schemas/PostgresPortabilityHealth'
+          - type: 'null'
         schedule_store:
           default: inmemory
           title: Schedule Store

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -304,7 +304,8 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS` | `int` | `5` | — |
 | `AGENT_BOM_POSTGRES_GRAPH_SEARCH_TIMEOUT_MS` | `int` | `3000` | — |
 | `AGENT_BOM_POSTGRES_POOL_MAX_SIZE` | `int` | `20` | — |
-| `AGENT_BOM_POSTGRES_POOL_MIN_SIZE` | `int` | `5` | Used by api/postgres_store.py and shared Postgres-backed control-plane services such as the distributed rate limiter.  Defaults target multi-replica self-hosted control planes rather than a single local developer process. |
+| `AGENT_BOM_POSTGRES_POOL_MIN_SIZE` | `int` | `5` | Used by api/postgres_store.py and shared Postgres-backed control-plane services such as the distributed rate limiter. Defaults target multi-replica self-hosted control planes rather than a single local developer process. |
+| `AGENT_BOM_POSTGRES_PROVIDER` | `str` | `'auto'` | Operator hint only; never changes the PostgreSQL contract or implies certification. |
 | `AGENT_BOM_POSTGRES_STATEMENT_TIMEOUT_MS` | `int` | `15000` | — |
 | `AGENT_BOM_WORKER_THREAD_LIMIT` | `int` | `POSTGRES_POOL_MAX_SIZE` | Route handlers offload synchronous store reads to worker threads. AnyIO's own default allows 40 concurrent threads, so leaving it alone lets offloaded reads outnumber connections two to one and queue inside the pool until they time out. Der |
 

--- a/docs/schemas/v1/HealthResponse.json
+++ b/docs/schemas/v1/HealthResponse.json
@@ -122,6 +122,47 @@
       "title": "EntitlementHealth",
       "type": "object"
     },
+    "PostgresPortabilityHealth": {
+      "description": "Non-secret, operator-declared PostgreSQL compatibility posture.",
+      "properties": {
+        "contract": {
+          "default": "postgresql",
+          "title": "Contract",
+          "type": "string"
+        },
+        "declared_hint": {
+          "title": "Declared Hint",
+          "type": "string"
+        },
+        "evidence": {
+          "default": "provider_unverified",
+          "title": "Evidence",
+          "type": "string"
+        },
+        "next_action": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "agent-bom doctor",
+          "title": "Next Action"
+        },
+        "provider": {
+          "title": "Provider",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "declared_hint"
+      ],
+      "title": "PostgresPortabilityHealth",
+      "type": "object"
+    },
     "StorageHealth": {
       "properties": {
         "audit_log": {
@@ -168,6 +209,17 @@
           "default": "inmemory",
           "title": "Policy Store",
           "type": "string"
+        },
+        "postgres": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PostgresPortabilityHealth"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "schedule_store": {
           "default": "inmemory",

--- a/docs/schemas/v1/PostgresPortabilityHealth.json
+++ b/docs/schemas/v1/PostgresPortabilityHealth.json
@@ -1,0 +1,41 @@
+{
+  "description": "Non-secret, operator-declared PostgreSQL compatibility posture.",
+  "properties": {
+    "contract": {
+      "default": "postgresql",
+      "title": "Contract",
+      "type": "string"
+    },
+    "declared_hint": {
+      "title": "Declared Hint",
+      "type": "string"
+    },
+    "evidence": {
+      "default": "provider_unverified",
+      "title": "Evidence",
+      "type": "string"
+    },
+    "next_action": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": "agent-bom doctor",
+      "title": "Next Action"
+    },
+    "provider": {
+      "title": "Provider",
+      "type": "string"
+    }
+  },
+  "required": [
+    "provider",
+    "declared_hint"
+  ],
+  "title": "PostgresPortabilityHealth",
+  "type": "object"
+}

--- a/docs/schemas/v1/StorageHealth.json
+++ b/docs/schemas/v1/StorageHealth.json
@@ -1,4 +1,47 @@
 {
+  "$defs": {
+    "PostgresPortabilityHealth": {
+      "description": "Non-secret, operator-declared PostgreSQL compatibility posture.",
+      "properties": {
+        "contract": {
+          "default": "postgresql",
+          "title": "Contract",
+          "type": "string"
+        },
+        "declared_hint": {
+          "title": "Declared Hint",
+          "type": "string"
+        },
+        "evidence": {
+          "default": "provider_unverified",
+          "title": "Evidence",
+          "type": "string"
+        },
+        "next_action": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "agent-bom doctor",
+          "title": "Next Action"
+        },
+        "provider": {
+          "title": "Provider",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "declared_hint"
+      ],
+      "title": "PostgresPortabilityHealth",
+      "type": "object"
+    }
+  },
   "properties": {
     "audit_log": {
       "default": "inmemory",
@@ -44,6 +87,17 @@
       "default": "inmemory",
       "title": "Policy Store",
       "type": "string"
+    },
+    "postgres": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PostgresPortabilityHealth"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
     },
     "schedule_store": {
       "default": "inmemory",

--- a/docs/schemas/v1/index.json
+++ b/docs/schemas/v1/index.json
@@ -172,6 +172,11 @@
       "schema": "PolicyUpdate.json"
     },
     {
+      "doc": "Non-secret, operator-declared PostgreSQL compatibility posture.",
+      "name": "PostgresPortabilityHealth",
+      "schema": "PostgresPortabilityHealth.json"
+    },
+    {
       "doc": "Request body for POST /v1/scan/prompt-scan.",
       "name": "PromptScanRequest",
       "schema": "PromptScanRequest.json"

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -425,6 +425,16 @@ class AnalyticsHealth(BaseModel):
     dropped_count: int | None = None
 
 
+class PostgresPortabilityHealth(BaseModel):
+    """Non-secret, operator-declared PostgreSQL compatibility posture."""
+
+    provider: str
+    declared_hint: str
+    contract: str = "postgresql"
+    evidence: str = "provider_unverified"
+    next_action: str | None = "agent-bom doctor"
+
+
 class StorageHealth(BaseModel):
     control_plane_backend: str = "inmemory"
     job_store: str = "inmemory"
@@ -438,6 +448,7 @@ class StorageHealth(BaseModel):
     graph_store: str = "inmemory"
     key_store: str = "inmemory"
     audit_log: str = "inmemory"
+    postgres: PostgresPortabilityHealth | None = None
 
 
 class EntitlementHealth(BaseModel):

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -43,6 +43,7 @@ from agent_bom.api.models import (
     EntitlementHealth,
     HealthResponse,
     JobStatus,
+    PostgresPortabilityHealth,
     PublicHealthResponse,
     ScanJob,
     ScanRequest,
@@ -184,6 +185,22 @@ def _control_plane_backend(storage: StorageHealth) -> str:
     return "inmemory"
 
 
+def _postgres_portability_health(control_plane_backend: str) -> PostgresPortabilityHealth | None:
+    """Return declarative Postgres posture without blocking the health route."""
+    if control_plane_backend != "postgres":
+        return None
+    from agent_bom.storage.postgres_capabilities import declared_postgres_portability
+
+    posture = declared_postgres_portability()
+    return PostgresPortabilityHealth(
+        provider=posture.provider,
+        declared_hint=posture.declared_hint,
+        contract=posture.contract,
+        evidence=posture.evidence,
+        next_action=posture.next_action,
+    )
+
+
 def _storage_health() -> StorageHealth:
     try:
         source_store = _get_source_store()
@@ -212,6 +229,7 @@ def _storage_health() -> StorageHealth:
         audit_log=_backend_name(get_audit_log()),
     )
     storage.control_plane_backend = _control_plane_backend(storage)
+    storage.postgres = _postgres_portability_health(storage.control_plane_backend)
     return storage
 
 

--- a/src/agent_bom/cli/_doctor.py
+++ b/src/agent_bom/cli/_doctor.py
@@ -31,6 +31,8 @@ def doctor_cmd() -> None:
     cloud_sdk_checks: list[tuple[str, str, str]] = []
     cloud_api_checks: list[tuple[str, str, str]] = []
     pin_drift_checks: list[tuple[str, str, str]] = []
+    postgres_checks: list[tuple[str, str, str]] = []
+    postgres_payload: dict[str, object] | None = None
 
     # Python version
     py_ver = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
@@ -188,7 +190,40 @@ def doctor_cmd() -> None:
     except Exception:
         pin_drift_checks.append(("Cloud SDK pin drift", "check unavailable", "info"))
 
-    checks = [*core_checks, *runtime_checks, *platform_checks]
+    postgres_url = os.environ.get("AGENT_BOM_POSTGRES_URL", "")
+    database_url = os.environ.get("AGENT_BOM_DB", "")
+    if postgres_url or database_url.startswith(("postgres://", "postgresql://")):
+        from agent_bom.storage.postgres_capabilities import probe_postgres_portability
+
+        probe = probe_postgres_portability()
+        postgres_payload = probe.to_dict()
+        probe_status = "ok" if probe.status == "ready" else "warn"
+        postgres_checks.extend(
+            [
+                ("Provider", probe.provider, probe_status),
+                ("Evidence", probe.evidence, "ok" if probe.evidence == "controlled_verified" else "info"),
+                ("Contract", probe.contract, "ok"),
+                ("Server", probe.server_version or "unavailable", probe_status),
+                ("TLS", "active" if probe.tls else "inactive or unavailable", probe_status),
+                (
+                    "Runtime role",
+                    "RLS-safe" if probe.runtime_role_rls_safe else "unsafe or unavailable",
+                    probe_status,
+                ),
+                (
+                    "Migrations",
+                    "present" if probe.alembic_schema_present and probe.control_plane_schema_present else "missing or unavailable",
+                    probe_status,
+                ),
+                (
+                    "Maintenance role",
+                    "configured" if probe.maintenance_role_configured else "not configured",
+                    "ok" if probe.maintenance_role_configured else "warn",
+                ),
+            ]
+        )
+
+    checks = [*core_checks, *runtime_checks, *platform_checks, *postgres_checks]
     warns = sum(1 for _, _, s in checks if s == "warn")
 
     from agent_bom.cli._agent_mode import agent_mode_requested
@@ -219,6 +254,7 @@ def doctor_cmd() -> None:
                 "cloud_sdk": _section(cloud_sdk_checks),
                 "cloud_api_deprecations": _section(cloud_api_checks),
                 "cloud_sdk_pin_drift": _section(pin_drift_checks),
+                "postgres_portability": postgres_payload,
                 "capabilities": capabilities,
                 "coverage": coverage,
                 "ready": warns == 0,
@@ -238,6 +274,8 @@ def doctor_cmd() -> None:
     _print_section(console, "Cloud SDK freshness", cloud_sdk_checks)
     _print_section(console, "Cloud API deprecations", cloud_api_checks)
     _print_section(console, "Cloud SDK pin drift", pin_drift_checks)
+    if postgres_checks:
+        _print_section(console, "Postgres portability", postgres_checks)
 
     # Nothing-silent capability view — every gated feature with its state and
     # unlock path, so a skipped/degraded capability is never silent.

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -585,12 +585,11 @@ API_BODY_MIN_BPS = _int("AGENT_BOM_BODY_MIN_BPS", 256)
 
 
 # ── PostgreSQL Control Plane Tuning ──────────────────────────────────────
+# Operator hint only; never changes the PostgreSQL contract or implies certification.
+POSTGRES_PROVIDER = _str("AGENT_BOM_POSTGRES_PROVIDER", "auto")
 # Used by api/postgres_store.py and shared Postgres-backed control-plane
-# services such as the distributed rate limiter.
-#
-# Defaults target multi-replica self-hosted control planes rather than a
-# single local developer process.
-
+# services such as the distributed rate limiter. Defaults target multi-replica
+# self-hosted control planes rather than a single local developer process.
 POSTGRES_POOL_MIN_SIZE = _int("AGENT_BOM_POSTGRES_POOL_MIN_SIZE", 5)
 POSTGRES_POOL_MAX_SIZE = _int("AGENT_BOM_POSTGRES_POOL_MAX_SIZE", 20)
 # Route handlers offload synchronous store reads to worker threads. AnyIO's

--- a/src/agent_bom/storage/postgres_capabilities.py
+++ b/src/agent_bom/storage/postgres_capabilities.py
@@ -1,0 +1,216 @@
+"""Provider-neutral PostgreSQL portability posture and live diagnostics.
+
+The control plane intentionally targets the PostgreSQL protocol and catalog
+contract instead of inferring capabilities from a hostname.  Provider hints
+are declarative and never upgrade compatibility into certification; the live
+probe reports only bounded, non-identifying facts needed to operate safely.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+_SCHEMA_VERSION = "postgres-portability.v1"
+_DATABASE_UNAVAILABLE_ACTION = "verify the Postgres secret, network policy, and TLS settings; then rerun agent-bom doctor"
+
+_PROVIDER_ALIASES = {
+    "postgres": "postgres",
+    "postgresql": "postgres",
+    "community": "postgres",
+    "community_postgres": "postgres",
+    "aws": "aws_rds",
+    "aws_rds": "aws_rds",
+    "rds": "aws_rds",
+    "aurora": "aurora",
+    "aurora_postgres": "aurora",
+    "gcp": "cloud_sql",
+    "cloud_sql": "cloud_sql",
+    "cloudsql": "cloud_sql",
+    "azure": "azure_postgres",
+    "azure_postgres": "azure_postgres",
+    "supabase": "supabase",
+    "crunchy": "crunchy",
+    "crunchy_bridge": "crunchy",
+    "edb": "edb",
+    "enterprisedb": "edb",
+    "snowflake_pg": "snowflake_postgres",
+    "snowflake_postgres": "snowflake_postgres",
+    "clickhouse": "clickhouse_postgres",
+    "clickhouse_pg": "clickhouse_postgres",
+    "clickhouse_postgres": "clickhouse_postgres",
+}
+
+
+def _safe_declared_hint(raw: str) -> str:
+    return re.sub(r"[^a-z0-9._-]+", "_", raw.strip().lower()).strip("_")[:64]
+
+
+def _normalized_hint(raw: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "_", raw.strip().lower()).strip("_")
+    return normalized[:64]
+
+
+@dataclass(frozen=True)
+class PostgresProviderPosture:
+    provider: str
+    declared_hint: str
+    contract: str = "postgresql"
+    evidence: str = "provider_unverified"
+    next_action: str | None = "agent-bom doctor"
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class PostgresPortabilityProbe:
+    status: str
+    provider: str
+    contract: str
+    evidence: str
+    server_version: str | None = None
+    server_version_num: int | None = None
+    tls: bool | None = None
+    runtime_role_rls_safe: bool | None = None
+    alembic_schema_present: bool | None = None
+    control_plane_schema_present: bool | None = None
+    maintenance_role_configured: bool = False
+    reasons: tuple[str, ...] = field(default_factory=tuple)
+    next_action: str | None = None
+    schema_version: str = _SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "status": self.status,
+            "provider": self.provider,
+            "contract": self.contract,
+            "evidence": self.evidence,
+            "server_version": self.server_version,
+            "server_version_num": self.server_version_num,
+            "tls": self.tls,
+            "runtime_role_rls_safe": self.runtime_role_rls_safe,
+            "alembic_schema_present": self.alembic_schema_present,
+            "control_plane_schema_present": self.control_plane_schema_present,
+            "maintenance_role_configured": self.maintenance_role_configured,
+            "reasons": list(self.reasons),
+            "next_action": self.next_action,
+        }
+
+
+def declared_postgres_portability() -> PostgresProviderPosture:
+    """Return the operator-declared provider posture without DSN inference."""
+    raw_hint = os.environ.get("AGENT_BOM_POSTGRES_PROVIDER", "auto")
+    hint = _normalized_hint(raw_hint) or "auto"
+    declared_hint = _safe_declared_hint(raw_hint) or "auto"
+    if hint in {"auto", "unspecified"}:
+        return PostgresProviderPosture(provider="unspecified_postgres", declared_hint=declared_hint)
+
+    provider = _PROVIDER_ALIASES.get(hint)
+    if provider is None:
+        return PostgresProviderPosture(provider="other", declared_hint=declared_hint)
+    if provider == "postgres":
+        return PostgresProviderPosture(
+            provider=provider,
+            declared_hint=hint,
+            evidence="controlled_verified",
+        )
+    return PostgresProviderPosture(
+        provider=provider,
+        declared_hint=hint,
+        evidence="compatible_unverified",
+    )
+
+
+def _next_action(reasons: list[str]) -> str | None:
+    if not reasons:
+        return None
+    actions: list[str] = []
+    if "runtime_role_bypasses_rls" in reasons:
+        actions.append("use a NOSUPERUSER NOBYPASSRLS runtime role")
+    if "alembic_schema_missing" in reasons or "control_plane_schema_missing" in reasons:
+        actions.append("run the Postgres migration preflight and Alembic upgrade")
+    if "maintenance_role_not_configured" in reasons:
+        actions.append("configure AGENT_BOM_POSTGRES_MAINTENANCE_URL for multi-replica maintenance")
+    if "tls_not_active" in reasons:
+        actions.append("require TLS for the production Postgres connection")
+    return "; ".join(actions) + "; then rerun agent-bom doctor"
+
+
+def probe_postgres_portability(*, pool: Any | None = None) -> PostgresPortabilityProbe:
+    """Probe the portable Postgres contract without returning connection identity."""
+    posture = declared_postgres_portability()
+    maintenance_configured = bool(os.environ.get("AGENT_BOM_POSTGRES_MAINTENANCE_URL", "").strip())
+    try:
+        if pool is None:
+            from agent_bom.api.postgres_common import _get_pool
+
+            pool = _get_pool()
+        with pool.connection() as conn:
+            row = conn.execute(
+                """
+                SELECT
+                    current_setting('server_version'),
+                    current_setting('server_version_num')::INTEGER,
+                    COALESCE((SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()), FALSE),
+                    role.rolsuper,
+                    role.rolbypassrls,
+                    to_regclass('public.alembic_version') IS NOT NULL,
+                    to_regclass('public.control_plane_schema_versions') IS NOT NULL
+                FROM pg_roles AS role
+                WHERE role.rolname = current_user
+                """
+            ).fetchone()
+        if row is None:
+            raise RuntimeError("Postgres role probe returned no row")
+
+        server_version, version_num, tls, role_super, role_bypass_rls, alembic_present, schema_present = row
+        role_safe = not bool(role_super) and not bool(role_bypass_rls)
+        reasons: list[str] = []
+        if not role_safe:
+            reasons.append("runtime_role_bypasses_rls")
+        if not bool(alembic_present):
+            reasons.append("alembic_schema_missing")
+        if not bool(schema_present):
+            reasons.append("control_plane_schema_missing")
+        if not maintenance_configured:
+            reasons.append("maintenance_role_not_configured")
+        if not bool(tls):
+            reasons.append("tls_not_active")
+
+        return PostgresPortabilityProbe(
+            status="ready" if not reasons else "degraded",
+            provider=posture.provider,
+            contract=posture.contract,
+            evidence=posture.evidence,
+            server_version=str(server_version),
+            server_version_num=int(version_num),
+            tls=bool(tls),
+            runtime_role_rls_safe=role_safe,
+            alembic_schema_present=bool(alembic_present),
+            control_plane_schema_present=bool(schema_present),
+            maintenance_role_configured=maintenance_configured,
+            reasons=tuple(reasons),
+            next_action=_next_action(reasons),
+        )
+    except Exception:
+        return PostgresPortabilityProbe(
+            status="unavailable",
+            provider=posture.provider,
+            contract=posture.contract,
+            evidence=posture.evidence,
+            maintenance_role_configured=maintenance_configured,
+            reasons=("database_unavailable",),
+            next_action=_DATABASE_UNAVAILABLE_ACTION,
+        )
+
+
+__all__ = [
+    "PostgresPortabilityProbe",
+    "PostgresProviderPosture",
+    "declared_postgres_portability",
+    "probe_postgres_portability",
+]

--- a/tests/test_postgres_portability.py
+++ b/tests/test_postgres_portability.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+
+
+class _Result:
+    def __init__(self, row: tuple[object, ...]) -> None:
+        self._row = row
+
+    def fetchone(self) -> tuple[object, ...]:
+        return self._row
+
+
+class _Connection:
+    def execute(self, query: str) -> _Result:
+        assert "server_version" in query
+        assert "rolsuper" in query
+        assert "pg_stat_ssl" in query
+        assert "alembic_version" in query
+        assert "control_plane_schema_versions" in query
+        return _Result(("16.4", 160004, True, False, False, True, True))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args) -> None:
+        return None
+
+
+class _Pool:
+    def connection(self) -> _Connection:
+        return _Connection()
+
+
+def test_provider_posture_normalizes_aliases_without_inflating_certification(monkeypatch) -> None:
+    from agent_bom.storage.postgres_capabilities import declared_postgres_portability
+
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_PROVIDER", "snowflake-pg")
+    posture = declared_postgres_portability()
+
+    assert posture.provider == "snowflake_postgres"
+    assert posture.contract == "postgresql"
+    assert posture.evidence == "compatible_unverified"
+    assert posture.next_action == "agent-bom doctor"
+
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_PROVIDER", "clickhouse")
+    posture = declared_postgres_portability()
+    assert posture.provider == "clickhouse_postgres"
+    assert posture.evidence == "compatible_unverified"
+
+
+def test_provider_posture_keeps_unknown_provider_explicit(monkeypatch) -> None:
+    from agent_bom.storage.postgres_capabilities import declared_postgres_portability
+
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_PROVIDER", "private-pg-service")
+    posture = declared_postgres_portability()
+
+    assert posture.provider == "other"
+    assert posture.evidence == "provider_unverified"
+    assert posture.declared_hint == "private-pg-service"
+
+
+def test_live_postgres_probe_checks_portable_contract_without_exposing_identity(monkeypatch) -> None:
+    from agent_bom.storage.postgres_capabilities import probe_postgres_portability
+
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_PROVIDER", "postgres")
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_MAINTENANCE_URL", "postgresql://maintenance:secret@db/agent_bom")
+
+    probe = probe_postgres_portability(pool=_Pool())
+    payload = probe.to_dict()
+
+    assert payload == {
+        "schema_version": "postgres-portability.v1",
+        "status": "ready",
+        "provider": "postgres",
+        "contract": "postgresql",
+        "evidence": "controlled_verified",
+        "server_version": "16.4",
+        "server_version_num": 160004,
+        "tls": True,
+        "runtime_role_rls_safe": True,
+        "alembic_schema_present": True,
+        "control_plane_schema_present": True,
+        "maintenance_role_configured": True,
+        "reasons": [],
+        "next_action": None,
+    }
+    assert "secret" not in json.dumps(payload)
+    assert "current_user" not in payload
+
+
+def test_live_postgres_probe_sanitizes_connection_failure(monkeypatch) -> None:
+    from agent_bom.storage.postgres_capabilities import probe_postgres_portability
+
+    class BrokenPool:
+        def connection(self):
+            raise RuntimeError("postgresql://user:top-secret@private-db.internal/customer")
+
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_PROVIDER", "aws-rds")
+    probe = probe_postgres_portability(pool=BrokenPool())
+    payload = probe.to_dict()
+
+    assert payload["status"] == "unavailable"
+    assert payload["reasons"] == ["database_unavailable"]
+    assert payload["next_action"] == "verify the Postgres secret, network policy, and TLS settings; then rerun agent-bom doctor"
+    assert "top-secret" not in json.dumps(payload)
+    assert "private-db" not in json.dumps(payload)
+
+
+def test_doctor_surfaces_postgres_portability_in_human_and_agent_modes(monkeypatch) -> None:
+    from agent_bom.storage.postgres_capabilities import PostgresPortabilityProbe
+
+    probe = PostgresPortabilityProbe(
+        status="ready",
+        provider="snowflake_postgres",
+        contract="postgresql",
+        evidence="compatible_unverified",
+        server_version="17.2",
+        server_version_num=170002,
+        tls=True,
+        runtime_role_rls_safe=True,
+        alembic_schema_present=True,
+        control_plane_schema_present=True,
+        maintenance_role_configured=True,
+    )
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://app:redacted@example/agent_bom")
+    monkeypatch.setattr("agent_bom.storage.postgres_capabilities.probe_postgres_portability", lambda: probe)
+
+    human = CliRunner().invoke(main, ["doctor"])
+    assert human.exit_code == 0, human.output
+    assert "Postgres portability" in human.output
+    assert "snowflake_postgres" in human.output
+    assert "compatible_unverified" in human.output
+
+    agent = CliRunner().invoke(main, ["--agent-mode", "doctor"])
+    assert agent.exit_code == 0, agent.output
+    payload = json.loads(agent.stdout)
+    assert payload["data"]["postgres_portability"]["provider"] == "snowflake_postgres"
+    assert payload["data"]["postgres_portability"]["status"] == "ready"
+
+
+def test_authenticated_health_model_has_additive_postgres_posture(monkeypatch) -> None:
+    from agent_bom.api.server import _postgres_portability_health
+
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_PROVIDER", "clickhouse-postgres")
+    health = _postgres_portability_health("postgres")
+
+    assert health is not None
+    assert health.provider == "clickhouse_postgres"
+    assert health.contract == "postgresql"
+    assert health.evidence == "compatible_unverified"
+    assert _postgres_portability_health("sqlite") is None


### PR DESCRIPTION
## Summary

- normalize operator-declared PostgreSQL provider hints without inferring certification from a DSN or hostname
- add a bounded live portability probe for version, TLS, tenant-RLS role safety, migrations, and maintenance-role posture
- expose additive authenticated health metadata and human/agent-mode doctor diagnostics without connection identity or raw errors

## Verification

- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_postgres_portability.py tests/test_doctor_cli.py tests/test_health_checks.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check src tests
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff format --check src tests
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python scripts/check_exception_sanitization.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight

## Notes

- managed-provider hints remain compatible_unverified until provider-specific controlled evidence exists
- the health route reports declarative posture only; agent-bom doctor performs the live database probe