### PR TITLE
fix(release): require exact-main green CI proof

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      actions: read
       contents: read
     outputs:
       version: ${{ steps.meta.outputs.version }}
@@ -24,6 +25,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Verify tag commit is exact green main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python3 scripts/check_release_main_ci.py
+          --repo "${{ github.repository }}"
+          --sha "${{ github.sha }}"
+          --branch main
+          --workflow ci.yml
 
       - name: Extract version from tag
         id: meta

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -19,6 +19,7 @@ signed release evidence.
 
 | Surface | Command | Release bar |
 |---|---|---|
+| Exact main CI | `uv run python scripts/check_release_main_ci.py --repo msaad00/agent-bom --sha "$(git rev-parse HEAD)" --branch main --workflow ci.yml` | Candidate equals current `main` and its exact `CI/CD Pipeline` main-push run is completed successfully; pending, canceled, stale, or PR-only runs fail closed. |
 | Version alignment | `uv run python scripts/check_release_consistency.py` | Package, docs, OpenAPI, Docker, Helm, and integration versions agree. |
 | Evidence matrix | `uv run python scripts/check_release_evidence_matrix.py` | Every published surface retains a named pre- or post-publish verification path. |
 | Product contract | `uv run python scripts/check_product_surface_contract.py` | README/product-surface claims match generated metrics and exposed surfaces. |

