### PR TITLE
feat(deploy): verify managed Postgres readiness

### DIFF
--- a/deploy/helm/agent-bom/README.md
+++ b/deploy/helm/agent-bom/README.md
@@ -26,6 +26,10 @@ maintenance into the API, admin + app + maintenance into the migration Job, and
 maintenance only into backups; duplicate or missing names fail template
 validation. The migration hook runs the idempotent packaged upgrade/reconcile
 entrypoint and never inherits or falls back to generic API credentials.
+The chart then runs a post-migration portability hook using only the app and
+maintenance references; it fails closed when TLS, schema, or runtime-role RLS
+safety is not ready. Set `controlPlane.postgres.provider` to label the managed
+service in health and doctor output; the label never implies certification.
 Secret-sync and workload releases are isolated by the standard Helm instance
 label, including teardown cleanup; uninstalling one release cannot
 collection-delete ExternalSecrets owned by the other.
@@ -158,6 +162,8 @@ blank `collectorImage.tag` falls back to `image.tag`.
 | `collectorImage.repository` | `agentbom/agent-bom-collector` | Cloud-SDK collector image the scan CronJob runs |
 | `collectorImage.tag` | release version | Collector tag — override to bump the SDK layer independently of the control plane; blank falls back to `image.tag` |
 | `controlPlane.enabled` | `false` | Package API + dashboard Deployments |
+| `controlPlane.postgres.provider` | `auto` | Diagnostic provider hint; does not change the PostgreSQL contract or certification state |
+| `controlPlane.postgres.verification.enabled` | `true` | Run a post-install/post-upgrade portability probe for canonical Postgres deployments |
 | `controlPlane.ingress.enabled` | `false` | Same-origin ingress for UI + API |
 | `monitor.enabled` | `false` | Optional node-wide runtime monitor |
 | `sidecarInjection.enabled` | `false` | Mutating webhook for proxy sidecars |

--- a/deploy/helm/agent-bom/examples/byo-postgres-values.yaml
+++ b/deploy/helm/agent-bom/examples/byo-postgres-values.yaml
@@ -26,9 +26,24 @@
 #   driver. Keep it in "candidate / smoke-test required" status until migrations,
 #   API startup, graph writes, fleet sync, policy, audit, and backup/restore
 #   posture have been validated in the target account and region.
+#
+# Declare the provider label without putting it in a Secret:
+#
+#   --set controlPlane.postgres.provider=aws-rds
+#
+# Accepted aliases include postgres, aws-rds, aurora-postgres, cloud-sql,
+# azure-postgres, supabase, crunchy, edb, snowflake-pg, clickhouse-postgres,
+# and other. Managed providers remain `compatible_unverified` until controlled
+# provider-specific evidence exists. The post-migration `postgres-verification`
+# hook runs the same bounded probe exposed by `agent-bom doctor` and fails the
+# Helm release when TLS, migrations, or the runtime RLS role are not ready.
 
 controlPlane:
   enabled: true
+  postgres:
+    provider: auto
+    verification:
+      enabled: true
   postgresSecrets:
     enabled: true
     appSecretRef:

--- a/deploy/helm/agent-bom/examples/postgres-secret.example.yaml
+++ b/deploy/helm/agent-bom/examples/postgres-secret.example.yaml
@@ -10,7 +10,7 @@ stringData:
   # Keep this file as an example only; create the real Secret from your
   # platform secret manager, External Secrets Operator, SOPS, or CI secret
   # store so the credential is not committed.
-  AGENT_BOM_POSTGRES_URL: postgresql://agent_bom_app:REPLACE_ME_APP_PASSWORD@REPLACE_ME_POSTGRES_HOST:5432/agent_bom
+  AGENT_BOM_POSTGRES_URL: postgresql://agent_bom_app:REPLACE_ME_APP_PASSWORD@REPLACE_ME_POSTGRES_HOST:5432/agent_bom?sslmode=require
 ---
 apiVersion: v1
 kind: Secret
@@ -21,7 +21,7 @@ type: Opaque
 stringData:
   # Trusted cross-tenant maintenance credential. The database also requires a
   # scoped app.bypass_rls flag, so possession alone does not activate bypass.
