### PR TITLE
feat(endpoint): establish truthful workstation sweep

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -54,7 +54,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
 | `docs/openapi/v1.json` | paths | 328 |
-| `docs/openapi/v1.json` | component schemas | 142 |
+| `docs/openapi/v1.json` | component schemas | 143 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 856,
+      "value": 858,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 48 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 856 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 858 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -6861,6 +6861,20 @@
         "additionalProperties": true,
         "description": "Canonical evidence-quality contract, separate from job lifecycle.",
         "properties": {
+          "complete_scope_count": {
+            "default": 0,
+            "maximum": 100.0,
+            "minimum": 0.0,
+            "title": "Complete Scope Count",
+            "type": "integer"
+          },
+          "incomplete_scope_count": {
+            "default": 0,
+            "maximum": 100.0,
+            "minimum": 0.0,
+            "title": "Incomplete Scope Count",
+            "type": "integer"
+          },
           "issues": {
             "items": {
               "$ref": "#/components/schemas/ScanIssuePayload"
@@ -6879,6 +6893,21 @@
             "title": "Outcome",
             "type": "string"
           },
+          "requested_scope_count": {
+            "default": 0,
+            "maximum": 100.0,
+            "minimum": 0.0,
+            "title": "Requested Scope Count",
+            "type": "integer"
+          },
+          "scopes": {
+            "items": {
+              "$ref": "#/components/schemas/ScanScopePayload"
+            },
+            "maxItems": 100,
+            "title": "Scopes",
+            "type": "array"
+          },
           "warning_count": {
             "default": 0,
             "maximum": 100.0,
@@ -6888,6 +6917,59 @@
           }
         },
         "title": "ScanRunPayload",
+        "type": "object"
+      },
+      "ScanScopePayload": {
+        "additionalProperties": false,
+        "description": "Bounded completeness metadata for one requested collection scope.",
+        "properties": {
+          "item_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Count"
+          },
+          "message": {
+            "default": "",
+            "maxLength": 500,
+            "title": "Message",
+            "type": "string"
+          },
+          "name": {
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "requested": {
+            "default": true,
+            "title": "Requested",
+            "type": "boolean"
+          },
+          "status": {
+            "enum": [
+              "complete",
+              "partial",
+              "unsupported",
+              "unavailable",
+              "permission_denied",
+              "skipped"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "status"
+        ],
+        "title": "ScanScopePayload",
         "type": "object"
       },
       "ScheduleCreate": {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -4812,6 +4812,18 @@ components:
       additionalProperties: true
       description: Canonical evidence-quality contract, separate from job lifecycle.
       properties:
+        complete_scope_count:
+          default: 0
+          maximum: 100.0
+          minimum: 0.0
+          title: Complete Scope Count
+          type: integer
+        incomplete_scope_count:
+          default: 0
+          maximum: 100.0
+          minimum: 0.0
+          title: Incomplete Scope Count
+          type: integer
         issues:
           items:
             $ref: '#/components/schemas/ScanIssuePayload'
@@ -4826,6 +4838,18 @@ components:
           - failed
           title: Outcome
           type: string
+        requested_scope_count:
+          default: 0
+          maximum: 100.0
+          minimum: 0.0
+          title: Requested Scope Count
+          type: integer
+        scopes:
+          items:
+            $ref: '#/components/schemas/ScanScopePayload'
+          maxItems: 100
+          title: Scopes
+          type: array
         warning_count:
           default: 0
           maximum: 100.0
@@ -4833,6 +4857,45 @@ components:
           title: Warning Count
           type: integer
       title: ScanRunPayload
+      type: object
+    ScanScopePayload:
+      additionalProperties: false
+      description: Bounded completeness metadata for one requested collection scope.
+      properties:
+        item_count:
+          anyOf:
+          - minimum: 0.0
+            type: integer
+          - type: 'null'
+          title: Item Count
+        message:
+          default: ''
+          maxLength: 500
+          title: Message
+          type: string
+        name:
+          maxLength: 100
+          minLength: 1
+          title: Name
+          type: string
+        requested:
+          default: true
+          title: Requested
+          type: boolean
+        status:
+          enum:
+          - complete
+          - partial
+          - unsupported
+          - unavailable
+          - permission_denied
+          - skipped
+          title: Status
+          type: string
+      required:
+      - name
+      - status
+      title: ScanScopePayload
       type: object
     ScheduleCreate:
       additionalProperties: false

--- a/docs/schemas/v1/PushPayload.json
+++ b/docs/schemas/v1/PushPayload.json
@@ -56,6 +56,20 @@
       "additionalProperties": true,
       "description": "Canonical evidence-quality contract, separate from job lifecycle.",
       "properties": {
+        "complete_scope_count": {
+          "default": 0,
+          "maximum": 100,
+          "minimum": 0,
+          "title": "Complete Scope Count",
+          "type": "integer"
+        },
+        "incomplete_scope_count": {
+          "default": 0,
+          "maximum": 100,
+          "minimum": 0,
+          "title": "Incomplete Scope Count",
+          "type": "integer"
+        },
         "issues": {
           "items": {
             "$ref": "#/$defs/ScanIssuePayload"
@@ -74,6 +88,21 @@
           "title": "Outcome",
           "type": "string"
         },
+        "requested_scope_count": {
+          "default": 0,
+          "maximum": 100,
+          "minimum": 0,
+          "title": "Requested Scope Count",
+          "type": "integer"
+        },
+        "scopes": {
+          "items": {
+            "$ref": "#/$defs/ScanScopePayload"
+          },
+          "maxItems": 100,
+          "title": "Scopes",
+          "type": "array"
+        },
         "warning_count": {
           "default": 0,
           "maximum": 100,
@@ -83,6 +112,60 @@
         }
       },
       "title": "ScanRunPayload",
+      "type": "object"
+    },
+    "ScanScopePayload": {
+      "additionalProperties": false,
+      "description": "Bounded completeness metadata for one requested collection scope.",
+      "properties": {
+        "item_count": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Item Count"
+        },
+        "message": {
+          "default": "",
+          "maxLength": 500,
+          "title": "Message",
+          "type": "string"
+        },
+        "name": {
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "requested": {
+          "default": true,
+          "title": "Requested",
+          "type": "boolean"
+        },
+        "status": {
+          "enum": [
+            "complete",
+            "partial",
+            "unsupported",
+            "unavailable",
+            "permission_denied",
+            "skipped"
+          ],
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "status"
+      ],
+      "title": "ScanScopePayload",
       "type": "object"
     }
   },

--- a/docs/schemas/v1/ScanRunPayload.json
+++ b/docs/schemas/v1/ScanRunPayload.json
@@ -51,11 +51,79 @@
       ],
       "title": "ScanIssuePayload",
       "type": "object"
+    },
+    "ScanScopePayload": {
+      "additionalProperties": false,
+      "description": "Bounded completeness metadata for one requested collection scope.",
+      "properties": {
+        "item_count": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Item Count"
+        },
+        "message": {
+          "default": "",
+          "maxLength": 500,
+          "title": "Message",
+          "type": "string"
+        },
+        "name": {
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "requested": {
+          "default": true,
+          "title": "Requested",
+          "type": "boolean"
+        },
+        "status": {
+          "enum": [
+            "complete",
+            "partial",
+            "unsupported",
+            "unavailable",
+            "permission_denied",
+            "skipped"
+          ],
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "status"
+      ],
+      "title": "ScanScopePayload",
+      "type": "object"
     }
   },
   "additionalProperties": true,
   "description": "Canonical evidence-quality contract, separate from job lifecycle.",
   "properties": {
+    "complete_scope_count": {
+      "default": 0,
+      "maximum": 100,
+      "minimum": 0,
+      "title": "Complete Scope Count",
+      "type": "integer"
+    },
+    "incomplete_scope_count": {
+      "default": 0,
+      "maximum": 100,
+      "minimum": 0,
+      "title": "Incomplete Scope Count",
+      "type": "integer"
+    },
     "issues": {
       "items": {
         "$ref": "#/$defs/ScanIssuePayload"
@@ -73,6 +141,21 @@
       ],
       "title": "Outcome",
       "type": "string"
+    },
+    "requested_scope_count": {
+      "default": 0,
+      "maximum": 100,
+      "minimum": 0,
+      "title": "Requested Scope Count",
+      "type": "integer"
+    },
+    "scopes": {
+      "items": {
+        "$ref": "#/$defs/ScanScopePayload"
+      },
+      "maxItems": 100,
+      "title": "Scopes",
+      "type": "array"
     },
     "warning_count": {
       "default": 0,

--- a/docs/schemas/v1/ScanScopePayload.json
+++ b/docs/schemas/v1/ScanScopePayload.json
@@ -1,0 +1,54 @@
+{
+  "additionalProperties": false,
+  "description": "Bounded completeness metadata for one requested collection scope.",
+  "properties": {
+    "item_count": {
+      "anyOf": [
+        {
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Item Count"
+    },
+    "message": {
+      "default": "",
+      "maxLength": 500,
+      "title": "Message",
+      "type": "string"
+    },
+    "name": {
+      "maxLength": 100,
+      "minLength": 1,
+      "title": "Name",
+      "type": "string"
+    },
+    "requested": {
+      "default": true,
+      "title": "Requested",
+      "type": "boolean"
+    },
+    "status": {
+      "enum": [
+        "complete",
+        "partial",
+        "unsupported",
+        "unavailable",
+        "permission_denied",
+        "skipped"
+      ],
+      "title": "Status",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "status"
+  ],
+  "title": "ScanScopePayload",
+  "type": "object"
+}

--- a/docs/schemas/v1/index.json
+++ b/docs/schemas/v1/index.json
@@ -247,6 +247,11 @@
       "schema": "ScanRunPayload.json"
     },
     {
+      "doc": "Bounded completeness metadata for one requested collection scope.",
+      "name": "ScanScopePayload",
+      "schema": "ScanScopePayload.json"
+    },
+    {
       "doc": "",
       "name": "ScheduleCreate",
       "schema": "ScheduleCreate.json"

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -738,13 +738,28 @@ class ScanIssuePayload(BaseModel):
     affects_coverage: bool = True
 
 
+class ScanScopePayload(BaseModel):
+    """Bounded completeness metadata for one requested collection scope."""
+
+    model_config = ConfigDict(extra="forbid")
+    name: str = Field(min_length=1, max_length=100)
+    status: Literal["complete", "partial", "unsupported", "unavailable", "permission_denied", "skipped"]
+    requested: bool = True
+    item_count: int | None = Field(default=None, ge=0)
+    message: str = Field(default="", max_length=500)
+
+
 class ScanRunPayload(BaseModel):
     """Canonical evidence-quality contract, separate from job lifecycle."""
 
     model_config = ConfigDict(extra="allow")
     outcome: Literal["complete", "partial", "failed"] = "complete"
     issues: list[ScanIssuePayload] = Field(default_factory=list, max_length=100)
+    scopes: list[ScanScopePayload] = Field(default_factory=list, max_length=100)
     warning_count: int = Field(default=0, ge=0, le=100)
+    requested_scope_count: int = Field(default=0, ge=0, le=100)
+    complete_scope_count: int = Field(default=0, ge=0, le=100)
+    incomplete_scope_count: int = Field(default=0, ge=0, le=100)
 
 
 class PushPayload(BaseModel):

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -113,7 +113,7 @@ def _normalize_pushed_report(body: PushPayload, *, fallback_scan_id: str) -> dic
             agent["servers"] = sanitized_servers
         normalized_agents.append(agent)
     report["agents"] = normalized_agents
-    from agent_bom.evidence.scan_run import ScanIssue, ScanOutcome, ScanRun
+    from agent_bom.evidence.scan_run import ScanIssue, ScanOutcome, ScanRun, ScanScope, ScanScopeStatus
 
     raw_scan_run_value = report.get("scan_run")
     raw_scan_run: dict[str, Any] = raw_scan_run_value if isinstance(raw_scan_run_value, dict) else {}
@@ -149,7 +149,20 @@ def _normalize_pushed_report(body: PushPayload, *, fallback_scan_id: str) -> dic
             existing_messages.add(issue.message)
     raw_outcome = str(raw_scan_run.get("outcome") or "complete")
     outcome = ScanOutcome(raw_outcome)
-    scan_run = ScanRun(outcome=outcome, issues=issues)
+    scopes: list[ScanScope] = []
+    for raw_scope in raw_scan_run.get("scopes", []) or []:
+        if not isinstance(raw_scope, dict):
+            continue
+        scopes.append(
+            ScanScope(
+                name=str(raw_scope.get("name") or "unknown"),
+                status=ScanScopeStatus(str(raw_scope.get("status") or "skipped")),
+                requested=bool(raw_scope.get("requested", True)),
+                item_count=raw_scope.get("item_count") if isinstance(raw_scope.get("item_count"), int) else None,
+                message=str(raw_scope.get("message") or ""),
+            )
+        )
+    scan_run = ScanRun(outcome=outcome, issues=issues, scopes=scopes)
     report["scan_run"] = {**raw_scan_run, **scan_run.to_dict()}
     report["warnings"] = scan_run.warnings
     return report

--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -36,6 +36,20 @@ def _aggregate_sast_path_results(path_results: list[dict]) -> dict:
     )
 
 
+def _merge_unique_agents(primary: list[Any], additional: list[Any]) -> list[Any]:
+    """Merge project and ambient discovery without duplicating identities."""
+
+    merged = list(primary)
+    seen = {str(getattr(agent, "canonical_id", "") or getattr(agent, "stable_id", "") or getattr(agent, "name", "")) for agent in merged}
+    for agent in additional:
+        identity = str(getattr(agent, "canonical_id", "") or getattr(agent, "stable_id", "") or getattr(agent, "name", ""))
+        if identity in seen:
+            continue
+        seen.add(identity)
+        merged.append(agent)
+    return merged
+
+
 def _first_run_hints() -> list[tuple[str, str]]:
     """Return concrete config locations for common MCP clients on this platform."""
     system = platform.system()
@@ -114,6 +128,7 @@ def run_local_discovery(
     smithery_flag: bool = False,
     mcp_registry_flag: bool = False,
     os_packages: bool = False,
+    workstation_sweep: bool = False,
     _discover_all: Any = None,
     **kwargs: Any,
 ) -> None:
@@ -183,6 +198,23 @@ def run_local_discovery(
                 k8s_all_namespaces=k8s_all_namespaces,
                 k8s_context=k8s_mcp_context,
             )
+
+    if workstation_sweep and not no_discover and (project or config_dir):
+        # A project-scoped discovery intentionally skips ambient host surfaces.
+        # Workstation mode needs both, so collect global configs plus the
+        # opt-in MCP process/container evidence and merge by stable identity.
+        ambient_agents = _discover(
+            project_dir=None,
+            dynamic=dynamic_discovery,
+            dynamic_max_depth=dynamic_max_depth,
+            include_processes=include_processes,
+            include_containers=include_containers,
+            include_k8s_mcp=False,
+            k8s_namespace=k8s_namespace,
+            k8s_all_namespaces=False,
+            k8s_context=None,
+        )
+        ctx.agents = _merge_unique_agents(ctx.agents, ambient_agents)
 
     any_cloud = kwargs.get("_any_cloud", False)
     if (

--- a/src/agent_bom/cli/agents/_post.py
+++ b/src/agent_bom/cli/agents/_post.py
@@ -466,7 +466,10 @@ def compute_exit_code(
         scan_outcome = effective_scan_run(report).outcome
         if scan_outcome is not ScanOutcome.COMPLETE:
             if not quiet and not ctx.cloud_provider_failures:
-                con.print(f"\n  [red]Exiting with code 1: scan execution was {scan_outcome.value}; inspect scan_run.issues[/red]")
+                con.print(
+                    f"\n  [red]Exiting with code 1: scan execution was {scan_outcome.value}; "
+                    "inspect scan_run.scopes and scan_run.issues[/red]"
+                )
             exit_code = 1
 
     # Every branch above prints the specific reason it tripped. What none of

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -635,6 +635,12 @@ def scan(
     elif preset == "quick":
         transitive = False
         enrich = False
+    elif preset == "workstation":
+        browser_extensions = True
+        os_packages = True
+        include_processes = True
+        include_containers = True
+        context_graph_flag = True
 
     # ── CI environment detection (informational only) ──
     # Auto-quiet removed: tests run in CI and need output.
@@ -1106,6 +1112,7 @@ def scan(
         smithery_flag=smithery_flag,
         mcp_registry_flag=mcp_registry_flag,
         os_packages=os_packages,
+        workstation_sweep=preset == "workstation",
         iac_paths=iac_paths,
         _image_only=_image_only,
         _any_cloud=any_cloud,
@@ -2236,6 +2243,19 @@ def scan(
             import logging as _glog
 
             _glog.getLogger(__name__).debug("Graph persistence skipped: %s", _graph_err)
+
+    if preset == "workstation":
+        from agent_bom.endpoint import workstation_scan_scopes
+
+        _browser_extension_count = len((ctx._browser_ext_results or {}).get("extensions", []))
+        _context_graph_node_count = len((report.context_graph_data or {}).get("nodes", []))
+        report.scan_run.set_scopes(
+            workstation_scan_scopes(
+                agents=agents,
+                browser_extension_count=_browser_extension_count,
+                context_graph_node_count=_context_graph_node_count,
+            )
+        )
 
     # ── License compliance check ─────────────────────────────────────
     if license_check and agents:

--- a/src/agent_bom/cli/options_sources.py
+++ b/src/agent_bom/cli/options_sources.py
@@ -376,11 +376,12 @@ def scan_control_options(fn):
             click.option("--max-depth", type=int, default=3, help="Maximum depth for transitive dependency resolution"),
             click.option(
                 "--preset",
-                type=click.Choice(["ci", "enterprise", "quick"]),
+                type=click.Choice(["ci", "enterprise", "quick", "workstation"]),
                 default=None,
                 help=(
                     "Scan preset: ci (quiet, json, fail-on-critical), enterprise (enrich, introspect,"
-                    " transitive, verify-integrity, verify-instructions), quick (no transitive, no enrich)"
+                    " transitive, verify-integrity, verify-instructions), quick (no transitive, no enrich),"
+                    " workstation (repository, agents/MCP, browser extensions, host packages, MCP processes/containers, graph)"
                 ),
             ),
         ]

--- a/src/agent_bom/endpoint/__init__.py
+++ b/src/agent_bom/endpoint/__init__.py
@@ -1,0 +1,5 @@
+"""Endpoint and workstation evidence contracts."""
+
+from agent_bom.endpoint.scope import workstation_scan_scopes
+
+__all__ = ["workstation_scan_scopes"]

--- a/src/agent_bom/endpoint/scope.py
+++ b/src/agent_bom/endpoint/scope.py
@@ -1,0 +1,138 @@
+"""Truthful per-scope evidence for the workstation scan preset."""
+
+from __future__ import annotations
+
+import importlib.util
+import platform
+import shutil
+import subprocess
+from typing import Any
+
+from agent_bom.evidence.scan_run import ScanScope, ScanScopeStatus
+
+
+def _source_item_count(agents: list[Any], source: str) -> int:
+    return sum(len(getattr(agent, "mcp_servers", []) or []) for agent in agents if getattr(agent, "source", "") == source)
+
+
+def _package_count(agents: list[Any], sources: set[str]) -> int:
+    return sum(
+        len(getattr(server, "packages", []) or [])
+        for agent in agents
+        if getattr(agent, "source", "") in sources
+        for server in (getattr(agent, "mcp_servers", []) or [])
+    )
+
+
+def _container_scope(agents: list[Any]) -> ScanScope:
+    count = _source_item_count(agents, "container")
+    if not shutil.which("docker"):
+        return ScanScope(
+            name="mcp_containers",
+            status=ScanScopeStatus.UNAVAILABLE,
+            message="Docker CLI is not available; MCP container evidence was not collected.",
+        )
+    try:
+        probe = subprocess.run(
+            ["docker", "info", "--format", "{{.ServerVersion}}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ScanScope(
+            name="mcp_containers",
+            status=ScanScopeStatus.UNAVAILABLE,
+            message="Docker runtime could not be reached; MCP container evidence was not collected.",
+        )
+    if probe.returncode != 0:
+        return ScanScope(
+            name="mcp_containers",
+            status=ScanScopeStatus.UNAVAILABLE,
+            message="Docker runtime could not be reached; MCP container evidence was not collected.",
+        )
+    return ScanScope(
+        name="mcp_containers",
+        status=ScanScopeStatus.COMPLETE,
+        item_count=count,
+        message="MCP-indicating running containers only.",
+    )
+
+
+def workstation_scan_scopes(
+    *,
+    agents: list[Any],
+    browser_extension_count: int,
+    context_graph_node_count: int,
+    system: str | None = None,
+) -> list[ScanScope]:
+    """Describe every scope requested by ``--preset workstation``.
+
+    ``complete`` means the collector ran successfully; a zero item count is a
+    valid complete result. Unsupported or unavailable collectors are explicit
+    and downgrade the enclosing scan rather than looking clean.
+    """
+
+    host_system = system or platform.system()
+    process_count = _source_item_count(agents, "process")
+    package_count = _package_count(agents, {"os-packages"})
+
+    if host_system == "Linux":
+        package_scope = ScanScope(name="os_packages", status=ScanScopeStatus.COMPLETE, item_count=package_count)
+    elif host_system == "Darwin":
+        package_scope = ScanScope(
+            name="os_packages",
+            status=ScanScopeStatus.UNSUPPORTED,
+            message="Host package inventory is not implemented for macOS; Homebrew and installed apps were not evaluated.",
+        )
+    elif host_system == "Windows":
+        package_scope = ScanScope(
+            name="os_packages",
+            status=ScanScopeStatus.UNSUPPORTED,
+            message="Host package inventory is not implemented for Windows; installed applications were not evaluated.",
+        )
+    else:
+        package_scope = ScanScope(
+            name="os_packages",
+            status=ScanScopeStatus.UNSUPPORTED,
+            message=f"Host package inventory is not implemented for {host_system or 'this platform'}.",
+        )
+
+    if importlib.util.find_spec("psutil") is None:
+        process_scope = ScanScope(
+            name="mcp_processes",
+            status=ScanScopeStatus.UNAVAILABLE,
+            message="MCP process discovery requires the optional psutil dependency.",
+        )
+    else:
+        process_scope = ScanScope(
+            name="mcp_processes",
+            status=ScanScopeStatus.COMPLETE,
+            item_count=process_count,
+            message="MCP server processes only; general process and service inventory is not evaluated.",
+        )
+
+    return [
+        ScanScope(
+            name="repository_inventory",
+            status=ScanScopeStatus.COMPLETE,
+            item_count=_package_count(agents, {"project", "filesystem"}),
+            message="Repository dependencies and supported static evidence only; installed applications are a separate scope.",
+        ),
+        ScanScope(
+            name="agents_mcp",
+            status=ScanScopeStatus.COMPLETE,
+            item_count=sum(len(getattr(agent, "mcp_servers", []) or []) for agent in agents),
+        ),
+        ScanScope(
+            name="browser_extensions",
+            status=ScanScopeStatus.COMPLETE,
+            item_count=browser_extension_count,
+            message="Medium-or-higher risk browser extensions reported by supported browser profiles.",
+        ),
+        package_scope,
+        process_scope,
+        _container_scope(agents),
+        ScanScope(name="context_graph", status=ScanScopeStatus.COMPLETE, item_count=context_graph_node_count),
+    ]

--- a/src/agent_bom/evidence/scan_run.py
+++ b/src/agent_bom/evidence/scan_run.py
@@ -21,6 +21,45 @@ class ScanOutcome(str, Enum):
     FAILED = "failed"
 
 
+class ScanScopeStatus(str, Enum):
+    """Completeness of one explicitly requested scan scope."""
+
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+    UNSUPPORTED = "unsupported"
+    UNAVAILABLE = "unavailable"
+    PERMISSION_DENIED = "permission_denied"
+    SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class ScanScope:
+    """Bounded evidence status for one requested collection scope."""
+
+    name: str
+    status: ScanScopeStatus
+    requested: bool = True
+    item_count: int | None = None
+    message: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", sanitize_text(self.name, max_len=100) or "unknown")
+        if isinstance(self.status, str):
+            object.__setattr__(self, "status", ScanScopeStatus(self.status))
+        if self.item_count is not None:
+            object.__setattr__(self, "item_count", max(0, int(self.item_count)))
+        object.__setattr__(self, "message", sanitize_text(self.message, max_len=500))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status.value,
+            "requested": self.requested,
+            "item_count": self.item_count,
+            "message": self.message,
+        }
+
+
 @dataclass(frozen=True)
 class ScanIssue:
     """One sanitized execution issue projected to every report surface."""
@@ -57,11 +96,13 @@ class ScanRun:
 
     outcome: ScanOutcome = ScanOutcome.COMPLETE
     issues: list[ScanIssue] = field(default_factory=list)
+    scopes: list[ScanScope] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if isinstance(self.outcome, str):
             self.outcome = ScanOutcome(self.outcome)
         self.issues = self._dedupe(self.issues)
+        self.scopes = self._dedupe_scopes(self.scopes)
         self._derive_partial()
 
     @staticmethod
@@ -76,11 +117,25 @@ class ScanRun:
         return unique
 
     def _derive_partial(self) -> None:
-        if self.outcome is ScanOutcome.COMPLETE and any(issue.affects_coverage for issue in self.issues):
+        scope_incomplete = any(
+            scope.requested and scope.status not in {ScanScopeStatus.COMPLETE, ScanScopeStatus.SKIPPED} for scope in self.scopes
+        )
+        if self.outcome is ScanOutcome.COMPLETE and (any(issue.affects_coverage for issue in self.issues) or scope_incomplete):
             self.outcome = ScanOutcome.PARTIAL
+
+    @staticmethod
+    def _dedupe_scopes(scopes: list[ScanScope]) -> list[ScanScope]:
+        unique: dict[str, ScanScope] = {}
+        for scope in scopes[:100]:
+            unique[scope.name] = scope
+        return list(unique.values())
 
     def add_issue(self, issue: ScanIssue) -> None:
         self.issues = self._dedupe([*self.issues, issue])
+        self._derive_partial()
+
+    def set_scopes(self, scopes: list[ScanScope]) -> None:
+        self.scopes = self._dedupe_scopes(scopes)
         self._derive_partial()
 
     def mark_failed(self) -> None:
@@ -91,10 +146,16 @@ class ScanRun:
         return [issue.message for issue in self.issues]
 
     def to_dict(self) -> dict[str, Any]:
+        requested_scopes = [scope for scope in self.scopes if scope.requested]
+        complete_scope_count = sum(scope.status is ScanScopeStatus.COMPLETE for scope in requested_scopes)
         return {
             "outcome": self.outcome.value,
             "issues": [issue.to_dict() for issue in self.issues],
             "warning_count": len(self.issues),
+            "requested_scope_count": len(requested_scopes),
+            "complete_scope_count": complete_scope_count,
+            "incomplete_scope_count": len(requested_scopes) - complete_scope_count,
+            "scopes": [scope.to_dict() for scope in self.scopes],
         }
 
 
@@ -104,6 +165,7 @@ def effective_scan_run(report: Any) -> ScanRun:
     run = ScanRun(
         outcome=getattr(raw, "outcome", ScanOutcome.COMPLETE),
         issues=list(getattr(raw, "issues", []) or []),
+        scopes=list(getattr(raw, "scopes", []) or []),
     )
     for warning in getattr(report, "coverage_warnings", []) or []:
         if not isinstance(warning, dict):
@@ -156,6 +218,8 @@ __all__ = [
     "ScanIssue",
     "ScanOutcome",
     "ScanRun",
+    "ScanScope",
+    "ScanScopeStatus",
     "effective_scan_run",
     "vulnerability_coverage_incomplete",
 ]

--- a/tests/test_endpoint_sweep_contract.py
+++ b/tests/test_endpoint_sweep_contract.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+from agent_bom.evidence.scan_run import ScanOutcome, ScanRun, ScanScope, ScanScopeStatus
+
+
+def test_requested_incomplete_scope_downgrades_scan_and_serializes_reason() -> None:
+    run = ScanRun(
+        scopes=[
+            ScanScope(name="agents_mcp", status=ScanScopeStatus.COMPLETE, item_count=0),
+            ScanScope(
+                name="os_packages",
+                status=ScanScopeStatus.UNSUPPORTED,
+                message="Host package inventory is not implemented for this platform.",
+            ),
+        ]
+    )
+
+    assert run.outcome is ScanOutcome.PARTIAL
+    assert run.to_dict()["requested_scope_count"] == 2
+    assert run.to_dict()["complete_scope_count"] == 1
+    assert run.to_dict()["incomplete_scope_count"] == 1
+    assert run.to_dict()["scopes"] == [
+        {
+            "name": "agents_mcp",
+            "status": "complete",
+            "requested": True,
+            "item_count": 0,
+            "message": "",
+        },
+        {
+            "name": "os_packages",
+            "status": "unsupported",
+            "requested": True,
+            "item_count": None,
+            "message": "Host package inventory is not implemented for this platform.",
+        },
+    ]
+
+
+def test_unrequested_skipped_scope_does_not_downgrade_complete_scan() -> None:
+    run = ScanRun(scopes=[ScanScope(name="mcp_containers", status="skipped", requested=False)])
+
+    assert run.outcome is ScanOutcome.COMPLETE
+
+
+def test_workstation_preset_on_macos_reports_unsupported_package_scope(tmp_path) -> None:
+    output = tmp_path / "workstation.json"
+
+    with (
+        patch("agent_bom.cli.agents.discover_all", return_value=[]),
+        patch("agent_bom.endpoint.scope.platform.system", return_value="Darwin"),
+        patch("agent_bom.parsers.browser_extensions.discover_browser_extensions", return_value=[]),
+    ):
+        result = CliRunner().invoke(
+            main,
+            [
+                "scan",
+                "--preset",
+                "workstation",
+                "--no-scan",
+                "--offline",
+                "--format",
+                "json",
+                "--output",
+                str(output),
+            ],
+        )
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(output.read_text())
+    scopes = {scope["name"]: scope for scope in payload["scan_run"]["scopes"]}
+    assert payload["scan_run"]["outcome"] == "partial"
+    assert scopes["agents_mcp"]["status"] == "complete"
+    assert scopes["browser_extensions"]["status"] == "complete"
+    assert scopes["os_packages"]["status"] == "unsupported"
+    assert scopes["context_graph"]["status"] == "complete"
+    assert "mcp_processes" in scopes
+    assert "mcp_containers" in scopes
+    assert "processes" not in scopes
+    assert "containers" not in scopes
+    assert "not implemented for macOS" in scopes["os_packages"]["message"]
+
+
+def test_workstation_is_a_documented_scan_preset() -> None:
+    result = CliRunner().invoke(main, ["scan", "--help"])
+
+    assert result.exit_code == 0
+    assert "workstation" in result.output
+
+
+def test_workstation_project_scan_also_collects_ambient_endpoint_surfaces(tmp_path) -> None:
+    output = tmp_path / "workstation.json"
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with (
+        patch("agent_bom.cli.agents.discover_all", side_effect=[[], []]) as discover,
+        patch("agent_bom.endpoint.scope.platform.system", return_value="Darwin"),
+        patch("agent_bom.parsers.browser_extensions.discover_browser_extensions", return_value=[]),
+    ):
+        result = CliRunner().invoke(
+            main,
+            [
+                "scan",
+                str(project),
+                "--preset",
+                "workstation",
+                "--no-scan",
+                "--offline",
+                "--format",
+                "json",
+                "--output",
+                str(output),
+            ],
+        )
+
+    assert result.exit_code == 1, result.output
+    assert discover.call_count == 2
+    assert discover.call_args_list[0].kwargs["project_dir"] == str(project)
+    assert discover.call_args_list[1].kwargs["project_dir"] is None
+    assert discover.call_args_list[1].kwargs["include_processes"] is True
+    assert discover.call_args_list[1].kwargs["include_containers"] is True
+
+
+def test_push_normalization_preserves_scope_truth_and_derives_partial() -> None:
+    from agent_bom.api.models import PushPayload
+    from agent_bom.api.routes.observability import _normalize_pushed_report
+
+    payload = PushPayload.model_validate(
+        {
+            "source_id": "endpoint-1",
+            "scan_run": {
+                "outcome": "complete",
+                "scopes": [
+                    {"name": "agents_mcp", "status": "complete", "item_count": 2},
+                    {
+                        "name": "os_packages",
+                        "status": "unsupported",
+                        "message": "Host package inventory is unavailable.",
+                    },
+                ],
+            },
+        }
+    )
+
+    normalized = _normalize_pushed_report(payload, fallback_scan_id="scan-1")
+
+    assert normalized["scan_run"]["outcome"] == "partial"
+    assert normalized["scan_run"]["scopes"][1] == {
+        "name": "os_packages",
+        "status": "unsupported",
+        "requested": True,
+        "item_count": None,
+        "message": "Host package inventory is unavailable.",
+    }


### PR DESCRIPTION
## Summary

- add a documented `--preset workstation` entry point that combines repository scanning with ambient agent, MCP, browser-extension, process, container, and graph discovery
- attach explicit requested scope, status, item count, and reason metadata to scan results and preserve it through authenticated control-plane push normalization
- derive partial outcomes from incomplete requested scopes so unsupported or unavailable endpoint evidence cannot be presented as complete
- regenerate OpenAPI, v1 schemas, and product metrics for the additive scan-scope contract

## User impact

Developers receive one workstation-oriented first command and an honest record of what was collected, unsupported, skipped, or unavailable. The contract establishes the foundation for the next OS application, process, service, listener, image, and container collectors without claiming those collectors are already present.

## Verification

- `pytest -q tests/test_endpoint_sweep_contract.py tests/test_push.py tests/test_findings_push.py tests/api/test_api_endpoints.py` — 116 passed
- `ruff check` and `ruff format --check` on changed Python sources and tests
- `mypy` on changed source modules
- `python scripts/check_exception_sanitization.py`
- `make preflight`
- real `agent-bom scan . --preset workstation --offline --format json` smoke — complete report with an honest partial verdict and explicit scope reasons
- `git diff --check`

## Notes

- Additive API/schema change; existing scan commands and response fields remain compatible.
- The real macOS smoke reported 1,074 repository packages, 26 agent/MCP observations, 6 browser-extension observations, and an 82-node context graph. Installed applications and host process/container collectors remain explicit gaps for the dependent collector change.