--- a/docs/release/release-evidence-matrix.json
+++ b/docs/release/release-evidence-matrix.json
@@ -1,6 +1,7 @@
 {
   "schema_version": "release-evidence-matrix.v1",
   "surfaces": [
+    {"surface": "source_commit", "phase": "pre_publish", "verification": "Require the release tag commit to equal current main and have a completed successful CI/CD Pipeline push run on that exact SHA.", "evidence_paths": ["scripts/check_release_main_ci.py", ".github/workflows/release.yml"]},
     {"surface": "python", "phase": "pre_publish_and_post_publish", "verification": "Build and inspect wheel and sdist, then install from PyPI in a clean environment.", "evidence_paths": ["scripts/verify_release_wheel.py", ".github/workflows/release.yml"]},
     {"surface": "dashboard", "phase": "pre_publish", "verification": "Build the bundled dashboard and verify its CSP and browser route contract.", "evidence_paths": ["scripts/build-ui.sh", "docs/RELEASE_VERIFICATION.md"]},
     {"surface": "docker_api", "phase": "post_publish", "verification": "Pull, inspect, smoke, scan, sign, and attest the API image by immutable digest.", "evidence_paths": ["Dockerfile", ".github/workflows/release.yml"]},

--- a/scripts/check_release_evidence_matrix.py
+++ b/scripts/check_release_evidence_matrix.py
@@ -10,6 +10,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 MATRIX = ROOT / "docs" / "release" / "release-evidence-matrix.json"
 REQUIRED_SURFACES = {
+    "source_commit",
     "python",
     "dashboard",
     "docker_api",
@@ -27,6 +28,7 @@ REQUIRED_SURFACES = {
 VALID_PHASES = {"pre_publish", "post_publish", "pre_publish_and_post_publish"}
 REQUIRED_MARKERS = {
     ".github/workflows/release.yml": (
+        "name: Verify tag commit is exact green main",
         "name: Publish to PyPI",
         "name: Publish to Docker Hub",
         "name: Publish cloud-SDK collector image",

--- a/scripts/check_release_main_ci.py
+++ b/scripts/check_release_main_ci.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Require a release tag to point at the exact, green main commit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+from collections.abc import Callable, Mapping
+from typing import Any
+from urllib.parse import quote, urlencode
+
+FetchJSON = Callable[[str], Mapping[str, Any]]
+
+
+class ReleaseProofError(RuntimeError):
+    """A release candidate lacks the required source or CI proof."""
+
+
+def _validate_inputs(repo: str, sha: str, branch: str, workflow: str) -> None:
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo):
+        raise ReleaseProofError("repository must use the owner/name form")
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", sha):
+        raise ReleaseProofError("candidate SHA must be a full 40-character commit SHA")
+    if not re.fullmatch(r"[A-Za-z0-9._/-]+", branch) or branch.startswith("/") or ".." in branch:
+        raise ReleaseProofError("branch contains unsupported characters")
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+", workflow):
+        raise ReleaseProofError("workflow must be a workflow filename")
+
+
+def _fetch_safely(fetch_json: FetchJSON, endpoint: str) -> Mapping[str, Any]:
+    try:
+        return fetch_json(endpoint)
+    except Exception as exc:
+        raise ReleaseProofError(f"release proof lookup failed ({type(exc).__name__})") from None
+
+
+def verify_release_candidate(
+    *,
+    repo: str,
+    sha: str,
+    branch: str = "main",
+    workflow: str = "ci.yml",
+    fetch_json: FetchJSON,
+) -> dict[str, str | int]:
+    """Return the exact successful CI run or fail closed."""
+    _validate_inputs(repo, sha, branch, workflow)
+    expected_sha = sha.lower()
+
+    ref_endpoint = f"/repos/{repo}/git/ref/heads/{quote(branch, safe='')}"
+    ref_payload = _fetch_safely(fetch_json, ref_endpoint)
+    ref_object = ref_payload.get("object")
+    main_sha = ref_object.get("sha") if isinstance(ref_object, Mapping) else None
+    if not isinstance(main_sha, str) or main_sha.lower() != expected_sha:
+        raise ReleaseProofError(f"candidate {expected_sha} does not equal current {branch}")
+
+    query = urlencode({"branch": branch, "event": "push", "per_page": 100})
+    runs_endpoint = f"/repos/{repo}/actions/workflows/{quote(workflow, safe='')}/runs?{query}"
+    runs_payload = _fetch_safely(fetch_json, runs_endpoint)
+    runs = runs_payload.get("workflow_runs")
+    if not isinstance(runs, list):
+        raise ReleaseProofError("release proof lookup returned an invalid workflow-run payload")
+
+    expected_path = f".github/workflows/{workflow}"
+    for run in runs:
+        if not isinstance(run, Mapping):
+            continue
+        if (
+            str(run.get("head_sha", "")).lower() == expected_sha
+            and run.get("head_branch") == branch
+            and run.get("event") == "push"
+            and run.get("path") == expected_path
+            and run.get("status") == "completed"
+            and run.get("conclusion") == "success"
+        ):
+            run_id = run.get("id")
+            run_url = run.get("html_url")
+            if isinstance(run_id, int) and isinstance(run_url, str) and run_url.startswith("https://"):
+                return {"sha": expected_sha, "run_id": run_id, "run_url": run_url}
+
+    raise ReleaseProofError(f"candidate {expected_sha} has no completed successful main push for {expected_path}")
+
+
+def _github_fetch(endpoint: str) -> Mapping[str, Any]:
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        request = urllib.request.Request(
+            f"https://api.github.com{endpoint}",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+            payload = json.load(response)
+    else:
+        result = subprocess.run(
+            ["gh", "api", endpoint.removeprefix("/")],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            raise RuntimeError("GitHub CLI request failed")
+        payload = json.loads(result.stdout)
+    if not isinstance(payload, dict):
+        raise RuntimeError("GitHub API returned a non-object payload")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="GitHub owner/repository")
+    parser.add_argument("--sha", required=True, help="Full release candidate commit SHA")
+    parser.add_argument("--branch", default="main")
+    parser.add_argument("--workflow", default="ci.yml")
+    args = parser.parse_args(argv)
+    try:
+        proof = verify_release_candidate(
+            repo=args.repo,
+            sha=args.sha,
+            branch=args.branch,
+            workflow=args.workflow,
+            fetch_json=_github_fetch,
+        )
+    except ReleaseProofError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"release source proof: OK sha={proof['sha']} run_id={proof['run_id']} run_url={proof['run_url']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -1956,11 +1956,7 @@ def _run_scan_sync(job: ScanJob) -> None:
 
             outcome = "failed" if terminal_status is JobStatus.FAILED else "complete"
             scan_run_payload = job.result.get("scan_run", {}) if isinstance(job.result, dict) else {}
-            if (
-                terminal_status is JobStatus.DONE
-                and isinstance(scan_run_payload, dict)
-                and scan_run_payload.get("outcome") == "partial"
-            ):
+            if terminal_status is JobStatus.DONE and isinstance(scan_run_payload, dict) and scan_run_payload.get("outcome") == "partial":
                 outcome = "partial"
             record_scan_completion_best_effort(
                 channel="control_plane",

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -1955,8 +1955,12 @@ def _run_scan_sync(job: ScanJob) -> None:
             from agent_bom.db.adoption_events import record_scan_completion_best_effort
 
             outcome = "failed" if terminal_status is JobStatus.FAILED else "complete"
-            scan_run = job.result.get("scan_run", {}) if isinstance(job.result, dict) else {}
-            if terminal_status is JobStatus.DONE and isinstance(scan_run, dict) and scan_run.get("outcome") == "partial":
+            scan_run_payload = job.result.get("scan_run", {}) if isinstance(job.result, dict) else {}
+            if (
+                terminal_status is JobStatus.DONE
+                and isinstance(scan_run_payload, dict)
+                and scan_run_payload.get("outcome") == "partial"
+            ):
                 outcome = "partial"
             record_scan_completion_best_effort(
                 channel="control_plane",

--- a/tests/test_adoption_release_proof.py
+++ b/tests/test_adoption_release_proof.py
@@ -74,6 +74,7 @@ def test_release_evidence_matrix_is_machine_checked() -> None:
     matrix = json.loads((ROOT / "docs" / "release" / "release-evidence-matrix.json").read_text())
     surfaces = {row["surface"] for row in matrix["surfaces"]}
     assert surfaces == {
+        "source_commit",
         "python",
         "dashboard",
         "docker_api",

--- a/tests/test_release_main_ci.py
+++ b/tests/test_release_main_ci.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_release_main_ci.py"
+SHA = "d" * 40
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("check_release_main_ci", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fetcher(*, branch_sha: str = SHA, runs: list[dict[str, Any]] | None = None):
+    run_rows = runs if runs is not None else [_run()]
+
+    def fetch(endpoint: str) -> dict[str, Any]:
+        if "/git/ref/heads/" in endpoint:
+            return {"object": {"sha": branch_sha}}
+        assert "/actions/workflows/ci.yml/runs?" in endpoint
+        return {"workflow_runs": run_rows}
+
+    return fetch
+
+
+def _run(**overrides: Any) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "id": 123,
+        "name": "CI/CD Pipeline",
+        "path": ".github/workflows/ci.yml",
+        "head_sha": SHA,
+        "head_branch": "main",
+        "event": "push",
+        "status": "completed",
+        "conclusion": "success",
+        "html_url": "https://github.com/msaad00/agent-bom/actions/runs/123",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_exact_main_completed_success_is_accepted() -> None:
+    checker = _load_script()
+
+    proof = checker.verify_release_candidate(
+        repo="msaad00/agent-bom",
+        sha=SHA,
+        branch="main",
+        workflow="ci.yml",
+        fetch_json=_fetcher(),
+    )
+
+    assert proof == {
+        "sha": SHA,
+        "run_id": 123,
+        "run_url": "https://github.com/msaad00/agent-bom/actions/runs/123",
+    }
+
+
+def test_stale_candidate_sha_is_rejected_before_ci_lookup() -> None:
+    checker = _load_script()
+
+    with pytest.raises(checker.ReleaseProofError, match="does not equal current main"):
+        checker.verify_release_candidate(
+            repo="msaad00/agent-bom",
+            sha=SHA,
+            branch="main",
+            workflow="ci.yml",
+            fetch_json=_fetcher(branch_sha="e" * 40),
+        )
+
+
+@pytest.mark.parametrize(
+    "run",
+    [
+        _run(status="in_progress", conclusion=None),
+        _run(status="completed", conclusion="cancelled"),
+        _run(event="pull_request"),
+        _run(head_sha="e" * 40),
+        _run(head_branch="feature/release"),
+        _run(path=".github/workflows/other.yml"),
+    ],
+)
+def test_only_exact_completed_successful_main_push_proves_release(run: dict[str, Any]) -> None:
+    checker = _load_script()
+
+    with pytest.raises(checker.ReleaseProofError, match="completed successful main push"):
+        checker.verify_release_candidate(
+            repo="msaad00/agent-bom",
+            sha=SHA,
+            branch="main",
+            workflow="ci.yml",
+            fetch_json=_fetcher(runs=[run]),
+        )
+
+
+def test_lookup_failures_do_not_expose_raw_remote_details() -> None:
+    checker = _load_script()
+
+    def fail(_endpoint: str) -> dict[str, Any]:
+        raise RuntimeError("Authorization: Bearer secret-token database.internal")
+
+    with pytest.raises(checker.ReleaseProofError) as caught:
+        checker.verify_release_candidate(
+            repo="msaad00/agent-bom",
+            sha=SHA,
+            branch="main",
+            workflow="ci.yml",
+            fetch_json=fail,
+        )
+
+    message = str(caught.value)
+    assert "release proof lookup failed" in message
+    assert "secret-token" not in message
+    assert "database.internal" not in message
+
+
+def test_release_workflow_requires_exact_main_ci_proof() -> None:
+    workflow_path = ROOT / ".github" / "workflows" / "release.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    guard = workflow["jobs"]["version-guard"]
+
+    assert guard["permissions"]["actions"] == "read"
+    step = next(step for step in guard["steps"] if step.get("name") == "Verify tag commit is exact green main")
+    assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
+    assert "scripts/check_release_main_ci.py" in step["run"]
+    assert '--sha "${{ github.sha }}"' in step["run"]


### PR DESCRIPTION
## Summary

- require a release tag to equal the current main SHA and have a completed successful CI/CD Pipeline main-push run on that exact commit
- fail closed for pending, canceled, stale, pull-request-only, wrong-branch, or wrong-workflow evidence without exposing remote error details
- register source-commit proof in the machine-checked release matrix and repair the existing full-mypy scan-pipeline name collision

## Verification

- `uv run pytest -q tests/test_release_main_ci.py tests/test_adoption_release_proof.py tests/test_ci_workflow_contract.py` (32 passed)
- `uv run pytest -q tests/test_adoption_events.py tests/api/test_api_pipeline_image_contract.py` (20 passed)
- `make lint`
- `make preflight`
- `actionlint .github/workflows/release.yml`
- `uv run python scripts/lint_release_workflow.py .github/workflows/release.yml`
- `uv run python scripts/check_exception_sanitization.py`
- `uv run python scripts/check_public_docs_hygiene.py`

## Notes

- no version, tag, artifact, registry, or public API changes
- the guard intentionally rejects a candidate while its exact main-push CI run is still pending
