### PR TITLE
fix(scan): scope hooks and stabilize baseline identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1444,6 +1444,9 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Verify uv lockfile freshness
+        run: uv lock --check
+
       - name: Verify version consistency
         run: |
           PYPROJECT_VER=$(python -c "import re, pathlib; text = pathlib.Path('pyproject.toml').read_text(); print(re.search(r'^version\\s*=\\s*\"([^\"]+)\"', text, re.M).group(1))")

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -27,7 +27,7 @@
     vulnerabilities; fail the commit on high-or-above severity findings.
   entry: agent-bom scan
   language: python
-  args: ["--fail-on-severity", "high"]
+  args: ["-p", ".", "--fail-on-severity", "high"]
   pass_filenames: false
   always_run: true
   minimum_pre_commit_version: "2.9.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The consumer pre-commit dependency hook now scopes scans to the downstream
+  repository instead of including unrelated workstation MCP configuration.
+- Baseline and history diffs keep a CVE attached to the same normalized package
+  across version upgrades, while inventory diffs continue to report the package
+  version change separately.
+
 ## [0.101.0] - 2026-08-16
 
 A workflow-completion and deployment-portability release. The same finding can

--- a/src/agent_bom/history.py
+++ b/src/agent_bom/history.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 from agent_bom.models import Package
-from agent_bom.package_utils import canonical_package_key
+from agent_bom.package_utils import canonical_package_key, vulnerability_occurrence_key
 from agent_bom.sbom import parse_sbom_document
 from agent_bom.security import sanitize_path_label, sanitize_text
 
@@ -210,16 +210,16 @@ def _vuln_key(vuln: dict) -> tuple:
     return (vuln.get("id", ""), vuln.get("package", ""), vuln.get("ecosystem", ""))
 
 
-def _extract_blast_vulns(report: dict) -> dict[tuple, dict]:
-    """Build a map of vuln_key → blast_radius entry from a report dict."""
-    result = {}
+def _extract_blast_vulns(report: dict) -> dict[tuple, list[dict]]:
+    """Group blast-radius entries by version-stable vulnerability identity."""
+    result: dict[tuple, list[dict]] = {}
     for br in report.get("blast_radius", []):