-  AGENT_BOM_POSTGRES_MAINTENANCE_URL: postgresql://agent_bom_maintenance:REPLACE_ME_MAINTENANCE_PASSWORD@REPLACE_ME_POSTGRES_HOST:5432/agent_bom
+  AGENT_BOM_POSTGRES_MAINTENANCE_URL: postgresql://agent_bom_maintenance:REPLACE_ME_MAINTENANCE_PASSWORD@REPLACE_ME_POSTGRES_HOST:5432/agent_bom?sslmode=require
 ---
 apiVersion: v1
 kind: Secret
@@ -31,4 +31,4 @@ metadata:
 type: Opaque
 stringData:
   # Migration/admin only. Never reference this Secret from API or backup pods.
-  ALEMBIC_DATABASE_URL: postgresql://agent_bom:REPLACE_ME_ADMIN_PASSWORD@REPLACE_ME_POSTGRES_HOST:5432/agent_bom
+  ALEMBIC_DATABASE_URL: postgresql://agent_bom:REPLACE_ME_ADMIN_PASSWORD@REPLACE_ME_POSTGRES_HOST:5432/agent_bom?sslmode=require

--- a/deploy/helm/agent-bom/templates/NOTES.txt
+++ b/deploy/helm/agent-bom/templates/NOTES.txt
@@ -52,6 +52,12 @@ Enterprise pilot notes:
 - For existing databases bootstrapped from `init.sql`, stamp the baseline once
   before the first hooked upgrade:
   `alembic -c deploy/supabase/postgres/alembic.ini stamp 20260416_01`.
+{{- if and .Values.controlPlane.postgresSecrets.enabled .Values.controlPlane.postgres.verification.enabled }}
+- After migrations, `{{ include "agent-bom.name" . }}-postgres-verify` runs the
+  bounded portability probe with only the app and maintenance Secret refs. It
+  fails the release when TLS, schema, or runtime-role safety is not ready and
+  never receives the migration/admin Secret.
+{{- end }}
 {{- else }}
 - SQLite pilot mode skips the Alembic migration hook. Do not use SQLite for
   multi-replica production control planes.

--- a/deploy/helm/agent-bom/templates/controlplane-api-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-api-deployment.yaml
@@ -8,7 +8,7 @@
 {{- fail "controlPlane.postgresSecrets app, maintenance, and admin Secret names must be distinct" }}
 {{- end }}
 {{- range $entry := .Values.controlPlane.api.env }}
-{{- if has (get $entry "name") (list "AGENT_BOM_POSTGRES_URL" "AGENT_BOM_POSTGRES_MAINTENANCE_URL" "ALEMBIC_DATABASE_URL") }}
+{{- if has (get $entry "name") (list "AGENT_BOM_POSTGRES_URL" "AGENT_BOM_POSTGRES_MAINTENANCE_URL" "AGENT_BOM_POSTGRES_PROVIDER" "ALEMBIC_DATABASE_URL") }}
 {{- fail "controlPlane.api.env cannot override canonical Postgres identity variables when controlPlane.postgresSecrets.enabled=true" }}
 {{- end }}
 {{- end }}
@@ -91,6 +91,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
             {{- if $postgresSecrets.enabled }}
