### PR TITLE
fix(evidence): unify persisted findings across surfaces

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -13911,7 +13911,7 @@
     },
     "/v1/compliance/narrative": {
       "get": {
-        "description": "Generate a review-ready compliance narrative from all completed scans.\n\nProduces human-readable stories for all supported framework mappings, a\ncross-framework executive summary, and a remediation-compliance bridge\nshowing which package upgrades resolve which controls.\n\nNo LLM is required \u2014 narratives are generated from template strings\nand the structured blast radius data in completed scan results.",
+        "description": "Generate a review-ready compliance narrative from current tenant evidence.\n\nProduces human-readable stories for all supported framework mappings, a\ncross-framework executive summary, and a remediation-compliance bridge\nshowing which package upgrades resolve which controls.\n\nNo LLM is required \u2014 narratives are generated from template strings and\nthe canonical current finding queue used by the REST/CLI/UI surfaces.",
         "operationId": "get_compliance_narrative_v1_compliance_narrative_get",
         "parameters": [
           {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -9536,12 +9536,12 @@ paths:
       - compliance
   /v1/compliance/narrative:
     get:
-      description: "Generate a review-ready compliance narrative from all completed\
-        \ scans.\n\nProduces human-readable stories for all supported framework mappings,\
-        \ a\ncross-framework executive summary, and a remediation-compliance bridge\n\
-        showing which package upgrades resolve which controls.\n\nNo LLM is required\
-        \ \u2014 narratives are generated from template strings\nand the structured\
-        \ blast radius data in completed scan results."
+      description: "Generate a review-ready compliance narrative from current tenant\
+        \ evidence.\n\nProduces human-readable stories for all supported framework\
+        \ mappings, a\ncross-framework executive summary, and a remediation-compliance\
+        \ bridge\nshowing which package upgrades resolve which controls.\n\nNo LLM\
+        \ is required \u2014 narratives are generated from template strings and\n\
+        the canonical current finding queue used by the REST/CLI/UI surfaces."
       operationId: get_compliance_narrative_v1_compliance_narrative_get
       parameters:
       - in: header

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -62,7 +62,6 @@ from agent_bom.rbac import require_authenticated_permission
 from agent_bom.security import sanitize_error, sanitize_text
 
 if TYPE_CHECKING:
-    from agent_bom.models import AIBOMReport
     from agent_bom.output.compliance_narrative import ComplianceNarrative
 
 
@@ -1064,97 +1063,19 @@ def _bucket_for(measured_at_iso: str, unit: str) -> str:
 # ─── Compliance Narrative ─────────────────────────────────────────────────
 
 
-def _latest_report(request: Request) -> "AIBOMReport | None":
-    """Return a synthetic AIBOMReport built from the latest completed scan result.
+def _current_narrative_evidence(request: Request) -> dict[str, Any] | None:
+    """Return the same persisted current finding snapshot the queue exposes."""
+    from agent_bom.api.routes.scan import current_findings_snapshot
 
-    The narrative generator expects a real ``AIBOMReport`` model object, but the
-    API layer stores scan results as plain dicts (the JSON-serialised output).
-    We reconstruct a minimal report with only the fields the narrative generator
-    reads (``blast_radii``, ``agents``, ``total_packages``, ``total_agents``).
-    """
-    from agent_bom.compliance_coverage import blast_radius_tag_kwargs
-    from agent_bom.models import (
-        Agent,
-        AgentType,
-        AIBOMReport,
-        BlastRadius,
-        MCPServer,
-        Package,
-        Severity,
-        Vulnerability,
-    )
-
-    # Merge blast_radius entries from ALL completed scans (same as /v1/compliance)
-    all_blast_dicts: list[dict] = []
-    total_agents_count = 0
-    total_packages_count = 0
-
-    for job in _tenant_jobs(request):
-        if job.status != JobStatus.DONE or not job.result:
-            continue
-        all_blast_dicts.extend(job.result.get("blast_radius", []))
-        summary = job.result.get("summary", {})
-        total_agents_count += summary.get("total_agents", 0)
-        total_packages_count += summary.get("total_packages", 0)
-
-    if not all_blast_dicts and total_agents_count == 0:
+    snapshot = current_findings_snapshot(request)
+    if not snapshot["findings"] and not snapshot["completed_scan_count"]:
         return None
-
-    # Build minimal BlastRadius objects the narrative module can read
-    blast_radii: list[BlastRadius] = []
-    for bd in all_blast_dicts:
-        raw_pkg = bd.get("package", "unknown@0.0")
-        if "@" in raw_pkg:
-            pkg_name, pkg_ver = raw_pkg.rsplit("@", 1)
-        else:
-            pkg_name, pkg_ver = raw_pkg, "0.0"
-
-        sev_str = (bd.get("severity") or "unknown").upper()
-        try:
-            sev = Severity(sev_str.lower())
-        except ValueError:
-            sev = Severity.UNKNOWN
-
-        vuln = Vulnerability(
-            id=bd.get("vulnerability_id", "UNKNOWN"),
-            summary="",
-            severity=sev,
-            fixed_version=bd.get("fixed_version"),
-            is_kev=bool(bd.get("is_kev") or bd.get("cisa_kev")),
-        )
-        pkg = Package(name=pkg_name, version=pkg_ver, ecosystem=bd.get("ecosystem", ""))
-
-        # Minimal affected agents (name only)
-        agents = [Agent(name=n, agent_type=AgentType.CUSTOM, config_path="") for n in bd.get("affected_agents", [])]
-        servers = [MCPServer(name=n) for n in bd.get("affected_servers", [])]
-
-        br = BlastRadius(
-            vulnerability=vuln,
-            package=pkg,
-            affected_servers=servers,
-            affected_agents=agents,
-            exposed_credentials=bd.get("exposed_credentials", []),
-            exposed_tools=[],
-            risk_score=float(bd.get("risk_score") or 0),
-        )
-        for tag_field, tags in blast_radius_tag_kwargs(bd).items():
-            setattr(br, tag_field, tags)
-        blast_radii.append(br)
-
-    # Pad agents list to match counts from scan summaries (narrative uses len(agents))
-    agents_list = [Agent(name=f"agent-{i}", agent_type=AgentType.CUSTOM, config_path="") for i in range(total_agents_count)]
-    # Pad packages via a synthetic server on the first agent
-    if agents_list and total_packages_count > 0:
-        dummy_pkgs = [Package(name=f"pkg-{i}", version="0.0", ecosystem="unknown") for i in range(total_packages_count)]
-        agents_list[0].mcp_servers.append(MCPServer(name="__summary__", packages=dummy_pkgs))
-
-    report = AIBOMReport(agents=agents_list, blast_radii=blast_radii)
-    return report
+    return snapshot
 
 
-def _narrative_to_dict(narrative: "ComplianceNarrative") -> dict:
+def _narrative_to_dict(narrative: "ComplianceNarrative", *, evidence: dict[str, Any] | None = None) -> dict:
     """Serialise a ComplianceNarrative dataclass to a JSON-safe dict."""
-    return {
+    payload: dict[str, Any] = {
         "executive_summary": narrative.executive_summary,
         "risk_narrative": narrative.risk_narrative,
         "generated_at": narrative.generated_at,
@@ -1195,26 +1116,37 @@ def _narrative_to_dict(narrative: "ComplianceNarrative") -> dict:
             for ri in narrative.remediation_impact
         ],
     }
+    if evidence is not None:
+        payload["evidence_snapshot"] = {
+            "schema_version": evidence.get("schema_version"),
+            "source": "scan_and_current_ingest_findings",
+            "tenant_id": evidence.get("tenant_id"),
+            "scan_ids": evidence.get("scan_ids", []),
+            "completed_scan_count": evidence.get("completed_scan_count", 0),
+            "returned": evidence.get("count", 0),
+            "total": evidence.get("total"),
+            "completeness": evidence.get("completeness"),
+            "count_metadata": evidence.get("count_metadata", {}),
+            "warnings": evidence.get("warnings", []),
+        }
+    return payload
 
 
 @router.get("/compliance/narrative", tags=["compliance"])
 async def get_compliance_narrative(request: Request) -> dict:
-    """Generate a review-ready compliance narrative from all completed scans.
+    """Generate a review-ready compliance narrative from current tenant evidence.
 
     Produces human-readable stories for all supported framework mappings, a
     cross-framework executive summary, and a remediation-compliance bridge
     showing which package upgrades resolve which controls.
 
-    No LLM is required — narratives are generated from template strings
-    and the structured blast radius data in completed scan results.
+    No LLM is required — narratives are generated from template strings and
+    the canonical current finding queue used by the REST/CLI/UI surfaces.
     """
-    from agent_bom.output.compliance_narrative import (
-        COMPLIANCE_CLAIM_BOUNDARY,
-        generate_compliance_narrative,
-    )
+    from agent_bom.output.compliance_narrative import COMPLIANCE_CLAIM_BOUNDARY
 
-    report = _latest_report(request)
-    if report is None:
+    evidence = _current_narrative_evidence(request)
+    if evidence is None:
         return {
             "executive_summary": "No completed scans available. Run agent-bom scan first.",
             "framework_narratives": [],
@@ -1224,8 +1156,15 @@ async def get_compliance_narrative(request: Request) -> dict:
             "claim_boundary": COMPLIANCE_CLAIM_BOUNDARY,
         }
 
-    narrative: ComplianceNarrative = generate_compliance_narrative(report)
-    return _narrative_to_dict(narrative)
+    from agent_bom.output.compliance_narrative import generate_compliance_narrative_from_findings
+
+    narrative: ComplianceNarrative = generate_compliance_narrative_from_findings(
+        evidence["findings"],
+        total_agents=evidence["total_agents"],
+        total_packages=evidence["total_packages"],
+        generated_at=evidence["generated_at"],
+    )
+    return _narrative_to_dict(narrative, evidence=evidence)
 
 
 @router.get("/compliance/narrative/{framework}", tags=["compliance"])
@@ -1242,7 +1181,6 @@ async def get_compliance_narrative_by_framework(request: Request, framework: str
     from agent_bom.output.compliance_narrative import (
         ALL_FRAMEWORK_SLUGS,
         COMPLIANCE_CLAIM_BOUNDARY,
-        generate_compliance_narrative,
     )
 
     canonical = normalize_framework_slug(framework)
@@ -1252,8 +1190,8 @@ async def get_compliance_narrative_by_framework(request: Request, framework: str
             detail=(f"Unknown framework '{framework}'. Supported: {', '.join(ALL_FRAMEWORK_SLUGS)}"),
         )
 
-    report = _latest_report(request)
-    if report is None:
+    evidence = _current_narrative_evidence(request)
+    if evidence is None:
         return {
             "executive_summary": "No completed scans available. Run agent-bom scan first.",
             "framework_narratives": [],
@@ -1263,8 +1201,16 @@ async def get_compliance_narrative_by_framework(request: Request, framework: str
             "claim_boundary": COMPLIANCE_CLAIM_BOUNDARY,
         }
 
-    narrative: ComplianceNarrative = generate_compliance_narrative(report, framework=canonical)
-    return _narrative_to_dict(narrative)
+    from agent_bom.output.compliance_narrative import generate_compliance_narrative_from_findings
+
+    narrative: ComplianceNarrative = generate_compliance_narrative_from_findings(
+        evidence["findings"],
+        total_agents=evidence["total_agents"],
+        total_packages=evidence["total_packages"],
+        generated_at=evidence["generated_at"],
+        framework=canonical,
+    )
+    return _narrative_to_dict(narrative, evidence=evidence)
 
 
 @router.get("/compliance/verification-key", tags=["compliance"])

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -83,7 +83,6 @@ from agent_bom.api.tenancy import require_body_tenant_match, require_request_ten
 from agent_bom.api.tenant_quota import enforce_active_scan_quota, enforce_retained_jobs_quota, tenant_quota_guard
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
 from agent_bom.canonical_ids import canonical_finding_id
-from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.finding_scope import (
     FINDING_SEVERITY_FILTERS,
     FindingClass,
@@ -361,6 +360,58 @@ def iter_tenant_scan_spine_findings(
     if scope:
         rows = [item for item in rows if _row_matches_scope(item, dict(scope))]
     return [safe_finding_response_payload(row) for row in rows]
+
+
+def persisted_finding_evidence(
+    *,
+    tenant_id: str,
+    cve_id: str,
+    scan_id: str | None = None,
+) -> dict[str, Any]:
+    """Return one vulnerability from the same persisted finding sources as REST.
+
+    MCP tools call this in-process instead of running a second laptop scan. The
+    response distinguishes an empty persisted estate from a process that has no
+    persisted scan evidence at all, allowing standalone MCP mode to retain its
+    local-scan fallback without mixing the two scopes.
+    """
+    scan_jobs = _completed_jobs_for_tenant(tenant_id)
+    if scan_id:
+        scan_jobs = [job for job in scan_jobs if str((job.result or {}).get("scan_id") or job.job_id) == scan_id]
+    rows = iter_tenant_scan_spine_findings(tenant_id, scan_id=scan_id, status="all")
+    bulk_rows = _bulk_ingested_findings_for_tenant(tenant_id)
+    if scan_id:
+        bulk_rows = [row for row in bulk_rows if str(row.get("scan_id") or "") == scan_id]
+    from agent_bom.finding_scope import safe_finding_response_payload
+
+    rows.extend(safe_finding_response_payload(row) for row in bulk_rows)
+    deduped: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for row in rows:
+        key = (
+            str(row.get("canonical_id") or row.get("id") or ""),
+            str(row.get("cve_id") or row.get("vulnerability_id") or ""),
+            str(row.get("package") or row.get("package_name") or ""),
+        )
+        deduped[key] = row
+    wanted = cve_id.strip().upper()
+    matched = [
+        row
+        for row in deduped.values()
+        if str(row.get("cve_id") or row.get("vulnerability_id") or row.get("id") or "").strip().upper() == wanted
+    ]
+    # An explicit scan scope must never fall through to an unrelated local MCP
+    # scan merely because the requested persisted scan is absent.
+    source_available = bool(scan_jobs or bulk_rows or scan_id)
+    return {
+        "available": source_available,
+        "source": "persisted_scan_findings",
+        "scope": {"tenant_id": tenant_id, "scan_id": scan_id},
+        "completeness": {
+            "status": "complete",
+            "reason": "",
+        },
+        "findings": matched,
+    }
 
 
 class BulkFindingsRequest(BaseModel):
@@ -1165,7 +1216,9 @@ def _redact_scan_result_for_response(result: dict[str, Any] | None) -> dict[str,
     findings = result.get("findings")
     if not isinstance(findings, list):
         return redacted
-    redacted["findings"] = redact_for_persistence(findings, EvidenceTier.SAFE_TO_STORE)
+    from agent_bom.finding_scope import safe_finding_response_payload
+
+    redacted["findings"] = [safe_finding_response_payload(item) for item in findings if isinstance(item, Mapping)]
     return redacted
 
 
@@ -2992,6 +3045,115 @@ def _list_findings_impl(
             "completeness": facet_completeness,
         }
     return envelope
+
+
+def current_findings_snapshot(request: Request, *, max_findings: int = 50_000) -> dict[str, Any]:
+    """Collect the canonical current finding queue for an internal consumer.
+
+    Compliance narratives and other in-process surfaces need the same merged
+    scan-job + current-ingest evidence as ``GET /v1/findings``. The walk uses
+    that endpoint's keyset contract and is explicitly bounded; a bound hit is
+    returned as partial evidence rather than silently called complete.
+    """
+    rows: list[dict[str, Any]] = []
+    cursor: str | None = None
+    first_total: int | None = None
+    first_metadata: dict[str, Any] | None = None
+    warnings: list[str] = []
+    while len(rows) < max_findings:
+        page = _list_findings_impl(
+            request,
+            q=None,
+            severity=None,
+            scan_id=None,
+            sort="effective_reach",
+            limit=min(1000, max_findings - len(rows)),
+            offset=0,
+            cursor=cursor,
+            approximate_total=cursor is not None,
+            window_days=None,
+            status=_DEFAULT_FINDING_STATUS,
+        )
+        if first_metadata is None:
+            first_metadata = page.get("count_metadata") if isinstance(page.get("count_metadata"), dict) else {}
+            first_total = page.get("total") if isinstance(page.get("total"), int) else None
+        page_rows = page.get("findings")
+        if isinstance(page_rows, list):
+            rows.extend(row for row in page_rows if isinstance(row, dict))
+        warnings.extend(str(item) for item in page.get("warnings", []) if str(item))
+        cursor = str(page.get("next_cursor") or "") or None
+        if not cursor:
+            break
+
+    tenant_id = _tenant_id(request)
+    jobs = _completed_jobs_for_tenant(tenant_id)
+    agent_names: set[str] = set()
+    package_keys: set[tuple[str, str, str]] = set()
+    summary_agent_counts: list[int] = []
+    summary_package_counts: list[int] = []
+    generated_values: list[str] = []
+    completed_scan_ids: set[str] = set()
+    for job in jobs:
+        result = job.result if isinstance(job.result, dict) else {}
+        completed_scan_ids.add(str(result.get("scan_id") or job.job_id))
+        for agent in result.get("agents", []) if isinstance(result.get("agents"), list) else []:
+            if isinstance(agent, dict) and str(agent.get("name") or "").strip():
+                agent_names.add(str(agent["name"]).strip())
+        for package in result.get("packages", []) if isinstance(result.get("packages"), list) else []:
+            if isinstance(package, dict):
+                package_keys.add(
+                    (
+                        str(package.get("name") or ""),
+                        str(package.get("version") or ""),
+                        str(package.get("ecosystem") or ""),
+                    )
+                )
+        raw_summary = result.get("summary")
+        summary: dict[str, Any] = raw_summary if isinstance(raw_summary, dict) else {}
+        if isinstance(summary.get("total_agents"), int):
+            summary_agent_counts.append(summary["total_agents"])
+        if isinstance(summary.get("total_packages"), int):
+            summary_package_counts.append(summary["total_packages"])
+        generated = result.get("generated_at") or job.completed_at
+        if isinstance(generated, str) and generated:
+            generated_values.append(generated)
+
+    # Bulk-ingested/current findings can carry useful inventory identity even
+    # when no full report envelope exists. Count the observed identities; never
+    # manufacture placeholder agents or packages to match a summary scalar.
+    for row in rows:
+        raw_agents = row.get("affected_agents")
+        if isinstance(raw_agents, list):
+            agent_names.update(str(name).strip() for name in raw_agents if str(name).strip())
+        raw_asset = row.get("asset")
+        asset = raw_asset if isinstance(raw_asset, dict) else {}
+        package_value = str(row.get("package") or row.get("package_name") or "").strip()
+        if package_value:
+            package_keys.add((package_value, str(row.get("package_version") or ""), str(row.get("ecosystem") or "")))
+        elif str(asset.get("asset_type") or "").lower() == "package" and str(asset.get("name") or "").strip():
+            package_keys.add((str(asset["name"]).strip(), "", ""))
+
+    truncated = cursor is not None
+    if truncated:
+        warnings.append(f"Narrative evidence is bounded to {max_findings} current findings; additional rows remain.")
+    return {
+        "schema_version": "finding-snapshot.v1",
+        "tenant_id": tenant_id,
+        "findings": rows,
+        "count": len(rows),
+        "total": first_total,
+        "total_agents": len(agent_names) if agent_names else max(summary_agent_counts, default=0),
+        "total_packages": len(package_keys) if package_keys else max(summary_package_counts, default=0),
+        "generated_at": max(generated_values, default=""),
+        "scan_ids": sorted(completed_scan_ids | {str(row.get("scan_id")) for row in rows if row.get("scan_id")}),
+        "completed_scan_count": len(jobs),
+        "warnings": list(dict.fromkeys(warnings)),
+        "count_metadata": first_metadata or {},
+        "completeness": {
+            "status": "partial" if truncated else "complete",
+            "reason": "snapshot row bound reached" if truncated else "",
+        },
+    }
 
 
 @router.post(

--- a/src/agent_bom/cli/_findings_group.py
+++ b/src/agent_bom/cli/_findings_group.py
@@ -190,11 +190,26 @@ def push_findings_cmd(
 
 @findings_cmd.command("list")
 @click.option("--severity", help="Filter findings by severity.")
+@click.option("--scan-id", help="Restrict results to one persisted scan id.")
+@click.option("--query", help="Search canonical finding identity and structural fields.")
+@click.option("--domain", help="Security lens filter (cspm, vuln, aspm, dspm, aispm).")
+@click.option("--provider", help="Provider scope, for example aws, azure, gcp, or snowflake.")
+@click.option("--account", help="Normalized account scope, for example aws:111111111111.")
+@click.option("--environment", help="Environment scope, for example prod or staging.")
+@click.option(
+    "--finding-class",
+    type=click.Choice(["vulnerability", "misconfiguration", "secret", "identity", "unclassified"]),
+    help="Canonical finding class.",
+)
+@click.option("--status", type=click.Choice(["open", "resolved", "all"]), help="Lifecycle status scope.")
+@click.option("--kev", is_flag=True, default=None, help="Return only CISA KEV findings.")
+@click.option("--window-days", type=click.IntRange(min=0, max=3650), help="Current-state lookback; 0 means all retained history.")
 @click.option("--framework", help="Compliance framework drill-through (e.g. soc2, nist-csf).")
 @click.option("--control", help="Framework control code; narrows within --framework (e.g. CC6.1).")
 @click.option("--sort", default="effective_reach", show_default=True, help="Sort field used by the API.")
 @click.option("--limit", default=500, show_default=True, type=click.IntRange(min=1, max=1000), help="Maximum rows to return.")
 @click.option("--offset", default=0, show_default=True, type=click.IntRange(min=0), help="Rows to skip.")
+@click.option("--cursor", help="Keyset cursor returned by the prior page.")
 @click.option("--format", "output_format", type=click.Choice(["table", "json"]), default="table", show_default=True)
 @_common_api_options
 def list_findings_cmd(
@@ -203,20 +218,50 @@ def list_findings_cmd(
     bearer_token: str | None,
     tenant_id: str | None,
     severity: str | None,
+    scan_id: str | None,
+    query: str | None,
+    domain: str | None,
+    provider: str | None,
+    account: str | None,
+    environment: str | None,
+    finding_class: str | None,
+    status: str | None,
+    kev: bool | None,
+    window_days: int | None,
     framework: str | None,
     control: str | None,
     sort: str,
     limit: int,
     offset: int,
+    cursor: str | None,
     output_format: str,
 ) -> None:
     """List findings with the same filters as the REST API."""
 
     client = _make_client(api_url, api_key, bearer_token, tenant_id)
-    payload = _run_request(
-        client,
-        lambda api: api.list_findings(severity=severity, sort=sort, limit=limit, offset=offset, framework=framework, control=control),
-    )
+    filters: dict[str, Any] = {
+        "severity": severity,
+        "sort": sort,
+        "limit": limit,
+        "offset": offset,
+        "framework": framework,
+        "control": control,
+    }
+    optional_filters = {
+        "scan_id": scan_id,
+        "query": query,
+        "domain": domain,
+        "provider": provider,
+        "account": account,
+        "environment": environment,
+        "finding_class": finding_class,
+        "status": status,
+        "kev": kev,
+        "window_days": window_days,
+        "cursor": cursor,
+    }
+    filters.update({key: value for key, value in optional_filters.items() if value is not None})
+    payload = _run_request(client, lambda api: api.list_findings(**filters))
     if output_format == "json":
         _emit_json(payload)
     else:

--- a/src/agent_bom/client.py
+++ b/src/agent_bom/client.py
@@ -338,6 +338,17 @@ class AgentBomClient:
         offset: int = 0,
         framework: str | None = None,
         control: str | None = None,
+        scan_id: str | None = None,
+        query: str | None = None,
+        domain: str | None = None,
+        provider: str | None = None,
+        account: str | None = None,
+        environment: str | None = None,
+        finding_class: str | None = None,
+        status: str | None = None,
+        kev: bool | None = None,
+        window_days: int | None = None,
+        cursor: str | None = None,
     ) -> JsonObject:
         """List normalized findings from scan jobs and bulk ingests.
 
@@ -357,6 +368,17 @@ class AgentBomClient:
                     "offset": offset,
                     "framework": framework,
                     "control": control,
+                    "scan_id": scan_id,
+                    "q": query,
+                    "domain": domain,
+                    "provider": provider,
+                    "account": account,
+                    "environment": environment,
+                    "finding_class": finding_class,
+                    "status": status,
+                    "kev": kev,
+                    "window_days": window_days,
+                    "cursor": cursor,
                 }
             ),
         )

--- a/src/agent_bom/finding_scope.py
+++ b/src/agent_bom/finding_scope.py
@@ -535,6 +535,7 @@ _FINDING_SEARCH_FIELDS = (
     "resource_name",
 )
 _CVSS_VECTOR_RE = re.compile(r"^[A-Za-z0-9.:/_-]{1,256}$")
+_STRUCTURAL_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/@+ -]{0,511}$")
 _LIFECYCLE_STATUSES = frozenset({"open", "reopened", "resolved", "suppressed", "accepted", "not_affected", "fixed"})
 
 
