### PR TITLE
feat(fleet): centralize workstation evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,23 +26,16 @@
   <a href="https://msaad00.github.io/agent-bom/">Docs</a>
 </p>
 
-## What it is
+## Scan, correlate, and act
 
-`agent-bom` scans repositories, images, and cloud accounts, then correlates what
-it finds into one Finding + UnifiedGraph model — powering CLI and CI artifacts,
-fleet and browser investigations, compliance evidence, and runtime policy. Run
-the scanner without an account, or deploy the control plane inside your own
-cloud, VPC, cluster, database, identity, and audit boundary.
+`agent-bom` scans repositories, developer endpoints, images, clusters, cloud and
+data platforms, MCP servers, and runtime activity, then normalizes the evidence
+into one Finding + UnifiedGraph model for prioritized investigation and action.
 
-Graph provenance stays explicit: collected, inferred, static, and runtime
-relationships remain distinct, and unavailable evidence is never upgraded to
-observed.
-
-### From source to verified action
-
-Repository, workstation, image, cluster, cloud, data-platform, MCP, and runtime
-evidence follows one workflow. Raw source and credentials stay local; only
-normalized evidence crosses into shared control-plane or fleet state.
+- **Start locally or in CI:** produce findings, SARIF, SBOMs, HTML reports, and graph exports without an account.
+- **Centralize when ready:** self-host fleet, browser, compliance, and audit evidence inside your cloud and identity boundary.
+- **Act with context:** follow Path → Impact → Owner → Fix → Verify, then export, rescan, or enforce at runtime.
+- **Keep evidence honest:** raw source and credentials stay local; collected, inferred, static, and runtime relationships stay distinct, while partial and unavailable evidence remains explicit.
 
 <p align="center">
   <picture>

--- a/deploy/snowflake/README.md
+++ b/deploy/snowflake/README.md
@@ -19,7 +19,7 @@ never leave your account. There are two packagings here:
 
 | File | Purpose |
 | --- | --- |
-| `setup.sql` | One-shot SPCS bring-up: database/schema, the four backing tables (`scan_jobs`, `fleet_agents`, `gateway_policies`, `policy_audit_log` — the same schema `snowflake_store.py` auto-creates), image repository, compute pool, and the `agent_bom_service`. |
+| `setup.sql` | One-shot SPCS bring-up: database/schema and backing tables (`scan_jobs`, `fleet_agents`, `fleet_endpoints`, `gateway_policies`, `policy_audit_log` — the same schema `snowflake_store.py` auto-creates), image repository, compute pool, and the `agent_bom_service`. |
 | `service-spec.yaml` | SPCS service spec for the two containers — the FastAPI API (`8422`) and the Next.js UI (`3000`). Both share the service network namespace, so the UI reaches the API on `localhost` with **no public egress**; both endpoints are declared `public: false`. |
 | `streamlit_app.py` | Streamlit-in-Snowflake dashboard that reads the backing tables **directly** (no HTTP round-trip) via `st.connection("snowflake")`. |
 | `environment.yml` | Conda environment (`plotly`, `pandas`) for the Streamlit-in-Snowflake app. |

--- a/deploy/snowflake/native-app/dcm/V003__fleet_endpoints.sql
+++ b/deploy/snowflake/native-app/dcm/V003__fleet_endpoints.sql
@@ -1,0 +1,9 @@
+-- Upgrade existing Native App installs with privacy-safe endpoint fleet state.
+CREATE TABLE IF NOT EXISTS core.fleet_endpoints (
+    tenant_id    VARCHAR NOT NULL,
+    endpoint_id  VARCHAR NOT NULL,
+    completeness VARCHAR NOT NULL,
+    updated_at   TIMESTAMP_TZ NOT NULL,
+    data         VARIANT NOT NULL,
+    PRIMARY KEY (tenant_id, endpoint_id)
+);

--- a/deploy/snowflake/native-app/scripts/setup.sql
+++ b/deploy/snowflake/native-app/scripts/setup.sql
@@ -43,6 +43,15 @@ CREATE TABLE IF NOT EXISTS core.fleet_agents (
     PRIMARY KEY (tenant_id, agent_id)
 );
 