+            - name: AGENT_BOM_POSTGRES_PROVIDER
+              value: {{ .Values.controlPlane.postgres.provider | quote }}
             - name: AGENT_BOM_POSTGRES_URL
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/agent-bom/templates/controlplane-postgres-verification-job.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-postgres-verification-job.yaml
@@ -1,0 +1,71 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.postgresSecrets.enabled .Values.controlPlane.postgres.verification.enabled }}
+{{- $postgresSecrets := .Values.controlPlane.postgresSecrets }}
+{{- $verification := .Values.controlPlane.postgres.verification }}
+{{- $appSecret := required "controlPlane.postgresSecrets.appSecretRef.name is required" $postgresSecrets.appSecretRef.name }}
+{{- $maintenanceSecret := required "controlPlane.postgresSecrets.maintenanceSecretRef.name is required" $postgresSecrets.maintenanceSecretRef.name }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "agent-bom.name" . }}-postgres-verify
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres-verification
+  annotations:
+    helm.sh/hook: {{ $verification.hooks | quote }}
+    helm.sh/hook-weight: {{ $verification.hookWeight | quote }}
+    helm.sh/hook-delete-policy: {{ $verification.deletePolicy | quote }}
+spec:
+  ttlSecondsAfterFinished: {{ $verification.ttlSecondsAfterFinished }}
+  backoffLimit: {{ $verification.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "agent-bom.labels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres-verification
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: postgres-verify
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - python
+            - -c
+            - |
+              import json
+              from agent_bom.storage.postgres_capabilities import probe_postgres_portability
+              result = probe_postgres_portability()
+              print(json.dumps(result.to_dict(), sort_keys=True))
+              raise SystemExit(0 if result.status == "ready" else 1)
+          env:
+            - name: AGENT_BOM_POSTGRES_PROVIDER
+              value: {{ .Values.controlPlane.postgres.provider | quote }}
+            - name: AGENT_BOM_POSTGRES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $appSecret | quote }}
+                  key: AGENT_BOM_POSTGRES_URL
+            - name: AGENT_BOM_POSTGRES_MAINTENANCE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $maintenanceSecret | quote }}
+                  key: AGENT_BOM_POSTGRES_MAINTENANCE_URL
+          resources:
+            {{- toYaml $verification.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -446,6 +446,26 @@ teardownHooks:
 
 controlPlane:
   enabled: false
+  # Provider label for diagnostics and evidence only. It never changes the
+  # PostgreSQL protocol contract or upgrades compatibility into certification.
+  postgres:
+    provider: auto
+    verification:
+      enabled: true
+      hooks: post-install,post-upgrade
+      hookWeight: "10"
+      # Keep successful output available until the TTL removes it; the next
+      # release still replaces any prior hook deterministically.
+      deletePolicy: before-hook-creation
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 600
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
   # Canonical Postgres Secret references. When enabled, the chart injects
   # app + maintenance into the API, admin + app + maintenance into the
   # migration Job, and maintenance only into backups. Names must be distinct.

--- a/site-docs/deployment/postgres-provisioning.md
+++ b/site-docs/deployment/postgres-provisioning.md
@@ -76,6 +76,23 @@ Recommended operator practice:
   - shared rate limiting in multi-replica deployments
   - tenant-scoped RLS enforcement in the database layer
 
+Declare the provider separately from credentials so health and diagnostic
+output can name the deployment without parsing or exposing a DSN:
+
+```bash
+helm upgrade agent-bom deploy/helm/agent-bom \
+  --reuse-values \
+  --set controlPlane.postgres.provider=aws-rds
+```
+
+The provider value is an evidence label, not a capability switch. Managed
+services remain `compatible_unverified` until a controlled provider-specific
+run exists. With canonical Postgres Secrets enabled, Helm runs the
+`agent-bom-postgres-verify` post-install/post-upgrade hook after migrations.
+The hook receives only the app and maintenance references, checks TLS, schema,
+and runtime-role RLS safety, emits sanitized JSON, and fails the release unless
+the result is `ready`. The migration/admin Secret is never projected into it.
+
 ## How Helm and Postgres relate
 
 Helm should own:

--- a/tests/test_helm_postgres_portability.py
+++ b/tests/test_helm_postgres_portability.py
@@ -1,0 +1,140 @@
+"""Contracts for provider-neutral Postgres Helm deployment verification."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HELM_DIR = REPO_ROOT / "deploy" / "helm" / "agent-bom"
+
+
+def _render(*args: str) -> list[dict]:
+    result = subprocess.run(
+        ["helm", "template", "agent-bom", str(HELM_DIR), *args],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [doc for doc in yaml.safe_load_all(result.stdout) if isinstance(doc, dict)]
+
+
+def _component(docs: list[dict], *, kind: str, component: str) -> dict:
+    return next(
+        doc
+        for doc in docs
+        if doc.get("kind") == kind and doc.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component") == component
+    )
+
+
+def test_chart_defaults_define_postgres_provider_and_verification_contract() -> None:
+    values = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    postgres = values["controlPlane"]["postgres"]
+
+    assert postgres["provider"] == "auto"
+    assert postgres["verification"] == {
+        "enabled": True,
+        "hooks": "post-install,post-upgrade",
+        "hookWeight": "10",
+        "deletePolicy": "before-hook-creation",
+        "backoffLimit": 0,
+        "ttlSecondsAfterFinished": 600,
+        "resources": {
+            "requests": {"cpu": "25m", "memory": "64Mi"},
+            "limits": {"cpu": "200m", "memory": "256Mi"},
+        },
+    }
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm binary not available")
+def test_byo_postgres_render_injects_provider_and_fails_closed_verification() -> None:
+    docs = _render(
+        "--values",
+        str(HELM_DIR / "examples" / "eks-mcp-pilot-values.yaml"),
+        "--values",
+        str(HELM_DIR / "examples" / "byo-postgres-values.yaml"),
+        "--set",
+        "controlPlane.postgres.provider=snowflake-pg",
+    )
+    api = _component(docs, kind="Deployment", component="api")
+    verification = _component(docs, kind="Job", component="postgres-verification")
+
+    api_env = {entry["name"]: entry for entry in api["spec"]["template"]["spec"]["containers"][0]["env"]}
+    assert api_env["AGENT_BOM_POSTGRES_PROVIDER"]["value"] == "snowflake-pg"
+
+    annotations = verification["metadata"]["annotations"]
+    assert annotations["helm.sh/hook"] == "post-install,post-upgrade"
+    assert annotations["helm.sh/hook-weight"] == "10"
+
+    container = verification["spec"]["template"]["spec"]["containers"][0]
+    env = {entry["name"]: entry for entry in container["env"]}
+    assert env["AGENT_BOM_POSTGRES_PROVIDER"]["value"] == "snowflake-pg"
+    assert env["AGENT_BOM_POSTGRES_URL"]["valueFrom"]["secretKeyRef"]["name"] == "agent-bom-control-plane-db"
+    assert env["AGENT_BOM_POSTGRES_MAINTENANCE_URL"]["valueFrom"]["secretKeyRef"]["name"] == "agent-bom-control-plane-maintenance"
+    assert "ALEMBIC_DATABASE_URL" not in env
+
+    command = "\n".join([*container.get("command", []), *container.get("args", [])])
+    assert "probe_postgres_portability" in command
+    assert 'result.status == "ready"' in command
+    assert "result.to_dict()" in command
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm binary not available")
+def test_sqlite_pilot_does_not_render_postgres_verification() -> None:
+    docs = _render("--values", str(HELM_DIR / "examples" / "eks-control-plane-sqlite-pilot-values.yaml"))
+    components = {doc.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component") for doc in docs if doc.get("kind") == "Job"}
+    assert "postgres-verification" not in components
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm binary not available")
+def test_chart_rejects_provider_override_when_canonical_postgres_wiring_is_enabled() -> None:
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "agent-bom",
+            str(HELM_DIR),
+            "--values",
+            str(HELM_DIR / "examples" / "eks-mcp-pilot-values.yaml"),
+            "--set",
+            "controlPlane.api.env[0].name=AGENT_BOM_POSTGRES_PROVIDER",
+            "--set",
+            "controlPlane.api.env[0].value=other",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "cannot override canonical Postgres" in result.stderr
+
+
+def test_byo_postgres_example_documents_provider_hint_and_live_verification() -> None:
+    body = (HELM_DIR / "examples" / "byo-postgres-values.yaml").read_text()
+
+    assert "controlPlane.postgres.provider" in body
+    assert "agent-bom doctor" in body
+    assert "postgres-verification" in body
+    assert "compatible_unverified" in body
+
+
+def test_packaged_postgres_secret_examples_require_tls() -> None:
+    documents = [
+        doc for doc in yaml.safe_load_all((HELM_DIR / "examples" / "postgres-secret.example.yaml").read_text()) if isinstance(doc, dict)
+    ]
+    database_urls = [
+        value
+        for document in documents
+        for key, value in (document.get("stringData") or {}).items()
+        if key in {"AGENT_BOM_POSTGRES_URL", "AGENT_BOM_POSTGRES_MAINTENANCE_URL", "ALEMBIC_DATABASE_URL"}
+    ]
+
+    assert len(database_urls) == 3
+    assert all("sslmode=require" in url for url in database_urls)


### PR DESCRIPTION
## Summary

- inject a chart-owned PostgreSQL provider evidence label into canonical control-plane deployments
- run a post-install/post-upgrade portability Job after migrations and fail closed unless TLS, schema, and runtime-role RLS posture are ready
- keep app, maintenance, and migration/admin credentials separated; require TLS in the packaged Secret examples

## Verification

- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_helm_postgres_portability.py tests/test_deploy_profiles.py tests/test_deploy_manifests.py tests/test_platform_eks_secret_wiring.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check tests/test_helm_postgres_portability.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff format --check tests/test_helm_postgres_portability.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python scripts/validate_helm_profiles.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mkdocs build --strict
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python scripts/check_public_docs_hygiene.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight

## Notes

- provider values are diagnostic evidence labels, not capability switches or certification claims
- successful verification output remains available until the 600-second TTL; failed Jobs remain for diagnosis