@@ -571,6 +572,65 @@ def _safe_finding_provenance(value: Any) -> dict[str, Any] | None:
     return sanitized or None
 
 
+def _safe_structural_text(value: Any, *, max_len: int) -> str | None:
+    """Return a bounded display identifier, never a path or credential value."""
+    safe = _safe_optional_text(value, max_len=max_len)
+    if safe is None or not _STRUCTURAL_TOKEN_RE.fullmatch(safe):
+        return None
+    return safe
+
+
+def _safe_asset_projection(value: Any) -> dict[str, str] | None:
+    """Project only the asset fields required to identify a finding in the UI.
+
+    Raw identifiers and locations can contain account ids, local paths, URLs, or
+    credentials. They remain default-deny. The human label, type, and stable
+    opaque id are enough to avoid a meaningless ``asset`` placeholder while
+    preserving the response's privacy boundary.
+    """
+    if not isinstance(value, Mapping):
+        return None
+    result: dict[str, str] = {}
+    name = _safe_optional_text(value.get("name"), max_len=256)
+    if name is not None and not name.startswith("<"):
+        result["name"] = name
+    for key, max_len in (("asset_type", 64), ("stable_id", 128)):
+        safe = _safe_structural_text(value.get(key), max_len=max_len)
+        if safe is not None:
+            result[key] = safe
+    if not result:
+        return None
+    return result
+
+
+def _safe_control_projection(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    controls: list[dict[str, Any]] = []
+    for raw in value[:100]:
+        if not isinstance(raw, Mapping):
+            continue
+        framework = _safe_structural_text(raw.get("framework"), max_len=64)
+        control = _safe_structural_text(
+            raw.get("control") or raw.get("control_id") or raw.get("id"),
+            max_len=128,
+        )
+        if framework is None or control is None:
+            continue
+        item: dict[str, Any] = {"framework": framework, "control": control}
+        for key in ("version", "source", "via"):
+            safe = _safe_structural_text(raw.get(key), max_len=128)
+            if safe is not None:
+                item[key] = safe
+        confidence = raw.get("confidence")
+        if isinstance(confidence, int | float) and not isinstance(confidence, bool):
+            score = float(confidence)
+            if math.isfinite(score) and 0.0 <= score <= 1.0:
+                item["confidence"] = score
+        controls.append(item)
+    return controls
+
+
 def safe_finding_response_payload(row: Mapping[str, Any]) -> dict[str, Any]:
     """Return the canonical public finding projection without replay-only data.
 
@@ -584,6 +644,20 @@ def safe_finding_response_payload(row: Mapping[str, Any]) -> dict[str, Any]:
 
     redacted = redact_for_persistence(dict(row), EvidenceTier.SAFE_TO_STORE)
     payload = dict(redacted) if isinstance(redacted, dict) else {}
+
+    asset = _safe_asset_projection(row.get("asset"))
+    if asset is not None:
+        payload["asset"] = asset
+
+    framework_tags = row.get("framework_tags")
+    if isinstance(framework_tags, list):
+        safe_tags = [safe for value in framework_tags[:200] if (safe := _safe_structural_text(value, max_len=128)) is not None]
+        if safe_tags:
+            payload["framework_tags"] = safe_tags
+
+    controls = _safe_control_projection(row.get("controls"))
+    if controls:
+        payload["controls"] = controls
 
     for key in _FINDING_RESPONSE_TIMESTAMPS:
         safe_value = _safe_timestamp(row.get(key))

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -520,6 +520,13 @@ async def _run_scan_pipeline(
     )
 
 
+def _persisted_finding_evidence(*, tenant_id: str, cve_id: str, scan_id: str | None = None) -> dict[str, Any]:
+    """Read the API's canonical persisted finding spine without an HTTP self-call."""
+    from agent_bom.api.routes.scan import persisted_finding_evidence
+
+    return persisted_finding_evidence(tenant_id=tenant_id, cve_id=cve_id, scan_id=scan_id)
+
+
 # ---------------------------------------------------------------------------
 # MCP Server factory
 # ---------------------------------------------------------------------------
@@ -915,13 +922,14 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
     @mcp.tool(annotations=_READ_ONLY, title="Blast Radius Analysis")
     async def blast_radius(
         cve_id: Annotated[str, Field(description="CVE identifier to look up, e.g. 'CVE-2024-1234' or 'GHSA-xxxx'.")],
+        tenant_id: Annotated[str, Field(description="Tenant scope for persisted findings. Defaults to 'default'.")] = "default",
+        scan_id: Annotated[str | None, Field(description="Optional persisted scan scope.")] = None,
     ) -> str:
         """Look up the blast radius of a specific CVE across your AI agent setup.
 
-        Scans local MCP configurations, finds the specified CVE, and returns
-        the full attack chain: which packages are affected, which MCP servers
-        use those packages, which agents connect to those servers, and what
-        credentials and tools are exposed.
+        Reads the tenant's persisted control-plane finding evidence when it is
+        available. Standalone MCP mode falls back to a local MCP configuration
+        scan and labels that narrower source explicitly.
 
         Args:
             cve_id: The CVE identifier (e.g. "CVE-2024-1234" or "GHSA-xxxx").
@@ -935,8 +943,11 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
             "blast_radius",
             blast_radius_impl,
             cve_id=cve_id,
+            tenant_id=tenant_id,
+            scan_id=scan_id,
             _validate_cve_id=_validate_cve_id,
             _run_scan_pipeline=_run_scan_pipeline,
+            _get_persisted_evidence=_persisted_finding_evidence,
             _truncate_response=_truncate_response,
         )
 

--- a/src/agent_bom/mcp_tools/analysis.py
+++ b/src/agent_bom/mcp_tools/analysis.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import Any, Callable
 
 from agent_bom.graph.completeness import graph_completeness
 from agent_bom.mcp_errors import (
@@ -22,9 +23,12 @@ logger = logging.getLogger(__name__)
 async def blast_radius_impl(
     *,
     cve_id: str,
+    tenant_id: str = "default",
+    scan_id: str | None = None,
     _validate_cve_id,
     _run_scan_pipeline,
     _truncate_response,
+    _get_persisted_evidence: Callable[..., dict[str, Any]] | None = None,
 ) -> str:
     """Implementation of the blast_radius tool."""
     try:
@@ -34,10 +38,46 @@ async def blast_radius_impl(
         return mcp_error_json(CODE_VALIDATION_INVALID_VULN_ID, exc, details={"argument": "cve_id"})
 
     try:
+        from agent_bom.mcp_tenant import resolve_mcp_tool_tenant_id
+
+        tenant_id = resolve_mcp_tool_tenant_id(tenant_id)
+        if _get_persisted_evidence is not None:
+            persisted = _get_persisted_evidence(tenant_id=tenant_id, cve_id=validated_cve, scan_id=scan_id)
+            if persisted.get("available"):
+                findings = persisted.get("findings")
+                rows = findings if isinstance(findings, list) else []
+                persisted_matches = [row for row in rows if isinstance(row, dict)]
+                if not persisted_matches:
+                    return mcp_error_json(
+                        CODE_NOT_FOUND_RESOURCE,
+                        "CVE not found in persisted tenant findings",
+                        details={
+                            "cve_id": validated_cve,
+                            "source": persisted.get("source"),
+                            "scope": persisted.get("scope"),
+                        },
+                    )
+                results = [_finding_blast_radius(row, validated_cve) for row in persisted_matches]
+                return _truncate_response(
+                    json.dumps(
+                        {
+                            "cve_id": validated_cve,
+                            "found": True,
+                            "source": persisted.get("source", "persisted_scan_findings"),
+                            "scope": persisted.get("scope", {"tenant_id": tenant_id, "scan_id": scan_id}),
+                            "count": len(results),
+                            "completeness": persisted.get("completeness", {"status": "complete", "reason": ""}),
+                            "blast_radii": results,
+                        },
+                        indent=2,
+                        default=str,
+                    )
+                )
+
         _agents, blast_radii, _warnings, _srcs = await _run_scan_pipeline()
 
-        matches = [br for br in blast_radii if br.vulnerability.id.upper() == validated_cve.upper()]
-        if not matches:
+        local_matches = [br for br in blast_radii if br.vulnerability.id.upper() == validated_cve.upper()]
+        if not local_matches:
             return mcp_error_json(
                 CODE_NOT_FOUND_RESOURCE,
                 "CVE not found in current scan results",
@@ -45,7 +85,7 @@ async def blast_radius_impl(
             )
 
         results = []
-        for br in matches:
+        for br in local_matches:
             results.append(
                 {
                     "cve_id": br.vulnerability.id,
@@ -62,10 +102,56 @@ async def blast_radius_impl(
                     "ai_risk_context": br.ai_risk_context,
                 }
             )
-        return _truncate_response(json.dumps({"cve_id": cve_id, "found": True, "blast_radii": results}, indent=2, default=str))
+        return _truncate_response(
+            json.dumps(
+                {
+                    "cve_id": validated_cve,
+                    "found": True,
+                    "source": "local_scan",
+                    "scope": {"tenant_id": None, "scan_id": None},
+                    "count": len(results),
+                    "completeness": {"status": "complete", "reason": "standalone MCP local scan"},
+                    "blast_radii": results,
+                },
+                indent=2,
+                default=str,
+            )
+        )
     except Exception as exc:
         logger.exception("MCP tool error")
         return mcp_error_json(CODE_INTERNAL_UNEXPECTED, exc)
+
+
+def _finding_blast_radius(row: dict[str, Any], fallback_cve: str) -> dict[str, Any]:
+    """Project a canonical persisted finding into the legacy blast-radius row."""
+
+    def string_list(value: object) -> list[str]:
+        return [str(item) for item in value] if isinstance(value, list | tuple | set) else []
+
+    raw_asset = row.get("asset")
+    asset: dict[str, Any] = raw_asset if isinstance(raw_asset, dict) else {}
+    package = row.get("package") or row.get("package_name") or asset.get("name") or ""
+    exposed_tools = row.get("exposed_tools")
+    if not isinstance(exposed_tools, list):
+        exposed_tools = row.get("reachable_tools")
+    return {
+        "finding_id": row.get("id"),
+        "cve_id": row.get("cve_id") or row.get("vulnerability_id") or fallback_cve,
+        "severity": row.get("effective_severity") or row.get("severity") or "unknown",
+        "cvss_score": row.get("cvss_score"),
+        "risk_score": row.get("risk_score") or row.get("effective_reach_score") or 0,
+        "package": package,
+        "ecosystem": row.get("ecosystem"),
+        "affected_servers": string_list(row.get("affected_servers")),
+        "affected_agents": string_list(row.get("affected_agents")),
+        "exposed_credentials": string_list(row.get("exposed_credentials")),
+        "exposed_tools": string_list(exposed_tools),
+        "fixed_version": row.get("fixed_version"),
+        "graph_reachable": row.get("graph_reachable"),
+        "graph_min_hop_distance": row.get("graph_min_hop_distance"),
+        "owner": row.get("owner"),
+        "sla_due_at": row.get("sla_due_at"),
+    }
 
 
 async def context_graph_impl(

--- a/src/agent_bom/output/compliance_narrative.py
+++ b/src/agent_bom/output/compliance_narrative.py
@@ -25,9 +25,11 @@ Supported frameworks (slug → display name):
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from agent_bom.models import AIBOMReport
@@ -640,9 +642,16 @@ def _build_risk_narrative(
     total_agents: int,
     total_vulns: int,
     critical_count: int,
+    finding_label: str = "vulnerability",
 ) -> str:
     """Plain-English top-risk explanation from scan data."""
+    plural_label = "vulnerabilities" if finding_label == "vulnerability" else f"{finding_label}s"
     if not blast_radii_dicts:
+        if finding_label != "vulnerability":
+            return (
+                "No security findings were detected in the current evidence scope. "
+                "This is not a claim that unscanned or unavailable sources are clean."
+            )
         return (
             "No vulnerabilities were detected in this scan. "
             "The AI agent environment appears clean based on the packages assessed. "
@@ -664,7 +673,9 @@ def _build_risk_narrative(
 
     # Lead sentence
     agent_str = f"{total_agents} agent{'s' if total_agents != 1 else ''}"
-    parts.append(f"This scan identified {total_vulns} vulnerabilit{'ies' if total_vulns != 1 else 'y'} across {agent_str}.")
+    item_word = finding_label if total_vulns == 1 else plural_label
+    evidence_subject = "This scan" if finding_label == "vulnerability" else "Current evidence"
+    parts.append(f"{evidence_subject} identified {total_vulns} {item_word} across {agent_str}.")
 
     # KEV callout
     if kev_entries:
@@ -713,30 +724,39 @@ def _build_executive_summary(
     total_vulns: int,
     critical_count: int,
     generated_at: str,
+    finding_label: str = "vulnerability",
 ) -> str:
     """3-5 sentence executive summary for compliance stakeholders."""
     action_fws = [fn for fn in framework_narratives if fn.status == "action_required"]
     review_fws = [fn for fn in framework_narratives if fn.status == "review"]
     evaluated_fws = [fn for fn in framework_narratives if fn.status in ("evidence_current", "review", "action_required")]
     # Lead: what was scanned
+    evidence_verb = "scanned on" if finding_label == "vulnerability" else "represented in current evidence through"
     sentences: list[str] = [
         f"This AI-BOM compliance report covers {total_agents} AI agent"
         f"{'s' if total_agents != 1 else ''} "
         f"and {total_packages} package{'s' if total_packages != 1 else ''} "
-        f"scanned on {generated_at[:10]}."
+        f"{evidence_verb} {generated_at[:10]}."
     ]
 
-    # Vulnerability posture
+    plural_label = "vulnerabilities" if finding_label == "vulnerability" else f"{finding_label}s"
+    item_word = finding_label if total_vulns == 1 else plural_label
+    # Finding posture
     if total_vulns == 0:
-        sentences.append("No vulnerabilities were detected; all assessed dependencies are clean.")
+        if finding_label == "vulnerability":
+            sentences.append("No vulnerabilities were detected; all assessed dependencies are clean.")
+        else:
+            sentences.append(
+                "No security findings were detected in the current evidence scope; unavailable or unscanned sources are not claimed clean."
+            )
     elif critical_count > 0:
         sentences.append(
-            f"{total_vulns} vulnerabilit{'ies were' if total_vulns > 1 else 'y was'} identified "
+            f"{total_vulns} {item_word} {'were' if total_vulns > 1 else 'was'} identified "
             f"including {critical_count} critical finding"
             f"{'s' if critical_count > 1 else ''} that require immediate remediation."
         )
     else:
-        sentences.append(f"{total_vulns} vulnerabilit{'ies were' if total_vulns > 1 else 'y was'} identified across the assessed packages.")
+        sentences.append(f"{total_vulns} {item_word} {'were' if total_vulns > 1 else 'was'} identified across the assessed evidence.")
 
     # Framework posture
     total_fws = len(framework_narratives)
@@ -760,7 +780,7 @@ def _build_executive_summary(
     # Closing action
     if action_fws or review_fws:
         sentences.append(
-            "Remediation of identified vulnerabilities is the highest-priority action; control owners must validate compliance separately."
+            f"Remediation of identified {plural_label} is the highest-priority action; control owners must validate compliance separately."
         )
     else:
         sentences.append("Continue regular scanning and independent control validation to maintain current evidence coverage.")
@@ -774,6 +794,8 @@ def _build_executive_summary(
 def generate_compliance_narrative(
     report: "AIBOMReport",
     framework: str | None = None,
+    *,
+    finding_label: str = "vulnerability",
 ) -> ComplianceNarrative:
     """Generate review-ready compliance narrative from scan results.
 
@@ -843,6 +865,7 @@ def generate_compliance_narrative(
         total_agents=report.total_agents,
         total_vulns=total_vulns,
         critical_count=critical_count,
+        finding_label=finding_label,
     )
 
     executive_summary = _build_executive_summary(
@@ -851,7 +874,8 @@ def generate_compliance_narrative(
         total_packages=report.total_packages,
         total_vulns=total_vulns,
         critical_count=critical_count,
-        generated_at=generated_at,
+        generated_at=_latest_scan or generated_at,
+        finding_label=finding_label,
     )
 
     # Catalog-backed NIST 800-53 line (vendor-asserted, scored over evaluated
@@ -874,3 +898,118 @@ def generate_compliance_narrative(
         claim_boundary=COMPLIANCE_CLAIM_BOUNDARY,
         nist_800_53_catalog=nist_800_53_catalog,
     )
+
+
+def generate_compliance_narrative_from_findings(
+    findings: list[Mapping[str, object]],
+    *,
+    total_agents: int,
+    total_packages: int,
+    generated_at: str | None = None,
+    framework: str | None = None,
+) -> ComplianceNarrative:
+    """Generate the narrative from the canonical persisted finding stream.
+
+    The control plane stores complete unified findings, not Python model
+    instances. Re-running a scanner or padding a model with ``agent-0`` and
+    ``pkg-0`` placeholders makes the narrative answer a different question from
+    the finding queue. This adapter preserves each persisted finding and its
+    control mappings, then reuses the established narrative calculation.
+    """
+    from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS
+
+    tag_aliases: dict[str, str] = {}
+    for metadata in TAG_MAPPED_FRAMEWORKS:
+        for alias in (
+            metadata.slug,
+            metadata.slug.replace("-", "_"),
+            metadata.output_key,
+            metadata.summary_prefix,
+            metadata.tag_field.removesuffix("_tags"),
+        ):
+            tag_aliases[alias.lower().replace("-", "_")] = metadata.tag_field
+
+    blast_radii: list[SimpleNamespace] = []
+    for row in findings:
+        tag_values: dict[str, list[str]] = {metadata.tag_field: [] for metadata in TAG_MAPPED_FRAMEWORKS}
+        for metadata in TAG_MAPPED_FRAMEWORKS:
+            raw_tags = row.get(metadata.tag_field)
+            if isinstance(raw_tags, (list, tuple, set)):
+                tag_values[metadata.tag_field].extend(str(tag) for tag in raw_tags if str(tag).strip())
+
+        controls = row.get("controls")
+        if isinstance(controls, list):
+            for control in controls:
+                if not isinstance(control, Mapping):
+                    continue
+                framework_name = str(control.get("framework") or "").strip().lower().replace("-", "_")
+                tag_field = tag_aliases.get(framework_name)
+                control_id = str(control.get("control") or control.get("id") or "").strip()
+                if tag_field and control_id:
+                    tag_values[tag_field].append(control_id)
+
+        flattened = row.get("framework_tags")
+        if isinstance(flattened, list):
+            for item in flattened:
+                prefix, separator, control_id = str(item).partition(":")
+                tag_field = tag_aliases.get(prefix.strip().lower().replace("-", "_"))
+                if separator and tag_field and control_id.strip():
+                    tag_values[tag_field].append(control_id.strip())
+
+        for tag_field, values in tag_values.items():
+            tag_values[tag_field] = list(dict.fromkeys(values))
+
+        raw_asset = row.get("asset")
+        asset: Mapping[str, object] = raw_asset if isinstance(raw_asset, Mapping) else {}
+        package_value = str(row.get("package") or row.get("package_name") or asset.get("name") or "Unavailable")
+        if "@" in package_value:
+            package_name, package_version = package_value.rsplit("@", 1)
+        else:
+            package_name = package_value
+            package_version = str(row.get("package_version") or "")
+        severity = str(row.get("effective_severity") or row.get("severity") or "unknown").lower()
+        vulnerability_id = str(row.get("cve_id") or row.get("vulnerability_id") or row.get("id") or "Unavailable")
+        raw_risk_score = row.get("risk_score") or row.get("effective_reach_score") or 0
+        try:
+            risk_score = float(raw_risk_score) if isinstance(raw_risk_score, int | float | str) else 0.0
+        except ValueError:
+            risk_score = 0.0
+        raw_agents = row.get("affected_agents")
+        affected_agents = raw_agents if isinstance(raw_agents, (list, tuple, set)) else []
+        raw_servers = row.get("affected_servers")
+        affected_servers = raw_servers if isinstance(raw_servers, (list, tuple, set)) else []
+        raw_credentials = row.get("exposed_credentials")
+        exposed_credentials = raw_credentials if isinstance(raw_credentials, (list, tuple, set)) else []
+        blast_radii.append(
+            SimpleNamespace(
+                vulnerability=SimpleNamespace(
+                    id=vulnerability_id,
+                    severity=SimpleNamespace(value=severity),
+                    fixed_version=row.get("fixed_version"),
+                    is_kev=bool(row.get("is_kev")),
+                ),
+                package=SimpleNamespace(name=package_name, version=package_version),
+                risk_score=risk_score,
+                affected_agents=[SimpleNamespace(name=str(name)) for name in affected_agents],
+                affected_servers=[SimpleNamespace(name=str(name)) for name in affected_servers],
+                exposed_credentials=[str(name) for name in exposed_credentials],
+                **tag_values,
+            )
+        )
+
+    observed_at: datetime | None = None
+    if generated_at:
+        try:
+            observed_at = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+        except ValueError:
+            observed_at = None
+    report = cast(
+        "AIBOMReport",
+        SimpleNamespace(
+            blast_radii=blast_radii,
+            total_agents=max(0, int(total_agents)),
+            total_packages=max(0, int(total_packages)),
+            generated_at=observed_at,
+        ),
+    )
+    return generate_compliance_narrative(report, framework=framework, finding_label="security finding")

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -642,13 +642,13 @@ def test_get_scan_redacts_result_findings_replay_only_fields():
 
     assert response.status_code == 200
     finding = response.json()["result"]["findings"][0]
-    assert finding == {
-        "id": "finding-1",
-        "title": "Unsafe package",
-        "package": "pillow",
-        "package_version": "10.0.0",
-        "severity": "high",
-    }
+    assert finding["id"] == "finding-1"
+    assert finding["title"] == "Unsafe package"
+    assert finding["package"] == "pillow"
+    assert finding["package_version"] == "10.0.0"
+    assert finding["severity"] == "high"
+    assert "description" not in finding
+    assert "raw_path" not in finding
     assert store.get("job-finding-redaction", all_tenants=True).result["findings"][0]["description"] == "Copied workspace details"
 
 

--- a/tests/test_cli_findings.py
+++ b/tests/test_cli_findings.py
@@ -171,6 +171,62 @@ def test_findings_list_passes_framework_and_control_filters(monkeypatch) -> None
     )
 
 
+def test_findings_list_passes_persisted_scan_and_scope_filters(monkeypatch) -> None:
+    fake = _install_fake_client(monkeypatch)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "findings",
+            "list",
+            "--scan-id",
+            "scan-42",
+            "--query",
+            "payments",
+            "--domain",
+            "aspm",
+            "--provider",
+            "aws",
+            "--account",
+            "aws:111111111111",
+            "--environment",
+            "prod",
+            "--finding-class",
+            "vulnerability",
+            "--status",
+            "open",
+            "--kev",
+            "--window-days",
+            "30",
+            "--cursor",
+            "next-page",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake.calls[0][1] == {
+        "severity": None,
+        "sort": "effective_reach",
+        "limit": 500,
+        "offset": 0,
+        "framework": None,
+        "control": None,
+        "scan_id": "scan-42",
+        "query": "payments",
+        "domain": "aspm",
+        "provider": "aws",
+        "account": "aws:111111111111",
+        "environment": "prod",
+        "finding_class": "vulnerability",
+        "status": "open",
+        "kev": True,
+        "window_days": 30,
+        "cursor": "next-page",
+    }
+
+
 def test_findings_triage_create_and_decide(monkeypatch) -> None:
     fake = _install_fake_client(monkeypatch)
     runner = CliRunner()

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -92,7 +92,7 @@ def test_compliance_tag_registry_covers_every_blast_radius_tag_field() -> None:
     assert set(COMPLIANCE_TAG_FIELDS).issubset(row)
 
 
-def test_narrative_and_evidence_index_preserve_all_framework_tags(monkeypatch) -> None:
+def test_evidence_index_preserves_all_framework_tags() -> None:
     from agent_bom.api.routes import compliance as route
     from agent_bom.compliance_coverage import COMPLIANCE_TAG_FIELDS
 
@@ -110,14 +110,6 @@ def test_narrative_and_evidence_index_preserve_all_framework_tags(monkeypatch) -
         created_at="2026-07-29T00:00:00Z",
         completed_at="2026-07-29T00:01:00Z",
     )