-        key = (
+        key = vulnerability_occurrence_key(
             br.get("vulnerability_id", ""),
             br.get("package", ""),
             br.get("ecosystem", ""),
         )
-        result[key] = br
+        result.setdefault(key, []).append(br)
     return result
 
 
@@ -235,16 +235,16 @@ def diff_reports(baseline: dict, current: dict) -> dict:
     baseline_vulns = _extract_blast_vulns(baseline)
     current_vulns = _extract_blast_vulns(current)
 
-    baseline_keys = set(baseline_vulns)
-    current_keys = set(current_vulns)
-
-    new_keys = current_keys - baseline_keys
-    resolved_keys = baseline_keys - current_keys
-    unchanged_keys = baseline_keys & current_keys
-
-    new = [current_vulns[k] for k in sorted(new_keys)]
-    resolved = [baseline_vulns[k] for k in sorted(resolved_keys)]
-    unchanged = [current_vulns[k] for k in sorted(unchanged_keys)]
+    new: list[dict] = []
+    resolved: list[dict] = []
+    unchanged: list[dict] = []
+    for key in sorted(set(baseline_vulns) | set(current_vulns)):
+        baseline_entries = baseline_vulns.get(key, [])
+        current_entries = current_vulns.get(key, [])
+        matched_count = min(len(baseline_entries), len(current_entries))
+        unchanged.extend(current_entries[:matched_count])
+        new.extend(current_entries[matched_count:])
+        resolved.extend(baseline_entries[matched_count:])
 
     # Package-level changes
     baseline_pkgs = _extract_packages(baseline)

--- a/src/agent_bom/package_utils.py
+++ b/src/agent_bom/package_utils.py
@@ -171,6 +171,31 @@ def canonical_package_key(name: str, version: str, ecosystem: str, purl: str | N
     return f"{normalized_ecosystem}:{normalized_name}{suffix}"
 
 
+def vulnerability_occurrence_key(vulnerability_id: str, package_ref: str, ecosystem: str = "") -> tuple[str, str, str]:
+    """Return stable finding identity across package-version remediation.
+
+    ``package_ref`` is the report form ``name@version``. The version is
+    deliberately excluded: upgrading a package must not turn an already-known
+    vulnerability into a phantom new finding. Package inventory diffing remains
+    version-aware and reports the upgrade separately.
+    """
+    raw_ref = (package_ref or "").strip()
+    package_name = raw_ref
+    if raw_ref.startswith("@"):
+        separator = raw_ref.rfind("@")
+        if separator > 0:
+            package_name = raw_ref[:separator]
+    elif "@" in raw_ref:
+        package_name = raw_ref.rsplit("@", 1)[0]
+
+    normalized_ecosystem = normalize_package_ecosystem(ecosystem)
+    return (
+        (vulnerability_id or "").strip().upper(),
+        normalized_ecosystem,
+        normalize_package_name(package_name, normalized_ecosystem),
+    )
+
+
 @lru_cache(maxsize=4096)
 def debian_release_branch(distro_version: str) -> str:
     """Normalize Debian ``VERSION_ID`` to the advisory release key.
@@ -332,4 +357,5 @@ __all__ = [
     "reference_host_and_path",
     "synthesize_purl",
     "ubuntu_release_branch",
+    "vulnerability_occurrence_key",
 ]

--- a/src/agent_bom/scan_delta.py
+++ b/src/agent_bom/scan_delta.py
@@ -4,16 +4,21 @@ Usage:
     agent-bom scan --baseline-file scan-main.json --delta
     agent-bom scan --delta   # auto-loads last saved baseline from ~/.agent-bom/baseline.json
 
-The delta key for deduplication is (vulnerability_id, package_name, package_version).
-Exit code is based on *new* findings only; pre-existing findings are suppressed.
+The delta key for deduplication is (vulnerability_id, ecosystem, package_name).
+Package versions stay in inventory diffs, but do not reclassify an existing CVE
+as new during remediation. Exit code is based on *new* findings only;
+pre-existing findings are suppressed.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+from collections import Counter
 from pathlib import Path
 from typing import Optional
+
+from agent_bom.package_utils import vulnerability_occurrence_key
 
 _logger = logging.getLogger(__name__)
 
@@ -25,18 +30,13 @@ _DEFAULT_BASELINE_PATH = Path.home() / ".agent-bom" / "baseline.json"
 # Finding key type
 # ---------------------------------------------------------------------------
 
-# A delta key uniquely identifies a vulnerability in a package at a version.
-# Using (vuln_id, package_name, package_version) gives stable, human-readable keys.
+# A delta key identifies a vulnerability occurrence across package upgrades.
 DeltaKey = tuple[str, str, str]
 
 
-def _make_key(vuln_id: str, package: str) -> DeltaKey:
-    """Build a delta key from a blast_radius JSON item.
-
-    ``package`` is in ``name@version`` format as serialized by json_fmt.py.
-    """
-    name, _, version = package.partition("@")
-    return (vuln_id.upper(), name.lower(), version or "")
+def _make_key(vuln_id: str, package: str, ecosystem: str = "") -> DeltaKey:
+    """Build a version-stable delta key from a blast-radius JSON item."""
+    return vulnerability_occurrence_key(vuln_id, package, ecosystem)
 
 
 def extract_delta_keys(scan_json: dict) -> set[DeltaKey]:
@@ -46,7 +46,7 @@ def extract_delta_keys(scan_json: dict) -> set[DeltaKey]:
         vuln_id = item.get("vulnerability_id", "")
         package = item.get("package", "")
         if vuln_id and package:
-            keys.add(_make_key(vuln_id, package))
+            keys.add(_make_key(vuln_id, package, item.get("ecosystem", "")))
     return keys
 
 
@@ -140,8 +140,13 @@ def compute_delta(
         :class:`DeltaResult` with ``new_items`` (not in baseline) and
         ``pre_existing_items`` (already in baseline).
     """
-    baseline_keys = extract_delta_keys(baseline)
-    _logger.debug("Baseline has %d findings", len(baseline_keys))
+    baseline_counts: Counter[DeltaKey] = Counter()
+    for item in baseline.get("blast_radius", []):
+        vuln_id = item.get("vulnerability_id", "")
+        package = item.get("package", "")
+        if vuln_id and package:
+            baseline_counts[_make_key(vuln_id, package, item.get("ecosystem", ""))] += 1
+    _logger.debug("Baseline has %d findings", sum(baseline_counts.values()))
 
     new_items: list[dict] = []
     pre_existing_items: list[dict] = []
@@ -152,8 +157,11 @@ def compute_delta(
         if not vuln_id or not package:
             _logger.debug("Skipping malformed blast_radius item: %s", item)
             continue
-        key = _make_key(vuln_id, package)
-        if key in baseline_keys:
+        key = _make_key(vuln_id, package, item.get("ecosystem", ""))
+        legacy_key: DeltaKey = (key[0], "", key[2])
+        matched_key = key if baseline_counts[key] else legacy_key
+        if baseline_counts[matched_key]:
+            baseline_counts[matched_key] -= 1
             pre_existing_items.append(item)
         else:
             new_items.append(item)
@@ -162,7 +170,7 @@ def compute_delta(
         "Delta: %d new, %d pre-existing (baseline had %d)",
         len(new_items),
         len(pre_existing_items),
-        len(baseline_keys),
+        sum(baseline_counts.values()) + len(pre_existing_items),
     )
     return DeltaResult(
         new_items=new_items,

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -130,6 +130,18 @@ def test_test_job_timeout_leaves_margin_over_observed_worst_case() -> None:
     assert _ci()["jobs"]["test"]["timeout-minutes"] == 35
 
 
+def test_version_alignment_fails_fast_when_uv_lock_is_stale() -> None:
+    """Reject dependency drift before Docker and full-suite jobs consume runners."""
+    steps = _ci()["jobs"]["version-check"]["steps"]
+    lock_check_index = next(index for index, step in enumerate(steps) if step.get("name") == "Verify uv lockfile freshness")
+    dependency_install_index = next(
+        index for index, step in enumerate(steps) if step.get("name") == "Install dependencies for CLI smoke checks"
+    )
+
+    assert steps[lock_check_index]["run"] == "uv lock --check"
+    assert lock_check_index < dependency_install_index
+
+
 def test_alpine_full_suite_timeout_leaves_musl_headroom() -> None:
     """Full-suite Alpine runs must leave cleanup margin over the 34m51s baseline."""
     assert _ci()["jobs"]["test-alpine"]["timeout-minutes"] == 45

--- a/tests/test_consumer_precommit_hooks.py
+++ b/tests/test_consumer_precommit_hooks.py
@@ -1,0 +1,24 @@
+"""Contracts for hooks installed into downstream repositories."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _hook(hook_id: str) -> dict[str, object]:
+    hooks = yaml.safe_load((ROOT / ".pre-commit-hooks.yaml").read_text(encoding="utf-8"))
+    matches = [hook for hook in hooks if hook.get("id") == hook_id]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def test_dependency_hook_scans_only_the_downstream_repository() -> None:
+    hook = _hook("agent-bom-scan")
+
+    assert hook["pass_filenames"] is False
+    assert hook["args"][:2] == ["-p", "."]
+    assert hook["args"][2:] == ["--fail-on-severity", "high"]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -680,6 +680,83 @@ def test_diff_resolved_finding():
     assert len(diff["resolved"]) == 1
 
 
+def test_diff_package_upgrade_keeps_finding_identity_and_reports_inventory_change():
+    from agent_bom.history import diff_reports
+
+    def report(version: str) -> dict:
+        return {
+            "generated_at": "2025-01-01T00:00:00",
+            "agents": [
+                {
+                    "name": "a",
+                    "mcp_servers": [
+                        {
+                            "packages": [
+                                {
+                                    "name": "requests",
+                                    "version": version,
+                                    "ecosystem": "pypi",
+                                }
+                            ]
+                        }
+                    ],
+                }
+            ],
+            "blast_radius": [
+                {
+                    "vulnerability_id": "CVE-2024-99",
+                    "package": f"requests@{version}",
+                    "ecosystem": "pypi",
+                    "severity": "HIGH",
+                }
+            ],
+        }
+
+    diff = diff_reports(report("2.19.1"), report("2.20.0"))
+
+    assert diff["summary"]["new_findings"] == 0
+    assert diff["summary"]["resolved_findings"] == 0
+    assert diff["summary"]["unchanged_findings"] == 1
+    assert diff["new_packages"] == ["pypi:requests@2.20.0"]
+    assert diff["removed_packages"] == ["pypi:requests@2.19.1"]
+
+
+def test_diff_package_upgrade_does_not_hide_an_added_vulnerable_instance():
+    from agent_bom.history import diff_reports
+
+    baseline = {
+        "agents": [],
+        "blast_radius": [
+            {
+                "vulnerability_id": "CVE-2024-99",
+                "package": "requests@2.19.1",
+                "ecosystem": "pypi",
+            }
+        ],
+    }
+    current = {
+        "agents": [],
+        "blast_radius": [
+            {
+                "vulnerability_id": "CVE-2024-99",
+                "package": "requests@2.20.0",
+                "ecosystem": "pypi",
+            },
+            {
+                "vulnerability_id": "CVE-2024-99",
+                "package": "requests@2.21.0",
+                "ecosystem": "pypi",
+            },
+        ],
+    }
+
+    diff = diff_reports(baseline, current)
+
+    assert diff["summary"]["unchanged_findings"] == 1
+    assert diff["summary"]["new_findings"] == 1
+    assert diff["summary"]["resolved_findings"] == 0
+
+
 def test_diff_reports_inventory_changes():
     from agent_bom.history import diff_reports
 

--- a/tests/test_scan_delta.py
+++ b/tests/test_scan_delta.py
@@ -31,13 +31,14 @@ def _scan_json(*blast_items) -> dict:
     }
 
 
-def _br(vuln_id: str, pkg: str = "requests@2.0.0", severity: str = "high") -> dict:
+def _br(vuln_id: str, pkg: str = "requests@2.0.0", severity: str = "high", ecosystem: str = "pypi") -> dict:
     return {
         "vulnerability_id": vuln_id,
         "package": pkg,
         "severity": severity,
         "risk_score": 7.0,
         "fixed_version": "2.1.0",
+        "ecosystem": ecosystem,
     }
 
 
@@ -49,8 +50,8 @@ def _br(vuln_id: str, pkg: str = "requests@2.0.0", severity: str = "high") -> di
 def test_extract_delta_keys_basic():
     scan = _scan_json(_br("CVE-2024-001"), _br("CVE-2024-002", "flask@1.0.0"))
     keys = extract_delta_keys(scan)
-    assert ("CVE-2024-001", "requests", "2.0.0") in keys
-    assert ("CVE-2024-002", "flask", "1.0.0") in keys
+    assert ("CVE-2024-001", "pypi", "requests") in keys
+    assert ("CVE-2024-002", "pypi", "flask") in keys
 
 
 def test_extract_delta_keys_empty_scan():
@@ -60,7 +61,7 @@ def test_extract_delta_keys_empty_scan():
 def test_extract_delta_keys_normalizes_vuln_id_to_upper():
     scan = _scan_json(_br("cve-2024-001"))
     keys = extract_delta_keys(scan)
-    assert ("CVE-2024-001", "requests", "2.0.0") in keys
+    assert ("CVE-2024-001", "pypi", "requests") in keys
 
 
 def test_extract_delta_keys_skips_malformed():
@@ -72,7 +73,7 @@ def test_extract_delta_keys_skips_malformed():
 def test_extract_delta_keys_package_without_version():
     scan = _scan_json({"vulnerability_id": "CVE-2024-001", "package": "requests", "severity": "high"})
     keys = extract_delta_keys(scan)
-    assert ("CVE-2024-001", "requests", "") in keys
+    assert ("CVE-2024-001", "", "requests") in keys
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +119,66 @@ def test_compute_delta_same_vuln_different_package_is_new():
     result = compute_delta(current, baseline)
     assert result.new_count == 1  # requests not in baseline
     assert result.pre_existing_count == 0
+
+
+def test_compute_delta_same_vuln_and_name_in_different_ecosystem_is_new():
+    baseline = _scan_json(_br("CVE-2024-001", pkg="shared@1.0.0", ecosystem="npm"))
+    current = _scan_json(_br("CVE-2024-001", pkg="shared@1.0.0", ecosystem="pypi"))
+
+    result = compute_delta(current, baseline)
+
+    assert result.new_count == 1
+    assert result.pre_existing_count == 0
+
+
+def test_compute_delta_package_upgrade_does_not_reclassify_same_cve_as_new():
+    """A remediation version change must not create a phantom new finding."""
+    baseline = _scan_json(_br("CVE-2024-001", pkg="requests@2.19.1"))
+    current = _scan_json(_br("CVE-2024-001", pkg="requests@2.20.0"))
+
+    result = compute_delta(current, baseline)
+
+    assert result.new_count == 0
+    assert result.pre_existing_count == 1
+
+
+def test_compute_delta_preserves_occurrence_multiplicity_across_upgrade():
+    baseline = _scan_json(_br("CVE-2024-001", pkg="requests@2.19.1"))
+    current = _scan_json(
+        _br("CVE-2024-001", pkg="requests@2.20.0"),
+        _br("CVE-2024-001", pkg="requests@2.21.0"),
+    )
+
+    result = compute_delta(current, baseline)
+
+    assert result.new_count == 1
+    assert result.pre_existing_count == 1
+
+
+def test_compute_delta_scoped_package_upgrade_preserves_package_identity():
+    baseline = _scan_json(_br("CVE-2024-001", pkg="@scope/server@1.0.0"))
+    current = _scan_json(_br("CVE-2024-001", pkg="@scope/server@1.1.0"))
+
+    result = compute_delta(current, baseline)
+
+    assert result.new_count == 0
+    assert result.pre_existing_count == 1
+
+
+def test_compute_delta_legacy_baseline_without_ecosystem_matches_current_package():
+    baseline = _scan_json(
+        {
+            "vulnerability_id": "CVE-2024-001",
+            "package": "requests@2.19.1",
+            "severity": "high",
+        }
+    )
+    current = _scan_json(_br("CVE-2024-001", pkg="requests@2.20.0", ecosystem="pypi"))
+
+    result = compute_delta(current, baseline)
+
+    assert result.new_count == 0
+    assert result.pre_existing_count == 1
 
 
 def test_compute_delta_case_insensitive_vuln_id():

--- a/uv.lock
+++ b/uv.lock
@@ -536,7 +536,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.33.0" },
     { name = "requests", marker = "extra == 'nebius'", specifier = ">=2.33.0" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.2" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.3" },
     { name = "scipy", marker = "extra == 'graph'", specifier = ">=1.13" },
     { name = "six", marker = "extra == 'azure'", specifier = ">=1.17.0" },
     { name = "smithery", marker = "extra == 'mcp-server'", specifier = ">=0.4" },
@@ -6215,7 +6215,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -6296,7 +6296,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- scope the consumer dependency pre-commit hook to the downstream repository so unrelated workstation MCP configuration cannot block commits
- make baseline and history finding identity stable across package upgrades while preserving ecosystem boundaries, occurrence counts, and version-aware inventory diffs

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_consumer_precommit_hooks.py tests/test_scan_delta.py tests/test_core.py tests/test_cli_history.py tests/test_cli_scan.py` — 434 passed
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check ...` — passed
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff format --check ...` — passed
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/package_utils.py src/agent_bom/scan_delta.py src/agent_bom/history.py` — passed
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight` — passed
- isolated repository scans with a clean profile wrote only the explicitly requested output and did not merge ambient MCP configuration when `-p .` was supplied

## Notes

- legacy baseline reports without an ecosystem remain compatible through a narrow same-CVE/same-package fallback
- a single baseline occurrence suppresses only one matching current occurrence; additional affected instances remain new findings
