### PR TITLE
fix(cloud): make AWS CIS scope evidence honest

### DIFF
--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -385,9 +385,14 @@ def _run_cis_benchmark(
     report: Any
     try:
         if requested == "aws":
-            from agent_bom.cloud.aws_cis_benchmark import run_benchmark as run_aws_cis
+            if region_arg:
+                from agent_bom.cloud.aws_cis_benchmark import run_benchmark
 
-            report = run_aws_cis(region=region_arg, profile=profile_arg, checks=check_list)
+                report = run_benchmark(region=region_arg, profile=profile_arg, checks=check_list)
+            else:
+                from agent_bom.cloud.aws_cis_benchmark import run_benchmark_all_regions
+
+                report = run_benchmark_all_regions(region=region_arg, profile=profile_arg, checks=check_list)
         elif requested == "azure":
             from agent_bom.cloud.azure_cis_benchmark import run_benchmark as run_azure_cis
 

--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -701,8 +701,15 @@ def _cis_summary(cis_dict: dict[str, Any]) -> dict[str, Any]:
     return {
         "benchmark": cis_dict.get("benchmark"),
         "benchmark_version": cis_dict.get("benchmark_version"),
+        "scope": cis_dict.get("scope"),
+        "completeness": cis_dict.get("completeness"),
+        "accounts_scanned": len(cis_dict.get("accounts_scanned") or []),
+        "regions_scanned": len(cis_dict.get("regions_scanned") or []),
         "passed": cis_dict.get("passed"),
         "failed": cis_dict.get("failed"),
+        "errored": cis_dict.get("errored"),
+        "not_applicable": cis_dict.get("not_applicable"),
+        "evaluated": cis_dict.get("evaluated"),
         "total": cis_dict.get("total"),
         "pass_rate": cis_dict.get("pass_rate"),
     }
@@ -834,11 +841,11 @@ def _run_aws_connection_scan(
 ) -> dict[str, Any]:
     """Broker the connection into a read-only session and run inventory + CIS.
 
-    Calls the **same** ``aws_inventory.discover_inventory`` and AWS CIS
-    ``run_benchmark`` the sibling cloud routes use — passing the brokered session
-    so the read-only code path runs against the assumed role — then persists the
-    result through the existing scan/graph stores (the pipeline's persistence
-    path), not a parallel one. Returns a non-secret scan summary.
+    Calls the same AWS inventory and CIS runners as the sibling cloud routes —
+    passing the brokered session so the read-only code path runs against the
+    assumed role — then persists the result through the existing scan/graph
+    stores (the pipeline's persistence path), not a parallel one. Returns a
+    non-secret scan summary.
 
     When ``connection_org_fanout_enabled(record)``, fans inventory (and CIS)
     across member accounts via the brokered management session — gated by the
@@ -848,6 +855,7 @@ def _run_aws_connection_scan(
     from agent_bom.cloud import aws_inventory, aws_organizations
     from agent_bom.cloud.aws_cis_benchmark import run_all_account_benchmarks
     from agent_bom.cloud.aws_cis_benchmark import run_benchmark as run_aws_cis
+    from agent_bom.cloud.aws_cis_benchmark import run_benchmark_all_regions as run_aws_cis_all_regions
     from agent_bom.cloud.connection_broker import broker_session
     from agent_bom.mcp_tools.posture import _summarize_inventory_payload
     from agent_bom.models import AIBOMReport
@@ -879,7 +887,7 @@ def _run_aws_connection_scan(
             )
         elif all_regions:
             inventory_payload = aws_inventory.discover_inventory_all_regions(force=True, session=session)
-            cis_report = run_aws_cis(region=region, session=session)
+            cis_report = run_aws_cis_all_regions(region=region, session=session)
         else:
             inventory_payload = aws_inventory.discover_inventory(region=region, force=True, session=session)
             cis_report = run_aws_cis(region=region, session=session)

--- a/src/agent_bom/cli/agents/_cloud.py
+++ b/src/agent_bom/cli/agents/_cloud.py
@@ -366,20 +366,24 @@ def run_benchmarks(
                 # member account of the organization (same boundary set the inventory
                 # fan-out uses) and aggregate with per-account attribution. Each
                 # account is reached via a read-only AssumeRole; an account that denies
-                # the role is skipped. Off = unchanged single-account/region run.
+                # the role is skipped. Off keeps one account while still
+                # enumerating all enabled regions for account-wide CIS truth.
                 if aws_organizations.org_fanout_enabled():
                     from agent_bom.cloud.aws_cis_benchmark import run_all_account_benchmarks
 
                     ctx.cis_benchmark_report = run_all_account_benchmarks(profile=aws_profile)
                 else:
-                    from agent_bom.cloud import aws_inventory
                     from agent_bom.cloud.aws_cis_benchmark import run_benchmark as run_cis
                     from agent_bom.cloud.aws_cis_benchmark import run_benchmark_all_regions
 
-                    if aws_inventory.all_regions_enabled():
-                        ctx.cis_benchmark_report = run_benchmark_all_regions(profile=aws_profile, region=aws_region)
+                    # CIS is an estate benchmark: enumerate every enabled
+                    # region by default so a quiet home region cannot produce
+                    # an account-wide PASS while resources exist elsewhere.
+                    # An explicit region remains a deliberate partial scope.
+                    if aws_region:
+                        ctx.cis_benchmark_report = run_cis(profile=aws_profile, region=aws_region)
                     else:
-                        ctx.cis_benchmark_report = run_cis(region=aws_region, profile=aws_profile)
+                        ctx.cis_benchmark_report = run_benchmark_all_regions(profile=aws_profile)
             passed = ctx.cis_benchmark_report.passed
             failed = ctx.cis_benchmark_report.failed
             total = ctx.cis_benchmark_report.total
@@ -387,9 +391,12 @@ def run_benchmarks(
             errored = getattr(ctx.cis_benchmark_report, "errored", 0)
             scanned = getattr(ctx.cis_benchmark_report, "accounts_scanned", []) or []
             regions_scanned = getattr(ctx.cis_benchmark_report, "regions_scanned", []) or []
+            completeness = str(getattr(ctx.cis_benchmark_report, "completeness", "partial") or "partial")
             scope = f"{len(scanned)} account(s)" if len(scanned) > 1 else ""
             if len(regions_scanned) > 1:
                 scope = f"{len(regions_scanned)} region(s)" if not scope else f"{scope}, {len(regions_scanned)} region(s)"
+            if completeness != "complete":
+                scope = f"{completeness} evidence" if not scope else f"{scope}, {completeness} evidence"
             if not quiet:
                 print_benchmark_line(
                     con,

--- a/src/agent_bom/cli/options_surfaces.py
+++ b/src/agent_bom/cli/options_surfaces.py
@@ -241,7 +241,12 @@ def cloud_options(fn):
     return _apply(
         [
             click.option("--aws", is_flag=True, help="Discover AI agents from AWS (Bedrock, Lambda, ECS — on by default)"),
-            click.option("--aws-region", default=None, metavar="REGION", help="AWS region (default: AWS_DEFAULT_REGION)"),
+            click.option(
+                "--aws-region",
+                default=None,
+                metavar="REGION",
+                help="Limit AWS work to one region; CIS scans all enabled regions when omitted",
+            ),
             click.option("--aws-profile", default=None, metavar="PROFILE", help="AWS credential profile"),
             click.option("--no-aws-lambda", is_flag=True, help="Skip standalone Lambda discovery when using --aws"),
             click.option("--aws-include-eks", is_flag=True, help="Discover EKS cluster workloads via kubectl (used with --aws)"),

--- a/src/agent_bom/cloud/aws_cis_benchmark.py
+++ b/src/agent_bom/cloud/aws_cis_benchmark.py
@@ -126,6 +126,10 @@ class CISBenchmarkReport:
     # read-only role could not be assumed). Empty on a single-account run.
     accounts_scanned: list[str] = field(default_factory=list)
     regions_scanned: list[str] = field(default_factory=list)
+    # Estate-scope truth. A selected-region benchmark is inherently partial for
+    # regional CIS controls; only an enabled-region fan-out may claim complete.
+    completeness: str = "partial"
+    scope: str = "selected-region"
     warnings: list[str] = field(default_factory=list)
 
     @property
@@ -167,6 +171,8 @@ class CISBenchmarkReport:
             "account_id": self.account_id,
             "accounts_scanned": self.accounts_scanned,
             "regions_scanned": self.regions_scanned,
+            "completeness": self.completeness,
+            "scope": self.scope,
             "region": self.region,
             "pass_rate": round(self.pass_rate, 1),
             "passed": self.passed,
@@ -2762,6 +2768,7 @@ def run_benchmark(
     checks: list[str] | None = None,
     *,
     session: Any = None,
+    region_scope_complete: bool = False,
 ) -> CISBenchmarkReport:
     """Run CIS AWS Foundations Benchmark v3.0 checks.
 
@@ -2774,8 +2781,11 @@ def run_benchmark(
             Runs all checks if *None*.
         session: Optional pre-built boto3 session (e.g. the read-only session
             the credential broker assumes from a stored connection). When
-            supplied it is used as-is and ``region`` / ``profile`` are ignored,
-            so the same read-only checks run against the brokered credentials.
+            supplied it provides credentials; ``region`` may still select the
+            regional client target while ``profile`` is ignored.
+        region_scope_complete: Internal fan-out proof. False for a direct
+            selected-region call; true only when the enabled-region wrapper has
+            established the complete region set.
 
     Returns:
         CISBenchmarkReport with per-check pass/fail results.
@@ -2794,7 +2804,7 @@ def run_benchmark(
             session_kwargs["profile_name"] = profile
 
         session = boto3.Session(**session_kwargs)
-    resolved_region = session.region_name or os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+    resolved_region = region or session.region_name or os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
 
     # Get account ID for the report
     account_id = ""
@@ -2805,7 +2815,14 @@ def run_benchmark(
         # Account ID lookup is non-fatal; continue with empty value
         logger.debug("Could not get AWS account ID: %s", exc)
 
-    report = CISBenchmarkReport(region=resolved_region, account_id=account_id)
+    report = CISBenchmarkReport(
+        region=resolved_region,
+        account_id=account_id,
+        accounts_scanned=[account_id] if account_id else [],
+        regions_scanned=[resolved_region],
+        completeness="complete" if region_scope_complete and account_id else ("partial" if account_id else "unavailable"),
+        scope="enabled-regions" if region_scope_complete else "selected-region",
+    )
 
     # Lazy client cache (one per service)
     clients: dict[str, Any] = {}
@@ -2887,6 +2904,16 @@ def run_benchmark(
 
     attach_all(report, cloud="aws")
 
+    if account_id and not region_scope_complete:
+        _demote_passes_to_unknown(
+            report,
+            check_ids=_REGIONAL_CIS_CHECK_IDS,
+            reason=(
+                "Only one selected region was evaluated. Run the enabled-region benchmark "
+                "before certifying regional CIS controls across all enabled AWS regions."
+            ),
+        )
+
     return report
 
 
@@ -2941,6 +2968,22 @@ _STATUS_RANK = {
 }
 
 
+def _demote_passes_to_unknown(
+    report: CISBenchmarkReport,
+    *,
+    check_ids: frozenset[str] | None,
+    reason: str,
+) -> None:
+    """Replace only optimistic PASS states when the evidence boundary is incomplete."""
+    for check in report.checks:
+        if check.status is not CheckStatus.PASS:
+            continue
+        if check_ids is not None and check.check_id not in check_ids:
+            continue
+        check.status = CheckStatus.ERROR
+        check.evidence = reason
+
+
 def _merge_regional_cis_check(existing: CISCheckResult, incoming: CISCheckResult, region: str) -> CISCheckResult:
     """Merge two results for the same check_id across regions (worst status wins)."""
     if _STATUS_RANK[incoming.status] < _STATUS_RANK[existing.status]:
@@ -2972,6 +3015,7 @@ def run_benchmark_all_regions(
     checks: list[str] | None = None,
     *,
     regions: list[str] | None = None,
+    session: Any = None,
 ) -> CISBenchmarkReport:
     """Run CIS AWS checks across every enabled region in the account.
 
@@ -2986,25 +3030,50 @@ def run_benchmark_all_regions(
     from agent_bom.cloud.aws_inventory import _resolve_region_list
     from agent_bom.cloud.normalization import sanitize_discovery_warning
 
-    session_kwargs: dict[str, Any] = {}
-    if region:
-        session_kwargs["region_name"] = region
-    if profile:
-        session_kwargs["profile_name"] = profile
-    session = boto3.Session(**session_kwargs)
+    if session is None:
+        session_kwargs: dict[str, Any] = {}
+        if region:
+            session_kwargs["region_name"] = region
+        if profile:
+            session_kwargs["profile_name"] = profile
+        session = boto3.Session(**session_kwargs)
     default_region = session.region_name or os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
     scan_warnings: list[str] = []
     region_list = _resolve_region_list(session, default_region, regions=regions, warnings=scan_warnings)
     if len(region_list) <= 1:
-        report = run_benchmark(region=default_region, profile=profile, checks=checks, session=session)
+        complete = not scan_warnings
+        report = run_benchmark(
+            region=default_region,
+            profile=profile,
+            checks=checks,
+            session=session,
+            region_scope_complete=complete,
+        )
+        report.regions_scanned = list(region_list)
+        report.scope = "enabled-regions"
+        report.completeness = "complete" if complete and report.account_id else "partial" if report.account_id else "unavailable"
         report.warnings.extend(scan_warnings)
+        if not complete:
+            _demote_passes_to_unknown(
+                report,
+                check_ids=_REGIONAL_CIS_CHECK_IDS,
+                reason="Region enumeration was incomplete; PASS is unavailable for regional CIS controls.",
+            )
         return report
 
     home_region = region_list[0]
-    merged = run_benchmark(region=home_region, profile=profile, checks=checks)
+    merged = run_benchmark(
+        region=home_region,
+        profile=profile,
+        checks=checks,
+        session=session,
+        region_scope_complete=True,
+    )
     merged.regions_scanned = list(region_list)
     merged.region = f"multi:{','.join(region_list)}"
     merged.warnings.extend(scan_warnings)
+    merged.scope = "enabled-regions"
+    merged.completeness = "complete" if not scan_warnings and merged.account_id else "partial" if merged.account_id else "unavailable"
 
     if checks is None:
         regional_ids = sorted(_REGIONAL_CIS_CHECK_IDS)
@@ -3014,10 +3083,18 @@ def run_benchmark_all_regions(
         return merged
 
     by_id = {check.check_id: check for check in merged.checks}
+    regional_failures = False
     for scan_region in region_list[1:]:
         try:
-            partial = run_benchmark(region=scan_region, profile=profile, checks=regional_ids)
+            partial = run_benchmark(
+                region=scan_region,
+                profile=profile,
+                checks=regional_ids,
+                session=session,
+                region_scope_complete=True,
+            )
         except Exception as exc:  # noqa: BLE001
+            regional_failures = True
             merged.warnings.append(f"CIS benchmark skipped region {scan_region}: {sanitize_discovery_warning(exc)}")
             continue
         for check in partial.checks:
@@ -3034,6 +3111,13 @@ def run_benchmark_all_regions(
     from agent_bom.cloud.cis_remediation import attach_all
 
     attach_all(merged, cloud="aws")
+    if scan_warnings or regional_failures:
+        merged.completeness = "partial" if merged.account_id else "unavailable"
+        _demote_passes_to_unknown(
+            merged,
+            check_ids=_REGIONAL_CIS_CHECK_IDS,
+            reason="Region enumeration was incomplete; PASS is unavailable for regional CIS controls.",
+        )
     return merged
 
 
@@ -3094,12 +3178,17 @@ def run_all_account_benchmarks(
 
     if not account_ids:
         # Standalone account (not in an org) — single-account benchmark.
-        return run_benchmark(profile=profile, checks=checks, session=session)
+        return run_benchmark_all_regions(profile=profile, checks=checks, session=session)
 
     cap = aws_organizations.max_accounts()
     capped = account_ids[:cap]
 
-    aggregate = CISBenchmarkReport(account_id=", ".join(capped))
+    aggregate = CISBenchmarkReport(
+        account_id=", ".join(capped),
+        scope="organization-enabled-regions",
+        completeness="complete",
+    )
+    scope_partial = len(account_ids) > cap
     if len(account_ids) > cap:
         aggregate.warnings.append(
             f"AWS multi-account CIS benchmark capped at {cap} of {len(account_ids)} accounts (set AGENT_BOM_AWS_MAX_ACCOUNTS to raise)."
@@ -3113,7 +3202,7 @@ def run_all_account_benchmarks(
             external_id=external_id,
             base_session=session,
         )
-        return account_id, run_benchmark(session=assumed, checks=checks)
+        return account_id, run_benchmark_all_regions(session=assumed, checks=checks)
 
     # Deterministic aggregation: collect per-account reports keyed by id, then
     # merge in enumeration order so output is stable across runs.
@@ -3126,6 +3215,7 @@ def run_all_account_benchmarks(
                 _aid, account_report = future.result()
                 reports[account_id] = account_report
             except Exception as exc:  # noqa: BLE001 — one unreadable account must not sink the rest
+                scope_partial = True
                 aggregate.warnings.append(f"Account {account_id} skipped: {sanitize_discovery_warning(exc)}")
 
     for account_id in capped:
@@ -3133,9 +3223,19 @@ def run_all_account_benchmarks(
         if merged is None:
             continue
         aggregate.accounts_scanned.append(account_id)
+        for scan_region in merged.regions_scanned:
+            if scan_region not in aggregate.regions_scanned:
+                aggregate.regions_scanned.append(scan_region)
+        if merged.completeness != "complete":
+            scope_partial = True
         for check in merged.checks:
             check.account_id = account_id
             aggregate.checks.append(check)
         aggregate.warnings.extend(merged.warnings)
+
+    if not aggregate.accounts_scanned:
+        aggregate.completeness = "unavailable"
+    elif scope_partial:
+        aggregate.completeness = "partial"
 
     return aggregate

--- a/src/agent_bom/mcp_server_operator_tools.py
+++ b/src/agent_bom/mcp_server_operator_tools.py
@@ -486,7 +486,7 @@ def register_operator_tools(
         ] = None,
         region: Annotated[
             str | None,
-            Field(description="AWS region (only for provider=aws). Defaults to us-east-1."),
+            Field(description="Optional AWS region scope. Omit to evaluate CIS across all enabled AWS regions."),
         ] = None,
         profile: Annotated[
             str | None,

--- a/src/agent_bom/mcp_tools/compliance.py
+++ b/src/agent_bom/mcp_tools/compliance.py
@@ -203,9 +203,14 @@ async def cis_benchmark_impl(
 
         cis_report: object
         if provider == "aws":
-            from agent_bom.cloud.aws_cis_benchmark import run_benchmark as run_aws_cis
+            if region:
+                from agent_bom.cloud.aws_cis_benchmark import run_benchmark
 
-            cis_report = run_aws_cis(region=region, profile=profile, checks=check_list)
+                cis_report = run_benchmark(region=region, profile=profile, checks=check_list)
+            else:
+                from agent_bom.cloud.aws_cis_benchmark import run_benchmark_all_regions
+
+                cis_report = run_benchmark_all_regions(region=region, profile=profile, checks=check_list)
         elif provider == "snowflake":
             from agent_bom.cloud.snowflake_cis_benchmark import run_benchmark as run_sf_cis
 

--- a/tests/cloud/test_connection_all_regions.py
+++ b/tests/cloud/test_connection_all_regions.py
@@ -77,9 +77,36 @@ class TestAwsScanFansOutOnAllRegions:
 
         class _Cis:
             def to_dict(self) -> dict[str, Any]:
-                return {"benchmark": "cis", "passed": 0, "failed": 0, "total": 0, "pass_rate": 0}
+                return {
+                    "benchmark": "cis",
+                    "scope": "enabled-regions",
+                    "completeness": "complete",
+                    "accounts_scanned": ["123456789012"],
+                    "regions_scanned": ["us-east-1", "eu-west-1"],
+                    "passed": 0,
+                    "failed": 0,
+                    "errored": 0,
+                    "not_applicable": 0,
+                    "evaluated": 0,
+                    "total": 0,
+                    "pass_rate": 0,
+                }
 
-        monkeypatch.setattr(aws_cis_benchmark, "run_benchmark", lambda **_kw: _Cis())
+        def _cis_single(**_kw: Any) -> _Cis:
+            calls["cis_single"] = True
+            return _Cis()
+
+        def _cis_multi(**_kw: Any) -> _Cis:
+            calls["cis_multi"] = True
+            calls["cis_multi_session"] = _kw.get("session")
+            return _Cis()
+
+        monkeypatch.setattr(aws_cis_benchmark, "run_benchmark", _cis_single)
+        monkeypatch.setattr(
+            aws_cis_benchmark,
+            "run_benchmark_all_regions",
+            _cis_multi,
+        )
         monkeypatch.setattr(
             routes,
             "_persist_connection_report",
@@ -93,7 +120,12 @@ class TestAwsScanFansOutOnAllRegions:
         assert calls.get("multi") is True
         assert calls.get("single") is None
         assert calls.get("multi_session") is not None  # brokered session threaded in
+        assert calls.get("cis_multi") is True
+        assert calls.get("cis_single") is None
+        assert calls.get("cis_multi_session") is not None
         assert result["scan_id"] == "scan-123"
+        assert result["cis_benchmark"]["completeness"] == "complete"
+        assert result["cis_benchmark"]["regions_scanned"] == 2
 
     def test_single_region_uses_single_discovery(self, monkeypatch: pytest.MonkeyPatch) -> None:
         calls: dict[str, Any] = {}
@@ -102,3 +134,5 @@ class TestAwsScanFansOutOnAllRegions:
         assert calls.get("single") is True
         assert calls.get("multi") is None
         assert calls.get("single_region") == "us-east-1"
+        assert calls.get("cis_single") is True
+        assert calls.get("cis_multi") is None

--- a/tests/test_aws_cis_scope_truth.py
+++ b/tests/test_aws_cis_scope_truth.py
@@ -1,0 +1,252 @@
+"""AWS CIS scope must never turn partial or unauthenticated reads into PASS."""
+
+from __future__ import annotations
+
+import inspect
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_bom.cloud import aws_cis_benchmark as cis
+
+
+def _install_boto_modules(monkeypatch) -> None:
+    boto3 = types.ModuleType("boto3")
+    botocore = types.ModuleType("botocore")
+    exceptions = types.ModuleType("botocore.exceptions")
+
+    class ClientError(Exception):
+        pass
+
+    exceptions.ClientError = ClientError
+    monkeypatch.setitem(sys.modules, "boto3", boto3)
+    monkeypatch.setitem(sys.modules, "botocore", botocore)
+    monkeypatch.setitem(sys.modules, "botocore.exceptions", exceptions)
+
+
+def _passing_check(_client) -> cis.CISCheckResult:
+    """CIS 5.2 — No unrestricted ingress to admin ports."""
+    return cis.CISCheckResult(
+        check_id="5.2",
+        title="No unrestricted ingress to admin ports",
+        status=cis.CheckStatus.PASS,
+        severity="high",
+        evidence="No security groups allow unrestricted ingress to SSH/RDP.",
+    )
+
+
+def _session(*, account: str | None = "123456789012") -> MagicMock:
+    session = MagicMock()
+    session.region_name = "us-east-1"
+    sts = MagicMock()
+    if account is None:
+        sts.get_caller_identity.side_effect = RuntimeError("unverified")
+    else:
+        sts.get_caller_identity.return_value = {"Account": account}
+    session.client.side_effect = lambda service, **_kwargs: sts if service == "sts" else MagicMock()
+    return session
+
+
+def test_single_region_result_cannot_certify_regional_pass(monkeypatch) -> None:
+    _install_boto_modules(monkeypatch)
+    monkeypatch.setattr(cis, "_CHECKS", [("ec2", _passing_check)])
+    monkeypatch.setattr(cis, "_SPECIAL_CHECKS", [])
+
+    report = cis.run_benchmark(session=_session(), checks=["5.2"])
+
+    assert report.completeness == "partial"
+    assert report.regions_scanned == ["us-east-1"]
+    assert report.checks[0].status is cis.CheckStatus.ERROR
+    assert "enabled AWS regions" in report.checks[0].evidence
+
+
+def test_unverified_account_identity_cannot_report_pass(monkeypatch) -> None:
+    _install_boto_modules(monkeypatch)
+    monkeypatch.setattr(cis, "_CHECKS", [("ec2", _passing_check)])
+    monkeypatch.setattr(cis, "_SPECIAL_CHECKS", [])
+
+    report = cis.run_benchmark(session=_session(account=None), checks=["5.2"], region_scope_complete=True)
+
+    assert report.completeness == "unavailable"
+    assert report.account_id == ""
+    assert report.checks[0].status is cis.CheckStatus.ERROR
+    assert "GetCallerIdentity" in report.checks[0].evidence
+
+
+def test_complete_region_enumeration_preserves_pass(monkeypatch) -> None:
+    _install_boto_modules(monkeypatch)
+    home = cis.CISBenchmarkReport(
+        account_id="123456789012",
+        checks=[_passing_check(None)],
+    )
+    other = cis.CISBenchmarkReport(
+        account_id="123456789012",
+        checks=[_passing_check(None)],
+    )
+    run = MagicMock(side_effect=[home, other])
+    monkeypatch.setattr(cis, "run_benchmark", run)
+    monkeypatch.setattr(
+        "agent_bom.cloud.aws_inventory._resolve_region_list",
+        lambda *_args, **_kwargs: ["us-east-1", "eu-west-1"],
+    )
+
+    report = cis.run_benchmark_all_regions(session=_session())
+
+    assert report.completeness == "complete"
+    assert report.regions_scanned == ["us-east-1", "eu-west-1"]
+    assert report.checks[0].status is cis.CheckStatus.PASS
+    assert all(call.kwargs["region_scope_complete"] is True for call in run.call_args_list)
+
+
+def test_failed_region_enumeration_marks_regional_pass_unknown(monkeypatch) -> None:
+    _install_boto_modules(monkeypatch)
+    home = cis.CISBenchmarkReport(
+        account_id="123456789012",
+        checks=[_passing_check(None)],
+    )
+    monkeypatch.setattr(cis, "run_benchmark", MagicMock(return_value=home))
+
+    def _partial(_session, default_region, *, regions, warnings):
+        warnings.append(f"Could not enumerate enabled AWS regions; scanning {default_region} only")
+        return [default_region]
+
+    monkeypatch.setattr("agent_bom.cloud.aws_inventory._resolve_region_list", _partial)
+
+    report = cis.run_benchmark_all_regions(session=_session())
+
+    assert report.completeness == "partial"
+    assert report.checks[0].status is cis.CheckStatus.ERROR
+    assert "Region enumeration was incomplete" in report.checks[0].evidence
+
+
+def test_failed_regional_scan_marks_merged_pass_unknown(monkeypatch) -> None:
+    _install_boto_modules(monkeypatch)
+    home = cis.CISBenchmarkReport(
+        account_id="123456789012",
+        checks=[_passing_check(None)],
+    )
+    run = MagicMock(side_effect=[home, RuntimeError("regional failure")])
+    monkeypatch.setattr(cis, "run_benchmark", run)
+    monkeypatch.setattr(
+        "agent_bom.cloud.aws_inventory._resolve_region_list",
+        lambda *_args, **_kwargs: ["us-east-1", "eu-west-1"],
+    )
+
+    report = cis.run_benchmark_all_regions(session=_session())
+
+    assert report.completeness == "partial"
+    assert report.checks[0].status is cis.CheckStatus.ERROR
+    assert any("skipped region eu-west-1" in warning for warning in report.warnings)
+
+
+def test_report_serializes_scope_and_completeness() -> None:
+    report = cis.CISBenchmarkReport(
+        account_id="123456789012",
+        accounts_scanned=["123456789012"],
+        regions_scanned=["us-east-1", "eu-west-1"],
+        completeness="complete",
+        scope="enabled-regions",
+    )
+
+    payload = report.to_dict()
+
+    assert payload["completeness"] == "complete"
+    assert payload["scope"] == "enabled-regions"
+    assert payload["accounts_scanned"] == ["123456789012"]
+    assert payload["regions_scanned"] == ["us-east-1", "eu-west-1"]
+
+
+@pytest.mark.parametrize(
+    ("entrypoint", "explicit_scope_guard"),
+    [
+        pytest.param("cli", "if aws_region:", id="cli"),
+        pytest.param("rest", "if region_arg:", id="rest"),
+        pytest.param("mcp", "if region:", id="mcp"),
+    ],
+)
+def test_public_estate_benchmark_entrypoints_preserve_explicit_region_scope(
+    entrypoint: str,
+    explicit_scope_guard: str,
+) -> None:
+    if entrypoint == "cli":
+        from agent_bom.cli.agents._cloud import run_benchmarks as target
+    elif entrypoint == "rest":
+        from agent_bom.api.routes.cloud import _run_cis_benchmark as target
+    else:
+        from agent_bom.mcp_tools.compliance import cis_benchmark_impl as target
+
+    source = inspect.getsource(target)
+    assert "run_benchmark_all_regions" in source
+    assert explicit_scope_guard in source
+
+
+class _SerializedReport:
+    def to_dict(self) -> dict[str, object]:
+        return {"benchmark": "CIS AWS Foundations", "completeness": "complete", "checks": []}
+
+
+@pytest.mark.asyncio
+async def test_mcp_omitted_region_fans_out_but_explicit_region_stays_scoped(monkeypatch) -> None:
+    from agent_bom.cloud import ambient_credentials, aws_cis_benchmark
+    from agent_bom.mcp_tools.compliance import cis_benchmark_impl
+
+    calls: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(ambient_credentials, "ambient_cis_enabled", lambda: True)
+    monkeypatch.setattr(ambient_credentials, "configured_aws_profile", lambda: None)
+    monkeypatch.setattr(
+        aws_cis_benchmark,
+        "run_benchmark_all_regions",
+        lambda **kwargs: calls.append(("all", kwargs.get("region"))) or _SerializedReport(),
+    )
+    monkeypatch.setattr(
+        aws_cis_benchmark,
+        "run_benchmark",
+        lambda **kwargs: calls.append(("one", kwargs.get("region"))) or _SerializedReport(),
+    )
+
+    await cis_benchmark_impl(
+        provider="aws",
+        region=None,
+        profile=None,
+        subscription_id=None,
+        project_id=None,
+        checks=None,
+        _truncate_response=lambda value: value,
+    )
+    await cis_benchmark_impl(
+        provider="aws",
+        region="eu-west-1",
+        profile=None,
+        subscription_id=None,
+        project_id=None,
+        checks=None,
+        _truncate_response=lambda value: value,
+    )
+
+    assert calls == [("all", None), ("one", "eu-west-1")]
+
+
+def test_rest_omitted_region_fans_out_but_explicit_region_stays_scoped(monkeypatch) -> None:
+    from agent_bom.api.routes.cloud import _run_cis_benchmark
+    from agent_bom.cloud import aws_cis_benchmark
+
+    calls: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(
+        aws_cis_benchmark,
+        "run_benchmark_all_regions",
+        lambda **kwargs: calls.append(("all", kwargs.get("region"))) or _SerializedReport(),
+    )
+    monkeypatch.setattr(
+        aws_cis_benchmark,
+        "run_benchmark",
+        lambda **kwargs: calls.append(("one", kwargs.get("region"))) or _SerializedReport(),
+    )
+
+    all_regions = _run_cis_benchmark("tenant-a", "aws", None, None, None, "", "")
+    one_region = _run_cis_benchmark("tenant-a", "aws", None, "eu-west-1", None, "", "")
+
+    assert all_regions["completeness"] == "complete"
+    assert one_region["completeness"] == "complete"
+    assert calls == [("all", None), ("one", "eu-west-1")]

--- a/tests/test_aws_org_scan_fanout.py
+++ b/tests/test_aws_org_scan_fanout.py
@@ -313,7 +313,12 @@ def test_summarize_account_scan_buckets_by_status() -> None:
 
 
 def _cis_report(account_id: str) -> CISBenchmarkReport:
-    report = CISBenchmarkReport(account_id=account_id)
+    report = CISBenchmarkReport(
+        account_id=account_id,
+        completeness="complete",
+        scope="enabled-regions",
+        regions_scanned=["us-east-1", "eu-west-1"],
+    )
     report.checks.append(CISCheckResult(check_id="1.4", title="t", status=CheckStatus.PASS, severity="critical"))
     report.checks.append(CISCheckResult(check_id="3.1", title="t", status=CheckStatus.FAIL, severity="high"))
     return report
@@ -330,7 +335,7 @@ def test_cis_fanout_per_account_attribution(monkeypatch) -> None:
     def _fake_run(*, session=None, checks=None):
         return _cis_report(str(session).split("::")[-1])
 
-    monkeypatch.setattr(aws_cis, "run_benchmark", _fake_run)
+    monkeypatch.setattr(aws_cis, "run_benchmark_all_regions", _fake_run)
 
     report = aws_cis.run_all_account_benchmarks()
     assert report.accounts_scanned == ["111111111111", "222222222222"]
@@ -338,6 +343,9 @@ def test_cis_fanout_per_account_attribution(monkeypatch) -> None:
     assert report.passed == 2
     assert report.failed == 2
     assert report.total == 4
+    assert report.completeness == "complete"
+    assert report.scope == "organization-enabled-regions"
+    assert report.regions_scanned == ["us-east-1", "eu-west-1"]
     payload = report.to_dict()
     assert payload["accounts_scanned"] == ["111111111111", "222222222222"]
     assert {c["account_id"] for c in payload["checks"]} == {"111111111111", "222222222222"}
@@ -352,12 +360,17 @@ def test_cis_fanout_skips_denied_account_with_warning(monkeypatch) -> None:
         return f"session::{aid}"
 
     monkeypatch.setattr(aws_orgs, "assume_account_session", _fake_assume)
-    monkeypatch.setattr(aws_cis, "run_benchmark", lambda *, session=None, checks=None: _cis_report(str(session).split("::")[-1]))
+    monkeypatch.setattr(
+        aws_cis,
+        "run_benchmark_all_regions",
+        lambda *, session=None, checks=None: _cis_report(str(session).split("::")[-1]),
+    )
 
     report = aws_cis.run_all_account_benchmarks()
     assert report.accounts_scanned == ["ok-acct"]
     assert {c.account_id for c in report.checks} == {"ok-acct"}
     assert any("denied-acct skipped" in w for w in report.warnings)
+    assert report.completeness == "partial"
     assert report.total == 2
 
 
@@ -365,11 +378,16 @@ def test_cis_fanout_caps_accounts_with_warning(monkeypatch) -> None:
     monkeypatch.setenv("AGENT_BOM_AWS_MAX_ACCOUNTS", "1")
     monkeypatch.setattr(aws_orgs, "list_member_account_ids", lambda profile=None, *, force=False, session=None: ["a1", "a2", "a3"])
     monkeypatch.setattr(aws_orgs, "assume_account_session", lambda aid, **kw: f"session::{aid}")
-    monkeypatch.setattr(aws_cis, "run_benchmark", lambda *, session=None, checks=None: _cis_report(str(session).split("::")[-1]))
+    monkeypatch.setattr(
+        aws_cis,
+        "run_benchmark_all_regions",
+        lambda *, session=None, checks=None: _cis_report(str(session).split("::")[-1]),
+    )
 
     report = aws_cis.run_all_account_benchmarks()
     assert report.accounts_scanned == ["a1"]
     assert any("capped at 1 of 3" in w for w in report.warnings)
+    assert report.completeness == "partial"
 
 
 def test_cis_fanout_falls_back_to_single_account(monkeypatch) -> None:
@@ -380,7 +398,7 @@ def test_cis_fanout_falls_back_to_single_account(monkeypatch) -> None:
         called.append(True)
         return _cis_report("solo")
 
-    monkeypatch.setattr(aws_cis, "run_benchmark", _single)
+    monkeypatch.setattr(aws_cis, "run_benchmark_all_regions", _single)
     report = aws_cis.run_all_account_benchmarks()
     assert called == [True]
     assert report.account_id == "solo"

--- a/tests/test_cli_cloud_scan.py
+++ b/tests/test_cli_cloud_scan.py
@@ -465,7 +465,7 @@ class TestRequestedProviderHardFailExits:
         def _raise_cis(**kwargs):
             raise CloudDiscoveryError("boto3 is required for AWS scanning.")
 
-        monkeypatch.setattr("agent_bom.cloud.aws_cis_benchmark.run_benchmark", _raise_cis)
+        monkeypatch.setattr("agent_bom.cloud.aws_cis_benchmark.run_benchmark_all_regions", _raise_cis)
 
         r = CliRunner().invoke(main, ["scan", "--aws", "--aws-cis-benchmark", "--no-discover", "--offline"])
         assert r.exit_code == 1

--- a/tests/test_cli_terminal_ux.py
+++ b/tests/test_cli_terminal_ux.py
@@ -120,7 +120,7 @@ def test_run_benchmarks_does_not_render_cis_inline(monkeypatch):
     fake_report.pass_rate = 50.0
     fake_report.to_dict.return_value = {"checks": []}
 
-    monkeypatch.setattr("agent_bom.cloud.aws_cis_benchmark.run_benchmark", lambda **kwargs: fake_report)
+    monkeypatch.setattr("agent_bom.cloud.aws_cis_benchmark.run_benchmark_all_regions", lambda **kwargs: fake_report)
     monkeypatch.setattr(
         "agent_bom.cli.agents._cloud.render_cis_findings_from_context",
         lambda _ctx: (_ for _ in ()).throw(AssertionError("CIS must not render mid-scan")),


### PR DESCRIPTION
## Summary

- evaluate AWS CIS across every enabled region by default while preserving an explicit region as a deliberately partial scope
- withhold regional PASS when account identity, region enumeration, a regional scan, or organization fan-out is incomplete
- expose scope, completeness, evaluated/error counts, and bounded account/region counts consistently through CLI, REST, MCP, and connection summaries

## Verification

- 468 affected AWS CIS, CLI, API, MCP, connection, and org-fan-out tests passed
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache make lint`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python scripts/check_exception_sanitization.py`
- `git diff --check origin/main...HEAD`

## Notes

- All provider calls remain read-only. No cloud resources are created or mutated.
- Omitted region means enabled-region estate coverage; an explicit region remains supported and is labeled partial rather than promoted to account-wide compliance.
- Existing failed and not-applicable results are preserved; only unsupported affirmative PASS states become ERROR/unknown.