-    monkeypatch.setattr(route, "_tenant_jobs", lambda _request: [job])
-
-    report = route._latest_report(object())
-    assert report is not None
-    rebuilt = report.blast_radii[0]
-    for field in COMPLIANCE_TAG_FIELDS:
-        assert getattr(rebuilt, field) == [f"tag:{field}"]
-
     index = route._index_blast_radii_by_tag([job])
     for field in COMPLIANCE_TAG_FIELDS:
         assert f"tag:{field}" in index

--- a/tests/test_cross_surface_scan_evidence.py
+++ b/tests/test_cross_surface_scan_evidence.py
@@ -1,0 +1,230 @@
+"""One persisted scan-evidence contract across API, compliance, and MCP."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+from agent_bom.api.routes.scan import _redact_scan_result_for_response
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import _get_store, set_job_store
+from agent_bom.finding_scope import safe_finding_response_payload
+
+
+def _finding() -> dict[str, object]:
+    return {
+        "id": "finding-1",
+        "canonical_id": "finding-1",
+        "finding_type": "MCP_TOOL_POISONING",
+        "source": "MCP_SCAN",
+        "severity": "high",
+        "title": "Tool description can redirect execution",
+        "asset": {
+            "name": "payments-mcp",
+            "asset_type": "mcp_server",
+            "identifier": "server:payments-mcp",
+            "location": "/Users/example/.config/mcp.json",
+            "stable_id": "asset-1",
+        },
+        "package": "mcp-payments@1.2.3",
+        "cve_id": "CVE-2026-4242",
+        "affected_agents": ["developer-agent"],
+        "affected_servers": ["payments-mcp"],
+        "framework_tags": ["owasp_llm:LLM01", "soc2:CC6.1"],
+        "controls": [
+            {"framework": "owasp_llm", "control": "LLM01", "source": "scanner"},
+            {"framework": "soc2", "control_id": "CC6.1", "source": "scanner"},
+        ],
+        "owasp_tags": ["LLM01"],
+        "soc2_tags": ["CC6.1"],
+        "first_seen": "2026-08-17T12:00:00Z",
+        "last_observed": "2026-08-17T12:05:00Z",
+        "status": "open",
+        "fixed_version": "1.2.4",
+    }
+
+
+def test_full_scan_job_and_findings_list_share_the_canonical_safe_projection() -> None:
+    finding = _finding()
+
+    list_projection = safe_finding_response_payload(finding)
+    result_projection = _redact_scan_result_for_response(
+        {
+            "scan_id": "scan-1",
+            "findings": [finding],
+            "summary": {"total_findings": 1},
+        }
+    )
+
+    assert result_projection is not None
+    assert result_projection["findings"] == [list_projection]
+    projected = list_projection
+    assert projected["asset"] == {
+        "name": "payments-mcp",
+        "asset_type": "mcp_server",
+        "stable_id": "asset-1",
+    }
+    assert projected["framework_tags"] == ["owasp_llm:LLM01", "soc2:CC6.1"]
+    assert projected["controls"] == [
+        {"framework": "owasp_llm", "control": "LLM01", "source": "scanner"},
+        {"framework": "soc2", "control": "CC6.1", "source": "scanner"},
+    ]
+    assert safe_finding_response_payload({**finding, "asset": {"stable_id": "asset-only"}})["asset"] == {"stable_id": "asset-only"}
+
+
+def test_unified_finding_drives_compliance_narrative_without_placeholder_entities() -> None:
+    from agent_bom.output.compliance_narrative import generate_compliance_narrative_from_findings
+
+    narrative = generate_compliance_narrative_from_findings(
+        [_finding()],
+        total_agents=1,
+        total_packages=1,
+        generated_at="2026-08-17T12:05:00Z",
+        framework="owasp-llm",
+    )
+
+    framework = narrative.framework_narratives[0]
+    llm01 = next(control for control in framework.failing_controls if control.control_id == "LLM01")
+    assert llm01.affected_findings == ["CVE-2026-4242"]
+    assert llm01.affected_packages == ["mcp-payments@1.2.3"]
+    assert "agent-0" not in narrative.executive_summary
+    assert "pkg-0" not in narrative.executive_summary
+
+
+@pytest.mark.asyncio
+async def test_mcp_blast_radius_prefers_the_persisted_tenant_evidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.mcp_tools.analysis import blast_radius_impl
+
+    monkeypatch.setenv("AGENT_BOM_MCP_TENANT_ID", "tenant-a")
+
+    async def _must_not_scan_local():
+        raise AssertionError("persisted control-plane evidence must not trigger a laptop scan")
+
+    def _persisted(*, tenant_id: str, cve_id: str, scan_id: str | None) -> dict[str, object]:
+        assert tenant_id == "tenant-a"
+        assert cve_id == "CVE-2026-4242"
+        assert scan_id == "scan-1"
+        return {
+            "available": True,
+            "source": "persisted_scan_findings",
+            "scope": {"tenant_id": tenant_id, "scan_id": scan_id},
+            "completeness": {"status": "complete", "reason": ""},
+            "findings": [safe_finding_response_payload(_finding())],
+        }
+
+    encoded = await blast_radius_impl(
+        cve_id="CVE-2026-4242",
+        tenant_id="tenant-a",
+        scan_id="scan-1",
+        _validate_cve_id=lambda value: value.upper(),
+        _run_scan_pipeline=_must_not_scan_local,
+        _get_persisted_evidence=_persisted,
+        _truncate_response=lambda value: value,
+    )
+    payload = json.loads(encoded)
+
+    assert payload["found"] is True
+    assert payload["source"] == "persisted_scan_findings"
+    assert payload["scope"] == {"tenant_id": "tenant-a", "scan_id": "scan-1"}
+    assert payload["count"] == 1
+    assert payload["blast_radii"][0]["affected_agents"] == ["developer-agent"]
+
+
+def test_scan_job_model_keeps_the_same_result_summary_contract() -> None:
+    """The additive projection must not mutate the durable job model itself."""
+    job = ScanJob(
+        job_id="scan-1",
+        tenant_id="tenant-a",
+        status=JobStatus.DONE,
+        created_at="2026-08-17T12:00:00Z",
+        completed_at="2026-08-17T12:05:00Z",
+        request=ScanRequest(),
+        result={"scan_id": "scan-1", "summary": {"total_findings": 1}, "findings": [_finding()]},
+    )
+    projected = _redact_scan_result_for_response(job.result)
+    assert projected is not job.result
+    assert job.result["findings"][0]["asset"]["location"] == "/Users/example/.config/mcp.json"
+    assert projected["summary"] == job.result["summary"]
+
+
+def test_compliance_endpoint_reads_the_current_persisted_finding_queue() -> None:
+    from agent_bom.api.routes import compliance
+
+    previous_store = _get_store()
+    store = InMemoryJobStore()
+    set_job_store(store)
+    finding = _finding()
+    finding["scan_id"] = "scan-persisted"
+    job = ScanJob(
+        job_id="scan-persisted",
+        tenant_id="tenant-parity",
+        status=JobStatus.DONE,
+        created_at="2026-08-17T12:00:00Z",
+        completed_at="2026-08-17T12:05:00Z",
+        request=ScanRequest(),
+        result={
+            "scan_id": "scan-persisted",
+            "generated_at": "2026-08-17T12:05:00Z",
+            "summary": {"total_agents": 0, "total_packages": 0, "total_findings": 1},
+            "findings": [finding],
+            "blast_radius": [],
+        },
+    )
+    store.put(job)
+    request = SimpleNamespace(state=SimpleNamespace(tenant_id="tenant-parity"), headers={})
+
+    try:
+        payload = asyncio.run(compliance.get_compliance_narrative(request))
+    finally:
+        set_job_store(previous_store)
+
+    assert payload["evidence_snapshot"]["returned"] == 1
+    assert payload["evidence_snapshot"]["total"] == 1
+    assert payload["evidence_snapshot"]["scan_ids"] == ["scan-persisted"]
+    assert "covers 1 AI agent and 1 package represented in current evidence through 2026-08-17" in payload["executive_summary"]
+    assert "Current evidence identified 1 security finding across 1 agent" in payload["risk_narrative"]
+    framework = next(item for item in payload["framework_narratives"] if item["slug"] == "owasp-llm")
+    llm01 = next(item for item in framework["failing_controls"] if item["control_id"] == "LLM01")
+    assert llm01["affected_findings"] == ["CVE-2026-4242"]
+    assert "agent-0" not in payload["executive_summary"]
+    assert "pkg-0" not in payload["executive_summary"]
+
+
+def test_completed_empty_scan_is_not_reported_as_no_scan() -> None:
+    from agent_bom.api.routes import compliance
+
+    previous_store = _get_store()
+    store = InMemoryJobStore()
+    set_job_store(store)
+    store.put(
+        ScanJob(
+            job_id="scan-empty",
+            tenant_id="tenant-empty-scan",
+            status=JobStatus.DONE,
+            created_at="2026-08-17T12:00:00Z",
+            completed_at="2026-08-17T12:05:00Z",
+            request=ScanRequest(),
+            result={
+                "scan_id": "scan-empty",
+                "generated_at": "2026-08-17T12:05:00Z",
+                "summary": {"total_agents": 1, "total_packages": 1, "total_findings": 0},
+                "findings": [],
+                "blast_radius": [],
+            },
+        )
+    )
+    request = SimpleNamespace(state=SimpleNamespace(tenant_id="tenant-empty-scan"), headers={})
+
+    try:
+        payload = asyncio.run(compliance.get_compliance_narrative(request))
+    finally:
+        set_job_store(previous_store)
+
+    assert payload["evidence_snapshot"]["completed_scan_count"] == 1
+    assert payload["evidence_snapshot"]["returned"] == 0
+    assert "No completed scans available" not in payload["executive_summary"]
+    assert "unavailable or unscanned sources are not claimed clean" in payload["executive_summary"]

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -102,7 +102,13 @@ function collectUnifiedFindings(findings: UnifiedFinding[]): EnrichedVuln[] {
       effective_reach_score?: number;
       attack_vector_summary?: string;
     };
-    const assetName = finding.asset?.name?.trim() || finding.asset?.identifier || finding.asset?.stable_id || "asset";
+    const assetName =
+      finding.asset?.name?.trim() ||
+      finding.package?.trim() ||
+      finding.package_name?.trim() ||
+      finding.asset?.identifier ||
+      finding.asset?.stable_id ||
+      "Unavailable";
     const findingLabel = finding.cve_id || finding.title || finding.id;
     const sourceLabel = uniqueStrings([finding.source, finding.finding_type, ...(finding.scan_sources ?? [])]);
     const evidence = finding.evidence ?? {};

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2095,6 +2095,7 @@ export interface ControlNarrative {
   narrative: string;
   affected_packages: string[];
   affected_agents: string[];
+  affected_findings: string[];
   remediation_steps: string[];
 }
 
@@ -2123,6 +2124,19 @@ export interface ComplianceNarrativeResponse {
   remediation_impact: RemediationImpact[];
   risk_narrative: string;
   generated_at: string;
+  claim_boundary: string;
+  evidence_snapshot?: {
+    schema_version?: string | null;
+    source: "scan_and_current_ingest_findings" | string;
+    tenant_id?: string | null;
+    scan_ids: string[];
+    completed_scan_count: number;
+    returned: number;
+    total: number | null;
+    completeness: { status: "complete" | "partial" | "unknown"; reason: string } | null;
+    count_metadata: Record<string, unknown>;
+    warnings: string[];
+  } | undefined;
 }
 
 export interface ComplianceControl {

--- a/ui/tests/findings-page.test.tsx
+++ b/ui/tests/findings-page.test.tsx
@@ -109,6 +109,30 @@ describe("FindingsPage", () => {
     });
   });
 
+  it("uses the persisted package identity when an older finding has no asset object", async () => {
+    apiMock.listFindings.mockResolvedValue({
+      schema_version: "v1",
+      findings: [
+        {
+          id: "finding-legacy-asset",
+          finding_class: "vulnerability",
+          severity: "high",
+          cve_id: "CVE-2026-7777",
+          package: "requests@2.32.4",
+          source: "osv",
+        },
+      ],
+      total: 1,
+      has_more: false,
+      next_cursor: "",
+    });
+
+    render(<FindingsPage />);
+
+    expect(await screen.findByText("requests@2.32.4")).toBeInTheDocument();
+    expect(screen.queryByText("asset")).not.toBeInTheDocument();
+  });
+
   it("projects canonical vulnerability intelligence into the finding drawer without inventing missing facts", async () => {
     apiMock.listFindings.mockResolvedValue({
       total: 1,


### PR DESCRIPTION
## Summary

- make scan-detail and findings-list responses share one safe structural projection, preserving usable asset/control identity without exposing raw paths or resource identifiers
- drive compliance narratives and MCP blast-radius analysis from the tenant-scoped persisted finding stream, with explicit source, scope, counts, completeness, and honest empty/partial states
- align REST client, CLI filters, OpenAPI, and the findings UI with the same persisted evidence contract and remove fabricated placeholder entities

## Verification

- `PYTHONPATH=src /Users/mohamedsaad/repos/Agent-Bom/.venv/bin/pytest -q tests/test_cross_surface_scan_evidence.py tests/test_compliance_narrative.py tests/test_compliance_honesty.py tests/test_compliance.py tests/test_cli_findings.py tests/test_api_findings_surface_parity.py tests/test_mcp_tool_impls.py tests/test_mcp_server.py tests/test_mcp_introspect.py tests/test_mcp_http_scan_contract.py` — 341 passed
- `PATH=/Users/mohamedsaad/repos/Agent-Bom/.venv/bin:$PATH make preflight` — passed
- Ruff check/format and mypy on the changed Python surfaces — passed
- `scripts/check_exception_sanitization.py` — passed
- Node 24.18.0 / npm 10.9.7: toolchain verification, typecheck, focused Vitest (17 tests), and production build (52 pages) — passed

## Notes

- Existing response fields and standalone MCP behavior remain backward compatible; standalone MCP performs a labeled local scan only when no persisted control-plane evidence exists.
- Count-bearing compliance evidence is bounded and reports partial completeness if the bound is reached.
- Tenant selection remains server-bound through the existing MCP tenant resolver.