+CREATE TABLE IF NOT EXISTS core.fleet_endpoints (
+    tenant_id VARCHAR NOT NULL,
+    endpoint_id VARCHAR NOT NULL,
+    completeness VARCHAR NOT NULL,
+    updated_at TIMESTAMP_TZ NOT NULL,
+    data VARIANT NOT NULL,
+    PRIMARY KEY (tenant_id, endpoint_id)
+);
+
 CREATE TABLE IF NOT EXISTS core.gateway_policies (
     policy_id VARCHAR PRIMARY KEY,
     name VARCHAR NOT NULL,

--- a/deploy/snowflake/setup.sql
+++ b/deploy/snowflake/setup.sql
@@ -34,6 +34,15 @@ CREATE TABLE IF NOT EXISTS fleet_agents (
     PRIMARY KEY (tenant_id, agent_id)
 );
 
+CREATE TABLE IF NOT EXISTS fleet_endpoints (
+    tenant_id VARCHAR NOT NULL,
+    endpoint_id VARCHAR NOT NULL,
+    completeness VARCHAR NOT NULL,
+    updated_at TIMESTAMP_TZ NOT NULL,
+    data VARIANT NOT NULL,
+    PRIMARY KEY (tenant_id, endpoint_id)
+);
+
 CREATE TABLE IF NOT EXISTS gateway_policies (
     policy_id VARCHAR PRIMARY KEY,
     name VARCHAR NOT NULL,

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -192,6 +192,17 @@ CREATE INDEX IF NOT EXISTS idx_fleet_name ON fleet_agents(name);
 CREATE INDEX IF NOT EXISTS idx_fleet_state ON fleet_agents(lifecycle_state);
 CREATE INDEX IF NOT EXISTS idx_fleet_tenant ON fleet_agents(tenant_id);
 
+CREATE TABLE IF NOT EXISTS fleet_endpoints (
+    tenant_id    TEXT NOT NULL,
+    endpoint_id  TEXT NOT NULL,
+    completeness TEXT NOT NULL,
+    updated_at   TEXT NOT NULL,
+    data         JSONB NOT NULL,
+    PRIMARY KEY (tenant_id, endpoint_id)
+);
+CREATE INDEX IF NOT EXISTS idx_fleet_endpoints_tenant_updated
+    ON fleet_endpoints(tenant_id, updated_at DESC, endpoint_id);
+
 -- ── Tables: Gateway Policies ──────────────────────────────────────────────────
 
 CREATE TABLE IF NOT EXISTS gateway_policies (
@@ -875,6 +886,9 @@ ALTER TABLE trend_history FORCE ROW LEVEL SECURITY;
 ALTER TABLE fleet_agents ENABLE ROW LEVEL SECURITY;
 ALTER TABLE fleet_agents FORCE ROW LEVEL SECURITY;
 
+ALTER TABLE fleet_endpoints ENABLE ROW LEVEL SECURITY;
+ALTER TABLE fleet_endpoints FORCE ROW LEVEL SECURITY;
+
 ALTER TABLE scan_jobs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE scan_jobs FORCE ROW LEVEL SECURITY;
 
@@ -892,6 +906,21 @@ BEGIN
         CREATE POLICY teams_tenant_isolation ON teams
             USING (public.abom_rls_bypass() OR team_id = public.abom_current_tenant())
             WITH CHECK (public.abom_rls_bypass() OR team_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'fleet_endpoints'
+          AND policyname = 'fleet_endpoints_tenant_isolation'
+    ) THEN
+        CREATE POLICY fleet_endpoints_tenant_isolation ON fleet_endpoints
+            USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
     END IF;
 END
 $$;

--- a/deploy/supabase/postgres/runtime-schema.sql
+++ b/deploy/supabase/postgres/runtime-schema.sql
@@ -41,6 +41,8 @@ ALTER TABLE fleet_agents ADD COLUMN IF NOT EXISTS canonical_id TEXT NOT NULL DEF
 CREATE INDEX IF NOT EXISTS idx_fleet_canonical_id ON fleet_agents(canonical_id);
 CREATE INDEX IF NOT EXISTS idx_fleet_tenant_state_trust_name ON fleet_agents(tenant_id,lifecycle_state,trust_score DESC,name);
 CREATE INDEX IF NOT EXISTS idx_fleet_tenant_name_lower ON fleet_agents(tenant_id,LOWER(name));
+CREATE TABLE IF NOT EXISTS fleet_endpoints (tenant_id TEXT NOT NULL,endpoint_id TEXT NOT NULL,completeness TEXT NOT NULL,updated_at TEXT NOT NULL,data JSONB NOT NULL,PRIMARY KEY(tenant_id,endpoint_id));
+CREATE INDEX IF NOT EXISTS idx_fleet_endpoints_tenant_updated ON fleet_endpoints(tenant_id,updated_at DESC,endpoint_id);
 CREATE INDEX IF NOT EXISTS idx_pg_jobs_team_created ON scan_jobs(team_id,created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_pg_jobs_batch ON scan_jobs(team_id,batch_id,created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_pg_jobs_parent ON scan_jobs(team_id,parent_job_id,created_at DESC);
@@ -242,7 +244,7 @@ BEGIN
     'idempotency_keys','proxy_replay_log','tenant_quota_overrides','tenant_graph_retention_overrides','tenant_score_config_overrides',
     'mcp_client_configs','model_provider_keys','model_virtual_keys','risk_campaign_workflows','governance_audit_log','cloud_connections','ticketing_connections','ticket_links',
     'control_plane_sources','credential_refs','audit_chain_checkpoint','managed_trial_invitations','managed_trial_tenants','compliance_hub_findings','hub_findings_current',
-    'hub_findings_current_observations','hub_cve_intel','hub_framework_refs'
+    'hub_findings_current_observations','hub_cve_intel','hub_framework_refs','fleet_endpoints'
   ] LOOP
     EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY',t);
     EXECUTE format('ALTER TABLE %I FORCE ROW LEVEL SECURITY',t);

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -23,7 +23,7 @@ the caller wants to explore or to invoke — not by whether it is human.
 | Area | Shipped today |
 |---|---|
 | MCP security tools | 81 tools, 6 resources, 8 workflow prompts |
-| REST API | 389 operations across 47 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
+| REST API | 391 operations across 47 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |
 | Runtime proxy | stdio/local MCP inline enforcement (7 detectors) |

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 328 |
+| `docs/openapi/v1.json` | paths | 330 |
 | `docs/openapi/v1.json` | component schemas | 143 |
 
 <!-- DATA_MODEL_ATLAS:END -->
@@ -353,6 +353,7 @@ single-node `agent-bom serve` deployment.
 | `vulns`, `affected`, `cpe_matches`, `epss_scores`, `kev_entries` | Offline OSV/GHSA/NVD/Alpine/Debian-Security-Tracker/EPSS/KEV catalog plus NVD CPE applicability (`cpe_matches`) (`affected` rows are release-scoped for distro ecosystems, e.g. `debian:10`) | n/a (read-only catalog) |
 | `jobs` | Scan job state | yes (per-tenant SQLite path or in-row column) |
 | `fleet_agents` | Fleet inventory | yes |
+| `fleet_endpoints` | Latest privacy-safe workstation evidence per source ID | yes |
 | `gateway_policies` | Gateway policy rules | yes |
 | `policy_audit_log` | Gateway policy mutation audit | yes |
 | `sources` | Source registry | yes |
@@ -370,6 +371,7 @@ list/put plus session-scoped `app.current_tenant` for RLS.
 | `scan_jobs` | `ScanJob` (api/models.py) | global `job_id` PK + tenant column (`team_id` / `tenant_id`) |
 | `cis_benchmark_checks` | CIS benchmark JSON blobs normalized via `analytics_contract.build_cis_benchmark_check_rows` | indexed cloud/status/priority remediation rows for `/v1/cis/checks`; backfilled by `scripts/migrations/backfill_cis_benchmark_checks.py` |
 | `fleet_agents` | `FleetAgent` (api/fleet_store.py) | trust score + lifecycle state |
+| `fleet_endpoints` | `FleetEndpoint` (api/fleet_store.py) | platform, bounded counts, collector truth, and privacy contract; no raw process rows |
 | `api_keys` | `ApiKey` (api/auth.py) | scrypt hashes, expiry, role, tenant |
 | `exceptions` | `Exception` (api/exceptions.py) | suppression workflow |
 | `gateway_policies` + `policy_audit_log` | `GatewayPolicy` | RBAC-gated mutations, tenant-native reads |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -384,6 +384,7 @@ Additional env vars: `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_USER`, `SNOWFLAKE_DATABASE`
 |-------|---------|
 | `scan_jobs` | Scan job persistence (status, results as VARIANT) |
 | `fleet_agents` | Fleet agent lifecycle (trust scores, states) |
+| `fleet_endpoints` | Latest privacy-safe workstation sweep summary per tenant/source ID |
 | `gateway_policies` | Runtime MCP gateway policies |
 | `policy_audit_log` | Policy enforcement audit trail |
 

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 859,
+      "value": 860,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 48 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 859 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 860 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
-- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (328 paths / 389 operations)
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (330 paths / 391 operations)
 
 ## AI / agent developers (MCP · clients · tools)
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -47,7 +47,7 @@ docker compose -f deploy/docker-compose.pilot.yml up -d
 
 - Deployment chooser (Docker / Helm / EKS / Postgres):
   [`../site-docs/deployment/overview.md`](../site-docs/deployment/overview.md)
-- API contract (389 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
+- API contract (391 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
 - Enterprise auth, tenancy, RBAC: [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md),
   [`PERMISSIONS.md`](PERMISSIONS.md)
 - Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -1,129 +1,102 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="960" height="620" viewBox="0 0 960 620" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="1320" viewBox="0 0 1120 1320" fill="none">
 <title>agent-bom control-plane architecture</title>
-<desc>Layered sources, processing engine, platform, and consumers.</desc>
-<rect width="960" height="620" rx="14" fill="#0a0a0c"/>
-<rect x="12" y="12" width="936" height="596" rx="18" fill="none" stroke="#6366f1" stroke-width="2" opacity="0.22"/>
-<rect x="842" y="20" width="90" height="22" rx="11" fill="#312e81" opacity="0.85"/>
-<text x="887" y="35" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.8" font-weight="800" letter-spacing="0.14em" fill="#c7d2fe">LAYERED</text>
-<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="22.0" font-weight="800" fill="#f4f4f5">Control-plane architecture</text>
-<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="11.0" font-weight="500" fill="#71717a">Vertical tiers · sources feed engine · evidence + platform · people + agents consume</text>
-<rect x="28" y="78" width="904" height="102" rx="12" fill="#0f0f13" stroke="#38bdf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="78" width="904" height="3" rx="12" fill="#38bdf8" opacity="0.55"/>
-<rect x="40" y="88" width="4" height="22" rx="2" fill="#38bdf8"/><text x="54" y="103" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#38bdf8">INTAKE SOURCES</text><text x="910" y="103" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#bae6fd">read-only</text>
-<rect x="40" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="48" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="78" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Supply chain</text>
-<text x="78" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">15 eco</text>
-<rect x="166" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="174" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(178,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="204" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Agents &amp; MCP</text>
-<text x="204" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">29 clients</text>
-<rect x="292" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="300" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(304,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="330" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Cloud</text>
-<text x="330" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">4 connect · 16 scan</text>
-<rect x="418" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="426" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(430,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="456" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">IaC &amp; OCI</text>
-<text x="456" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">TF·K8s·img</text>
-<rect x="544" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="552" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(556,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
-<text x="582" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Secrets</text>
-<text x="582" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">refs only</text>
-<rect x="670" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="678" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(682,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="708" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Models</text>
-<text x="708" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">13 formats</text>
-<rect x="796" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="804" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(808,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="834" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">SBOM import</text>
-<text x="834" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">CDX·SPDX</text>
-<line x1="480" y1="182" x2="480" y2="196" stroke="#38bdf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,200 476,194 484,194" fill="#38bdf8"/><text x="480" y="177" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="800" letter-spacing="0.1em" fill="#38bdf8">INGEST</text>
-<rect x="28" y="192" width="904" height="96" rx="12" fill="#0f0f13" stroke="#818cf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="192" width="904" height="3" rx="12" fill="#818cf8" opacity="0.55"/>
-<rect x="40" y="202" width="4" height="22" rx="2" fill="#818cf8"/><text x="54" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#818cf8">PROCESSING ENGINE</text><text x="910" y="217" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#c7d2fe">local scan</text>
-<rect x="40" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="48" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="78" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">OSV scan</text>
-<text x="78" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">batch</text>
-<rect x="218" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="226" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(230,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="256" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Enrichment</text>
-<text x="256" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">NVD·EPSS</text>
-<rect x="396" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="404" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(408,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="434" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Posture</text>
-<text x="434" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">CIS·MCP</text>
-<rect x="574" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="582" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(586,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="612" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Blast radius</text>
-<text x="612" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">fusion</text>
-<rect x="752" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="760" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(764,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="790" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Policy</text>
-<text x="790" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">as-code</text>
-<line x1="480" y1="290" x2="480" y2="304" stroke="#818cf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,308 476,302 484,302" fill="#818cf8"/><text x="480" y="285" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="800" letter-spacing="0.1em" fill="#818cf8">PROCESS</text>
-<rect x="28" y="300" width="904" height="136" rx="12" fill="#0f0f13" stroke="#2dd4bf" stroke-width="1.2" opacity="0.95"/><rect x="28" y="300" width="904" height="3" rx="12" fill="#2dd4bf" opacity="0.55"/>
-<rect x="40" y="310" width="4" height="22" rx="2" fill="#2dd4bf"/><text x="54" y="325" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#2dd4bf">EVIDENCE &amp; PLATFORM</text><text x="910" y="325" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#99f6e4">auth · self-hosted</text>
-<rect x="40" y="332" width="214" height="29" rx="8" fill="#15121f" stroke="#2dd4bf" stroke-width="1.5"/>
-<rect x="48" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,338) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6.5c0 4.5-3.2 7.8-8 9.5-4.8-1.7-8-5-8-9.5V6z"/><path d="M12 9v4"/><path d="M12 16.5h.01"/></g>
-<text x="78" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Unified Finding</text>
-<text x="78" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#2dd4bf">one schema</text>
-<rect x="258" y="332" width="214" height="29" rx="8" fill="#15121f" stroke="#2dd4bf" stroke-width="1.5"/>
-<rect x="266" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(270,338) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="296" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">UnifiedGraph</text>
-<text x="296" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#2dd4bf">attack paths</text>
-<rect x="40" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="48" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
-<text x="78" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Stores</text>
-<text x="78" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">PG·SQLite</text>
-<rect x="258" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="266" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(270,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="296" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Audit chain</text>
-<text x="296" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">signed</text>
-<rect x="488" y="332" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="496" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,338) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="526" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">REST API</text>
-<text x="526" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">389 ops</text>
-<rect x="706" y="332" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="714" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(718,338) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="744" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Gateway</text>
-<text x="744" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">runtime</text>
-<rect x="488" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="496" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">MCP server</text>
-<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">81 tools</text>
-<rect x="706" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="714" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(718,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Fleet jobs</text>
-<text x="744" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">Helm·EKS</text>
-<rect x="488" y="398" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="496" y="400" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,404) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="526" y="411" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Scheduler / events</text>
-<text x="526" y="422" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">cadence·change</text>
-<line x1="480" y1="438" x2="480" y2="452" stroke="#2dd4bf" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,456 476,450 484,450" fill="#2dd4bf"/><text x="480" y="433" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">DELIVER</text>
-<rect x="28" y="448" width="904" height="140" rx="12" fill="#0f0f13" stroke="#c084fc" stroke-width="1.2" opacity="0.95"/><rect x="28" y="448" width="904" height="3" rx="12" fill="#c084fc" opacity="0.55"/>
-<rect x="40" y="458" width="4" height="22" rx="2" fill="#c084fc"/><text x="54" y="473" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#c084fc">CONSUMERS &amp; ARTIFACTS</text><text x="910" y="473" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#e9d5ff">deliver</text>
-<text x="182" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="800" letter-spacing="0.1em" fill="#c084fc">PEOPLE</text>
-<rect x="40" y="492" width="285" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
-<rect x="50" y="495" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(54,499) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
-<text x="80" y="511" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#e9e9ec">CLI</text>
-<rect x="40" y="527" width="285" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
-<rect x="50" y="530" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(54,534) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="80" y="546" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#e9e9ec">Web UI</text>
-<text x="479" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="800" letter-spacing="0.1em" fill="#c084fc">AGENTS</text>
-<rect x="337" y="492" width="285" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
-<rect x="347" y="495" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(351,499) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="377" y="511" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#e9e9ec">MCP</text>
-<rect x="337" y="527" width="285" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
-<rect x="347" y="530" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(351,534) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="377" y="546" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#e9e9ec">SDK</text>
-<text x="776" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="800" letter-spacing="0.1em" fill="#c084fc">ARTIFACTS</text>
-<rect x="634" y="492" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="679.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#a1a1aa">SARIF</text>
-<rect x="730" y="492" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="775.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#a1a1aa">CDX</text>
-<rect x="826" y="492" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="871.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#a1a1aa">SPDX</text>
-<rect x="634" y="517" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="679.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#a1a1aa">OCSF</text>
-<rect x="730" y="517" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="775.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#a1a1aa">HTML</text>
-<rect x="826" y="517" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="871.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#a1a1aa">JSON</text>
-<text x="776" y="552" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="600" fill="#6b6b75">SIEM · webhooks</text>
-<rect x="24" y="582" width="912" height="26" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="480" y="600" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="600" fill="#4ade80">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
+<desc>Sources enter a local processing engine, become tenant-scoped evidence, and leave through human, agent, and artifact surfaces.</desc>
+<rect width="1120" height="1320" rx="22" fill="#0a0a0c"/>
+<text x="36" y="48" font-family="ui-monospace,monospace" font-size="15" font-weight="800" letter-spacing="0.14em" fill="#a78bfa">CONTROL-PLANE ARCHITECTURE</text>
+<text x="36" y="86" font-family="Inter,system-ui,sans-serif" font-size="28" font-weight="800" fill="#f4f4f5">Four layers from read-only intake to verified action</text>
+<rect x="36" y="122" width="1048" height="260" rx="16" fill="#0f0f13" stroke="#38bdf8" stroke-width="1.5"/>
+<rect x="36" y="122" width="6" height="260" rx="3" fill="#38bdf8"/>
+<text x="58" y="157" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" letter-spacing="0.06em" fill="#38bdf8">1 · INTAKE SOURCES</text>
+<text x="1062" y="157" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="700" fill="#82828c">read-only collectors</text>
+<rect x="53" y="176" width="330" height="82" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="69" y="194" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(73,198) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="121" y="215" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Code + supply chain</text>
+<text x="121" y="241" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">repos · CI · packages · secrets</text>
+<rect x="395" y="176" width="330" height="82" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="411" y="194" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(415,198) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="463" y="215" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Agents + MCP + models</text>
+<text x="463" y="241" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">clients · servers · model files</text>
+<rect x="737" y="176" width="330" height="82" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="753" y="194" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(757,198) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="805" y="215" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Cloud + data</text>
+<text x="805" y="241" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">AWS · Azure · GCP · Snowflake</text>
+<rect x="224" y="270" width="330" height="82" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="240" y="288" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(244,292) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="292" y="309" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Images + infrastructure</text>
+<text x="292" y="335" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">OCI · K8s · IaC · workloads</text>
+<rect x="566" y="270" width="330" height="82" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="582" y="288" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(586,292) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="634" y="309" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Imported evidence</text>
+<text x="634" y="335" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">CDX · SPDX · SARIF · scans</text>
+<line x1="560" y1="384" x2="560" y2="398" stroke="#38bdf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="560,402 556,396 564,396" fill="#38bdf8"/><text x="560" y="379" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.5" font-weight="800" letter-spacing="0.1em" fill="#38bdf8">COLLECT</text>
+<rect x="36" y="414" width="1048" height="224" rx="16" fill="#0f0f13" stroke="#818cf8" stroke-width="1.5"/>
+<rect x="36" y="414" width="6" height="224" rx="3" fill="#818cf8"/>
+<text x="58" y="449" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" letter-spacing="0.06em" fill="#818cf8">2 · LOCAL PROCESSING ENGINE</text>
+<text x="1062" y="449" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="700" fill="#82828c">bounded + failure-honest</text>
+<rect x="58" y="476" width="244" height="104" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="74" y="494" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(78,498) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="126" y="515" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Scan</text>
+<text x="126" y="541" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">OSV · SAST · posture</text>
+<rect x="312" y="476" width="244" height="104" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="328" y="494" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(332,498) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="380" y="515" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Enrich</text>
+<text x="380" y="541" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">NVD · EPSS · KEV</text>
+<rect x="566" y="476" width="244" height="104" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="582" y="494" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(586,498) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="634" y="515" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Correlate</text>
+<text x="634" y="541" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">identity · reachability</text>
+<rect x="820" y="476" width="244" height="104" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="836" y="494" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(840,498) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="888" y="515" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Prioritize</text>
+<text x="888" y="541" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">blast radius · policy</text>
+<line x1="560" y1="640" x2="560" y2="654" stroke="#818cf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="560,658 556,652 564,652" fill="#818cf8"/><text x="560" y="635" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.5" font-weight="800" letter-spacing="0.1em" fill="#818cf8">PERSIST</text>
+<rect x="36" y="670" width="1048" height="342" rx="16" fill="#0f0f13" stroke="#2dd4bf" stroke-width="1.5"/>
+<rect x="36" y="670" width="6" height="342" rx="3" fill="#2dd4bf"/>
+<text x="58" y="705" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" letter-spacing="0.06em" fill="#2dd4bf">3 · EVIDENCE + SERVING PLANE</text>
+<text x="1062" y="705" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="700" fill="#82828c">tenant-scoped · authenticated</text>
+<text x="54" y="740" font-family="ui-monospace,monospace" font-size="14" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">EVIDENCE MODEL</text>
+<text x="569" y="740" font-family="ui-monospace,monospace" font-size="14" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">CONTROL + DELIVERY</text>
+<rect x="54" y="758" width="497" height="64" rx="12" fill="#15121f" stroke="#2dd4bf" stroke-width="1.6"/>
+<rect x="70" y="776" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(74,780) scale(1.25)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6.5c0 4.5-3.2 7.8-8 9.5-4.8-1.7-8-5-8-9.5V6z"/><path d="M12 9v4"/><path d="M12 16.5h.01"/></g>
+<text x="122" y="797" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Unified Finding</text>
+<text x="122" y="823" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#2dd4bf">scope · completeness · provenance</text>
+<rect x="54" y="832" width="497" height="64" rx="12" fill="#15121f" stroke="#2dd4bf" stroke-width="1.6"/>
+<rect x="70" y="850" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(74,854) scale(1.25)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="122" y="871" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">UnifiedGraph</text>
+<text x="122" y="897" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#2dd4bf">assets · identities · paths</text>
+<rect x="54" y="906" width="497" height="64" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="70" y="924" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(74,928) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
+<text x="122" y="945" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Portable stores</text>
+<text x="122" y="971" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">SQLite · Postgres · Snowflake</text>
+<rect x="569" y="758" width="497" height="64" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="585" y="776" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(589,780) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="637" y="797" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">REST API + MCP</text>
+<text x="637" y="823" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">391 operations · 81 tools</text>
+<rect x="569" y="832" width="497" height="64" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="585" y="850" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(589,854) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="637" y="871" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Fleet + scheduler</text>
+<text x="637" y="897" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">endpoints · jobs · change events</text>
+<rect x="569" y="906" width="497" height="64" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="585" y="924" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(589,928) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="637" y="945" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Gateway + policy</text>
+<text x="637" y="971" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">observe · decide · enforce</text>
+<line x1="560" y1="1014" x2="560" y2="1028" stroke="#2dd4bf" stroke-width="1.6" stroke-linecap="round"/><polygon points="560,1032 556,1026 564,1026" fill="#2dd4bf"/><text x="560" y="1009" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.5" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">DELIVER</text>
+<rect x="36" y="1044" width="1048" height="206" rx="16" fill="#0f0f13" stroke="#c084fc" stroke-width="1.5"/>
+<rect x="36" y="1044" width="6" height="206" rx="3" fill="#c084fc"/>
+<text x="58" y="1079" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" letter-spacing="0.06em" fill="#c084fc">4 · CONSUMERS + VERIFIED OUTCOMES</text>
+<text x="1062" y="1079" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="700" fill="#82828c">least-privilege delivery</text>
+<rect x="58" y="1110" width="330" height="92" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="74" y="1128" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(78,1132) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="126" y="1149" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">People</text>
+<text x="126" y="1175" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">CLI · Web UI · operators</text>
+<rect x="398" y="1110" width="330" height="92" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="414" y="1128" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(418,1132) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="466" y="1149" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Agents</text>
+<text x="466" y="1175" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">MCP · SDK · automation</text>
+<rect x="738" y="1110" width="330" height="92" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="754" y="1128" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(758,1132) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="806" y="1149" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Artifacts</text>
+<text x="806" y="1175" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">SBOM · SARIF · OCSF · HTML/JSON</text>
+<rect x="24" y="1270" width="1072" height="38" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="560" y="1300" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="12.5" font-weight="600" fill="#4ade80">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -1,129 +1,102 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="960" height="620" viewBox="0 0 960 620" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="1320" viewBox="0 0 1120 1320" fill="none">
 <title>agent-bom control-plane architecture</title>
-<desc>Layered sources, processing engine, platform, and consumers.</desc>
-<rect width="960" height="620" rx="14" fill="#ffffff"/>
-<rect x="12" y="12" width="936" height="596" rx="18" fill="none" stroke="#6366f1" stroke-width="2" opacity="0.22"/>
-<rect x="842" y="20" width="90" height="22" rx="11" fill="#312e81" opacity="0.85"/>
-<text x="887" y="35" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.8" font-weight="800" letter-spacing="0.14em" fill="#c7d2fe">LAYERED</text>
-<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="22.0" font-weight="800" fill="#18181b">Control-plane architecture</text>
-<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="11.0" font-weight="500" fill="#71717a">Vertical tiers · sources feed engine · evidence + platform · people + agents consume</text>
-<rect x="28" y="78" width="904" height="102" rx="12" fill="#fafafa" stroke="#38bdf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="78" width="904" height="3" rx="12" fill="#38bdf8" opacity="0.55"/>
-<rect x="40" y="88" width="4" height="22" rx="2" fill="#38bdf8"/><text x="54" y="103" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#38bdf8">INTAKE SOURCES</text><text x="910" y="103" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#bae6fd">read-only</text>
-<rect x="40" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="48" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="78" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Supply chain</text>
-<text x="78" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">15 eco</text>
-<rect x="166" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="174" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(178,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="204" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Agents &amp; MCP</text>
-<text x="204" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">29 clients</text>
-<rect x="292" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="300" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(304,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="330" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Cloud</text>
-<text x="330" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">4 connect · 16 scan</text>
-<rect x="418" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="426" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(430,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="456" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">IaC &amp; OCI</text>
-<text x="456" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">TF·K8s·img</text>
-<rect x="544" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="552" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(556,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
-<text x="582" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Secrets</text>
-<text x="582" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">refs only</text>
-<rect x="670" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="678" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(682,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="708" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Models</text>
-<text x="708" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">13 formats</text>
-<rect x="796" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="804" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(808,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="834" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">SBOM import</text>
-<text x="834" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">CDX·SPDX</text>
-<line x1="480" y1="182" x2="480" y2="196" stroke="#38bdf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,200 476,194 484,194" fill="#38bdf8"/><text x="480" y="177" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="800" letter-spacing="0.1em" fill="#38bdf8">INGEST</text>
-<rect x="28" y="192" width="904" height="96" rx="12" fill="#fafafa" stroke="#818cf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="192" width="904" height="3" rx="12" fill="#818cf8" opacity="0.55"/>
-<rect x="40" y="202" width="4" height="22" rx="2" fill="#818cf8"/><text x="54" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#818cf8">PROCESSING ENGINE</text><text x="910" y="217" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#c7d2fe">local scan</text>
-<rect x="40" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="48" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="78" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">OSV scan</text>
-<text x="78" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">batch</text>
-<rect x="218" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="226" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(230,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="256" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Enrichment</text>
-<text x="256" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">NVD·EPSS</text>
-<rect x="396" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="404" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(408,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="434" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Posture</text>
-<text x="434" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">CIS·MCP</text>
-<rect x="574" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="582" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(586,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="612" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Blast radius</text>
-<text x="612" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">fusion</text>
-<rect x="752" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="760" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(764,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="790" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Policy</text>
-<text x="790" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">as-code</text>
-<line x1="480" y1="290" x2="480" y2="304" stroke="#818cf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,308 476,302 484,302" fill="#818cf8"/><text x="480" y="285" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="800" letter-spacing="0.1em" fill="#818cf8">PROCESS</text>
-<rect x="28" y="300" width="904" height="136" rx="12" fill="#fafafa" stroke="#2dd4bf" stroke-width="1.2" opacity="0.95"/><rect x="28" y="300" width="904" height="3" rx="12" fill="#2dd4bf" opacity="0.55"/>
-<rect x="40" y="310" width="4" height="22" rx="2" fill="#2dd4bf"/><text x="54" y="325" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#2dd4bf">EVIDENCE &amp; PLATFORM</text><text x="910" y="325" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#99f6e4">auth · self-hosted</text>
-<rect x="40" y="332" width="214" height="29" rx="8" fill="#f5f3ff" stroke="#2dd4bf" stroke-width="1.5"/>
-<rect x="48" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,338) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6.5c0 4.5-3.2 7.8-8 9.5-4.8-1.7-8-5-8-9.5V6z"/><path d="M12 9v4"/><path d="M12 16.5h.01"/></g>
-<text x="78" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Unified Finding</text>
-<text x="78" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#2dd4bf">one schema</text>
-<rect x="258" y="332" width="214" height="29" rx="8" fill="#f5f3ff" stroke="#2dd4bf" stroke-width="1.5"/>
-<rect x="266" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(270,338) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="296" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">UnifiedGraph</text>
-<text x="296" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#2dd4bf">attack paths</text>
-<rect x="40" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="48" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
-<text x="78" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Stores</text>
-<text x="78" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">PG·SQLite</text>
-<rect x="258" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="266" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(270,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="296" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Audit chain</text>
-<text x="296" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">signed</text>
-<rect x="488" y="332" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="496" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,338) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="526" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">REST API</text>
-<text x="526" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">389 ops</text>
-<rect x="706" y="332" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="714" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(718,338) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="744" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Gateway</text>
-<text x="744" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">runtime</text>
-<rect x="488" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="496" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">MCP server</text>
-<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">81 tools</text>
-<rect x="706" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="714" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(718,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Fleet jobs</text>
-<text x="744" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">Helm·EKS</text>
-<rect x="488" y="398" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="496" y="400" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,404) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="526" y="411" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Scheduler / events</text>
-<text x="526" y="422" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">cadence·change</text>
-<line x1="480" y1="438" x2="480" y2="452" stroke="#2dd4bf" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,456 476,450 484,450" fill="#2dd4bf"/><text x="480" y="433" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">DELIVER</text>
-<rect x="28" y="448" width="904" height="140" rx="12" fill="#fafafa" stroke="#c084fc" stroke-width="1.2" opacity="0.95"/><rect x="28" y="448" width="904" height="3" rx="12" fill="#c084fc" opacity="0.55"/>
-<rect x="40" y="458" width="4" height="22" rx="2" fill="#c084fc"/><text x="54" y="473" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#c084fc">CONSUMERS &amp; ARTIFACTS</text><text x="910" y="473" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#e9d5ff">deliver</text>
-<text x="182" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="800" letter-spacing="0.1em" fill="#c084fc">PEOPLE</text>
-<rect x="40" y="492" width="285" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="50" y="495" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(54,499) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
-<text x="80" y="511" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#18181b">CLI</text>
-<rect x="40" y="527" width="285" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="50" y="530" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(54,534) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="80" y="546" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#18181b">Web UI</text>
-<text x="479" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="800" letter-spacing="0.1em" fill="#c084fc">AGENTS</text>
-<rect x="337" y="492" width="285" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="347" y="495" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(351,499) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="377" y="511" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#18181b">MCP</text>
-<rect x="337" y="527" width="285" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="347" y="530" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(351,534) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="377" y="546" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#18181b">SDK</text>
-<text x="776" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="800" letter-spacing="0.1em" fill="#c084fc">ARTIFACTS</text>
-<rect x="634" y="492" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="679.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#52525b">SARIF</text>
-<rect x="730" y="492" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="775.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#52525b">CDX</text>
-<rect x="826" y="492" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="871.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#52525b">SPDX</text>
-<rect x="634" y="517" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="679.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#52525b">OCSF</text>
-<rect x="730" y="517" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="775.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#52525b">HTML</text>
-<rect x="826" y="517" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="871.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#52525b">JSON</text>
-<text x="776" y="552" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="600" fill="#9a9aa4">SIEM · webhooks</text>
-<rect x="24" y="582" width="912" height="26" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="480" y="600" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="600" fill="#15803d">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
+<desc>Sources enter a local processing engine, become tenant-scoped evidence, and leave through human, agent, and artifact surfaces.</desc>
+<rect width="1120" height="1320" rx="22" fill="#ffffff"/>
+<text x="36" y="48" font-family="ui-monospace,monospace" font-size="15" font-weight="800" letter-spacing="0.14em" fill="#7c3aed">CONTROL-PLANE ARCHITECTURE</text>
+<text x="36" y="86" font-family="Inter,system-ui,sans-serif" font-size="28" font-weight="800" fill="#18181b">Four layers from read-only intake to verified action</text>
+<rect x="36" y="122" width="1048" height="260" rx="16" fill="#fafafa" stroke="#38bdf8" stroke-width="1.5"/>
+<rect x="36" y="122" width="6" height="260" rx="3" fill="#38bdf8"/>
+<text x="58" y="157" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" letter-spacing="0.06em" fill="#38bdf8">1 · INTAKE SOURCES</text>
+<text x="1062" y="157" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="700" fill="#71717a">read-only collectors</text>
+<rect x="53" y="176" width="330" height="82" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="69" y="194" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(73,198) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="121" y="215" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Code + supply chain</text>
+<text x="121" y="241" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">repos · CI · packages · secrets</text>
+<rect x="395" y="176" width="330" height="82" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="411" y="194" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(415,198) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="463" y="215" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Agents + MCP + models</text>
+<text x="463" y="241" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">clients · servers · model files</text>
+<rect x="737" y="176" width="330" height="82" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="753" y="194" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(757,198) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="805" y="215" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Cloud + data</text>
+<text x="805" y="241" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">AWS · Azure · GCP · Snowflake</text>
+<rect x="224" y="270" width="330" height="82" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="240" y="288" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(244,292) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="292" y="309" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Images + infrastructure</text>
+<text x="292" y="335" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">OCI · K8s · IaC · workloads</text>
+<rect x="566" y="270" width="330" height="82" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="582" y="288" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(586,292) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="634" y="309" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Imported evidence</text>
+<text x="634" y="335" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">CDX · SPDX · SARIF · scans</text>
+<line x1="560" y1="384" x2="560" y2="398" stroke="#38bdf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="560,402 556,396 564,396" fill="#38bdf8"/><text x="560" y="379" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.5" font-weight="800" letter-spacing="0.1em" fill="#38bdf8">COLLECT</text>
+<rect x="36" y="414" width="1048" height="224" rx="16" fill="#fafafa" stroke="#818cf8" stroke-width="1.5"/>
+<rect x="36" y="414" width="6" height="224" rx="3" fill="#818cf8"/>
+<text x="58" y="449" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" letter-spacing="0.06em" fill="#818cf8">2 · LOCAL PROCESSING ENGINE</text>
+<text x="1062" y="449" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="700" fill="#71717a">bounded + failure-honest</text>
+<rect x="58" y="476" width="244" height="104" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="74" y="494" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(78,498) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="126" y="515" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Scan</text>
+<text x="126" y="541" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">OSV · SAST · posture</text>
+<rect x="312" y="476" width="244" height="104" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="328" y="494" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(332,498) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="380" y="515" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Enrich</text>
+<text x="380" y="541" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">NVD · EPSS · KEV</text>
+<rect x="566" y="476" width="244" height="104" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="582" y="494" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(586,498) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="634" y="515" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Correlate</text>
+<text x="634" y="541" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">identity · reachability</text>
+<rect x="820" y="476" width="244" height="104" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="836" y="494" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(840,498) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="888" y="515" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Prioritize</text>
+<text x="888" y="541" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">blast radius · policy</text>
+<line x1="560" y1="640" x2="560" y2="654" stroke="#818cf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="560,658 556,652 564,652" fill="#818cf8"/><text x="560" y="635" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.5" font-weight="800" letter-spacing="0.1em" fill="#818cf8">PERSIST</text>
+<rect x="36" y="670" width="1048" height="342" rx="16" fill="#fafafa" stroke="#2dd4bf" stroke-width="1.5"/>
+<rect x="36" y="670" width="6" height="342" rx="3" fill="#2dd4bf"/>
+<text x="58" y="705" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" letter-spacing="0.06em" fill="#2dd4bf">3 · EVIDENCE + SERVING PLANE</text>
+<text x="1062" y="705" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="700" fill="#71717a">tenant-scoped · authenticated</text>
+<text x="54" y="740" font-family="ui-monospace,monospace" font-size="14" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">EVIDENCE MODEL</text>
+<text x="569" y="740" font-family="ui-monospace,monospace" font-size="14" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">CONTROL + DELIVERY</text>
+<rect x="54" y="758" width="497" height="64" rx="12" fill="#f5f3ff" stroke="#2dd4bf" stroke-width="1.6"/>
+<rect x="70" y="776" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(74,780) scale(1.25)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6.5c0 4.5-3.2 7.8-8 9.5-4.8-1.7-8-5-8-9.5V6z"/><path d="M12 9v4"/><path d="M12 16.5h.01"/></g>
+<text x="122" y="797" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Unified Finding</text>
+<text x="122" y="823" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#2dd4bf">scope · completeness · provenance</text>
+<rect x="54" y="832" width="497" height="64" rx="12" fill="#f5f3ff" stroke="#2dd4bf" stroke-width="1.6"/>
+<rect x="70" y="850" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(74,854) scale(1.25)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="122" y="871" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">UnifiedGraph</text>
+<text x="122" y="897" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#2dd4bf">assets · identities · paths</text>
+<rect x="54" y="906" width="497" height="64" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="70" y="924" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(74,928) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
+<text x="122" y="945" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Portable stores</text>
+<text x="122" y="971" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">SQLite · Postgres · Snowflake</text>
+<rect x="569" y="758" width="497" height="64" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="585" y="776" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(589,780) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="637" y="797" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">REST API + MCP</text>
+<text x="637" y="823" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">391 operations · 81 tools</text>
+<rect x="569" y="832" width="497" height="64" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="585" y="850" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(589,854) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="637" y="871" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Fleet + scheduler</text>
+<text x="637" y="897" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">endpoints · jobs · change events</text>
+<rect x="569" y="906" width="497" height="64" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="585" y="924" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(589,928) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="637" y="945" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Gateway + policy</text>
+<text x="637" y="971" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">observe · decide · enforce</text>
+<line x1="560" y1="1014" x2="560" y2="1028" stroke="#2dd4bf" stroke-width="1.6" stroke-linecap="round"/><polygon points="560,1032 556,1026 564,1026" fill="#2dd4bf"/><text x="560" y="1009" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.5" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">DELIVER</text>
+<rect x="36" y="1044" width="1048" height="206" rx="16" fill="#fafafa" stroke="#c084fc" stroke-width="1.5"/>
+<rect x="36" y="1044" width="6" height="206" rx="3" fill="#c084fc"/>
+<text x="58" y="1079" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" letter-spacing="0.06em" fill="#c084fc">4 · CONSUMERS + VERIFIED OUTCOMES</text>
+<text x="1062" y="1079" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="700" fill="#71717a">least-privilege delivery</text>
+<rect x="58" y="1110" width="330" height="92" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="74" y="1128" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(78,1132) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="126" y="1149" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">People</text>
+<text x="126" y="1175" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">CLI · Web UI · operators</text>
+<rect x="398" y="1110" width="330" height="92" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="414" y="1128" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(418,1132) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="466" y="1149" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Agents</text>
+<text x="466" y="1175" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">MCP · SDK · automation</text>
+<rect x="738" y="1110" width="330" height="92" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="754" y="1128" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(758,1132) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="806" y="1149" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Artifacts</text>
+<text x="806" y="1175" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">SBOM · SARIF · OCSF · HTML/JSON</text>
+<rect x="24" y="1270" width="1072" height="38" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="560" y="1300" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="12.5" font-weight="600" fill="#15803d">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -18,7 +18,7 @@
 <rect x="35" y="126" width="378" height="52" rx="8" fill="none" stroke="#fb7185" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#fb7185"/>
 <text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">389 API ops · 81 MCP tools · SARIF</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">391 API ops · 81 MCP tools · SARIF</text>
 <rect x="439" y="18" width="402" height="174" rx="12" fill="#2dd4bf"/>
 <rect x="439" y="22" width="402" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="453" y="32" width="40" height="40" rx="11" fill="#2dd4bf" opacity="0.16"/><g transform="translate(457,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#2dd4bf"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#2dd4bf"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#2dd4bf"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#2dd4bf" stroke-width="1.05"/></g></g>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -18,7 +18,7 @@
 <rect x="35" y="126" width="378" height="52" rx="8" fill="none" stroke="#e11d48" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#e11d48"/>
 <text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#18181b">Agent-native surface</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">389 API ops · 81 MCP tools · SARIF</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">391 API ops · 81 MCP tools · SARIF</text>
 <rect x="439" y="18" width="402" height="174" rx="12" fill="#0d9488"/>
 <rect x="439" y="22" width="402" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="453" y="32" width="40" height="40" rx="11" fill="#0d9488" opacity="0.10"/><g transform="translate(457,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0d9488"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0d9488"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0d9488"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#ffffff" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#0d9488" stroke-width="1.05"/></g></g>

--- a/docs/images/workflow-dark.svg
+++ b/docs/images/workflow-dark.svg
@@ -1,90 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="720" viewBox="0 0 1400 720" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="1290" viewBox="0 0 1120 1290" fill="none">
 <title>agent-bom end-to-end evidence workflow</title>
 <desc>Sources flow through collection, normalization, correlation, ownership, remediation, verification, and action.</desc>
-<rect width="1400" height="720" rx="24" fill="#0a0a0c"/>
-<text x="40" y="50" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="800" letter-spacing="0.16em" fill="#a78bfa">FROM SOURCE TO VERIFIED ACTION</text>
-<text x="40" y="86" font-family="Inter,system-ui,sans-serif" font-size="24" font-weight="750" fill="#f4f4f5">One workflow across developer, endpoint, CI, cloud, control plane, and runtime</text>
-<text x="40" y="112" font-family="ui-monospace,monospace" font-size="13" font-weight="800" letter-spacing="0.13em" fill="#a78bfa">SOURCES</text>
-<rect x="40" y="126" width="252" height="96" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="54" y="141" width="28" height="28" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(58,145) scale(0.8333333333333334)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="92" y="160" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="750" fill="#e9e9ec">Repository + CI</text>
-<text x="54" y="187" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#82828c">code · deps · IaC · secrets</text>
-<rect x="306" y="126" width="252" height="96" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="320" y="141" width="28" height="28" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(324,145) scale(0.8333333333333334)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="358" y="160" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="750" fill="#e9e9ec">Workstation / endpoint</text>
-<text x="320" y="187" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#82828c">configs · agents · MCP · browsers</text>
-<rect x="572" y="126" width="252" height="96" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="586" y="141" width="28" height="28" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(590,145) scale(0.8333333333333334)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="624" y="160" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="750" fill="#e9e9ec">Images + Kubernetes</text>
-<text x="586" y="187" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#82828c">registry · filesystem · workloads</text>
-<rect x="838" y="126" width="252" height="96" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="852" y="141" width="28" height="28" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(856,145) scale(0.8333333333333334)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="890" y="160" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="750" fill="#e9e9ec">Cloud + data platforms</text>
-<text x="852" y="187" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#82828c">accounts · identity · posture</text>
-<rect x="852" y="195" width="68" height="22" rx="6" fill="#ffffff" stroke="#d4d4d8"/><g transform="translate(856,197) scale(0.45)"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+<rect width="1120" height="1290" rx="24" fill="#0a0a0c"/>
+<text x="36" y="45" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="800" letter-spacing="0.16em" fill="#a78bfa">FROM SOURCE TO VERIFIED ACTION</text>
+<text x="36" y="82" font-family="Inter,system-ui,sans-serif" font-size="28" font-weight="750" fill="#f4f4f5">One evidence workflow across every environment</text>
+<text x="36" y="114" font-family="ui-monospace,monospace" font-size="15" font-weight="800" letter-spacing="0.13em" fill="#a78bfa">1 · EVIDENCE SOURCES</text>
+<rect x="36.0" y="128" width="340" height="112" rx="14" fill="#161619" stroke="#2a2a31"/>
+<rect x="52.0" y="144" width="34" height="34" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(56.0,148) scale(1.0833333333333333)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="98.0" y="168" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="750" fill="#e9e9ec">Repository + CI</text>
+<text x="52.0" y="204" font-family="Inter,system-ui,sans-serif" font-size="14" fill="#82828c">code · dependencies · IaC · secrets</text>
+<rect x="390.0" y="128" width="340" height="112" rx="14" fill="#161619" stroke="#2a2a31"/>
+<rect x="406.0" y="144" width="34" height="34" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(410.0,148) scale(1.0833333333333333)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="452.0" y="168" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="750" fill="#e9e9ec">Workstation + endpoint</text>
+<text x="406.0" y="204" font-family="Inter,system-ui,sans-serif" font-size="14" fill="#82828c">apps · processes · agents · MCP</text>
+<rect x="744.0" y="128" width="340" height="112" rx="14" fill="#161619" stroke="#2a2a31"/>
+<rect x="760.0" y="144" width="34" height="34" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(764.0,148) scale(1.0833333333333333)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="806.0" y="168" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="750" fill="#e9e9ec">Images + Kubernetes</text>
+<text x="760.0" y="204" font-family="Inter,system-ui,sans-serif" font-size="14" fill="#82828c">registry · filesystem · workloads</text>
+<rect x="213.0" y="254" width="340" height="112" rx="14" fill="#161619" stroke="#2a2a31"/>
+<rect x="229.0" y="270" width="34" height="34" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(233.0,274) scale(1.0833333333333333)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="275.0" y="294" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="750" fill="#e9e9ec">Cloud + data platforms</text>
+<text x="229.0" y="330" font-family="Inter,system-ui,sans-serif" font-size="14" fill="#82828c">accounts · identity · posture</text>
+<rect x="229.0" y="336" width="92" height="26" rx="7" fill="#ffffff" stroke="#d4d4d8"/><g transform="translate(234.0,338) scale(0.55)"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
 <rect fill="#242F3E" x="0" y="0" width="40" height="40"/>
 <path d="M28.993,27.9952689 L11.487,27.9762689 C9.121,27.9742689 7.154,26.1292689 7.012,23.7752689 C7.004,23.6522689 7,23.5262689 7,23.3972689 C7,20.2992689 9.091,19.2872689 10.337,18.9592689 C10.577,18.8962689 10.735,18.6662689 10.707,18.4192689 C10.676,18.1492689 10.659,17.8752689 10.659,17.5962689 C10.659,15.1322689 12.308,12.4822689 14.415,11.5632689 C15.359,11.1502689 16.232,10.9862689 17.023,10.9862689 C19.276,10.9862689 20.867,12.3152689 21.561,13.0332689 C22.329,13.8262689 22.927,14.8382689 23.34,16.0422689 C23.4,16.2192689 23.555,16.3472689 23.74,16.3742689 C23.918,16.4012689 24.109,16.3232689 24.219,16.1712689 C24.807,15.3502689 25.766,14.9822689 26.659,15.2392689 C27.782,15.5602689 28.516,16.7272689 28.62,18.3072689 C28.578,18.5762689 28.759,18.8292689 29.027,18.8772689 C30.222,19.0892689 33,19.9572689 33,23.4402689 C33,27.5892689 29.114,27.9822689 28.993,27.9952689 M29.594,17.9742689 C29.379,16.0672689 28.4,14.6962689 26.934,14.2782689 C25.899,13.9822689 24.811,14.2452689 23.989,14.9502689 C23.553,13.9362689 22.979,13.0602689 22.28,12.3382689 C20.023,10.0052689 16.933,9.37226889 14.014,10.6462689 C11.531,11.7302689 9.659,14.7182689 9.659,17.5962689 C9.659,17.7702689 9.665,17.9432689 9.676,18.1142689 C8.319,18.5732689 6,19.8752689 6,23.3972689 C6,23.5492689 6.004,23.6962689 6.014,23.8382689 C6.188,26.7162689 8.593,28.9732689 11.486,28.9762689 L29.034,28.9932689 C29.084,28.9892689 34,28.5192689 34,23.4402689 C34,19.5022689 31.003,18.3142689 29.594,17.9742689" fill="#FFFFFF"/>
-</g></g><text x="879" y="211" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="700" fill="#18181b">AWS</text>
-<rect x="926" y="195" width="68" height="22" rx="6" fill="#ffffff" stroke="#d4d4d8"/><g transform="translate(930,197) scale(1.0)"><defs><linearGradient id="wf-dark-1-azure-cloud-gradient" x1="8.99" y1="16.61" x2="8.99" y2="-1.27" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#0078d4"/><stop offset="0.16" stop-color="#1380da"/><stop offset="0.53" stop-color="#3c91e5"/><stop offset="0.82" stop-color="#559cec"/><stop offset="1" stop-color="#5ea0ef"/></linearGradient></defs>
+</g></g><text x="265.0" y="354" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="700" fill="#18181b">AWS</text>
+<rect x="329.0" y="336" width="92" height="26" rx="7" fill="#ffffff" stroke="#d4d4d8"/><g transform="translate(334.0,338) scale(1.2222222222222223)"><defs><linearGradient id="wf-dark-1-azure-cloud-gradient" x1="8.99" y1="16.61" x2="8.99" y2="-1.27" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#0078d4"/><stop offset="0.16" stop-color="#1380da"/><stop offset="0.53" stop-color="#3c91e5"/><stop offset="0.82" stop-color="#559cec"/><stop offset="1" stop-color="#5ea0ef"/></linearGradient></defs>
 <path d="M18,10.55a4.11,4.11,0,0,0-3.51-4,5.14,5.14,0,0,0-5.25-5,5.26,5.26,0,0,0-5,3.47A4.87,4.87,0,0,0,0,9.82a4.94,4.94,0,0,0,5.07,4.8l.44,0h8.21a1.46,1.46,0,0,0,.22,0A4.13,4.13,0,0,0,18,10.55Z" fill="url(#wf-dark-1-azure-cloud-gradient)"/>
 <circle cx="5.24" cy="9.65" r="0.71" fill="#e3e3e3"/>
 <path d="M7.74,9.92V9.35l-.08,0-.61-.2-.16-.39.31-.66-.4-.4-.08,0L6.15,8l-.39-.16-.25-.69H4.94l0,.08-.2.61L4.32,8l-.65-.31-.4.4,0,.08.29.57-.16.39-.7.25V10l.08,0,.61.2.16.39-.31.66.4.4.08,0,.57-.29.39.16.25.69h.57l0-.08.2-.61.39-.16.66.31.4-.4,0-.08-.29-.57.16-.39Zm-2.5.83a1.1,1.1,0,1,1,1.1-1.1A1.09,1.09,0,0,1,5.24,10.75Z" fill="#fff"/>
 <circle cx="10" cy="6.59" r="0.84" fill="#e3e3e3"/>
-<path d="M13,6.91V6.23l-.09,0L12.17,6,12,5.49l.37-.8-.48-.48-.09,0-.69.35-.46-.19-.3-.83H9.64l0,.1-.24.73-.47.19-.78-.37-.48.48.05.09L8,5.5,7.84,6,7,6.27V7l.1,0,.73.24L8,7.69l-.37.8L8.13,9l.1-.05.68-.35.47.19.3.83h.68l0-.1.24-.73.47-.19.79.37.48-.48-.05-.09L12,7.68l.19-.47Zm-3,1a1.32,1.32,0,1,1,1.32-1.32A1.31,1.31,0,0,1,10,7.91Z" fill="#fff"/></g><text x="953" y="211" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="700" fill="#18181b">Azure</text>
-<rect x="1000" y="195" width="68" height="22" rx="6" fill="#ffffff" stroke="#d4d4d8"/><g transform="translate(1004,197) scale(0.03515625)"><rect width="512" height="512" fill="none"/>
+<path d="M13,6.91V6.23l-.09,0L12.17,6,12,5.49l.37-.8-.48-.48-.09,0-.69.35-.46-.19-.3-.83H9.64l0,.1-.24.73-.47.19-.78-.37-.48.48.05.09L8,5.5,7.84,6,7,6.27V7l.1,0,.73.24L8,7.69l-.37.8L8.13,9l.1-.05.68-.35.47.19.3.83h.68l0-.1.24-.73.47-.19.79.37.48-.48-.05-.09L12,7.68l.19-.47Zm-3,1a1.32,1.32,0,1,1,1.32-1.32A1.31,1.31,0,0,1,10,7.91Z" fill="#fff"/></g><text x="365.0" y="354" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="700" fill="#18181b">Azure</text>
+<rect x="429.0" y="336" width="92" height="26" rx="7" fill="#ffffff" stroke="#d4d4d8"/><g transform="translate(434.0,338) scale(0.04296875)"><rect width="512" height="512" fill="none"/>
 <path d="M239.85,490c-1.54,0-3.11-.22-4.64-.69-6.73-2.04-11.33-8.25-11.33-15.28v-165.79h-121.9c-5.9,0-11.31-3.25-14.09-8.45-2.78-5.2-2.46-11.51.82-16.41L258.96,29.09c3.91-5.84,11.19-8.44,17.92-6.4s11.33,8.25,11.33,15.28v165.78h121.82c5.9,0,11.31,3.25,14.09,8.45s2.46,11.51-.81,16.41l-170.18,254.3c-3.02,4.51-8.05,7.09-13.28,7.09ZM131.89,276.29h107.96c8.82,0,15.97,7.15,15.97,15.97v129.17l124.3-185.74h-107.89c-8.82,0-15.97-7.15-15.97-15.97V90.54l-124.37,185.75h0Z" fill="#9aa0a6"/>
 <path d="M418.56,235.7h-146.33c-8.82,0-15.97-7.15-15.97-15.97V33.12c1.4-2.09,3.01-5.12,5.69-7.37,2.52-2.11,6.13-3.74,10.28-3.74,8.82,0,15.97,7.15,15.97,15.97v165.78h121.82c8.82,0,15.97,7.15,15.97,15.97,0,5.33-2.4,8.46-4.12,10.98-1.46,2.14-2.34,3.52-3.33,4.99h.02Z" fill="#2b80f8"/>
-<path d="M239.85,490c-8.82,0-15.97-7.15-15.97-15.97v-197.73h15.97c8.82,0,15.97,7.15,15.97,15.97v186.61c-1.75,2.7-3.28,5.33-5.49,7.2-2.73,2.31-6.21,3.92-10.49,3.92h.01Z" fill="#2b80f8"/></g><text x="1027" y="211" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="700" fill="#18181b">GCP</text>
-<rect x="1104" y="126" width="252" height="96" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="1118" y="141" width="28" height="28" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(1122,145) scale(0.8333333333333334)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a4.5 4.5 0 0 0-6.1 6.1L5 16l3 3 3.6-3.6a4.5 4.5 0 0 0 6.1-6.1l-2.4 2.4"/></g>
-<text x="1156" y="160" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="750" fill="#e9e9ec">MCP + runtime</text>
-<text x="1118" y="187" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#82828c">servers · tools · live decisions</text>
-<rect x="40" y="286" width="252" height="176" rx="14" fill="#0f0f13" stroke="#38bdf8" stroke-width="1.4"/>
-<text x="56" y="316" font-family="ui-monospace,monospace" font-size="13" font-weight="800" fill="#38bdf8">01</text>
-<text x="56" y="347" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="800" fill="#e9e9ec">COLLECT + SCAN</text>
-<text x="56" y="390" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="650" fill="#e9e9ec">Read-only intake</text>
-<text x="56" y="418" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#82828c">scope + completeness</text>
-<line x1="295" y1="374" x2="298" y2="374" stroke="#8b5cf6" stroke-width="2"/><polygon points="303,374 296,369 296,379" fill="#8b5cf6"/>
-<rect x="306" y="286" width="252" height="176" rx="14" fill="#0f0f13" stroke="#818cf8" stroke-width="1.4"/>
-<text x="322" y="316" font-family="ui-monospace,monospace" font-size="13" font-weight="800" fill="#818cf8">02</text>
-<text x="322" y="347" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="800" fill="#e9e9ec">NORMALIZE</text>
-<text x="322" y="390" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="650" fill="#e9e9ec">Finding + UnifiedGraph</text>
-<text x="322" y="418" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#82828c">identity + provenance</text>
-<line x1="561" y1="374" x2="564" y2="374" stroke="#8b5cf6" stroke-width="2"/><polygon points="569,374 562,369 562,379" fill="#8b5cf6"/>
-<rect x="572" y="286" width="252" height="176" rx="14" fill="#0f0f13" stroke="#a78bfa" stroke-width="1.4"/>
-<text x="588" y="316" font-family="ui-monospace,monospace" font-size="13" font-weight="800" fill="#a78bfa">03</text>
-<text x="588" y="347" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="800" fill="#e9e9ec">CORRELATE + PRIORITIZE</text>
-<text x="588" y="390" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="650" fill="#e9e9ec">reachability + blast radius</text>
-<text x="588" y="418" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#82828c">evidence-backed rank</text>
-<line x1="827" y1="374" x2="830" y2="374" stroke="#8b5cf6" stroke-width="2"/><polygon points="835,374 828,369 828,379" fill="#8b5cf6"/>
-<rect x="838" y="286" width="252" height="176" rx="14" fill="#0f0f13" stroke="#34d399" stroke-width="1.4"/>
-<text x="854" y="316" font-family="ui-monospace,monospace" font-size="13" font-weight="800" fill="#34d399">04</text>
-<text x="854" y="347" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="800" fill="#e9e9ec">OWN + REMEDIATE</text>
-<text x="854" y="390" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="650" fill="#e9e9ec">owner + SLA + ticket</text>
-<text x="854" y="418" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#82828c">fix or accept risk</text>
-<line x1="1093" y1="374" x2="1096" y2="374" stroke="#8b5cf6" stroke-width="2"/><polygon points="1101,374 1094,369 1094,379" fill="#8b5cf6"/>
-<rect x="1104" y="286" width="252" height="176" rx="14" fill="#0f0f13" stroke="#fbbf24" stroke-width="1.4"/>
-<text x="1120" y="316" font-family="ui-monospace,monospace" font-size="13" font-weight="800" fill="#fbbf24">05</text>
-<text x="1120" y="347" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="800" fill="#e9e9ec">VERIFY + ACT</text>
-<text x="1120" y="390" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="650" fill="#e9e9ec">rescan + terminal state</text>
-<text x="1120" y="418" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#82828c">export · centralize · enforce</text>
-<rect x="40" y="488" width="1316" height="52" rx="12" fill="#15121f" stroke="#5b4bbd"/>
-<text x="698" y="521" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#a78bfa">Path -&gt; Impact -&gt; Owner -&gt; Fix -&gt; Verify</text>
-<rect x="40" y="568" width="207" height="46" rx="10" fill="#161619" stroke="#2a2a31"/>
-<text x="143.5" y="597" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="750" fill="#a1a1aa">SARIF</text>
-<rect x="259" y="568" width="207" height="46" rx="10" fill="#161619" stroke="#2a2a31"/>
-<text x="362.5" y="597" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="750" fill="#a1a1aa">CycloneDX</text>
-<rect x="478" y="568" width="207" height="46" rx="10" fill="#161619" stroke="#2a2a31"/>
-<text x="581.5" y="597" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="750" fill="#a1a1aa">SPDX</text>
-<rect x="697" y="568" width="207" height="46" rx="10" fill="#161619" stroke="#2a2a31"/>
-<text x="800.5" y="597" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="750" fill="#a1a1aa">HTML / JSON</text>
-<rect x="916" y="568" width="207" height="46" rx="10" fill="#161619" stroke="#2a2a31"/>
-<text x="1019.5" y="597" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="750" fill="#a1a1aa">Control plane</text>
-<rect x="1135" y="568" width="207" height="46" rx="10" fill="#161619" stroke="#2a2a31"/>
-<text x="1238.5" y="597" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="750" fill="#a1a1aa">Runtime policy</text>
-<rect x="40" y="642" width="650" height="44" rx="10" fill="#0c1a14" stroke="#1f4438"/>
-<text x="365" y="670" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="700" fill="#4ade80">Raw source + credentials stay local</text>
-<rect x="706" y="642" width="650" height="44" rx="10" fill="#121016" stroke="#2a2733"/>
-<text x="1031" y="670" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="700" fill="#82828c">Unavailable remains unavailable · partial stays explicit</text>
+<path d="M239.85,490c-8.82,0-15.97-7.15-15.97-15.97v-197.73h15.97c8.82,0,15.97,7.15,15.97,15.97v186.61c-1.75,2.7-3.28,5.33-5.49,7.2-2.73,2.31-6.21,3.92-10.49,3.92h.01Z" fill="#2b80f8"/></g><text x="465.0" y="354" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="700" fill="#18181b">GCP</text>
+<rect x="567.0" y="254" width="340" height="112" rx="14" fill="#161619" stroke="#2a2a31"/>
+<rect x="583.0" y="270" width="34" height="34" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(587.0,274) scale(1.0833333333333333)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a4.5 4.5 0 0 0-6.1 6.1L5 16l3 3 3.6-3.6a4.5 4.5 0 0 0 6.1-6.1l-2.4 2.4"/></g>
+<text x="629.0" y="294" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="750" fill="#e9e9ec">MCP + runtime</text>
+<text x="583.0" y="330" font-family="Inter,system-ui,sans-serif" font-size="14" fill="#82828c">servers · tools · live decisions</text>
+<text x="36" y="436" font-family="ui-monospace,monospace" font-size="15" font-weight="800" letter-spacing="0.13em" fill="#a78bfa">2 · EVIDENCE PIPELINE</text>
+<rect x="84" y="454" width="952" height="102" rx="16" fill="#0f0f13" stroke="#38bdf8" stroke-width="1.6"/>
+<text x="106" y="492" font-family="ui-monospace,monospace" font-size="17" font-weight="800" fill="#38bdf8">01</text>
+<rect x="154" y="476" width="42" height="42" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(158,480) scale(1.4166666666666667)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="214" y="493" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#e9e9ec">COLLECT + SCAN</text>
+<text x="214" y="526" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="700" fill="#e9e9ec">Read-only intake</text>
+<text x="554" y="526" font-family="Inter,system-ui,sans-serif" font-size="15" fill="#82828c">Scope and completeness stay explicit</text>
+<line x1="560.0" y1="558" x2="560.0" y2="565" stroke="#8b5cf6" stroke-width="2"/><polygon points="560.0,570 555.0,563 565.0,563" fill="#8b5cf6"/>
+<rect x="84" y="570" width="952" height="102" rx="16" fill="#0f0f13" stroke="#818cf8" stroke-width="1.6"/>
+<text x="106" y="608" font-family="ui-monospace,monospace" font-size="17" font-weight="800" fill="#818cf8">02</text>
+<rect x="154" y="592" width="42" height="42" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(158,596) scale(1.4166666666666667)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="214" y="609" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#e9e9ec">NORMALIZE</text>
+<text x="214" y="642" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="700" fill="#e9e9ec">Finding + UnifiedGraph</text>
+<text x="554" y="642" font-family="Inter,system-ui,sans-serif" font-size="15" fill="#82828c">Identity, provenance, and evidence state</text>
+<line x1="560.0" y1="674" x2="560.0" y2="681" stroke="#8b5cf6" stroke-width="2"/><polygon points="560.0,686 555.0,679 565.0,679" fill="#8b5cf6"/>
+<rect x="84" y="686" width="952" height="102" rx="16" fill="#0f0f13" stroke="#a78bfa" stroke-width="1.6"/>
+<text x="106" y="724" font-family="ui-monospace,monospace" font-size="17" font-weight="800" fill="#a78bfa">03</text>
+<rect x="154" y="708" width="42" height="42" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(158,712) scale(1.4166666666666667)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="214" y="725" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#e9e9ec">CORRELATE + PRIORITIZE</text>
+<text x="214" y="758" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="700" fill="#e9e9ec">Reachability + blast radius</text>
+<text x="554" y="758" font-family="Inter,system-ui,sans-serif" font-size="15" fill="#82828c">Rank paths with evidence, not raw volume</text>
+<line x1="560.0" y1="790" x2="560.0" y2="797" stroke="#8b5cf6" stroke-width="2"/><polygon points="560.0,802 555.0,795 565.0,795" fill="#8b5cf6"/>
+<rect x="84" y="802" width="952" height="102" rx="16" fill="#0f0f13" stroke="#34d399" stroke-width="1.6"/>
+<text x="106" y="840" font-family="ui-monospace,monospace" font-size="17" font-weight="800" fill="#34d399">04</text>
+<rect x="154" y="824" width="42" height="42" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(158,828) scale(1.4166666666666667)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a4.5 4.5 0 0 0-6.1 6.1L5 16l3 3 3.6-3.6a4.5 4.5 0 0 0 6.1-6.1l-2.4 2.4"/></g>
+<text x="214" y="841" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#e9e9ec">OWN + REMEDIATE</text>
+<text x="214" y="874" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="700" fill="#e9e9ec">Owner + SLA + ticket</text>
+<text x="554" y="874" font-family="Inter,system-ui,sans-serif" font-size="15" fill="#82828c">Fix, accept risk, or mark a false positive</text>
+<line x1="560.0" y1="906" x2="560.0" y2="913" stroke="#8b5cf6" stroke-width="2"/><polygon points="560.0,918 555.0,911 565.0,911" fill="#8b5cf6"/>
+<rect x="84" y="918" width="952" height="102" rx="16" fill="#0f0f13" stroke="#fbbf24" stroke-width="1.6"/>
+<text x="106" y="956" font-family="ui-monospace,monospace" font-size="17" font-weight="800" fill="#fbbf24">05</text>
+<rect x="154" y="940" width="42" height="42" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(158,944) scale(1.4166666666666667)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="214" y="957" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#e9e9ec">VERIFY + ACT</text>
+<text x="214" y="990" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="700" fill="#e9e9ec">Rescan + terminal state</text>
+<text x="554" y="990" font-family="Inter,system-ui,sans-serif" font-size="15" fill="#82828c">Export, centralize, or enforce at runtime</text>
+<rect x="84" y="1044" width="952" height="54" rx="12" fill="#15121f" stroke="#5b4bbd"/>
+<text x="560.0" y="1079" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#a78bfa">3 · INVESTIGATE  ›  PATH  ›  IMPACT  ›  OWNER  ›  FIX  ›  VERIFY</text>
+<text x="36" y="1114" font-family="ui-monospace,monospace" font-size="15" font-weight="800" letter-spacing="0.13em" fill="#a78bfa">4 · VERIFIED OUTCOMES</text>
+<rect x="36" y="1128" width="164" height="52" rx="11" fill="#161619" stroke="#2a2a31"/>
+<text x="118.0" y="1161" text-anchor="middle" font-family="ui-monospace,monospace" font-size="14" font-weight="750" fill="#a1a1aa">SARIF</text>
+<rect x="212" y="1128" width="164" height="52" rx="11" fill="#161619" stroke="#2a2a31"/>
+<text x="294.0" y="1161" text-anchor="middle" font-family="ui-monospace,monospace" font-size="14" font-weight="750" fill="#a1a1aa">CycloneDX</text>
+<rect x="388" y="1128" width="164" height="52" rx="11" fill="#161619" stroke="#2a2a31"/>
+<text x="470.0" y="1161" text-anchor="middle" font-family="ui-monospace,monospace" font-size="14" font-weight="750" fill="#a1a1aa">SPDX</text>
+<rect x="564" y="1128" width="164" height="52" rx="11" fill="#161619" stroke="#2a2a31"/>
+<text x="646.0" y="1161" text-anchor="middle" font-family="ui-monospace,monospace" font-size="14" font-weight="750" fill="#a1a1aa">HTML + JSON</text>
+<rect x="740" y="1128" width="164" height="52" rx="11" fill="#161619" stroke="#2a2a31"/>
+<text x="822.0" y="1161" text-anchor="middle" font-family="ui-monospace,monospace" font-size="14" font-weight="750" fill="#a1a1aa">Control plane</text>
+<rect x="916" y="1128" width="164" height="52" rx="11" fill="#161619" stroke="#2a2a31"/>
+<text x="998.0" y="1161" text-anchor="middle" font-family="ui-monospace,monospace" font-size="14" font-weight="750" fill="#a1a1aa">Runtime policy</text>
+<rect x="36" y="1208" width="516" height="50" rx="11" fill="#0c1a14" stroke="#1f4438"/>
+<text x="294" y="1240" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="700" fill="#4ade80">Raw source + credentials stay local</text>
+<rect x="568" y="1208" width="516" height="50" rx="11" fill="#121016" stroke="#2a2733"/>
+<text x="826" y="1240" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="700" fill="#82828c">Unavailable remains unavailable · partial stays explicit</text>
 </svg>

--- a/docs/images/workflow-light.svg
+++ b/docs/images/workflow-light.svg
@@ -1,90 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="720" viewBox="0 0 1400 720" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="1290" viewBox="0 0 1120 1290" fill="none">
 <title>agent-bom end-to-end evidence workflow</title>
 <desc>Sources flow through collection, normalization, correlation, ownership, remediation, verification, and action.</desc>
-<rect width="1400" height="720" rx="24" fill="#ffffff"/>
-<text x="40" y="50" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="800" letter-spacing="0.16em" fill="#7c3aed">FROM SOURCE TO VERIFIED ACTION</text>
-<text x="40" y="86" font-family="Inter,system-ui,sans-serif" font-size="24" font-weight="750" fill="#18181b">One workflow across developer, endpoint, CI, cloud, control plane, and runtime</text>
-<text x="40" y="112" font-family="ui-monospace,monospace" font-size="13" font-weight="800" letter-spacing="0.13em" fill="#7c3aed">SOURCES</text>
-<rect x="40" y="126" width="252" height="96" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="54" y="141" width="28" height="28" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(58,145) scale(0.8333333333333334)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="92" y="160" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="750" fill="#18181b">Repository + CI</text>
-<text x="54" y="187" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#71717a">code · deps · IaC · secrets</text>
-<rect x="306" y="126" width="252" height="96" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="320" y="141" width="28" height="28" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(324,145) scale(0.8333333333333334)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="358" y="160" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="750" fill="#18181b">Workstation / endpoint</text>
-<text x="320" y="187" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#71717a">configs · agents · MCP · browsers</text>
-<rect x="572" y="126" width="252" height="96" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="586" y="141" width="28" height="28" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(590,145) scale(0.8333333333333334)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="624" y="160" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="750" fill="#18181b">Images + Kubernetes</text>
-<text x="586" y="187" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#71717a">registry · filesystem · workloads</text>
-<rect x="838" y="126" width="252" height="96" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="852" y="141" width="28" height="28" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(856,145) scale(0.8333333333333334)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="890" y="160" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="750" fill="#18181b">Cloud + data platforms</text>
-<text x="852" y="187" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#71717a">accounts · identity · posture</text>
-<rect x="852" y="195" width="68" height="22" rx="6" fill="#ffffff" stroke="#d4d4d8"/><g transform="translate(856,197) scale(0.45)"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+<rect width="1120" height="1290" rx="24" fill="#ffffff"/>
+<text x="36" y="45" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="800" letter-spacing="0.16em" fill="#7c3aed">FROM SOURCE TO VERIFIED ACTION</text>
+<text x="36" y="82" font-family="Inter,system-ui,sans-serif" font-size="28" font-weight="750" fill="#18181b">One evidence workflow across every environment</text>
+<text x="36" y="114" font-family="ui-monospace,monospace" font-size="15" font-weight="800" letter-spacing="0.13em" fill="#7c3aed">1 · EVIDENCE SOURCES</text>
+<rect x="36.0" y="128" width="340" height="112" rx="14" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="52.0" y="144" width="34" height="34" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(56.0,148) scale(1.0833333333333333)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="98.0" y="168" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="750" fill="#18181b">Repository + CI</text>
+<text x="52.0" y="204" font-family="Inter,system-ui,sans-serif" font-size="14" fill="#71717a">code · dependencies · IaC · secrets</text>
+<rect x="390.0" y="128" width="340" height="112" rx="14" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="406.0" y="144" width="34" height="34" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(410.0,148) scale(1.0833333333333333)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="452.0" y="168" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="750" fill="#18181b">Workstation + endpoint</text>
+<text x="406.0" y="204" font-family="Inter,system-ui,sans-serif" font-size="14" fill="#71717a">apps · processes · agents · MCP</text>
+<rect x="744.0" y="128" width="340" height="112" rx="14" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="760.0" y="144" width="34" height="34" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(764.0,148) scale(1.0833333333333333)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="806.0" y="168" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="750" fill="#18181b">Images + Kubernetes</text>
+<text x="760.0" y="204" font-family="Inter,system-ui,sans-serif" font-size="14" fill="#71717a">registry · filesystem · workloads</text>
+<rect x="213.0" y="254" width="340" height="112" rx="14" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="229.0" y="270" width="34" height="34" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(233.0,274) scale(1.0833333333333333)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="275.0" y="294" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="750" fill="#18181b">Cloud + data platforms</text>
+<text x="229.0" y="330" font-family="Inter,system-ui,sans-serif" font-size="14" fill="#71717a">accounts · identity · posture</text>
+<rect x="229.0" y="336" width="92" height="26" rx="7" fill="#ffffff" stroke="#d4d4d8"/><g transform="translate(234.0,338) scale(0.55)"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
 <rect fill="#242F3E" x="0" y="0" width="40" height="40"/>
 <path d="M28.993,27.9952689 L11.487,27.9762689 C9.121,27.9742689 7.154,26.1292689 7.012,23.7752689 C7.004,23.6522689 7,23.5262689 7,23.3972689 C7,20.2992689 9.091,19.2872689 10.337,18.9592689 C10.577,18.8962689 10.735,18.6662689 10.707,18.4192689 C10.676,18.1492689 10.659,17.8752689 10.659,17.5962689 C10.659,15.1322689 12.308,12.4822689 14.415,11.5632689 C15.359,11.1502689 16.232,10.9862689 17.023,10.9862689 C19.276,10.9862689 20.867,12.3152689 21.561,13.0332689 C22.329,13.8262689 22.927,14.8382689 23.34,16.0422689 C23.4,16.2192689 23.555,16.3472689 23.74,16.3742689 C23.918,16.4012689 24.109,16.3232689 24.219,16.1712689 C24.807,15.3502689 25.766,14.9822689 26.659,15.2392689 C27.782,15.5602689 28.516,16.7272689 28.62,18.3072689 C28.578,18.5762689 28.759,18.8292689 29.027,18.8772689 C30.222,19.0892689 33,19.9572689 33,23.4402689 C33,27.5892689 29.114,27.9822689 28.993,27.9952689 M29.594,17.9742689 C29.379,16.0672689 28.4,14.6962689 26.934,14.2782689 C25.899,13.9822689 24.811,14.2452689 23.989,14.9502689 C23.553,13.9362689 22.979,13.0602689 22.28,12.3382689 C20.023,10.0052689 16.933,9.37226889 14.014,10.6462689 C11.531,11.7302689 9.659,14.7182689 9.659,17.5962689 C9.659,17.7702689 9.665,17.9432689 9.676,18.1142689 C8.319,18.5732689 6,19.8752689 6,23.3972689 C6,23.5492689 6.004,23.6962689 6.014,23.8382689 C6.188,26.7162689 8.593,28.9732689 11.486,28.9762689 L29.034,28.9932689 C29.084,28.9892689 34,28.5192689 34,23.4402689 C34,19.5022689 31.003,18.3142689 29.594,17.9742689" fill="#FFFFFF"/>
-</g></g><text x="879" y="211" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="700" fill="#18181b">AWS</text>
-<rect x="926" y="195" width="68" height="22" rx="6" fill="#ffffff" stroke="#d4d4d8"/><g transform="translate(930,197) scale(1.0)"><defs><linearGradient id="wf-light-1-azure-cloud-gradient" x1="8.99" y1="16.61" x2="8.99" y2="-1.27" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#0078d4"/><stop offset="0.16" stop-color="#1380da"/><stop offset="0.53" stop-color="#3c91e5"/><stop offset="0.82" stop-color="#559cec"/><stop offset="1" stop-color="#5ea0ef"/></linearGradient></defs>
+</g></g><text x="265.0" y="354" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="700" fill="#18181b">AWS</text>
+<rect x="329.0" y="336" width="92" height="26" rx="7" fill="#ffffff" stroke="#d4d4d8"/><g transform="translate(334.0,338) scale(1.2222222222222223)"><defs><linearGradient id="wf-light-1-azure-cloud-gradient" x1="8.99" y1="16.61" x2="8.99" y2="-1.27" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#0078d4"/><stop offset="0.16" stop-color="#1380da"/><stop offset="0.53" stop-color="#3c91e5"/><stop offset="0.82" stop-color="#559cec"/><stop offset="1" stop-color="#5ea0ef"/></linearGradient></defs>
 <path d="M18,10.55a4.11,4.11,0,0,0-3.51-4,5.14,5.14,0,0,0-5.25-5,5.26,5.26,0,0,0-5,3.47A4.87,4.87,0,0,0,0,9.82a4.94,4.94,0,0,0,5.07,4.8l.44,0h8.21a1.46,1.46,0,0,0,.22,0A4.13,4.13,0,0,0,18,10.55Z" fill="url(#wf-light-1-azure-cloud-gradient)"/>
 <circle cx="5.24" cy="9.65" r="0.71" fill="#e3e3e3"/>
 <path d="M7.74,9.92V9.35l-.08,0-.61-.2-.16-.39.31-.66-.4-.4-.08,0L6.15,8l-.39-.16-.25-.69H4.94l0,.08-.2.61L4.32,8l-.65-.31-.4.4,0,.08.29.57-.16.39-.7.25V10l.08,0,.61.2.16.39-.31.66.4.4.08,0,.57-.29.39.16.25.69h.57l0-.08.2-.61.39-.16.66.31.4-.4,0-.08-.29-.57.16-.39Zm-2.5.83a1.1,1.1,0,1,1,1.1-1.1A1.09,1.09,0,0,1,5.24,10.75Z" fill="#fff"/>
 <circle cx="10" cy="6.59" r="0.84" fill="#e3e3e3"/>
-<path d="M13,6.91V6.23l-.09,0L12.17,6,12,5.49l.37-.8-.48-.48-.09,0-.69.35-.46-.19-.3-.83H9.64l0,.1-.24.73-.47.19-.78-.37-.48.48.05.09L8,5.5,7.84,6,7,6.27V7l.1,0,.73.24L8,7.69l-.37.8L8.13,9l.1-.05.68-.35.47.19.3.83h.68l0-.1.24-.73.47-.19.79.37.48-.48-.05-.09L12,7.68l.19-.47Zm-3,1a1.32,1.32,0,1,1,1.32-1.32A1.31,1.31,0,0,1,10,7.91Z" fill="#fff"/></g><text x="953" y="211" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="700" fill="#18181b">Azure</text>
-<rect x="1000" y="195" width="68" height="22" rx="6" fill="#ffffff" stroke="#d4d4d8"/><g transform="translate(1004,197) scale(0.03515625)"><rect width="512" height="512" fill="none"/>
+<path d="M13,6.91V6.23l-.09,0L12.17,6,12,5.49l.37-.8-.48-.48-.09,0-.69.35-.46-.19-.3-.83H9.64l0,.1-.24.73-.47.19-.78-.37-.48.48.05.09L8,5.5,7.84,6,7,6.27V7l.1,0,.73.24L8,7.69l-.37.8L8.13,9l.1-.05.68-.35.47.19.3.83h.68l0-.1.24-.73.47-.19.79.37.48-.48-.05-.09L12,7.68l.19-.47Zm-3,1a1.32,1.32,0,1,1,1.32-1.32A1.31,1.31,0,0,1,10,7.91Z" fill="#fff"/></g><text x="365.0" y="354" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="700" fill="#18181b">Azure</text>
+<rect x="429.0" y="336" width="92" height="26" rx="7" fill="#ffffff" stroke="#d4d4d8"/><g transform="translate(434.0,338) scale(0.04296875)"><rect width="512" height="512" fill="none"/>
 <path d="M239.85,490c-1.54,0-3.11-.22-4.64-.69-6.73-2.04-11.33-8.25-11.33-15.28v-165.79h-121.9c-5.9,0-11.31-3.25-14.09-8.45-2.78-5.2-2.46-11.51.82-16.41L258.96,29.09c3.91-5.84,11.19-8.44,17.92-6.4s11.33,8.25,11.33,15.28v165.78h121.82c5.9,0,11.31,3.25,14.09,8.45s2.46,11.51-.81,16.41l-170.18,254.3c-3.02,4.51-8.05,7.09-13.28,7.09ZM131.89,276.29h107.96c8.82,0,15.97,7.15,15.97,15.97v129.17l124.3-185.74h-107.89c-8.82,0-15.97-7.15-15.97-15.97V90.54l-124.37,185.75h0Z" fill="#9aa0a6"/>
 <path d="M418.56,235.7h-146.33c-8.82,0-15.97-7.15-15.97-15.97V33.12c1.4-2.09,3.01-5.12,5.69-7.37,2.52-2.11,6.13-3.74,10.28-3.74,8.82,0,15.97,7.15,15.97,15.97v165.78h121.82c8.82,0,15.97,7.15,15.97,15.97,0,5.33-2.4,8.46-4.12,10.98-1.46,2.14-2.34,3.52-3.33,4.99h.02Z" fill="#2b80f8"/>
-<path d="M239.85,490c-8.82,0-15.97-7.15-15.97-15.97v-197.73h15.97c8.82,0,15.97,7.15,15.97,15.97v186.61c-1.75,2.7-3.28,5.33-5.49,7.2-2.73,2.31-6.21,3.92-10.49,3.92h.01Z" fill="#2b80f8"/></g><text x="1027" y="211" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="700" fill="#18181b">GCP</text>
-<rect x="1104" y="126" width="252" height="96" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="1118" y="141" width="28" height="28" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(1122,145) scale(0.8333333333333334)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a4.5 4.5 0 0 0-6.1 6.1L5 16l3 3 3.6-3.6a4.5 4.5 0 0 0 6.1-6.1l-2.4 2.4"/></g>
-<text x="1156" y="160" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="750" fill="#18181b">MCP + runtime</text>
-<text x="1118" y="187" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#71717a">servers · tools · live decisions</text>
-<rect x="40" y="286" width="252" height="176" rx="14" fill="#fafafa" stroke="#38bdf8" stroke-width="1.4"/>
-<text x="56" y="316" font-family="ui-monospace,monospace" font-size="13" font-weight="800" fill="#38bdf8">01</text>
-<text x="56" y="347" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="800" fill="#18181b">COLLECT + SCAN</text>
-<text x="56" y="390" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="650" fill="#18181b">Read-only intake</text>
-<text x="56" y="418" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#71717a">scope + completeness</text>
-<line x1="295" y1="374" x2="298" y2="374" stroke="#7c3aed" stroke-width="2"/><polygon points="303,374 296,369 296,379" fill="#7c3aed"/>
-<rect x="306" y="286" width="252" height="176" rx="14" fill="#fafafa" stroke="#818cf8" stroke-width="1.4"/>
-<text x="322" y="316" font-family="ui-monospace,monospace" font-size="13" font-weight="800" fill="#818cf8">02</text>
-<text x="322" y="347" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="800" fill="#18181b">NORMALIZE</text>
-<text x="322" y="390" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="650" fill="#18181b">Finding + UnifiedGraph</text>
-<text x="322" y="418" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#71717a">identity + provenance</text>
-<line x1="561" y1="374" x2="564" y2="374" stroke="#7c3aed" stroke-width="2"/><polygon points="569,374 562,369 562,379" fill="#7c3aed"/>
-<rect x="572" y="286" width="252" height="176" rx="14" fill="#fafafa" stroke="#a78bfa" stroke-width="1.4"/>
-<text x="588" y="316" font-family="ui-monospace,monospace" font-size="13" font-weight="800" fill="#a78bfa">03</text>
-<text x="588" y="347" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="800" fill="#18181b">CORRELATE + PRIORITIZE</text>
-<text x="588" y="390" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="650" fill="#18181b">reachability + blast radius</text>
-<text x="588" y="418" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#71717a">evidence-backed rank</text>
-<line x1="827" y1="374" x2="830" y2="374" stroke="#7c3aed" stroke-width="2"/><polygon points="835,374 828,369 828,379" fill="#7c3aed"/>
-<rect x="838" y="286" width="252" height="176" rx="14" fill="#fafafa" stroke="#34d399" stroke-width="1.4"/>
-<text x="854" y="316" font-family="ui-monospace,monospace" font-size="13" font-weight="800" fill="#34d399">04</text>
-<text x="854" y="347" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="800" fill="#18181b">OWN + REMEDIATE</text>
-<text x="854" y="390" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="650" fill="#18181b">owner + SLA + ticket</text>
-<text x="854" y="418" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#71717a">fix or accept risk</text>
-<line x1="1093" y1="374" x2="1096" y2="374" stroke="#7c3aed" stroke-width="2"/><polygon points="1101,374 1094,369 1094,379" fill="#7c3aed"/>
-<rect x="1104" y="286" width="252" height="176" rx="14" fill="#fafafa" stroke="#fbbf24" stroke-width="1.4"/>
-<text x="1120" y="316" font-family="ui-monospace,monospace" font-size="13" font-weight="800" fill="#fbbf24">05</text>
-<text x="1120" y="347" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="800" fill="#18181b">VERIFY + ACT</text>
-<text x="1120" y="390" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="650" fill="#18181b">rescan + terminal state</text>
-<text x="1120" y="418" font-family="Inter,system-ui,sans-serif" font-size="13" fill="#71717a">export · centralize · enforce</text>
-<rect x="40" y="488" width="1316" height="52" rx="12" fill="#f5f3ff" stroke="#c4b5fd"/>
-<text x="698" y="521" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#7c3aed">Path -&gt; Impact -&gt; Owner -&gt; Fix -&gt; Verify</text>
-<rect x="40" y="568" width="207" height="46" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<text x="143.5" y="597" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="750" fill="#52525b">SARIF</text>
-<rect x="259" y="568" width="207" height="46" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<text x="362.5" y="597" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="750" fill="#52525b">CycloneDX</text>
-<rect x="478" y="568" width="207" height="46" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<text x="581.5" y="597" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="750" fill="#52525b">SPDX</text>
-<rect x="697" y="568" width="207" height="46" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<text x="800.5" y="597" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="750" fill="#52525b">HTML / JSON</text>
-<rect x="916" y="568" width="207" height="46" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<text x="1019.5" y="597" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="750" fill="#52525b">Control plane</text>
-<rect x="1135" y="568" width="207" height="46" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<text x="1238.5" y="597" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="750" fill="#52525b">Runtime policy</text>
-<rect x="40" y="642" width="650" height="44" rx="10" fill="#ecfdf5" stroke="#bbf7d0"/>
-<text x="365" y="670" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="700" fill="#15803d">Raw source + credentials stay local</text>
-<rect x="706" y="642" width="650" height="44" rx="10" fill="#f4f4f6" stroke="#e4e4e7"/>
-<text x="1031" y="670" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="700" fill="#71717a">Unavailable remains unavailable · partial stays explicit</text>
+<path d="M239.85,490c-8.82,0-15.97-7.15-15.97-15.97v-197.73h15.97c8.82,0,15.97,7.15,15.97,15.97v186.61c-1.75,2.7-3.28,5.33-5.49,7.2-2.73,2.31-6.21,3.92-10.49,3.92h.01Z" fill="#2b80f8"/></g><text x="465.0" y="354" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="700" fill="#18181b">GCP</text>
+<rect x="567.0" y="254" width="340" height="112" rx="14" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="583.0" y="270" width="34" height="34" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(587.0,274) scale(1.0833333333333333)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a4.5 4.5 0 0 0-6.1 6.1L5 16l3 3 3.6-3.6a4.5 4.5 0 0 0 6.1-6.1l-2.4 2.4"/></g>
+<text x="629.0" y="294" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="750" fill="#18181b">MCP + runtime</text>
+<text x="583.0" y="330" font-family="Inter,system-ui,sans-serif" font-size="14" fill="#71717a">servers · tools · live decisions</text>
+<text x="36" y="436" font-family="ui-monospace,monospace" font-size="15" font-weight="800" letter-spacing="0.13em" fill="#7c3aed">2 · EVIDENCE PIPELINE</text>
+<rect x="84" y="454" width="952" height="102" rx="16" fill="#fafafa" stroke="#38bdf8" stroke-width="1.6"/>
+<text x="106" y="492" font-family="ui-monospace,monospace" font-size="17" font-weight="800" fill="#38bdf8">01</text>
+<rect x="154" y="476" width="42" height="42" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(158,480) scale(1.4166666666666667)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="214" y="493" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#18181b">COLLECT + SCAN</text>
+<text x="214" y="526" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="700" fill="#18181b">Read-only intake</text>
+<text x="554" y="526" font-family="Inter,system-ui,sans-serif" font-size="15" fill="#71717a">Scope and completeness stay explicit</text>
+<line x1="560.0" y1="558" x2="560.0" y2="565" stroke="#7c3aed" stroke-width="2"/><polygon points="560.0,570 555.0,563 565.0,563" fill="#7c3aed"/>
+<rect x="84" y="570" width="952" height="102" rx="16" fill="#fafafa" stroke="#818cf8" stroke-width="1.6"/>
+<text x="106" y="608" font-family="ui-monospace,monospace" font-size="17" font-weight="800" fill="#818cf8">02</text>
+<rect x="154" y="592" width="42" height="42" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(158,596) scale(1.4166666666666667)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="214" y="609" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#18181b">NORMALIZE</text>
+<text x="214" y="642" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="700" fill="#18181b">Finding + UnifiedGraph</text>
+<text x="554" y="642" font-family="Inter,system-ui,sans-serif" font-size="15" fill="#71717a">Identity, provenance, and evidence state</text>
+<line x1="560.0" y1="674" x2="560.0" y2="681" stroke="#7c3aed" stroke-width="2"/><polygon points="560.0,686 555.0,679 565.0,679" fill="#7c3aed"/>
+<rect x="84" y="686" width="952" height="102" rx="16" fill="#fafafa" stroke="#a78bfa" stroke-width="1.6"/>
+<text x="106" y="724" font-family="ui-monospace,monospace" font-size="17" font-weight="800" fill="#a78bfa">03</text>
+<rect x="154" y="708" width="42" height="42" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(158,712) scale(1.4166666666666667)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="214" y="725" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#18181b">CORRELATE + PRIORITIZE</text>
+<text x="214" y="758" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="700" fill="#18181b">Reachability + blast radius</text>
+<text x="554" y="758" font-family="Inter,system-ui,sans-serif" font-size="15" fill="#71717a">Rank paths with evidence, not raw volume</text>
+<line x1="560.0" y1="790" x2="560.0" y2="797" stroke="#7c3aed" stroke-width="2"/><polygon points="560.0,802 555.0,795 565.0,795" fill="#7c3aed"/>
+<rect x="84" y="802" width="952" height="102" rx="16" fill="#fafafa" stroke="#34d399" stroke-width="1.6"/>
+<text x="106" y="840" font-family="ui-monospace,monospace" font-size="17" font-weight="800" fill="#34d399">04</text>
+<rect x="154" y="824" width="42" height="42" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(158,828) scale(1.4166666666666667)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a4.5 4.5 0 0 0-6.1 6.1L5 16l3 3 3.6-3.6a4.5 4.5 0 0 0 6.1-6.1l-2.4 2.4"/></g>
+<text x="214" y="841" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#18181b">OWN + REMEDIATE</text>
+<text x="214" y="874" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="700" fill="#18181b">Owner + SLA + ticket</text>
+<text x="554" y="874" font-family="Inter,system-ui,sans-serif" font-size="15" fill="#71717a">Fix, accept risk, or mark a false positive</text>
+<line x1="560.0" y1="906" x2="560.0" y2="913" stroke="#7c3aed" stroke-width="2"/><polygon points="560.0,918 555.0,911 565.0,911" fill="#7c3aed"/>
+<rect x="84" y="918" width="952" height="102" rx="16" fill="#fafafa" stroke="#fbbf24" stroke-width="1.6"/>
+<text x="106" y="956" font-family="ui-monospace,monospace" font-size="17" font-weight="800" fill="#fbbf24">05</text>
+<rect x="154" y="940" width="42" height="42" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(158,944) scale(1.4166666666666667)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="214" y="957" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#18181b">VERIFY + ACT</text>
+<text x="214" y="990" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="700" fill="#18181b">Rescan + terminal state</text>
+<text x="554" y="990" font-family="Inter,system-ui,sans-serif" font-size="15" fill="#71717a">Export, centralize, or enforce at runtime</text>
+<rect x="84" y="1044" width="952" height="54" rx="12" fill="#f5f3ff" stroke="#c4b5fd"/>
+<text x="560.0" y="1079" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#7c3aed">3 · INVESTIGATE  ›  PATH  ›  IMPACT  ›  OWNER  ›  FIX  ›  VERIFY</text>
+<text x="36" y="1114" font-family="ui-monospace,monospace" font-size="15" font-weight="800" letter-spacing="0.13em" fill="#7c3aed">4 · VERIFIED OUTCOMES</text>
+<rect x="36" y="1128" width="164" height="52" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<text x="118.0" y="1161" text-anchor="middle" font-family="ui-monospace,monospace" font-size="14" font-weight="750" fill="#52525b">SARIF</text>
+<rect x="212" y="1128" width="164" height="52" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<text x="294.0" y="1161" text-anchor="middle" font-family="ui-monospace,monospace" font-size="14" font-weight="750" fill="#52525b">CycloneDX</text>
+<rect x="388" y="1128" width="164" height="52" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<text x="470.0" y="1161" text-anchor="middle" font-family="ui-monospace,monospace" font-size="14" font-weight="750" fill="#52525b">SPDX</text>
+<rect x="564" y="1128" width="164" height="52" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<text x="646.0" y="1161" text-anchor="middle" font-family="ui-monospace,monospace" font-size="14" font-weight="750" fill="#52525b">HTML + JSON</text>
+<rect x="740" y="1128" width="164" height="52" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<text x="822.0" y="1161" text-anchor="middle" font-family="ui-monospace,monospace" font-size="14" font-weight="750" fill="#52525b">Control plane</text>
+<rect x="916" y="1128" width="164" height="52" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<text x="998.0" y="1161" text-anchor="middle" font-family="ui-monospace,monospace" font-size="14" font-weight="750" fill="#52525b">Runtime policy</text>
+<rect x="36" y="1208" width="516" height="50" rx="11" fill="#ecfdf5" stroke="#bbf7d0"/>
+<text x="294" y="1240" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="700" fill="#15803d">Raw source + credentials stay local</text>
+<rect x="568" y="1208" width="516" height="50" rx="11" fill="#f4f4f6" stroke="#e4e4e7"/>
+<text x="826" y="1240" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="700" fill="#71717a">Unavailable remains unavailable · partial stays explicit</text>
 </svg>

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -5879,6 +5879,7 @@
           },
           "source_id": {
             "default": "",
+            "maxLength": 200,
             "title": "Source Id",
             "type": "string"
           },
@@ -5958,6 +5959,18 @@
             "title": "Blast Radii",
             "type": "array"
           },
+          "endpoint_inventory": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Endpoint Inventory"
+          },
           "idempotency_key": {
             "default": "",
             "title": "Idempotency Key",
@@ -5975,6 +5988,7 @@
           },
           "source_id": {
             "default": "",
+            "maxLength": 200,
             "title": "Source Id",
             "type": "string"
           },
@@ -18878,6 +18892,139 @@
           }
         },
         "summary": "List Fleet",
+        "tags": [
+          "fleet"
+        ]
+      }
+    },
+    "/v1/fleet/endpoints": {
+      "get": {
+        "description": "List latest privacy-safe workstation evidence, one row per endpoint.",
+        "operationId": "list_fleet_endpoints_v1_fleet_endpoints_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          },
+          {
+            "in": "query",
+            "name": "completeness",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Completeness"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Fleet Endpoints V1 Fleet Endpoints Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Fleet Endpoints",
+        "tags": [
+          "fleet"
+        ]
+      }
+    },
+    "/v1/fleet/endpoints/{endpoint_id}": {
+      "get": {
+        "description": "Return one tenant-scoped endpoint inventory summary.",
+        "operationId": "get_fleet_endpoint_v1_fleet_endpoints__endpoint_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "endpoint_id",
+            "required": true,
+            "schema": {
+              "title": "Endpoint Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Fleet Endpoint V1 Fleet Endpoints  Endpoint Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Fleet Endpoint",
         "tags": [
           "fleet"
         ]

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -4185,6 +4185,7 @@ components:
           type: string
         source_id:
           default: ''
+          maxLength: 200
           title: Source Id
           type: string
         summary:
@@ -4241,6 +4242,12 @@ components:
             type: object
           title: Blast Radii
           type: array
+        endpoint_inventory:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Endpoint Inventory
         idempotency_key:
           default: ''
           title: Idempotency Key
@@ -4251,6 +4258,7 @@ components:
           - type: 'null'
         source_id:
           default: ''
+          maxLength: 200
           title: Source Id
           type: string
         warnings:
@@ -12723,6 +12731,88 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: List Fleet
+      tags:
+      - fleet
+  /v1/fleet/endpoints:
+    get:
+      description: List latest privacy-safe workstation evidence, one row per endpoint.
+      operationId: list_fleet_endpoints_v1_fleet_endpoints_get
+      parameters:
+      - in: query
+        name: search
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Search
+      - in: query
+        name: completeness
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Completeness
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 50
+          title: Limit
+          type: integer
+      - in: query
+        name: offset
+        required: false
+        schema:
+          default: 0
+          title: Offset
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response List Fleet Endpoints V1 Fleet Endpoints Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: List Fleet Endpoints
+      tags:
+      - fleet
+  /v1/fleet/endpoints/{endpoint_id}:
+    get:
+      description: Return one tenant-scoped endpoint inventory summary.
+      operationId: get_fleet_endpoint_v1_fleet_endpoints__endpoint_id__get
+      parameters:
+      - in: path
+        name: endpoint_id
+        required: true
+        schema:
+          title: Endpoint Id
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Fleet Endpoint V1 Fleet Endpoints  Endpoint Id  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Fleet Endpoint
       tags:
       - fleet
   /v1/fleet/stats:

--- a/docs/schemas/v1/ProxyAuditIngestRequest.json
+++ b/docs/schemas/v1/ProxyAuditIngestRequest.json
@@ -21,6 +21,7 @@
     },
     "source_id": {
       "default": "",
+      "maxLength": 200,
       "title": "Source Id",
       "type": "string"
     },

--- a/docs/schemas/v1/PushPayload.json
+++ b/docs/schemas/v1/PushPayload.json
@@ -187,6 +187,19 @@
       "title": "Blast Radii",
       "type": "array"
     },
+    "endpoint_inventory": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Endpoint Inventory"
+    },
     "idempotency_key": {
       "default": "",
       "title": "Idempotency Key",
@@ -205,6 +218,7 @@
     },
     "source_id": {
       "default": "",
+      "maxLength": 200,
       "title": "Source Id",
       "type": "string"
     },

--- a/scripts/generate_doc_architecture_svgs.py
+++ b/scripts/generate_doc_architecture_svgs.py
@@ -241,7 +241,7 @@ def _tier_down_arrow(cx: int, y: int, label: str, color: str) -> str:
             **{
                 "text-anchor": "middle",
                 "font-family": "Inter,system-ui,sans-serif",
-                "font-size": "7",
+                "font-size": "11.5",
                 "font-weight": "800",
                 "letter-spacing": "0.1em",
                 "fill": color,
@@ -297,7 +297,7 @@ def _hub_node(
     )
 
 
-def _trust_footer(w: int, h: int, t: dict, message: str, *, height: int = 28) -> str:
+def _trust_footer(w: int, h: int, t: dict, message: str, *, height: int = 28, font_size: float = 8.5) -> str:
     y = h - height - 12
     return f'<rect x="24" y="{y}" width="{w - 48}" height="{height}" rx="8" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>' + _text(
         w // 2,
@@ -306,7 +306,7 @@ def _trust_footer(w: int, h: int, t: dict, message: str, *, height: int = 28) ->
         **{
             "text-anchor": "middle",
             "font-family": "Inter,system-ui,sans-serif",
-            "font-size": "8.5",
+            "font-size": str(font_size),
             "font-weight": "600",
             "fill": t["trust"],
         },
@@ -1120,7 +1120,11 @@ def how_it_works(theme_name: str) -> str:
 def workflow(theme_name: str) -> str:
     """Render the end-to-end evidence workflow from source to verified action."""
     t = THEMES[theme_name]
-    width, height = 1400, 720
+    # README renders this image at roughly 900px. A wide five-column canvas
+    # made technically-correct copy land below a comfortable reading size.
+    # Keep the canvas close to its rendered width and use vertical layers:
+    # sources -> processing -> decisions -> outcomes -> trust boundary.
+    width, height = 1120, 1290
     parts = _svg_open(
         width,
         height,
@@ -1130,12 +1134,12 @@ def workflow(theme_name: str) -> str:
     parts.append(f'<rect width="{width}" height="{height}" rx="24" fill="{t["bg"]}"/>')
     parts.append(
         _text(
-            40,
-            50,
+            36,
+            45,
             "FROM SOURCE TO VERIFIED ACTION",
             **{
                 "font-family": "Inter,system-ui,sans-serif",
-                "font-size": "13",
+                "font-size": "15",
                 "font-weight": "800",
                 "letter-spacing": "0.16em",
                 "fill": t["accent"],
@@ -1144,12 +1148,12 @@ def workflow(theme_name: str) -> str:
     )
     parts.append(
         _text(
-            40,
-            86,
-            "One workflow across developer, endpoint, CI, cloud, control plane, and runtime",
+            36,
+            82,
+            "One evidence workflow across every environment",
             **{
                 "font-family": "Inter,system-ui,sans-serif",
-                "font-size": "24",
+                "font-size": "28",
                 "font-weight": "750",
                 "fill": t["title"],
             },
@@ -1157,8 +1161,8 @@ def workflow(theme_name: str) -> str:
     )
 
     source_cards = (
-        ("repo", "Repository + CI", "code · deps · IaC · secrets"),
-        ("endpoint", "Workstation / endpoint", "configs · agents · MCP · browsers"),
+        ("repo", "Repository + CI", "code · dependencies · IaC · secrets"),
+        ("endpoint", "Workstation + endpoint", "apps · processes · agents · MCP"),
         ("cluster", "Images + Kubernetes", "registry · filesystem · workloads"),
         ("cloud", "Cloud + data platforms", "accounts · identity · posture"),
         ("runtime", "MCP + runtime", "servers · tools · live decisions"),
@@ -1170,15 +1174,15 @@ def workflow(theme_name: str) -> str:
         "cloud": ICONS["cloud"],
         "runtime": ICONS["tool"],
     }
-    left, gap, card_w, source_y, source_h = 40, 14, 252, 126, 96
+    left, gap, card_w, source_y, source_h = 36, 14, 340, 128, 112
     parts.append(
         _text(
             left,
             source_y - 14,
-            "SOURCES",
+            "1 · EVIDENCE SOURCES",
             **{
                 "font-family": "ui-monospace,monospace",
-                "font-size": "13",
+                "font-size": "15",
                 "font-weight": "800",
                 "letter-spacing": "0.13em",
                 "fill": t["lane"],
@@ -1186,19 +1190,21 @@ def workflow(theme_name: str) -> str:
         )
     )
     for index, (key, title, detail) in enumerate(source_cards):
-        x = left + index * (card_w + gap)
-        parts.append(
-            f'<rect x="{x}" y="{source_y}" width="{card_w}" height="{source_h}" rx="12" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>'
-        )
-        parts.append(_icon_box(x + 14, source_y + 15, source_icons[key], t, accent=True, size=28))
+        row, col = divmod(index, 3)
+        row_count = 3 if row == 0 else 2
+        row_width = row_count * card_w + (row_count - 1) * gap
+        x = (width - row_width) / 2 + col * (card_w + gap)
+        y = source_y + row * (source_h + gap)
+        parts.append(f'<rect x="{x}" y="{y}" width="{card_w}" height="{source_h}" rx="14" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(x + 16, y + 16, source_icons[key], t, accent=True, size=34))
         parts.append(
             _text(
-                x + 52,
-                source_y + 34,
+                x + 62,
+                y + 40,
                 title,
                 **{
                     "font-family": "Inter,system-ui,sans-serif",
-                    "font-size": "14",
+                    "font-size": "18",
                     "font-weight": "750",
                     "fill": t["text"],
                 },
@@ -1206,18 +1212,18 @@ def workflow(theme_name: str) -> str:
         )
         parts.append(
             _text(
-                x + 14,
-                source_y + 61,
+                x + 16,
+                y + 76,
                 detail,
                 **{
                     "font-family": "Inter,system-ui,sans-serif",
-                    "font-size": "13",
+                    "font-size": "14",
                     "fill": t["text_muted"],
                 },
             )
         )
         if key == "cloud":
-            logo_y = source_y + 69
+            logo_y = y + 82
             official_icons = (
                 ("aws-cloud.svg", "AWS"),
                 ("azure-cloud.svg", "Azure"),
@@ -1228,19 +1234,19 @@ def workflow(theme_name: str) -> str:
                     filename,
                     uid=f"wf-{theme_name}-{logo_index}",
                 )
-                chip_x = x + 14 + logo_index * 74
-                logo_size = 18
+                chip_x = x + 16 + logo_index * 100
+                logo_size = 22
                 scale = min(logo_size / vb_w, logo_size / vb_h)
                 parts.append(
-                    f'<rect x="{chip_x}" y="{logo_y}" width="68" height="22" rx="6" fill="#ffffff" stroke="#d4d4d8"/>'
-                    f'<g transform="translate({chip_x + 4},{logo_y + 2}) scale({scale})">{inner}</g>'
+                    f'<rect x="{chip_x}" y="{logo_y}" width="92" height="26" rx="7" fill="#ffffff" stroke="#d4d4d8"/>'
+                    f'<g transform="translate({chip_x + 5},{logo_y + 2}) scale({scale})">{inner}</g>'
                     + _text(
-                        chip_x + 27,
-                        logo_y + 16,
+                        chip_x + 36,
+                        logo_y + 18,
                         label,
                         **{
                             "font-family": "Inter,system-ui,sans-serif",
-                            "font-size": "13",
+                            "font-size": "13.5",
                             "font-weight": "700",
                             "fill": "#18181b",
                         },
@@ -1248,41 +1254,55 @@ def workflow(theme_name: str) -> str:
                 )
 
     stages = (
-        ("01", "COLLECT + SCAN", "Read-only intake", "scope + completeness"),
-        ("02", "NORMALIZE", "Finding + UnifiedGraph", "identity + provenance"),
-        ("03", "CORRELATE + PRIORITIZE", "reachability + blast radius", "evidence-backed rank"),
-        ("04", "OWN + REMEDIATE", "owner + SLA + ticket", "fix or accept risk"),
-        ("05", "VERIFY + ACT", "rescan + terminal state", "export · centralize · enforce"),
+        ("01", "COLLECT + SCAN", "Read-only intake", "Scope and completeness stay explicit", "#38bdf8", "bug"),
+        ("02", "NORMALIZE", "Finding + UnifiedGraph", "Identity, provenance, and evidence state", "#818cf8", "package"),
+        ("03", "CORRELATE + PRIORITIZE", "Reachability + blast radius", "Rank paths with evidence, not raw volume", "#a78bfa", "graph"),
+        ("04", "OWN + REMEDIATE", "Owner + SLA + ticket", "Fix, accept risk, or mark a false positive", "#34d399", "tool"),
+        ("05", "VERIFY + ACT", "Rescan + terminal state", "Export, centralize, or enforce at runtime", "#fbbf24", "shield"),
     )
-    stage_y, stage_h = 286, 176
-    for index, (number, title, line_one, line_two) in enumerate(stages):
-        x = left + index * (card_w + gap)
-        accent = ("#38bdf8", "#818cf8", "#a78bfa", "#34d399", "#fbbf24")[index]
+    stage_left, stage_w, stage_y, stage_h, stage_gap = 84, 952, 454, 102, 14
+    parts.append(
+        _text(
+            left,
+            stage_y - 18,
+            "2 · EVIDENCE PIPELINE",
+            **{
+                "font-family": "ui-monospace,monospace",
+                "font-size": "15",
+                "font-weight": "800",
+                "letter-spacing": "0.13em",
+                "fill": t["lane"],
+            },
+        )
+    )
+    for index, (number, title, line_one, line_two, accent, icon_key) in enumerate(stages):
+        x = stage_left
+        y = stage_y + index * (stage_h + stage_gap)
         parts.append(
-            f'<rect x="{x}" y="{stage_y}" width="{card_w}" height="{stage_h}" rx="14" '
-            f'fill="{t["panel"]}" stroke="{accent}" stroke-width="1.4"/>'
+            f'<rect x="{x}" y="{y}" width="{stage_w}" height="{stage_h}" rx="16" fill="{t["panel"]}" stroke="{accent}" stroke-width="1.6"/>'
         )
         parts.append(
             _text(
-                x + 16,
-                stage_y + 30,
+                x + 22,
+                y + 38,
                 number,
                 **{
                     "font-family": "ui-monospace,monospace",
-                    "font-size": "13",
+                    "font-size": "17",
                     "font-weight": "800",
                     "fill": accent,
                 },
             )
         )
+        parts.append(_icon_box(x + 70, y + 22, ICONS[icon_key], t, accent=True, size=42))
         parts.append(
             _text(
-                x + 16,
-                stage_y + 61,
+                x + 130,
+                y + 39,
                 title,
                 **{
                     "font-family": "Inter,system-ui,sans-serif",
-                    "font-size": "13",
+                    "font-size": "18",
                     "font-weight": "800",
                     "fill": t["text"],
                 },
@@ -1290,45 +1310,46 @@ def workflow(theme_name: str) -> str:
         )
         parts.append(
             _text(
-                x + 16,
-                stage_y + 104,
+                x + 130,
+                y + 72,
                 line_one,
                 **{
                     "font-family": "Inter,system-ui,sans-serif",
-                    "font-size": "13",
-                    "font-weight": "650",
+                    "font-size": "15",
+                    "font-weight": "700",
                     "fill": t["text"],
                 },
             )
         )
         parts.append(
             _text(
-                x + 16,
-                stage_y + 132,
+                x + 470,
+                y + 72,
                 line_two,
                 **{
                     "font-family": "Inter,system-ui,sans-serif",
-                    "font-size": "13",
+                    "font-size": "15",
                     "fill": t["text_muted"],
                 },
             )
         )
         if index < len(stages) - 1:
-            start = x + card_w + 3
-            end = x + card_w + gap - 3
-            mid_y = stage_y + stage_h // 2
+            mid_x = width / 2
+            start_y = y + stage_h
+            end_y = y + stage_h + stage_gap
             parts.append(
-                f'<line x1="{start}" y1="{mid_y}" x2="{end - 5}" y2="{mid_y}" '
+                f'<line x1="{mid_x}" y1="{start_y + 2}" x2="{mid_x}" y2="{end_y - 5}" '
                 f'stroke="{t["arrow_accent"]}" stroke-width="2"/>'
-                f'<polygon points="{end},{mid_y} {end - 7},{mid_y - 5} {end - 7},{mid_y + 5}" fill="{t["arrow_accent"]}"/>'
+                f'<polygon points="{mid_x},{end_y} {mid_x - 5},{end_y - 7} {mid_x + 5},{end_y - 7}" fill="{t["arrow_accent"]}"/>'
             )
 
-    parts.append(f'<rect x="40" y="488" width="1316" height="52" rx="12" fill="{t["accent_fill"]}" stroke="{t["accent_stroke"]}"/>')
+    decision_y = stage_y + len(stages) * (stage_h + stage_gap) + 10
+    parts.append(f'<rect x="84" y="{decision_y}" width="952" height="54" rx="12" fill="{t["accent_fill"]}" stroke="{t["accent_stroke"]}"/>')
     parts.append(
         _text(
-            698,
-            521,
-            "Path -> Impact -> Owner -> Fix -> Verify",
+            width / 2,
+            decision_y + 35,
+            "3 · INVESTIGATE  ›  PATH  ›  IMPACT  ›  OWNER  ›  FIX  ›  VERIFY",
             **{
                 "text-anchor": "middle",
                 "font-family": "Inter,system-ui,sans-serif",
@@ -1339,51 +1360,66 @@ def workflow(theme_name: str) -> str:
         )
     )
 
-    outcomes = ("SARIF", "CycloneDX", "SPDX", "HTML / JSON", "Control plane", "Runtime policy")
-    chip_y, chip_gap, chip_w = 568, 12, 207
+    outcomes = ("SARIF", "CycloneDX", "SPDX", "HTML + JSON", "Control plane", "Runtime policy")
+    chip_y, chip_gap, chip_w = decision_y + 84, 12, 164
+    parts.append(
+        _text(
+            left,
+            chip_y - 14,
+            "4 · VERIFIED OUTCOMES",
+            **{
+                "font-family": "ui-monospace,monospace",
+                "font-size": "15",
+                "font-weight": "800",
+                "letter-spacing": "0.13em",
+                "fill": t["lane"],
+            },
+        )
+    )
     for index, label in enumerate(outcomes):
         x = left + index * (chip_w + chip_gap)
-        parts.append(f'<rect x="{x}" y="{chip_y}" width="{chip_w}" height="46" rx="10" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(f'<rect x="{x}" y="{chip_y}" width="{chip_w}" height="52" rx="11" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
         parts.append(
             _text(
                 x + chip_w / 2,
-                chip_y + 29,
+                chip_y + 33,
                 label,
                 **{
                     "text-anchor": "middle",
                     "font-family": "ui-monospace,monospace",
-                    "font-size": "13",
+                    "font-size": "14",
                     "font-weight": "750",
                     "fill": t["chip"],
                 },
             )
         )
 
-    parts.append(f'<rect x="40" y="642" width="650" height="44" rx="10" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>')
+    trust_y = chip_y + 80
+    parts.append(f'<rect x="36" y="{trust_y}" width="516" height="50" rx="11" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>')
     parts.append(
         _text(
-            365,
-            670,
+            294,
+            trust_y + 32,
             "Raw source + credentials stay local",
             **{
                 "text-anchor": "middle",
                 "font-family": "Inter,system-ui,sans-serif",
-                "font-size": "13",
+                "font-size": "14",
                 "font-weight": "700",
                 "fill": t["trust"],
             },
         )
     )
-    parts.append(f'<rect x="706" y="642" width="650" height="44" rx="10" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>')
+    parts.append(f'<rect x="568" y="{trust_y}" width="516" height="50" rx="11" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>')
     parts.append(
         _text(
-            1031,
-            670,
+            826,
+            trust_y + 32,
             "Unavailable remains unavailable · partial stays explicit",
             **{
                 "text-anchor": "middle",
                 "font-family": "Inter,system-ui,sans-serif",
-                "font-size": "13",
+                "font-size": "14",
                 "font-weight": "700",
                 "fill": t["text_muted"],
             },
@@ -1394,305 +1430,202 @@ def workflow(theme_name: str) -> str:
 
 
 def architecture(theme_name: str) -> str:
-    """Layered control-plane map — visually distinct from the horizontal how-it-works pipeline."""
+    """Readable layered control-plane map for the README-scale embed."""
     t = THEMES[theme_name]
-    w, h = 960, 620
-    margin_x = 28
-    tier_w = w - 2 * margin_x
-    icon_size = 24
-
-    sources = [
-        ("package", "Supply chain", "15 eco"),
-        ("mcp", "Agents & MCP", "29 clients"),
-        ("cloud", "Cloud", "4 connect · 16 scan"),
-        ("iac", "IaC & OCI", "TF·K8s·img"),
-        ("lock", "Secrets", "refs only"),
-        ("model", "Models", "13 formats"),
-        ("sbom", "SBOM import", "CDX·SPDX"),
-    ]
-    engine_items = [
-        ("bug", "OSV scan", "batch"),
-        ("zap", "Enrichment", "NVD·EPSS"),
-        ("shield", "Posture", "CIS·MCP"),
-        ("graph", "Blast radius", "fusion"),
-        ("file", "Policy", "as-code"),
-    ]
-    evidence_items = [
-        ("finding", "Unified Finding", "one schema"),
-        ("graph", "UnifiedGraph", "attack paths"),
-        ("db", "Stores", "PG·SQLite"),
-        ("audit", "Audit chain", "signed"),
-    ]
-    platform_items = [
-        ("api", "REST API", f"{REST_OPERATION_COUNT} ops"),
-        ("gate", "Gateway", "runtime"),
-        ("mcp", "MCP server", f"{MCP_TOOL_COUNT} tools"),
-        ("fleet", "Fleet jobs", "Helm·EKS"),
-        ("audit", "Scheduler / events", "cadence·change"),
-    ]
-    people = [("cli", "CLI"), ("ui", "Web UI")]
-    agents = [("mcp", "MCP"), ("api", "SDK")]
-    artifacts = ["SARIF", "CDX", "SPDX", "OCSF", "HTML", "JSON"]
-
-    tier_y = [78, 192, 300, 448]
-    tier_h = [102, 96, 136, 140]
-    cx = w // 2
-
+    w, h = 1120, 1320
+    margin_x, band_w = 36, 1048
     parts = _svg_open(
         w,
         h,
         "agent-bom control-plane architecture",
-        "Layered sources, processing engine, platform, and consumers.",
+        "Sources enter a local processing engine, become tenant-scoped evidence, and leave through human, agent, and artifact surfaces.",
     )
     parts += [
-        f'<rect width="{w}" height="{h}" rx="14" fill="{t["bg"]}"/>',
-        f'<rect x="12" y="12" width="{w - 24}" height="{h - 24}" rx="18" fill="none" stroke="#6366f1" stroke-width="2" opacity="0.22"/>',
-        f'<rect x="{w - 118}" y="20" width="90" height="22" rx="11" fill="#312e81" opacity="0.85"/>',
+        f'<rect width="{w}" height="{h}" rx="22" fill="{t["bg"]}"/>',
         _text(
-            w - 73,
-            35,
-            "LAYERED",
+            36,
+            48,
+            "CONTROL-PLANE ARCHITECTURE",
             **{
-                "text-anchor": "middle",
-                "font-family": "Inter,system-ui,sans-serif",
-                "font-size": "8",
+                "font-family": "ui-monospace,monospace",
+                "font-size": "15",
                 "font-weight": "800",
                 "letter-spacing": "0.14em",
-                "fill": "#c7d2fe",
+                "fill": t["accent"],
             },
         ),
         _text(
-            margin_x,
-            40,
-            "Control-plane architecture",
-            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "20", "font-weight": "800", "fill": t["title"]},
-        ),
-        _text(
-            margin_x,
-            60,
-            "Vertical tiers · sources feed engine · evidence + platform · people + agents consume",
-            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "500", "fill": t["subtitle"]},
+            36,
+            86,
+            "Four layers from read-only intake to verified action",
+            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "28", "font-weight": "800", "fill": t["title"]},
         ),
     ]
 
-    def _tier_band(y: int, th: int, layer_key: str) -> str:
-        _, accent, _text_c = ARCH_LAYER_COLORS[layer_key]
-        return (
-            f'<rect x="{margin_x}" y="{y}" width="{tier_w}" height="{th}" rx="12" fill="{t["panel"]}" '
-            f'stroke="{accent}" stroke-width="1.2" opacity="0.95"/>'
-            f'<rect x="{margin_x}" y="{y}" width="{tier_w}" height="3" rx="12" fill="{accent}" opacity="0.55"/>'
-        )
-
-    def _tier_chip(
-        x: int,
-        y: int,
-        cw: int,
-        ch: int,
-        icon: str,
-        title: str,
-        badge: str,
-        layer_key: str,
-        *,
-        highlight: bool = False,
-    ) -> None:
-        _, accent, text_c = ARCH_LAYER_COLORS[layer_key]
-        fill = t["accent_fill"] if highlight else t["card"]
-        stroke = accent if highlight else t["card_stroke"]
-        text_x = x + icon_size + 14
+    def band(y: int, height: int, layer: str, number: str, title: str, boundary: str) -> None:
+        accent = ARCH_LAYER_COLORS[layer][1]
         parts.append(
-            f'<rect x="{x}" y="{y}" width="{cw}" height="{ch}" rx="8" fill="{fill}" stroke="{stroke}" '
-            f'stroke-width="{"1.5" if highlight else "1"}"/>'
+            f'<rect x="{margin_x}" y="{y}" width="{band_w}" height="{height}" rx="16" fill="{t["panel"]}" stroke="{accent}" stroke-width="1.5"/>'
         )
-        parts.append(_icon_box(x + 8, y + (ch - icon_size) // 2, ICONS[icon], t, accent=highlight, size=icon_size))
+        parts.append(f'<rect x="{margin_x}" y="{y}" width="6" height="{height}" rx="3" fill="{accent}"/>')
         parts.append(
             _text(
-                text_x,
-                y + ch // 2 - 1,
-                title,
-                **{"font-family": "Inter,system-ui,sans-serif", "font-size": "8.5", "font-weight": "700", "fill": t["text"]},
+                margin_x + 22,
+                y + 35,
+                f"{number} · {title}",
+                **{
+                    "font-family": "Inter,system-ui,sans-serif",
+                    "font-size": "17",
+                    "font-weight": "800",
+                    "letter-spacing": "0.06em",
+                    "fill": accent,
+                },
             )
         )
         parts.append(
             _text(
-                text_x,
-                y + ch // 2 + 10,
-                badge,
+                margin_x + band_w - 22,
+                y + 35,
+                boundary,
                 **{
-                    "font-family": "ui-monospace,monospace",
-                    "font-size": "6.5",
+                    "text-anchor": "end",
+                    "font-family": "Inter,system-ui,sans-serif",
+                    "font-size": "14",
+                    "font-weight": "700",
+                    "fill": t["text_muted"],
+                },
+            )
+        )
+
+    def card(x: int, y: int, width: int, height: int, icon: str, title: str, detail: str, layer: str, *, highlight: bool = False) -> None:
+        accent = ARCH_LAYER_COLORS[layer][1]
+        fill = t["accent_fill"] if highlight else t["card"]
+        stroke = accent if highlight else t["card_stroke"]
+        parts.append(
+            f'<rect x="{x}" y="{y}" width="{width}" height="{height}" rx="12" fill="{fill}" stroke="{stroke}" stroke-width="{"1.6" if highlight else "1"}"/>'
+        )
+        parts.append(_icon_box(x + 16, y + 18, ICONS[icon], t, accent=highlight, size=38))
+        parts.append(
+            _text(
+                x + 68,
+                y + 39,
+                title,
+                **{"font-family": "Inter,system-ui,sans-serif", "font-size": "17", "font-weight": "800", "fill": t["text"]},
+            )
+        )
+        parts.append(
+            _text(
+                x + 68,
+                y + 65,
+                detail,
+                **{
+                    "font-family": "Inter,system-ui,sans-serif",
+                    "font-size": "14",
                     "font-weight": "600",
                     "fill": accent if highlight else t["text_muted"],
                 },
             )
         )
 
-    # Tier 1 — sources
-    y0, h0 = tier_y[0], tier_h[0]
-    parts.append(_tier_band(y0, h0, "sources"))
-    parts.append(_arch_tier_label(margin_x + 12, y0 + 10, tier_w - 24, "INTAKE SOURCES", "read-only", "sources", t))
-    chip_gap = 8
-    chip_h = 44
-    chip_w = (tier_w - 24 - (len(sources) - 1) * chip_gap) // len(sources)
-    for i, (icon, title, badge) in enumerate(sources):
-        cx_chip = margin_x + 12 + i * (chip_w + chip_gap)
-        _tier_chip(cx_chip, y0 + 32, chip_w, chip_h, icon, title, badge, "sources")
+    # 1. Five source families, arranged 3 + 2 rather than seven tiny columns.
+    y1, h1 = 122, 260
+    band(y1, h1, "sources", "1", "INTAKE SOURCES", "read-only collectors")
+    source_cards = (
+        ("package", "Code + supply chain", "repos · CI · packages · secrets"),
+        ("mcp", "Agents + MCP + models", "clients · servers · model files"),
+        ("cloud", "Cloud + data", "AWS · Azure · GCP · Snowflake"),
+        ("iac", "Images + infrastructure", "OCI · K8s · IaC · workloads"),
+        ("sbom", "Imported evidence", "CDX · SPDX · SARIF · scans"),
+    )
+    card_w, card_h, card_gap = 330, 82, 12
+    for index, item in enumerate(source_cards):
+        row, col = divmod(index, 3)
+        count = 3 if row == 0 else 2
+        row_width = count * card_w + (count - 1) * card_gap
+        x = (w - row_width) // 2 + col * (card_w + card_gap)
+        y = y1 + 54 + row * (card_h + 12)
+        card(x, y, card_w, card_h, *item, "sources")
 
-    parts.append(_tier_down_arrow(cx, y0 + h0 + 2, "INGEST", ARCH_LAYER_COLORS["sources"][1]))
+    parts.append(_tier_down_arrow(w // 2, y1 + h1 + 2, "COLLECT", ARCH_LAYER_COLORS["sources"][1]))
 
-    # Tier 2 — processing engine
-    y1, h1 = tier_y[1], tier_h[1]
-    parts.append(_tier_band(y1, h1, "engine"))
-    parts.append(_arch_tier_label(margin_x + 12, y1 + 10, tier_w - 24, "PROCESSING ENGINE", "local scan", "engine", t))
-    eng_gap = 10
-    eng_w = (tier_w - 24 - (len(engine_items) - 1) * eng_gap) // len(engine_items)
-    for i, (icon, title, badge) in enumerate(engine_items):
-        ex = margin_x + 12 + i * (eng_w + eng_gap)
-        _tier_chip(ex, y1 + 36, eng_w, 52, icon, title, badge, "engine")
+    # 2. Processing is a short sequence, not a wall of independent boxes.
+    y2, h2 = 414, 224
+    band(y2, h2, "engine", "2", "LOCAL PROCESSING ENGINE", "bounded + failure-honest")
+    engine = (
+        ("bug", "Scan", "OSV · SAST · posture"),
+        ("zap", "Enrich", "NVD · EPSS · KEV"),
+        ("graph", "Correlate", "identity · reachability"),
+        ("shield", "Prioritize", "blast radius · policy"),
+    )
+    eng_w = 244
+    for index, item in enumerate(engine):
+        x = margin_x + 22 + index * (eng_w + 10)
+        card(x, y2 + 62, eng_w, 104, *item, "engine")
 
-    parts.append(_tier_down_arrow(cx, y1 + h1 + 2, "PROCESS", ARCH_LAYER_COLORS["engine"][1]))
+    parts.append(_tier_down_arrow(w // 2, y2 + h2 + 2, "PERSIST", ARCH_LAYER_COLORS["engine"][1]))
 
-    # Tier 3 — evidence + platform (two columns, 2x2 grids)
-    y2, h2 = tier_y[2], tier_h[2]
-    parts.append(_tier_band(y2, h2, "platform"))
-    parts.append(_arch_tier_label(margin_x + 12, y2 + 10, tier_w - 24, "EVIDENCE & PLATFORM", "auth · self-hosted", "platform", t))
-    col_gap = 16
-    col_w = (tier_w - 24 - col_gap) // 2
-    left_x = margin_x + 12
-    right_x = left_x + col_w + col_gap
-    mini_gap = 4
-    mini_w = (col_w - mini_gap) // 2
-    mini_h = 29
-    grid_y = y2 + 32
-
-    def _mini_chip(gx: int, gy: int, icon: str, title: str, badge: str, *, highlight: bool = False) -> None:
-        _tier_chip(gx, gy, mini_w, mini_h, icon, title, badge, "platform", highlight=highlight)
-
-    for i, (icon, title, badge) in enumerate(evidence_items):
-        col, row = i % 2, i // 2
-        gx = left_x + col * (mini_w + mini_gap)
-        gy = grid_y + row * (mini_h + mini_gap)
-        _mini_chip(gx, gy, icon, title, badge, highlight=title in ("Unified Finding", "UnifiedGraph"))
-
-    for i, (icon, title, badge) in enumerate(platform_items):
-        col, row = i % 2, i // 2
-        gx = right_x + col * (mini_w + mini_gap)
-        gy = grid_y + row * (mini_h + mini_gap)
-        _mini_chip(gx, gy, icon, title, badge)
-
-    parts.append(_tier_down_arrow(cx, y2 + h2 + 2, "DELIVER", ARCH_LAYER_COLORS["platform"][1]))
-
-    # Tier 4 — consumers
-    y3, h3 = tier_y[3], tier_h[3]
-    parts.append(_tier_band(y3, h3, "consumers"))
-    parts.append(_arch_tier_label(margin_x + 12, y3 + 10, tier_w - 24, "CONSUMERS & ARTIFACTS", "deliver", "consumers", t))
-
-    cons_gap = 12
-    cons_col_w = (tier_w - 24 - 2 * cons_gap) // 3
-    cons_left = margin_x + 12
-    cons_right = cons_left + cons_col_w + cons_gap
-
-    def _consumer_mini(y: int, x: int, cw: int, icon: str, label: str) -> int:
-        mh = 30
-        parts.append(f'<rect x="{x}" y="{y}" width="{cw}" height="{mh}" rx="7" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
-        parts.append(_icon_box(x + 10, y + 3, ICONS[icon], t, size=22))
-        parts.append(
-            _text(
-                x + 40,
-                y + 19,
-                label,
-                **{"font-family": "Inter,system-ui,sans-serif", "font-size": "9", "font-weight": "700", "fill": t["text"]},
-            )
-        )
-        return mh
-
-    cy = y3 + 34
+    # 3. Separate the evidence model from the serving plane.
+    y3, h3 = 670, 342
+    band(y3, h3, "platform", "3", "EVIDENCE + SERVING PLANE", "tenant-scoped · authenticated")
+    col_gap, col_w = 18, 497
+    left_x, right_x = margin_x + 18, margin_x + 18 + col_w + col_gap
     parts.append(
         _text(
-            cons_left + cons_col_w // 2,
-            cy,
-            "PEOPLE",
+            left_x,
+            y3 + 70,
+            "EVIDENCE MODEL",
             **{
-                "text-anchor": "middle",
-                "font-family": "Inter,system-ui,sans-serif",
-                "font-size": "7.5",
+                "font-family": "ui-monospace,monospace",
+                "font-size": "14",
                 "font-weight": "800",
                 "letter-spacing": "0.1em",
-                "fill": ARCH_LAYER_COLORS["consumers"][1],
+                "fill": ARCH_LAYER_COLORS["platform"][1],
             },
         )
     )
-    cy += 10
-    for icon, label in people:
-        h_card = _consumer_mini(cy, cons_left, cons_col_w, icon, label)
-        cy += h_card + 5
-
-    ay = y3 + 34
     parts.append(
         _text(
-            cons_right + cons_col_w // 2,
-            ay,
-            "AGENTS",
+            right_x,
+            y3 + 70,
+            "CONTROL + DELIVERY",
             **{
-                "text-anchor": "middle",
-                "font-family": "Inter,system-ui,sans-serif",
-                "font-size": "7.5",
+                "font-family": "ui-monospace,monospace",
+                "font-size": "14",
                 "font-weight": "800",
                 "letter-spacing": "0.1em",
-                "fill": ARCH_LAYER_COLORS["consumers"][1],
+                "fill": ARCH_LAYER_COLORS["platform"][1],
             },
         )
     )
-    ay += 10
-    for icon, label in agents:
-        h_card = _consumer_mini(ay, cons_right, cons_col_w, icon, label)
-        ay += h_card + 5
+    evidence = (
+        ("finding", "Unified Finding", "scope · completeness · provenance", True),
+        ("graph", "UnifiedGraph", "assets · identities · paths", True),
+        ("db", "Portable stores", "SQLite · Postgres · Snowflake", False),
+    )
+    delivery = (
+        ("api", "REST API + MCP", f"{REST_OPERATION_COUNT} operations · {MCP_TOOL_COUNT} tools", False),
+        ("fleet", "Fleet + scheduler", "endpoints · jobs · change events", False),
+        ("gate", "Gateway + policy", "observe · decide · enforce", False),
+    )
+    for index, (icon, title, detail, highlight) in enumerate(evidence):
+        card(left_x, y3 + 88 + index * 74, col_w, 64, icon, title, detail, "platform", highlight=highlight)
+    for index, (icon, title, detail, highlight) in enumerate(delivery):
+        card(right_x, y3 + 88 + index * 74, col_w, 64, icon, title, detail, "platform", highlight=highlight)
 
-    art_y = y3 + 34
-    art_x = cons_right + cons_col_w + cons_gap
-    art_w = cons_col_w
-    parts.append(
-        _text(
-            art_x + art_w // 2,
-            art_y,
-            "ARTIFACTS",
-            **{
-                "text-anchor": "middle",
-                "font-family": "Inter,system-ui,sans-serif",
-                "font-size": "7.5",
-                "font-weight": "800",
-                "letter-spacing": "0.1em",
-                "fill": ARCH_LAYER_COLORS["consumers"][1],
-            },
-        )
+    parts.append(_tier_down_arrow(w // 2, y3 + h3 + 2, "DELIVER", ARCH_LAYER_COLORS["platform"][1]))
+
+    # 4. Three outcome groups keep the audience and artifact story obvious.
+    y4, h4 = 1044, 206
+    band(y4, h4, "consumers", "4", "CONSUMERS + VERIFIED OUTCOMES", "least-privilege delivery")
+    outcomes = (
+        ("ui", "People", "CLI · Web UI · operators"),
+        ("mcp", "Agents", "MCP · SDK · automation"),
+        ("file", "Artifacts", "SBOM · SARIF · OCSF · HTML/JSON"),
     )
-    art_y += 10
-    chip_cols = 3
-    chip_gap = 5
-    chip_w = (art_w - (chip_cols - 1) * chip_gap) // chip_cols
-    chip_h = 20
-    for i, label in enumerate(artifacts):
-        col, row = i % chip_cols, i // chip_cols
-        ax = art_x + col * (chip_w + chip_gap)
-        ay_chip = art_y + row * (chip_h + chip_gap)
-        parts.append(
-            f'<rect x="{ax}" y="{ay_chip}" width="{chip_w}" height="{chip_h}" rx="5" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
-            f'<text x="{ax + chip_w / 2}" y="{ay_chip + 13}" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" '
-            f'font-weight="700" fill="{t["chip"]}">{_esc(label)}</text>'
-        )
-    parts.append(
-        _text(
-            art_x + art_w // 2,
-            art_y + 2 * (chip_h + chip_gap) + 10,
-            "SIEM · webhooks",
-            **{
-                "text-anchor": "middle",
-                "font-family": "Inter,system-ui,sans-serif",
-                "font-size": "7",
-                "font-weight": "600",
-                "fill": t["lane_muted"],
-            },
-        )
-    )
+    out_w = 330
+    for index, item in enumerate(outcomes):
+        x = margin_x + 22 + index * (out_w + 10)
+        card(x, y4 + 66, out_w, 92, *item, "consumers")
 
     parts.append(
         _trust_footer(
@@ -1700,11 +1633,12 @@ def architecture(theme_name: str) -> str:
             h,
             t,
             "READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence",
-            height=26,
+            height=38,
+            font_size=12.5,
         )
     )
     parts.append("</svg>")
-    return _scale_type("\n".join(parts), _ARCHITECTURE_TYPE_SCALE)
+    return "\n".join(parts)
 
 
 # Persona band accents — one restrained hue per buyer lane, on neutral cards.
@@ -2123,6 +2057,10 @@ def main() -> None:
         issues = _audit_layout(svg)
         if issues:
             raise SystemExit(f"{filename} layout issues: {issues[:5]}")
+        if filename.startswith(("workflow-", "architecture-")):
+            fit_issues = _audit_text_fit(svg)
+            if fit_issues:
+                raise SystemExit(f"{filename} text-fit issues: {fit_issues[:5]}")
         github_issues = _audit_github_safe(svg)
         if github_issues:
             raise SystemExit(f"{filename} GitHub SVG issues: {github_issues}")

--- a/site-docs/deployment/endpoint-fleet.md
+++ b/site-docs/deployment/endpoint-fleet.md
@@ -22,13 +22,35 @@ Fleet](proxy-vs-gateway-vs-fleet.md).
 
 ## What ships today
 
-The endpoint-fleet path is real, but it is an opt-in scan + push model:
+The endpoint-fleet path is real, but it is an opt-in scan + push model with two
+complementary commands:
 
 1. the laptop runs `agent-bom agents`
 2. discovery and live MCP introspection happen locally
 3. the result is sanitized and pushed to the control plane with `--push-url`
 4. the control plane surfaces it in `/fleet`, `/agents`, `/mesh`, `/security-graph`,
    `/gateway`, and `/findings`
+
+A bounded workstation sweep adds installed applications, running processes,
+services, local listeners, containers, and images. It collects names, state,
+counts, and local listener posture; it does not collect process arguments,
+environment values, browser history, arbitrary home-directory contents, or
+remote network addresses.
+
+```bash
+agent-bom scan \
+  --preset workstation \
+  --offline \
+  --push-url https://agent-bom.internal.example.com \
+  --push-api-key "$AGENT_BOM_PUSH_API_KEY"
+```
+
+The push client adds a stable hashed source ID by default. Set
+`AGENT_BOM_PUSH_SOURCE_ID` when an MDM or enrollment system owns the endpoint
+identity. The control plane keeps the latest bounded summary per tenant and
+source ID in `/fleet`; raw process/service rows remain in the authenticated scan
+result, not the fleet list or graph node. A missing runtime or denied collector
+is shown as partial/unavailable, never as zero or clean.
 
 The endpoint command is:
 
@@ -66,7 +88,7 @@ Inventory confidence on this path:
 
 Important boundary:
 
-- this is not a managed endpoint agent
+- this is not a managed endpoint agent or EDR
 - there is no MDM or quarantine control channel today
 - the pilot model is explicit local execution on a schedule you control
 

--- a/src/agent_bom/api/fleet_store.py
+++ b/src/agent_bom/api/fleet_store.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
 from agent_bom.canonical_ids import canonical_agent_id
 from agent_bom.platform_invariants import normalize_tenant_id, normalize_timestamp, now_utc_iso
+from agent_bom.security import sanitize_text
 
 # ─── Models ──────────────────────────────────────────────────────────────────
 
@@ -84,6 +85,128 @@ class FleetAgent(BaseModel):
                 device_fingerprint=self.device_fingerprint,
             )
         return self
+
+
+class FleetEndpoint(BaseModel):
+    """Privacy-safe latest workstation inventory for one enrolled endpoint."""
+
+    endpoint_id: str = Field(min_length=1, max_length=200)
+    tenant_id: str = "default"
+    platform: dict[str, str] = Field(default_factory=dict)
+    counts: dict[str, int | None] = Field(default_factory=dict)
+    collector_status: dict[str, str] = Field(default_factory=dict)
+    collector_messages: dict[str, str] = Field(default_factory=dict)
+    privacy: dict[str, bool] = Field(default_factory=dict)
+    completeness: str = "partial"
+    last_scan_id: str = ""
+    observed_at: str = ""
+    updated_at: str = ""
+
+    @field_validator("tenant_id", mode="before")
+    @classmethod
+    def _normalize_endpoint_tenant_id(cls, value: str | None) -> str:
+        return normalize_tenant_id(value)
+
+    @field_validator("observed_at", "updated_at", mode="before")
+    @classmethod
+    def _normalize_endpoint_timestamps(cls, value: str | None) -> str:
+        return normalize_timestamp(value) or ""
+
+    @model_validator(mode="after")
+    def _apply_endpoint_defaults(self) -> FleetEndpoint:
+        if not self.updated_at:
+            self.updated_at = now_utc_iso()
+        if not self.observed_at:
+            self.observed_at = self.updated_at
+        return self
+
+
+_ENDPOINT_COLLECTORS = ("applications", "processes", "services", "listeners", "containers", "images")
+_ENDPOINT_COLLECTOR_STATUSES = frozenset({"complete", "partial", "unsupported", "unavailable", "permission_denied", "skipped"})
+
+
+def endpoint_summary_from_inventory(
+    *,
+    endpoint_id: str,
+    tenant_id: str,
+    inventory: dict[str, Any],
+    scan_id: str = "",
+    observed_at: str = "",
+) -> FleetEndpoint:
+    """Reduce raw endpoint inventory to bounded, non-identifying fleet evidence."""
+
+    collector_rows = inventory.get("collectors") if isinstance(inventory, dict) else []
+    if not isinstance(collector_rows, list):
+        collector_rows = []
+    collector_by_name: dict[str, dict[str, Any]] = {}
+    for row in (collector_rows or [])[:100]:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("name") or "")
+        if name in _ENDPOINT_COLLECTORS and name not in collector_by_name:
+            collector_by_name[name] = row
+    statuses: dict[str, str] = {}
+    counts: dict[str, int | None] = {}
+    messages: dict[str, str] = {}
+    for name in _ENDPOINT_COLLECTORS:
+        row = collector_by_name.get(name)
+        if row is None:
+            continue
+        status = str(row.get("status") or "unavailable")
+        statuses[name] = status if status in _ENDPOINT_COLLECTOR_STATUSES else "unavailable"
+        raw_count = row.get("item_count")
+        counts[name] = max(0, min(raw_count, 2_147_483_647)) if type(raw_count) is int else None
+        if row.get("message"):
+            messages[name] = sanitize_text(str(row.get("message") or ""), max_len=300)
+    requested = [status for status in statuses.values() if status != "skipped"]
+    completeness = "complete" if requested and all(status == "complete" for status in requested) else "partial"
+    platform_raw = inventory.get("platform") if isinstance(inventory, dict) else {}
+    privacy_raw = inventory.get("privacy") if isinstance(inventory, dict) else {}
+    if not isinstance(platform_raw, dict):
+        platform_raw = {}
+    if not isinstance(privacy_raw, dict):
+        privacy_raw = {}
+    return FleetEndpoint(
+        endpoint_id=endpoint_id,
+        tenant_id=tenant_id,
+        platform={key: sanitize_text(str((platform_raw or {}).get(key) or ""), max_len=100) for key in ("system", "release", "machine")},
+        counts=counts,
+        collector_status=statuses,
+        collector_messages=messages,
+        privacy={
+            key: (privacy_raw or {}).get(key, False) is True
+            for key in (
+                "process_arguments_collected",
+                "environment_values_collected",
+                "browser_history_collected",
+                "arbitrary_home_directory_scan",
+                "network_remote_addresses_collected",
+            )
+        },
+        completeness=completeness,
+        last_scan_id=scan_id,
+        observed_at=observed_at,
+    )
+
+
+def endpoint_inventory_evidence(endpoint: FleetEndpoint) -> dict[str, Any]:
+    """Return the bounded endpoint payload safe for job and graph persistence."""
+
+    return {
+        "schema_version": "1",
+        "platform": dict(endpoint.platform),
+        "privacy": dict(endpoint.privacy),
+        "collectors": [
+            {
+                "name": name,
+                "status": endpoint.collector_status[name],
+                "item_count": endpoint.counts.get(name),
+                "message": endpoint.collector_messages.get(name, ""),
+            }
+            for name in _ENDPOINT_COLLECTORS
+            if name in endpoint.collector_status
+        ],
+    }
 
 
 def fleet_agent_natural_key(agent_type: str, name: str, config_path: str) -> tuple[str, str, str]:
@@ -184,6 +307,18 @@ class FleetStore(Protocol):
     # keyword: an unscoped state change is a cross-tenant write.
     def update_state(self, agent_id: str, state: FleetLifecycleState, *, tenant_id: str) -> bool: ...
     def batch_put(self, agents: list[FleetAgent]) -> int: ...
+    def put_endpoint(self, endpoint: FleetEndpoint) -> None: ...
+    def get_endpoint(self, endpoint_id: str, *, tenant_id: str) -> FleetEndpoint | None: ...
+    def delete_endpoint(self, endpoint_id: str, *, tenant_id: str) -> bool: ...
+    def query_endpoints(
+        self,
+        tenant_id: str,
+        *,
+        search: str | None = None,
+        completeness: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[FleetEndpoint], int]: ...
 
 
 # ─── In-Memory ───────────────────────────────────────────────────────────────
@@ -200,6 +335,7 @@ class InMemoryFleetStore:
 
     def __init__(self) -> None:
         self._agents: dict[tuple[str, str], FleetAgent] = {}
+        self._endpoints: dict[tuple[str, str], FleetEndpoint] = {}
         self._lock = threading.Lock()
 
     def put(self, agent: FleetAgent) -> None:
@@ -326,6 +462,44 @@ class InMemoryFleetStore:
                 self._agents[(normalized.tenant_id, normalized.agent_id)] = normalized
             return len(agents)
 
+    def put_endpoint(self, endpoint: FleetEndpoint) -> None:
+        normalized = FleetEndpoint.model_validate(endpoint.model_dump())
+        with self._lock:
+            self._endpoints[(normalized.tenant_id, normalized.endpoint_id)] = normalized
+
+    def get_endpoint(self, endpoint_id: str, *, tenant_id: str) -> FleetEndpoint | None:
+        with self._lock:
+            return self._endpoints.get((normalize_tenant_id(tenant_id), endpoint_id))
+
+    def delete_endpoint(self, endpoint_id: str, *, tenant_id: str) -> bool:
+        with self._lock:
+            return self._endpoints.pop((normalize_tenant_id(tenant_id), endpoint_id), None) is not None
+
+    def query_endpoints(
+        self,
+        tenant_id: str,
+        *,
+        search: str | None = None,
+        completeness: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[FleetEndpoint], int]:
+        normalized_tenant = normalize_tenant_id(tenant_id)
+        with self._lock:
+            endpoints = [endpoint for (tid, _), endpoint in self._endpoints.items() if tid == normalized_tenant]
+        if search:
+            needle = search.casefold()
+            endpoints = [
+                endpoint
+                for endpoint in endpoints
+                if needle in endpoint.endpoint_id.casefold() or any(needle in value.casefold() for value in endpoint.platform.values())
+            ]
+        if completeness:
+            endpoints = [endpoint for endpoint in endpoints if endpoint.completeness == completeness]
+        endpoints.sort(key=lambda endpoint: (endpoint.updated_at, endpoint.endpoint_id), reverse=True)
+        total = len(endpoints)
+        return endpoints[offset : offset + limit], total
+
 
 # ─── SQLite ──────────────────────────────────────────────────────────────────
 
@@ -351,6 +525,17 @@ _CREATE_FLEET_AGENTS_SQL = """
 """
 
 _FLEET_COLUMNS = "agent_id, canonical_id, name, lifecycle_state, trust_score, updated_at, device_fingerprint, tenant_id, data"
+
+_CREATE_FLEET_ENDPOINTS_SQL = """
+    CREATE TABLE IF NOT EXISTS fleet_endpoints (
+        tenant_id TEXT NOT NULL,
+        endpoint_id TEXT NOT NULL,
+        completeness TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        data TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, endpoint_id)
+    )
+"""
 
 
 def _fleet_row(agent: FleetAgent) -> tuple[Any, ...]:
@@ -391,6 +576,7 @@ class SQLiteFleetStore:
     def _init_db(self) -> None:
         ensure_sqlite_schema_version(self._conn, "fleet")
         self._conn.execute(_CREATE_FLEET_AGENTS_SQL.format(table="fleet_agents"))
+        self._conn.execute(_CREATE_FLEET_ENDPOINTS_SQL)
         if "canonical_id" not in _table_columns(self._conn, "fleet_agents"):
             self._conn.execute("ALTER TABLE fleet_agents ADD COLUMN canonical_id TEXT NOT NULL DEFAULT ''")
         if "device_fingerprint" not in _table_columns(self._conn, "fleet_agents"):
@@ -411,6 +597,9 @@ class SQLiteFleetStore:
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_agent_id_lower ON fleet_agents(lower(agent_id))")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_canonical_id_lower ON fleet_agents(lower(canonical_id))")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_tenant_name ON fleet_agents(tenant_id, name)")
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_fleet_endpoints_tenant_updated ON fleet_endpoints(tenant_id, updated_at DESC, endpoint_id)"
+        )
         self._conn.commit()
 
     def _migrate_to_tenant_scoped_key(self) -> None:
@@ -631,6 +820,63 @@ class SQLiteFleetStore:
         )
         self._conn.commit()
         return len(agents)
+
+    def put_endpoint(self, endpoint: FleetEndpoint) -> None:
+        normalized = FleetEndpoint.model_validate(endpoint.model_dump())
+        self._conn.execute(
+            "INSERT OR REPLACE INTO fleet_endpoints (tenant_id, endpoint_id, completeness, updated_at, data) VALUES (?, ?, ?, ?, ?)",
+            (
+                normalized.tenant_id,
+                normalized.endpoint_id,
+                normalized.completeness,
+                normalized.updated_at,
+                normalized.model_dump_json(),
+            ),
+        )
+        self._conn.commit()
+
+    def get_endpoint(self, endpoint_id: str, *, tenant_id: str) -> FleetEndpoint | None:
+        row = self._conn.execute(
+            "SELECT data FROM fleet_endpoints WHERE tenant_id = ? AND endpoint_id = ?",
+            (normalize_tenant_id(tenant_id), endpoint_id),
+        ).fetchone()
+        return FleetEndpoint.model_validate_json(row[0]) if row else None
+
+    def delete_endpoint(self, endpoint_id: str, *, tenant_id: str) -> bool:
+        cursor = self._conn.execute(
+            "DELETE FROM fleet_endpoints WHERE tenant_id = ? AND endpoint_id = ?",
+            (normalize_tenant_id(tenant_id), endpoint_id),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def query_endpoints(
+        self,
+        tenant_id: str,
+        *,
+        search: str | None = None,
+        completeness: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[FleetEndpoint], int]:
+        clauses = ["tenant_id = ?"]
+        params: list[Any] = [normalize_tenant_id(tenant_id)]
+        if completeness:
+            clauses.append("completeness = ?")
+            params.append(completeness)
+        if search:
+            clauses.append("(lower(endpoint_id) LIKE ? OR lower(data) LIKE ?)")
+            needle = f"%{search.casefold()}%"
+            params.extend((needle, needle))
+        where = " AND ".join(clauses)
+        total = int(
+            self._conn.execute(f"SELECT COUNT(*) FROM fleet_endpoints WHERE {where}", params).fetchone()[0]  # nosec B608
+        )
+        rows = self._conn.execute(
+            f"SELECT data FROM fleet_endpoints WHERE {where} ORDER BY updated_at DESC, endpoint_id LIMIT ? OFFSET ?",  # nosec B608
+            [*params, limit, offset],
+        ).fetchall()
+        return [FleetEndpoint.model_validate_json(row[0]) for row in rows], total
 
 
 def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -644,7 +644,7 @@ class EvaluateRequest(BaseModel):
 
 class ProxyAuditIngestRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    source_id: str = ""
+    source_id: str = Field(default="", max_length=200)
     session_id: str = ""
     idempotency_key: str = ""
     alerts: list[dict[str, Any]] = Field(default_factory=list)
@@ -765,12 +765,13 @@ class ScanRunPayload(BaseModel):
 class PushPayload(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    source_id: str = ""
+    source_id: str = Field(default="", max_length=200)
     idempotency_key: str = ""
     agents: list[dict[str, Any]] = Field(default_factory=list)
     blast_radii: list[dict[str, Any]] = Field(default_factory=list)
     warnings: list[dict[str, Any] | str] = Field(default_factory=list, max_length=100)
     scan_run: ScanRunPayload | None = None
+    endpoint_inventory: dict[str, Any] | None = None
 
 
 class ScheduleCreate(BaseModel):

--- a/src/agent_bom/api/postgres_fleet_store.py
+++ b/src/agent_bom/api/postgres_fleet_store.py
@@ -22,7 +22,7 @@ from agent_bom.api.storage_schema import ensure_postgres_schema_version
 if TYPE_CHECKING:
     # Imported lazily at runtime (inside methods) to avoid a circular import
     # with fleet_store; TYPE_CHECKING keeps the annotations resolvable.
-    from .fleet_store import FleetAgent, FleetLifecycleState
+    from .fleet_store import FleetAgent, FleetEndpoint, FleetLifecycleState
 
 # Every predicate that names a single agent: the caller's tenant and the RLS
 # session tenant must both match, so neither an unscoped caller nor an
@@ -80,7 +80,21 @@ class PostgresFleetStore:
             # three need an index or quarantine enforcement pages the roster.
             conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_tenant_agent_id_lower ON fleet_agents(tenant_id, lower(agent_id))")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_tenant_canonical_id_lower ON fleet_agents(tenant_id, lower(canonical_id))")
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS fleet_endpoints (
+                    tenant_id TEXT NOT NULL,
+                    endpoint_id TEXT NOT NULL,
+                    completeness TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    data JSONB NOT NULL,
+                    PRIMARY KEY (tenant_id, endpoint_id)
+                )
+            """)
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_fleet_endpoints_tenant_updated ON fleet_endpoints(tenant_id, updated_at DESC, endpoint_id)"
+            )
             _ensure_tenant_rls(conn, "fleet_agents", "tenant_id")
+            _ensure_tenant_rls(conn, "fleet_endpoints", "tenant_id")
             conn.commit()
 
     def put(self, agent: FleetAgent) -> None:
@@ -294,3 +308,74 @@ class PostgresFleetStore:
             self.put(agent)
             count += 1
         return count
+
+    def put_endpoint(self, endpoint: FleetEndpoint) -> None:
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                """INSERT INTO fleet_endpoints (tenant_id, endpoint_id, completeness, updated_at, data)
+                   VALUES (%s, %s, %s, %s, %s)
+                   ON CONFLICT (tenant_id, endpoint_id) DO UPDATE SET
+                     completeness = EXCLUDED.completeness,
+                     updated_at = EXCLUDED.updated_at,
+                     data = EXCLUDED.data""",
+                (
+                    endpoint.tenant_id,
+                    endpoint.endpoint_id,
+                    endpoint.completeness,
+                    endpoint.updated_at,
+                    endpoint.model_dump_json(),
+                ),
+            )
+            conn.commit()
+
+    def get_endpoint(self, endpoint_id: str, *, tenant_id: str) -> FleetEndpoint | None:
+        from .fleet_store import FleetEndpoint
+
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                "SELECT data FROM fleet_endpoints WHERE tenant_id = %s AND endpoint_id = %s",
+                (tenant_id, endpoint_id),
+            ).fetchone()
+        if row is None:
+            return None
+        return FleetEndpoint.model_validate_json(row[0] if isinstance(row[0], str) else json.dumps(row[0]))
+
+    def delete_endpoint(self, endpoint_id: str, *, tenant_id: str) -> bool:
+        with _tenant_connection(self._pool) as conn:
+            cursor = conn.execute(
+                "DELETE FROM fleet_endpoints WHERE tenant_id = %s AND endpoint_id = %s",
+                (tenant_id, endpoint_id),
+            )
+            conn.commit()
+            return bool(cursor.rowcount > 0)
+
+    def query_endpoints(
+        self,
+        tenant_id: str,
+        *,
+        search: str | None = None,
+        completeness: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[FleetEndpoint], int]:
+        from .fleet_store import FleetEndpoint
+
+        clauses = ["tenant_id = %s"]
+        params: list[object] = [tenant_id]
+        if completeness:
+            clauses.append("completeness = %s")
+            params.append(completeness)
+        if search:
+            clauses.append("(lower(endpoint_id) LIKE %s OR lower(data::text) LIKE %s)")
+            needle = f"%{search.casefold()}%"
+            params.extend((needle, needle))
+        where = " AND ".join(clauses)
+        with _tenant_connection(self._pool) as conn:
+            total_row = conn.execute(f"SELECT COUNT(*) FROM fleet_endpoints WHERE {where}", tuple(params)).fetchone()  # nosec B608
+            rows = conn.execute(
+                f"SELECT data FROM fleet_endpoints WHERE {where} "  # nosec B608
+                "ORDER BY updated_at DESC, endpoint_id LIMIT %s OFFSET %s",
+                (*params, int(limit), int(offset)),
+            ).fetchall()
+        endpoints = [FleetEndpoint.model_validate_json(row[0] if isinstance(row[0], str) else json.dumps(row[0])) for row in rows]
+        return endpoints, int(total_row[0] if total_row else 0)

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -193,6 +193,55 @@ async def fleet_stats(request: Request) -> dict[str, Any]:
     }
 
 
+@router.get("/fleet/endpoints", tags=["fleet"])
+async def list_fleet_endpoints(
+    request: Request,
+    search: str | None = None,
+    completeness: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """List latest privacy-safe workstation evidence, one row per endpoint."""
+
+    if completeness not in (None, "complete", "partial"):
+        raise HTTPException(status_code=422, detail="completeness must be complete or partial")
+    limit = max(1, min(limit, 200))
+    offset = max(0, offset)
+    tenant_id = require_request_tenant_id(request)
+    store = _get_fleet_store()
+    query = getattr(store, "query_endpoints", None)
+    if not callable(query):
+        return {"endpoints": [], "count": 0, "total": 0, "limit": limit, "offset": offset, "has_more": False}
+    endpoints, total = await _store_call(
+        query,
+        tenant_id,
+        search=(search or "").strip() or None,
+        completeness=completeness,
+        limit=limit,
+        offset=offset,
+    )
+    return {
+        "endpoints": [endpoint.model_dump() for endpoint in endpoints],
+        "count": len(endpoints),
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "has_more": offset + len(endpoints) < total,
+    }
+
+
+@router.get("/fleet/endpoints/{endpoint_id}", tags=["fleet"])
+async def get_fleet_endpoint(request: Request, endpoint_id: str) -> dict[str, Any]:
+    """Return one tenant-scoped endpoint inventory summary."""
+
+    tenant_id = require_request_tenant_id(request)
+    getter = getattr(_get_fleet_store(), "get_endpoint", None)
+    endpoint = await _store_call(getter, endpoint_id, tenant_id=tenant_id) if callable(getter) else None
+    if endpoint is None:
+        raise HTTPException(status_code=404, detail="Fleet endpoint not found")
+    return cast(dict[str, Any], endpoint.model_dump())
+
+
 @router.get("/fleet/{agent_id}", tags=["fleet"])
 async def get_fleet_agent(request: Request, agent_id: str) -> dict[str, Any]:
     """Get a single fleet agent with trust score breakdown."""

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -917,6 +917,8 @@ async def receive_push(request: Request, body: PushPayload) -> dict:
                 "results push payload missing recognized fields; expected at least one of source_id, agents, blast_radii, warnings, summary"
             ),
         )
+    if body.endpoint_inventory is not None and not body.source_id:
+        raise HTTPException(status_code=422, detail="endpoint_inventory requires a stable source_id")
     tenant_id = _tenant_id(request)
     job = ScanJob(
         job_id=str(uuid.uuid4()),
@@ -934,6 +936,21 @@ async def receive_push(request: Request, body: PushPayload) -> dict:
         job_result["pushed"] = True
         job.result = job_result
         job.progress.append(f"Received via push from source={body.source_id}")
+        if body.source_id and body.endpoint_inventory:
+            from agent_bom.api.fleet_store import endpoint_inventory_evidence, endpoint_summary_from_inventory
+
+            endpoint = endpoint_summary_from_inventory(
+                endpoint_id=body.source_id,
+                tenant_id=tenant_id,
+                inventory=body.endpoint_inventory,
+                scan_id=str(job_result.get("scan_id") or job.job_id),
+                observed_at=str(job_result.get("observed_at") or job_result.get("scan_timestamp") or job.created_at),
+            )
+            _get_fleet_store().put_endpoint(endpoint)
+            # Store and graph only the bounded evidence summary. Raw process,
+            # application, service, listener, container, and image rows remain
+            # on the source endpoint and never enter the control-plane job.
+            job_result["endpoint_inventory"] = endpoint_inventory_evidence(endpoint)
         try:
             _persist_graph_snapshot(job, job_result)
         except Exception as exc:  # noqa: BLE001

--- a/src/agent_bom/api/routes/privacy.py
+++ b/src/agent_bom/api/routes/privacy.py
@@ -109,6 +109,14 @@ def _tenant_dataset(tenant_id: str, *, include_records: bool = False, record_lim
     unavailable: dict[str, str] = {}
     jobs = _try_records("jobs", lambda: _get_store().list_summary(tenant_id=tenant_id), unavailable)
     fleet = _try_records("fleet_agents", lambda: _get_fleet_store().list_by_tenant(tenant_id), unavailable)
+    fleet_endpoints: list[Any] = []
+    fleet_endpoint_total = 0
+    try:
+        query_endpoints = getattr(_get_fleet_store(), "query_endpoints", None)
+        if callable(query_endpoints):
+            fleet_endpoints, fleet_endpoint_total = query_endpoints(tenant_id, limit=record_limit, offset=0)
+    except RuntimeError:
+        unavailable["fleet_endpoints"] = _TENANT_STORE_UNAVAILABLE
     policies = _try_records("gateway_policies", lambda: _get_policy_store().list_policies(tenant_id=tenant_id), unavailable)
     schedules = _try_records("scan_schedules", lambda: _get_schedule_store().list_all(tenant_id=tenant_id), unavailable)
     sources = _try_records("sources", lambda: _get_source_store().list_all(tenant_id=tenant_id), unavailable)
@@ -139,6 +147,7 @@ def _tenant_dataset(tenant_id: str, *, include_records: bool = False, record_lim
     counts = {
         "jobs": len(jobs),
         "fleet_agents": len(fleet),
+        "fleet_endpoints": fleet_endpoint_total,
         "gateway_policies": len(policies),
         "scan_schedules": len(schedules),
         "sources": len(sources),
@@ -167,6 +176,7 @@ def _tenant_dataset(tenant_id: str, *, include_records: bool = False, record_lim
         payload["records"] = {
             "jobs": jobs[:limit],
             "fleet_agents": [_dump_record(record) for record in fleet[:limit]],
+            "fleet_endpoints": [_dump_record(record) for record in fleet_endpoints[:limit]],
             "gateway_policies": [_dump_record(record) for record in policies[:limit]],
             "scan_schedules": [_dump_record(record) for record in schedules[:limit]],
             "sources": [_redact_source(record) for record in sources[:limit]],
@@ -191,6 +201,8 @@ def _delete_graph_tenant(tenant_id: str) -> int:
 def _delete_records(tenant_id: str) -> dict[str, int]:
     jobs = _get_store().list_summary(tenant_id=tenant_id)
     fleet = _get_fleet_store().list_by_tenant(tenant_id)
+    query_endpoints = getattr(_get_fleet_store(), "query_endpoints", None)
+    fleet_endpoints, _ = query_endpoints(tenant_id, limit=_MAX_EXPORT_RECORDS, offset=0) if callable(query_endpoints) else ([], 0)
     policies = _get_policy_store().list_policies(tenant_id=tenant_id)
     schedules = _get_schedule_store().list_all(tenant_id=tenant_id)
     sources = _get_source_store().list_all(tenant_id=tenant_id)
@@ -201,6 +213,9 @@ def _delete_records(tenant_id: str) -> dict[str, int]:
     deleted = {
         "jobs": sum(1 for record in jobs if _get_store().delete(str(record["job_id"]), tenant_id=tenant_id)),
         "fleet_agents": sum(1 for record in fleet if _get_fleet_store().delete(record.agent_id, tenant_id=tenant_id)),
+        "fleet_endpoints": sum(
+            1 for record in fleet_endpoints if _get_fleet_store().delete_endpoint(record.endpoint_id, tenant_id=tenant_id)
+        ),
         "gateway_policies": sum(1 for record in policies if _get_policy_store().delete_policy(record.policy_id, tenant_id=tenant_id)),
         "scan_schedules": sum(1 for record in schedules if _get_schedule_store().delete(record.schedule_id, tenant_id=tenant_id)),
         "sources": sum(1 for record in sources if _get_source_store().delete(record.source_id)),

--- a/src/agent_bom/api/snowflake_store.py
+++ b/src/agent_bom/api/snowflake_store.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any
 from agent_bom.cloud.snowflake_spcs_auth import apply_spcs_workload_identity, native_app_mode
 
 from .exception_store import ExceptionStatus, VulnException
-from .fleet_store import FleetAgent, FleetLifecycleState
+from .fleet_store import FleetAgent, FleetEndpoint, FleetLifecycleState
 from .policy_store import GatewayPolicy, PolicyAuditEntry
 from .server import ScanJob
 from .store import _literal_like_pattern
@@ -48,6 +48,7 @@ _SNOWFLAKE_TENANT_ROW_ACCESS_POLICY = "agent_bom_tenant_isolation"
 _SNOWFLAKE_TENANT_TABLES = (
     "scan_jobs",
     "fleet_agents",
+    "fleet_endpoints",
     "scan_schedules",
     "exceptions",
     "gateway_policies",
@@ -413,7 +414,17 @@ class SnowflakeFleetStore:
             """)
             cur.execute("ALTER TABLE fleet_agents ADD COLUMN IF NOT EXISTS canonical_id VARCHAR NOT NULL DEFAULT ''")
             cur.execute("ALTER TABLE fleet_agents ADD COLUMN IF NOT EXISTS tenant_id VARCHAR NOT NULL DEFAULT 'default'")
-            _ensure_tenant_row_access_policy(cur, ("fleet_agents",))
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS fleet_endpoints (
+                    tenant_id VARCHAR NOT NULL,
+                    endpoint_id VARCHAR NOT NULL,
+                    completeness VARCHAR NOT NULL,
+                    updated_at TIMESTAMP_TZ NOT NULL,
+                    data VARIANT NOT NULL,
+                    PRIMARY KEY (tenant_id, endpoint_id)
+                )
+            """)
+            _ensure_tenant_row_access_policy(cur, ("fleet_agents", "fleet_endpoints"))
 
     def put(self, agent: FleetAgent) -> None:
         with self._connect() as conn:
@@ -608,6 +619,81 @@ class SnowflakeFleetStore:
             total += len(batch)
 
         return total
+
+    def put_endpoint(self, endpoint: FleetEndpoint) -> None:
+        with self._connect() as conn:
+            conn.cursor().execute(
+                """MERGE INTO fleet_endpoints t USING (SELECT %s AS tenant_id, %s AS endpoint_id) s
+                   ON t.tenant_id = s.tenant_id AND t.endpoint_id = s.endpoint_id
+                   WHEN MATCHED THEN UPDATE SET completeness = %s, updated_at = %s, data = PARSE_JSON(%s)
+                   WHEN NOT MATCHED THEN INSERT (tenant_id, endpoint_id, completeness, updated_at, data)
+                   VALUES (%s, %s, %s, %s, PARSE_JSON(%s))""",
+                (
+                    endpoint.tenant_id,
+                    endpoint.endpoint_id,
+                    endpoint.completeness,
+                    endpoint.updated_at,
+                    endpoint.model_dump_json(),
+                    endpoint.tenant_id,
+                    endpoint.endpoint_id,
+                    endpoint.completeness,
+                    endpoint.updated_at,
+                    endpoint.model_dump_json(),
+                ),
+            )
+
+    def get_endpoint(self, endpoint_id: str, *, tenant_id: str) -> FleetEndpoint | None:
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT data FROM fleet_endpoints WHERE tenant_id = %s AND endpoint_id = %s",
+                (tenant_id, endpoint_id),
+            )
+            row = cur.fetchone()
+        if row is None:
+            return None
+        return FleetEndpoint.model_validate_json(row[0] if isinstance(row[0], str) else json.dumps(row[0]))
+
+    def delete_endpoint(self, endpoint_id: str, *, tenant_id: str) -> bool:
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "DELETE FROM fleet_endpoints WHERE tenant_id = %s AND endpoint_id = %s",
+                (tenant_id, endpoint_id),
+            )
+            return (cur.rowcount or 0) > 0
+
+    def query_endpoints(
+        self,
+        tenant_id: str,
+        *,
+        search: str | None = None,
+        completeness: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[FleetEndpoint], int]:
+        clauses = ["tenant_id = %s"]
+        params: list[Any] = [tenant_id]
+        if completeness:
+            clauses.append("completeness = %s")
+            params.append(completeness)
+        if search:
+            clauses.append("(lower(endpoint_id) LIKE %s OR lower(TO_VARCHAR(data)) LIKE %s)")
+            needle = f"%{search.casefold()}%"
+            params.extend((needle, needle))
+        where = " AND ".join(clauses)
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(f"SELECT COUNT(*) FROM fleet_endpoints WHERE {where}", params)  # nosec B608
+            total_row = cur.fetchone()
+            cur.execute(
+                f"SELECT data FROM fleet_endpoints WHERE {where} "  # nosec B608
+                "ORDER BY updated_at DESC, endpoint_id LIMIT %s OFFSET %s",
+                [*params, int(limit), int(offset)],
+            )
+            rows = cur.fetchall()
+        endpoints = [FleetEndpoint.model_validate_json(row[0] if isinstance(row[0], str) else json.dumps(row[0])) for row in rows]
+        return endpoints, int(total_row[0] if total_row else 0)
 
 
 # ─── Schedule Store ───────────────────────────────────────────────────────────

--- a/src/agent_bom/api/storage_schema.py
+++ b/src/agent_bom/api/storage_schema.py
@@ -53,7 +53,7 @@ CONTROL_PLANE_SCHEMA_COMPONENTS: tuple[StorageSchemaComponent, ...] = (
     StorageSchemaComponent("compliance_hub", "sqlite/postgres", ("compliance_hub_findings", "hub_findings_current")),
     StorageSchemaComponent("access_review_campaigns", "sqlite/postgres", ("access_review_campaigns", "access_review_items")),
     StorageSchemaComponent("risk_campaign_workflows", "sqlite/postgres", ("risk_campaign_workflows",)),
-    StorageSchemaComponent("fleet", "sqlite/postgres/clickhouse", ("fleet_agents",)),
+    StorageSchemaComponent("fleet", "sqlite/postgres/snowflake", ("fleet_agents", "fleet_endpoints")),
     StorageSchemaComponent("graph", "sqlite/postgres", ("graph_nodes", "graph_edges", "graph_node_search")),
     StorageSchemaComponent("identity_scim", "sqlite/postgres", ("scim_users", "scim_groups")),
     # Agent-identity lifecycle is durable by default (SQLite single-node) and

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -1201,6 +1201,13 @@ def build_unified_graph_from_report(
     except Exception:  # noqa: BLE001
         _logger.warning("ci-graph overlay failed", exc_info=True)
 
+    try:
+        from agent_bom.graph.endpoint_overlay import apply_endpoint_inventory_overlay
+
+        apply_endpoint_inventory_overlay(graph, report_json)
+    except Exception:  # noqa: BLE001
+        _logger.warning("endpoint-inventory overlay failed", exc_info=True)
+
     if span is not None:
         span.set_attribute("agent_bom.graph.scan_id", sid)
         span.set_attribute("agent_bom.graph.tenant_id", tenant_id or "default")

--- a/src/agent_bom/graph/endpoint_overlay.py
+++ b/src/agent_bom/graph/endpoint_overlay.py
@@ -1,0 +1,47 @@
+"""Privacy-safe endpoint inventory projection onto UnifiedGraph."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from agent_bom.api.fleet_store import endpoint_summary_from_inventory
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.node import NodeDimensions, UnifiedNode
+from agent_bom.graph.types import EntityType
+
+
+def apply_endpoint_inventory_overlay(graph: UnifiedGraph, report: Mapping[str, Any]) -> int:
+    """Add one bounded workstation root; raw process/service rows stay off graph."""
+
+    inventory = report.get("endpoint_inventory")
+    endpoint_id = str(report.get("source_id") or "").strip()
+    if not endpoint_id or not isinstance(inventory, dict):
+        return 0
+    summary = endpoint_summary_from_inventory(
+        endpoint_id=endpoint_id,
+        tenant_id=graph.tenant_id,
+        inventory=inventory,
+        scan_id=graph.scan_id,
+        observed_at=str(report.get("observed_at") or report.get("scan_timestamp") or ""),
+    )
+    graph.add_node(
+        UnifiedNode(
+            id=f"endpoint:{endpoint_id}",
+            entity_type=EntityType.FLEET,
+            label=endpoint_id,
+            attributes={
+                "endpoint_id": summary.endpoint_id,
+                "platform": summary.platform,
+                "counts": summary.counts,
+                "collector_status": summary.collector_status,
+                "collector_messages": summary.collector_messages,
+                "privacy": summary.privacy,
+                "completeness": summary.completeness,
+                "last_scan_id": summary.last_scan_id,
+            },
+            dimensions=NodeDimensions(surface="endpoint", environment="workstation"),
+            data_sources=["endpoint_inventory"],
+        )
+    )
+    return 1

--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -63,7 +63,7 @@ def test_workflow_maps_sources_to_verified_outcomes() -> None:
         assert label in svg
     for source in (
         "Repository + CI",
-        "Workstation / endpoint",
+        "Workstation + endpoint",
         "Images + Kubernetes",
         "Cloud + data platforms",
         "MCP + runtime",
@@ -72,7 +72,7 @@ def test_workflow_maps_sources_to_verified_outcomes() -> None:
     for outcome in ("SARIF", "CycloneDX", "SPDX", "Control plane", "Runtime policy"):
         assert outcome in svg
     assert "Finding + UnifiedGraph" in svg
-    assert "Path -&gt; Impact -&gt; Owner -&gt; Fix -&gt; Verify" in svg
+    assert "PATH  ›  IMPACT  ›  OWNER  ›  FIX  ›  VERIFY" in svg
     assert "Unavailable remains unavailable" in svg
     assert "Raw source + credentials stay local" in svg
     assert _audit_layout(svg) == []
@@ -84,10 +84,10 @@ def test_architecture_includes_core_surfaces() -> None:
     assert "Unified Finding" in svg
     assert "UnifiedGraph" in svg
     assert f"{MCP_TOOL_COUNT} tools" in svg
-    assert f"{REST_OPERATION_COUNT} ops" in svg
-    assert "Agents &amp; MCP" in svg
-    assert "4 connect · 16 scan" in svg
-    assert "Scheduler / events" in svg
+    assert f"{REST_OPERATION_COUNT} operations" in svg
+    assert "Agents + MCP + models" in svg
+    assert "Cloud + data" in svg
+    assert "Fleet + scheduler" in svg
 
 
 def test_persona_value_renders_buyer_lanes() -> None:
@@ -135,12 +135,13 @@ def test_readme_places_persona_artwork_before_the_compact_role_table() -> None:
 
 def test_readme_surfaces_the_end_to_end_workflow_before_architecture_detail() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
-    workflow_heading = readme.index("### From source to verified action")
+    workflow_heading = readme.index("## Scan, correlate, and act")
     workflow_art = readme.index("workflow-dark.svg", workflow_heading)
     architecture_detail = readme.index("<summary><b>Control-plane architecture</b></summary>")
     assert workflow_heading < workflow_art < architecture_detail
     assert "workflow-light.svg" in readme[workflow_heading:architecture_detail]
     assert "raw source and credentials stay local" in readme[workflow_heading:architecture_detail].lower()
+    assert "### From source to verified action" not in readme
 
 
 def test_persona_table_rows_all_carry_a_runnable_command() -> None:
@@ -237,7 +238,8 @@ def test_readme_flow_diagrams_keep_a_ten_pixel_rendered_text_floor() -> None:
 
     for name, (svg, readme_scale) in {
         "how-it-works": (how_it_works("light"), 1100 / 1120),
-        "workflow": (workflow("light"), 1100 / 1400),
+        "workflow": (workflow("light"), 1100 / 1120),
+        "architecture": (architecture("light"), 1000 / 1120),
         "blast-radius": (blast_radius("light"), 900 / 960),
     }.items():
         sizes = [float(value) for value in re.findall(r'font-size="([0-9.]+)"', svg)]
@@ -259,12 +261,11 @@ def test_dense_diagrams_hold_their_improved_rendered_text_floor() -> None:
     than the clipped version did *and* fits: 7.77px against the 7.05px that was
     overflowing.
 
-    Architecture keeps a single row and so keeps the lower floor. Reaching the
-    flow diagrams' 10px would need the same treatment — a design change rather
-    than a scale factor.
+    Architecture now uses the same layered reflow as the workflow diagram, so
+    it is covered by the ten-pixel README floor above. The persona band remains
+    intentionally denser because it is paired with an accessible HTML table.
     """
     for name, (svg, readme_scale, floor) in {
-        "architecture": (architecture("light"), 900 / 960, 6.5),
         "persona-value": (persona_value("light"), 900 / 1280, 7.5),
     }.items():
         sizes = [float(value) for value in re.findall(r'font-size="([0-9.]+)"', svg)]

--- a/tests/test_endpoint_fleet_surface.py
+++ b/tests/test_endpoint_fleet_surface.py
@@ -1,0 +1,147 @@
+"""Endpoint inventory persistence and graph contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.fleet_store import InMemoryFleetStore, SQLiteFleetStore, endpoint_summary_from_inventory
+from agent_bom.api.server import app, set_fleet_store, set_job_store
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.graph.builder import build_unified_graph_from_report
+from agent_bom.graph.types import EntityType
+
+
+def _endpoint_inventory(*, process_count: int = 2) -> dict:
+    return {
+        "schema_version": "1",
+        "platform": {"system": "Darwin", "release": "25.6", "machine": "arm64"},
+        "privacy": {
+            "process_arguments_collected": False,
+            "environment_values_collected": False,
+            "browser_history_collected": False,
+            "arbitrary_home_directory_scan": False,
+            "network_remote_addresses_collected": False,
+        },
+        "collectors": [
+            {"name": "applications", "status": "complete", "item_count": 1, "message": ""},
+            {"name": "processes", "status": "complete", "item_count": process_count, "message": ""},
+            {"name": "services", "status": "complete", "item_count": 3, "message": ""},
+            {"name": "listeners", "status": "complete", "item_count": 1, "message": ""},
+            {"name": "containers", "status": "unavailable", "item_count": None, "message": "runtime unavailable"},
+            {"name": "images", "status": "unavailable", "item_count": None, "message": "runtime unavailable"},
+        ],
+        "applications": [{"name": "Visual Studio Code", "version": "1.99"}],
+        "processes": [
+            {"pid": 10, "name": "Code", "username": "developer"},
+            {"pid": 11, "name": "node", "username": "developer"},
+        ],
+        "services": [{"name": "com.example.agent", "state": "running"}],
+        "listeners": [{"pid": 11, "process": "node", "address_scope": "loopback", "port": 8422}],
+        "containers": [],
+        "images": [],
+    }
+
+
+def test_results_push_upserts_tenant_scoped_endpoint_summary() -> None:
+    store = InMemoryFleetStore()
+    job_store = InMemoryJobStore()
+    set_fleet_store(store)
+    set_job_store(job_store)
+    client = TestClient(app)
+
+    first = client.post(
+        "/v1/results/push",
+        json={"source_id": "device-a", "endpoint_inventory": _endpoint_inventory()},
+    )
+    second = client.post(
+        "/v1/results/push",
+        json={"source_id": "device-a", "endpoint_inventory": _endpoint_inventory(process_count=4)},
+    )
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    response = client.get("/v1/fleet/endpoints?limit=25&offset=0")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 1
+    assert payload["endpoints"][0]["endpoint_id"] == "device-a"
+    assert payload["endpoints"][0]["counts"]["processes"] == 4
+    assert payload["endpoints"][0]["completeness"] == "partial"
+    serialized = str(payload)
+    assert "username" not in serialized
+    assert "pid" not in serialized
+
+    persisted = job_store.get(second.json()["job_id"], all_tenants=True)
+    assert persisted is not None
+    persisted_inventory = persisted.result["endpoint_inventory"]
+    assert set(persisted_inventory) == {"schema_version", "platform", "privacy", "collectors"}
+    persisted_text = str(persisted_inventory)
+    assert "Visual Studio Code" not in persisted_text
+    assert "developer" not in persisted_text
+    assert "com.example.agent" not in persisted_text
+    assert "pid" not in persisted_text
+
+
+def test_results_push_rejects_endpoint_inventory_without_stable_source_id() -> None:
+    set_fleet_store(InMemoryFleetStore())
+    response = TestClient(app).post("/v1/results/push", json={"endpoint_inventory": _endpoint_inventory()})
+    assert response.status_code == 422
+    assert response.json()["detail"] == "endpoint_inventory requires a stable source_id"
+
+
+def test_results_push_rejects_unbounded_endpoint_source_id() -> None:
+    set_fleet_store(InMemoryFleetStore())
+    response = TestClient(app).post(
+        "/v1/results/push",
+        json={"source_id": "e" * 201, "endpoint_inventory": _endpoint_inventory()},
+    )
+    assert response.status_code == 422
+
+
+def test_endpoint_inventory_is_a_privacy_safe_fleet_graph_node() -> None:
+    report = {
+        "source_id": "device-a",
+        "scan_id": "scan-a",
+        "scan_sources": ["endpoint_inventory"],
+        "endpoint_inventory": _endpoint_inventory(),
+    }
+
+    graph = build_unified_graph_from_report(report, tenant_id="tenant-a")
+    endpoints = graph.nodes_by_type(EntityType.FLEET)
+
+    assert len(endpoints) == 1
+    endpoint = endpoints[0]
+    assert endpoint.id == "endpoint:device-a"
+    assert endpoint.attributes["counts"]["applications"] == 1
+    assert endpoint.attributes["collector_status"]["containers"] == "unavailable"
+    assert endpoint.attributes["privacy"]["process_arguments_collected"] is False
+    serialized = str(endpoint.to_dict())
+    assert "developer" not in serialized
+    assert "Visual Studio Code" not in serialized
+    assert "com.example.agent" not in serialized
+
+
+def test_sqlite_endpoint_registry_is_tenant_scoped_filterable_and_paged(tmp_path: Path) -> None:
+    store = SQLiteFleetStore(str(tmp_path / "fleet.db"))
+    for tenant_id, endpoint_id, system in (
+        ("tenant-a", "device-a", "Darwin"),
+        ("tenant-a", "device-b", "Windows"),
+        ("tenant-b", "device-a", "Linux"),
+    ):
+        inventory = _endpoint_inventory()
+        inventory["platform"]["system"] = system
+        store.put_endpoint(
+            endpoint_summary_from_inventory(
+                endpoint_id=endpoint_id,
+                tenant_id=tenant_id,
+                inventory=inventory,
+            )
+        )
+
+    page, total = store.query_endpoints("tenant-a", search="windows", limit=1, offset=0)
+    assert total == 1
+    assert [endpoint.endpoint_id for endpoint in page] == ["device-b"]
+    assert store.get_endpoint("device-a", tenant_id="tenant-b").platform["system"] == "Linux"
+    assert store.get_endpoint("device-a", tenant_id="tenant-a").platform["system"] == "Darwin"

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -87,6 +87,7 @@ def test_all_expected_tables_exist():
         "job_queue",
         "api_rate_limits",
         "fleet_agents",
+        "fleet_endpoints",
         "gateway_policies",
         "policy_audit_log",
         "audit_log",
@@ -599,6 +600,13 @@ def test_rls_helpers_exist():
 def test_fleet_agents_rls_policy_exists():
     assert "ALTER TABLE fleet_agents ENABLE ROW LEVEL SECURITY" in SQL
     assert "CREATE POLICY fleet_agents_tenant_isolation ON fleet_agents" in SQL
+
+
+def test_fleet_endpoints_has_tenant_key_and_rls_policy():
+    assert {"tenant_id", "endpoint_id", "completeness", "updated_at", "data"}.issubset(_columns_for("fleet_endpoints"))
+    assert "PRIMARY KEY (tenant_id, endpoint_id)" in SQL
+    assert "ALTER TABLE fleet_endpoints ENABLE ROW LEVEL SECURITY" in SQL
+    assert "CREATE POLICY fleet_endpoints_tenant_isolation ON fleet_endpoints" in SQL
 
 
 def test_scan_schedules_rls_policy_exists():

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -128,7 +128,7 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
 
     markers = [
-        "## What it is",
+        "## Scan, correlate, and act",
         "<summary><b>Control-plane architecture</b></summary>",
         "## Who it is for",
         "## Quick start",
@@ -181,18 +181,14 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert "demo.agent-bom.com" not in readme
     assert "## How it works" not in readme
 
-    # Two paragraphs, not three: what it does and where it runs, then the
-    # provenance guarantee. The middle paragraph restated the first.
-    current_what_it_is = """`agent-bom` scans repositories, images, and cloud accounts, then correlates what
-it finds into one Finding + UnifiedGraph model — powering CLI and CI artifacts,
-fleet and browser investigations, compliance evidence, and runtime policy. Run
-the scanner without an account, or deploy the control plane inside your own
-cloud, VPC, cluster, database, identity, and audit boundary.
-
-Graph provenance stays explicit: collected, inferred, static, and runtime
-relationships remain distinct, and unavailable evidence is never upgraded to
-observed."""
-    assert current_what_it_is in readme
+    # The opening is one Agent-Bom product paragraph plus four scannable
+    # outcome/trust bullets. Workflow and architecture detail belongs in the
+    # diagrams, not in a second prose manifesto.
+    intro = readme.split("## Scan, correlate, and act", 1)[1].split("workflow-dark.svg", 1)[0]
+    assert "one Finding + UnifiedGraph model" in intro
+    for label in ("Start locally or in CI", "Centralize when ready", "Act with context", "Keep evidence honest"):
+        assert f"**{label}:**" in intro
+    assert "### From source to verified action" not in intro
 
     quick_start = readme.split("## Quick start", 1)[1].split("\n## ", 1)[0]
     primary_block = re.search(r"```bash\n(.*?)\n```", quick_start, re.S)

--- a/tests/test_snowflake_native_app.py
+++ b/tests/test_snowflake_native_app.py
@@ -311,6 +311,13 @@ def test_dcm_project_has_v001_migration():
     assert v001.is_file(), f"DCM project must have V001__core_schema.sql at {v001}"
 
 
+def test_dcm_v003_adds_tenant_scoped_fleet_endpoints_without_rewriting_v001():
+    v003 = (DCM_DIR / "V003__fleet_endpoints.sql").read_text(encoding="utf-8")
+    assert "CREATE TABLE IF NOT EXISTS core.fleet_endpoints" in v003
+    assert "PRIMARY KEY (tenant_id, endpoint_id)" in v003
+    assert "fleet_endpoints" not in (DCM_DIR / "V001__core_schema.sql").read_text(encoding="utf-8")
+
+
 def test_dcm_v001_creates_compliance_hub_table():
     """V001 must create the compliance_hub_findings table — Phase 2's
     Snowpark proc target. If V001 doesn't materialise the schema, Phase 2

--- a/ui/app/fleet/page.tsx
+++ b/ui/app/fleet/page.tsx
@@ -41,6 +41,7 @@ import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
 import { useChartTheme } from "@/lib/theme-colors";
+import { EndpointFleetPanel } from "@/components/endpoint-fleet-panel";
 
 function downloadJson(data: unknown, filename: string) {
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
@@ -257,6 +258,8 @@ export default function FleetPage() {
           </button>
         </div>
       </div>
+
+      <EndpointFleetPanel />
 
       {/* Trust Threshold Settings */}
       <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-4">

--- a/ui/components/endpoint-fleet-panel.tsx
+++ b/ui/components/endpoint-fleet-panel.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown, ChevronRight, Laptop, Loader2, Search } from "lucide-react";
+
+import { PaginationBar } from "@/components/pagination-bar";
+import { api, formatDate, type FleetEndpoint } from "@/lib/api";
+
+const PAGE_SIZE = 25;
+
+function countLabel(endpoint: FleetEndpoint, key: string, label: string) {
+  const count = endpoint.counts[key];
+  return typeof count === "number" ? `${count.toLocaleString()} ${label}` : `${label} unavailable`;
+}
+
+export function EndpointFleetPanel() {
+  const [endpoints, setEndpoints] = useState<FleetEndpoint[]>([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [query, setQuery] = useState("");
+  const [search, setSearch] = useState("");
+  const [completeness, setCompleteness] = useState<"all" | "complete" | "partial">("all");
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const requestId = useRef(0);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setOffset(0);
+      setSearch(query.trim());
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, [query]);
+
+  const load = useCallback(async () => {
+    const current = ++requestId.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await api.listFleetEndpoints({
+        search: search || undefined,
+        completeness: completeness === "all" ? undefined : completeness,
+        limit: PAGE_SIZE,
+        offset,
+      });
+      if (current !== requestId.current) return;
+      setEndpoints(response.endpoints);
+      setTotal(response.total);
+    } catch (reason) {
+      if (current !== requestId.current) return;
+      setEndpoints([]);
+      setTotal(0);
+      setError(reason instanceof Error ? reason.message : "Endpoint inventory request failed");
+    } finally {
+      if (current === requestId.current) setLoading(false);
+    }
+  }, [completeness, offset, search]);
+
+  useEffect(() => {
+    void load();
+    return () => {
+      requestId.current += 1;
+    };
+  }, [load]);
+
+  const page = Math.floor(offset / PAGE_SIZE) + 1;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const partialCount = useMemo(
+    () => endpoints.filter((endpoint) => endpoint.completeness === "partial").length,
+    [endpoints],
+  );
+
+  return (
+    <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)] p-4" aria-labelledby="endpoint-fleet-heading">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h2 id="endpoint-fleet-heading" className="flex items-center gap-2 text-base font-semibold text-[var(--foreground)]">
+            <Laptop className="h-4 w-4 text-cyan-500 dark:text-cyan-300" />
+            Developer endpoints
+          </h2>
+          <p className="mt-1 text-xs text-[var(--text-secondary)]">
+            Latest workstation sweep per endpoint. Process arguments and environment values are not collected.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs">
+          <span className="rounded-full border border-[var(--border-subtle)] px-2 py-1 text-[var(--text-secondary)]">{total} endpoints</span>
+          {partialCount > 0 && (
+            <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-amber-700 dark:text-amber-300">
+              {partialCount} partial on this page
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-2 sm:grid-cols-[minmax(0,1fr)_180px]">
+        <label className="relative">
+          <span className="sr-only">Filter endpoints</span>
+          <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-[var(--text-tertiary)]" />
+          <input
+            aria-label="Filter endpoints"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Filter by ID or platform"
+            className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] py-2 pl-9 pr-3 text-sm text-[var(--foreground)] placeholder:text-[var(--text-tertiary)]"
+          />
+        </label>
+        <select
+          aria-label="Filter endpoint completeness"
+          value={completeness}
+          onChange={(event) => {
+            setOffset(0);
+            setCompleteness(event.target.value as typeof completeness);
+          }}
+          className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)]"
+        >
+          <option value="all">All evidence states</option>
+          <option value="complete">Complete</option>
+          <option value="partial">Partial</option>
+        </select>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 py-8 text-sm text-[var(--text-secondary)]"><Loader2 className="h-4 w-4 animate-spin" /> Loading endpoints…</div>
+      ) : error ? (
+        <p role="alert" className="mt-4 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-700 dark:text-red-300">{error}</p>
+      ) : endpoints.length === 0 ? (
+        <div className="mt-4 rounded-lg border border-dashed border-[var(--border-subtle)] p-4 text-sm text-[var(--text-secondary)]">
+          <p className="font-medium text-[var(--foreground)]">No workstation evidence yet</p>
+          <p className="mt-1">Run <code className="rounded bg-[var(--surface-elevated)] px-1.5 py-0.5">agent-bom scan --preset workstation --push-url https://&lt;control-plane&gt;</code>.</p>
+        </div>
+      ) : (
+        <div className="mt-4 grid gap-2 xl:grid-cols-2">
+          {endpoints.map((endpoint) => {
+            const isExpanded = expanded.has(endpoint.endpoint_id);
+            const unavailable = Object.entries(endpoint.collector_status).filter(([, status]) => status !== "complete");
+            return (
+              <article key={endpoint.endpoint_id} data-testid="endpoint-row" className="min-w-0 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-3">
+                <button
+                  type="button"
+                  aria-expanded={isExpanded}
+                  onClick={() => setExpanded((current) => {
+                    const next = new Set(current);
+                    if (next.has(endpoint.endpoint_id)) next.delete(endpoint.endpoint_id); else next.add(endpoint.endpoint_id);
+                    return next;
+                  })}
+                  className="flex w-full items-start justify-between gap-3 text-left"
+                >
+                  <span className="min-w-0">
+                    <span className="block truncate text-sm font-semibold text-[var(--foreground)]">{endpoint.endpoint_id}</span>
+                    <span className="mt-0.5 block text-xs text-[var(--text-secondary)]">
+                      {[endpoint.platform.system, endpoint.platform.release, endpoint.platform.machine].filter(Boolean).join(" · ")}
+                    </span>
+                  </span>
+                  <span className="flex shrink-0 items-center gap-2">
+                    <span className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${endpoint.completeness === "complete" ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300" : "bg-amber-500/10 text-amber-700 dark:text-amber-300"}`}>
+                      {endpoint.completeness}
+                    </span>
+                    {isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+                  </span>
+                </button>
+                <div className="mt-3 flex flex-wrap gap-x-3 gap-y-1 text-xs text-[var(--text-secondary)]">
+                  <span>{countLabel(endpoint, "applications", "apps")}</span>
+                  <span>{countLabel(endpoint, "processes", "processes")}</span>
+                  <span>{countLabel(endpoint, "services", "services")}</span>
+                  <span>{countLabel(endpoint, "listeners", "listeners")}</span>
+                </div>
+                {isExpanded && (
+                  <div className="mt-3 border-t border-[var(--border-subtle)] pt-3 text-xs text-[var(--text-secondary)]">
+                    <div className="flex flex-wrap gap-x-3 gap-y-1">
+                      <span>{countLabel(endpoint, "containers", "containers")}</span>
+                      <span>{countLabel(endpoint, "images", "images")}</span>
+                      <span>Observed {formatDate(endpoint.observed_at)}</span>
+                    </div>
+                    {unavailable.length > 0 && (
+                      <ul className="mt-2 space-y-1 text-amber-700 dark:text-amber-300">
+                        {unavailable.map(([name, status]) => (
+                          <li key={name}>{name}: {status}{endpoint.collector_messages[name] ? ` — ${endpoint.collector_messages[name]}` : ""}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      )}
+
+      {total > 0 && (
+        <PaginationBar
+          className="mt-4 border-t border-[var(--border-subtle)] pt-3"
+          page={page}
+          totalPages={totalPages}
+          totalItems={total}
+          itemLabel="endpoints"
+          onPrevious={() => setOffset((value) => Math.max(0, value - PAGE_SIZE))}
+          onNext={() => setOffset((value) => value + PAGE_SIZE)}
+        />
+      )}
+    </section>
+  );
+}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2511,6 +2511,29 @@ export interface FleetStatsResponse {
   low_trust_count: number;
 }
 
+export interface FleetEndpoint {
+  endpoint_id: string;
+  tenant_id: string;
+  platform: Record<string, string>;
+  counts: Record<string, number | null>;
+  collector_status: Record<string, string>;
+  collector_messages: Record<string, string>;
+  privacy: Record<string, boolean>;
+  completeness: "complete" | "partial";
+  last_scan_id: string;
+  observed_at: string;
+  updated_at: string;
+}
+
+export interface FleetEndpointsResponse {
+  endpoints: FleetEndpoint[];
+  count: number;
+  total: number;
+  limit: number;
+  offset: number;
+  has_more: boolean;
+}
+
 export interface FleetSyncResult {
   synced: number;
   new: number;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -88,6 +88,8 @@ import type {
   FleetQuarantineResult,
   FleetStatsResponse,
   FleetSyncResult,
+  FleetEndpoint,
+  FleetEndpointsResponse,
   ScanSchedule,
   ScheduleCreateRequest,
   GatewayPolicy,
@@ -322,6 +324,8 @@ export type {
   FleetQuarantineResult,
   FleetStatsResponse,
   FleetSyncResult,
+  FleetEndpoint,
+  FleetEndpointsResponse,
   ScanSchedule,
   ScheduleCreateRequest,
   PolicyMode,
@@ -1409,6 +1413,22 @@ export const api = {
   quarantineFleetAgent: (agentId: string) =>
     post<FleetQuarantineResult>(`/v1/fleet/${encodeURIComponent(agentId)}/quarantine`, {}),
   getFleetStats: () => get<FleetStatsResponse>("/v1/fleet/stats"),
+  listFleetEndpoints: (filters?: {
+    search?: string | undefined;
+    completeness?: "complete" | "partial" | undefined;
+    limit?: number | undefined;
+    offset?: number | undefined;
+  }) => {
+    const params = new URLSearchParams();
+    if (filters?.search) params.set("search", filters.search);
+    if (filters?.completeness) params.set("completeness", filters.completeness);
+    if (filters?.limit != null) params.set("limit", String(filters.limit));
+    if (filters?.offset != null) params.set("offset", String(filters.offset));
+    const qs = params.toString();
+    return get<FleetEndpointsResponse>(`/v1/fleet/endpoints${qs ? `?${qs}` : ""}`);
+  },
+  getFleetEndpoint: (endpointId: string) =>
+    get<FleetEndpoint>(`/v1/fleet/endpoints/${encodeURIComponent(endpointId)}`),
 
   // ── Connectors / sources ──
   listConnectors: () => get<ConnectorsResponse>("/v1/connectors"),

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -95,7 +95,11 @@ const BUDGETS = {
   // Legitimate feature copy, not bloat (the api-types additions are erased at
   // compile). Restore ~16 KiB to 3776 KiB on the same terms as every raise
   // above; largest-chunk and shared-runtime budgets are unchanged.
-  totalClientJsBytes: 3_866_624,
+  // The endpoint fleet panel adds one measured 6.7 KiB route surface for
+  // search, evidence-state filtering, pagination, and partial-state detail.
+  // Linux CI measures 3783.0 KiB total with no new heavyweight dependency;
+  // keep bounded headroom at 3792 KiB while leaving both chunk ceilings fixed.
+  totalClientJsBytes: 3_883_008,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };

--- a/ui/tests/endpoint-fleet-panel.test.tsx
+++ b/ui/tests/endpoint-fleet-panel.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EndpointFleetPanel } from "@/components/endpoint-fleet-panel";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: { listFleetEndpoints: vi.fn() },
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, api: { ...actual.api, ...apiMock } };
+});
+
+function endpoint(id: string, system = "Darwin") {
+  return {
+    endpoint_id: id,
+    tenant_id: "default",
+    platform: { system, release: "25.6", machine: "arm64" },
+    counts: { applications: 192, processes: 463, services: 518, listeners: 5, containers: 0, images: 20 },
+    collector_status: { applications: "complete", processes: "complete", containers: "unavailable" },
+    collector_messages: { containers: "Podman unavailable" },
+    privacy: { process_arguments_collected: false, environment_values_collected: false },
+    completeness: "partial",
+    last_scan_id: "scan-a",
+    observed_at: "2026-08-17T00:00:00Z",
+    updated_at: "2026-08-17T00:00:00Z",
+  };
+}
+
+describe("EndpointFleetPanel", () => {
+  beforeEach(() => apiMock.listFleetEndpoints.mockReset());
+
+  it("shows a compact, honest endpoint summary and partial collector reason", async () => {
+    const user = userEvent.setup();
+    apiMock.listFleetEndpoints.mockResolvedValue({
+      endpoints: [endpoint("device-a")], count: 1, total: 1, limit: 25, offset: 0, has_more: false,
+    });
+    render(<EndpointFleetPanel />);
+
+    expect(await screen.findByText("device-a")).toBeInTheDocument();
+    expect(screen.getByText("192 apps")).toBeInTheDocument();
+    expect(screen.getByText("463 processes")).toBeInTheDocument();
+    const disclosure = screen.getByRole("button", { expanded: false });
+    disclosure.focus();
+    await user.keyboard("{Enter}");
+    expect(disclosure).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(/Podman unavailable/)).toBeInTheDocument();
+    expect(screen.getByText(/arguments and environment values are not collected/i)).toBeInTheDocument();
+  });
+
+  it("filters and paginates without rendering an unbounded endpoint list", async () => {
+    apiMock.listFleetEndpoints
+      .mockResolvedValueOnce({ endpoints: Array.from({ length: 25 }, (_, index) => endpoint(`device-${index}`)), count: 25, total: 26, limit: 25, offset: 0, has_more: true })
+      .mockResolvedValueOnce({ endpoints: [endpoint("device-25", "Windows")], count: 1, total: 26, limit: 25, offset: 25, has_more: false })
+      .mockResolvedValueOnce({ endpoints: [endpoint("device-25", "Windows")], count: 1, total: 1, limit: 25, offset: 0, has_more: false });
+
+    render(<EndpointFleetPanel />);
+    expect(await screen.findAllByTestId("endpoint-row")).toHaveLength(25);
+    fireEvent.click(screen.getByRole("button", { name: /Next/i }));
+    await waitFor(() => expect(apiMock.listFleetEndpoints).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 25 })));
+    fireEvent.change(screen.getByLabelText("Filter endpoints"), { target: { value: "windows" } });
+    await waitFor(() => expect(apiMock.listFleetEndpoints).toHaveBeenLastCalledWith(expect.objectContaining({ search: "windows", offset: 0 })));
+  });
+});


### PR DESCRIPTION
## Summary

- Persist privacy-safe workstation endpoint summaries with tenant-scoped SQLite, Postgres, and Snowflake storage, authenticated fleet APIs, privacy export/delete coverage, and a bounded UnifiedGraph endpoint overlay.
- Add a compact Fleet UI with search, completeness filtering, pagination, partial-evidence explanations, keyboard disclosure, and desktop/light/dark/responsive browser verification.
- Simplify the Agent-Bom README opening and reflow workflow/control-plane diagrams into readable layers using provenanced cloud vectors, neutral category icons, and automated text-fit guards.
- Keep raw application, process, service, listener, container, and image rows on the source endpoint; only bounded counts, platform, collector status, and declared privacy flags persist centrally.

## Verification

- `uv run pytest -q` on 391 affected endpoint, fleet, API, tenancy, Postgres, Snowflake, graph, SVG, and public-doc contracts
- `uv run ruff check src tests scripts/generate_doc_architecture_svgs.py`
- `uv run ruff format --check src tests scripts/generate_doc_architecture_svgs.py`
- `uv run mypy src/agent_bom`
- `uv run python scripts/check_exception_sanitization.py`
- `make preflight`
- Node 24.19.0 / npm 10.9.7: `npm run verify:toolchain`, `npm run typecheck`, 187 Vitest files / 1,182 tests, and `npm run build` (52 pages)
- Authenticated loopback browser walkthrough with three synthetic endpoint summaries: dark/light desktop, 390px responsive fallback, filtering, pagination, partial reason disclosure, and zero horizontal overflow

## Notes

- This is post-v0.101.0 work; it does not alter the already-published release artifacts.
- Credentialed production endpoint fleet scale remains a separate release-proof step.