### PR TITLE
fix(evidence): keep risk and coverage claims honest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ Versions follow [Semantic Versioning](https://semver.org/).
   require persistent HMAC signing for shared durable ledgers.
 - Bare ASGI startup enforces the database RLS-role preflight, while public-demo
   operator pages withhold deployment posture and integration diagnostics.
+- OWASP LLM, MCP, and Agentic Top 10 risks are reported as applicability
+  overlays instead of passed or failed controls across REST and MCP; the MCP
+  surface now includes the Agentic catalog and preserves scored totals.
+- Secret scans suppress explicit sample placeholders without hiding real
+  assigned passphrases, and MCP prompt heuristics no longer match words such as
+  `ecosystem` merely because they contain `system`.
+- Amazon Linux, Oracle Linux, and SLES package inventories now emit explicit
+  advisory-source-unavailable evidence instead of a false-clean zero while
+  their dedicated advisory feeds remain unsupported.
 
 ## [0.101.0] - 2026-08-16
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -405,9 +405,9 @@ agent-bom ships a curated control set per framework, sized to the AI/MCP/agent t
 <!-- compliance-coverage:start -->
 | Family | Framework | Bundled controls | Source-standard size (approx.) | What's covered |
 |---|---|---|---|---|
-| OWASP | LLM Top 10 (2025) | 10 / 10 | 10 | Full Top-10 |
-| OWASP | MCP Top 10 (2025) | 10 / 10 | 10 | Full Top-10 |
-| OWASP | Agentic Top 10 (2026) | 10 / 10 | 10 | Full Top-10 |
+| OWASP | LLM Top 10 (2025) | 10 / 10 | 10 | Applicability overlay (not scored): risks evidenced by observed AI/LLM findings |
+| OWASP | MCP Top 10 (2025) | 10 / 10 | 10 | Applicability overlay (not scored): risks evidenced by observed MCP findings |
+| OWASP | Agentic Top 10 (2026) | 10 / 10 | 10 | Applicability overlay (not scored): risks evidenced by observed agentic findings |
 | OWASP | AISVS v1.0 | 9 checks | ~50 verification reqs | Programmatically verifiable subset (AI-4/5/6/7/8 categories) |
 | NIST / FedRAMP | AI RMF 1.0 | 14 subcategories | ~70 | Govern / Map / Measure / Manage controls relevant to AI supply chain + MCP |
 | NIST / FedRAMP | CSF 2.0 | 14 categories | ~108 | Supply-chain, identity, asset, monitoring categories |

--- a/src/agent_bom/compliance_coverage.py
+++ b/src/agent_bom/compliance_coverage.py
@@ -92,8 +92,9 @@ TAG_MAPPED_FRAMEWORKS: tuple[ComplianceFrameworkMetadata, ...] = (
         report_label="OWASP LLM Top 10",
         bundled_unit="controls",
         source_standard_size="10",
-        coverage="Full Top-10",
+        coverage="Applicability overlay (not scored): risks evidenced by observed AI/LLM findings",
         full_catalog_size=10,
+        scored=False,
     ),
     ComplianceFrameworkMetadata(
         family="OWASP",
@@ -106,8 +107,9 @@ TAG_MAPPED_FRAMEWORKS: tuple[ComplianceFrameworkMetadata, ...] = (
         report_label="OWASP MCP Top 10",
         bundled_unit="controls",
         source_standard_size="10",
-        coverage="Full Top-10",
+        coverage="Applicability overlay (not scored): risks evidenced by observed MCP findings",
         full_catalog_size=10,
+        scored=False,
     ),
     ComplianceFrameworkMetadata(
         family="OWASP",
@@ -120,8 +122,9 @@ TAG_MAPPED_FRAMEWORKS: tuple[ComplianceFrameworkMetadata, ...] = (
         report_label="OWASP Agentic Top 10",
         bundled_unit="controls",
         source_standard_size="10",
-        coverage="Full Top-10",
+        coverage="Applicability overlay (not scored): risks evidenced by observed agentic findings",
         full_catalog_size=10,
+        scored=False,
     ),
     ComplianceFrameworkMetadata(
         family="NIST / FedRAMP",

--- a/src/agent_bom/coverage.py
+++ b/src/agent_bom/coverage.py
@@ -10,12 +10,16 @@ bill of health. It is a *warning-only* signal: it does not change version
 matching, suppression, or which advisories are reported. The per-release
 matching is correct; the data is simply absent.
 
-The check is data-source-agnostic and threshold-based — it fires for any
+For distro families with a supported advisory source, the check is
+data-source-agnostic and threshold-based — it fires for any
 ``ecosystem:release`` that has many packages present in the image but
 (near-)zero advisory rows in the local DB, *while the feed clearly carries the
 distro family at other releases*. That last gate keeps it quiet when the local
 DB is empty (e.g. a default online scan that resolves against the remote API),
-where every release legitimately has zero local rows.
+where every release legitimately has zero local rows. Known parsed RPM
+families without a supported advisory source are the exception: they emit an
+explicit source-unavailable warning even with an empty DB, because remote OSV
+cannot turn that missing feed into complete evidence.
 """
 
 from __future__ import annotations
@@ -41,6 +45,12 @@ _MAX_ROWS_FOR_UNCOVERED = 5
 # release". This gates out the empty/absent-DB case where every release has zero
 # local rows and the remote API is the live source.
 _MIN_FAMILY_ROWS = 50
+
+# These distro families are parsed, but their advisory sources are not present
+# in the supported OSV/local-DB routes. Keep their evidence explicitly partial
+# until dedicated, version-verified feeds land; never turn an empty lookup into
+# a clean result.
+_UNSUPPORTED_RPM_FAMILIES = frozenset({"amazon-linux", "oracle-linux", "sles"})
 
 
 @dataclass(frozen=True)
@@ -152,6 +162,15 @@ def _release_key(pkg: "Package") -> Optional[tuple[str, str]]:
             "alma": ("almalinux", f"almalinux:{major}"),
             "rocky": ("rocky", f"rocky linux:{major}"),
             "rocky linux": ("rocky", f"rocky linux:{major}"),
+            "amzn": ("amazon-linux", f"amazon-linux:{major}"),
+            "amazon": ("amazon-linux", f"amazon-linux:{major}"),
+            "amazon linux": ("amazon-linux", f"amazon-linux:{major}"),
+            "ol": ("oracle-linux", f"oracle-linux:{major}"),
+            "oracle": ("oracle-linux", f"oracle-linux:{major}"),
+            "oracle linux": ("oracle-linux", f"oracle-linux:{major}"),
+            "sles": ("sles", f"sles:{major}"),
+            "sled": ("sles", f"sles:{major}"),
+            "suse": ("sles", f"sles:{major}"),
         }
         return rpm_families.get(distro_name)
     return None
@@ -214,16 +233,40 @@ def detect_release_coverage_gaps(
     if not candidates:
         return []
 
+    warnings: list[dict] = []
+    supported_candidates: dict[tuple[str, str], int] = {}
+    for (family, release_key), pkg_count in sorted(candidates.items()):
+        if family not in _UNSUPPORTED_RPM_FAMILIES:
+            supported_candidates[(family, release_key)] = pkg_count
+            continue
+        warnings.append(
+            CoverageWarning(
+                ecosystem=family,
+                release=release_key,
+                reason="advisory_source_unavailable",
+                detail=(
+                    f"Vulnerability coverage for {release_key} is unavailable: Agent-Bom can "
+                    "inventory these RPM packages, but no supported, version-verified advisory "
+                    "feed is configured for this distro family. Findings may under-report and a "
+                    "low or zero vulnerability count is not a clean bill of health."
+                ),
+                package_count=pkg_count,
+                advisory_rows=0,
+            ).to_dict()
+        )
+
+    if not supported_candidates:
+        return warnings
+
     owns_conn = False
     if conn is None:
         conn = _open_readonly_db()
         owns_conn = conn is not None
     if conn is None:
-        return []
+        return warnings
 
     try:
-        warnings: list[dict] = []
-        for (family, release_key), pkg_count in sorted(candidates.items()):
+        for (family, release_key), pkg_count in sorted(supported_candidates.items()):
             try:
                 family_rows = _count_family_rows(conn, family)
             except sqlite3.Error as exc:

--- a/src/agent_bom/mcp_introspect.py
+++ b/src/agent_bom/mcp_introspect.py
@@ -35,7 +35,10 @@ DEFAULT_TIMEOUT = 10.0
 _PATH_HINT_RE = re.compile(r"(path|file|dir|cwd|workspace)", re.IGNORECASE)
 _URL_HINT_RE = re.compile(r"(url|uri|endpoint|host|domain|webhook)", re.IGNORECASE)
 _SHELL_HINT_RE = re.compile(r"(cmd|command|shell|exec|script)", re.IGNORECASE)
-_PROMPT_HINT_RE = re.compile(r"(prompt|instruction|system|markdown|html|svg)", re.IGNORECASE)
+_PROMPT_HINT_RE = re.compile(
+    r"(?<![A-Za-z0-9])(?:prompt|instruction|system|markdown|html|svg)(?![A-Za-z0-9])",
+    re.IGNORECASE,
+)
 
 
 def _safe_runtime_text(value: object, *, max_len: int = 1000) -> str:

--- a/src/agent_bom/mcp_tool_rules.py
+++ b/src/agent_bom/mcp_tool_rules.py
@@ -43,7 +43,10 @@ _PATH_HINT_RE = re.compile(r"(path|file|dir|cwd|workspace)", re.IGNORECASE)
 _URL_HINT_RE = re.compile(r"(url|uri|endpoint|host|domain|webhook)", re.IGNORECASE)
 _SHELL_HINT_RE = re.compile(r"(cmd|command|shell|exec|script)", re.IGNORECASE)
 _SQL_HINT_RE = re.compile(r"(query|sql|statement|stmt)", re.IGNORECASE)
-_PROMPT_HINT_RE = re.compile(r"(prompt|instruction|system|markdown|html|svg)", re.IGNORECASE)
+_PROMPT_HINT_RE = re.compile(
+    r"(?<![A-Za-z0-9])(?:prompt|instruction|system|markdown|html|svg)(?![A-Za-z0-9])",
+    re.IGNORECASE,
+)
 _CRED_HINT_RE = re.compile(r"(token|secret|password|credential|api[_-]?key|access[_-]?key)", re.IGNORECASE)
 
 

--- a/src/agent_bom/mcp_tools/compliance.py
+++ b/src/agent_bom/mcp_tools/compliance.py
@@ -48,6 +48,7 @@ async def compliance_impl(
         from agent_bom.atlas import ATLAS_TECHNIQUES
         from agent_bom.nist_ai_rmf import NIST_AI_RMF
         from agent_bom.owasp import OWASP_LLM_TOP10
+        from agent_bom.owasp_agentic import OWASP_AGENTIC_TOP10
         from agent_bom.owasp_mcp import OWASP_MCP_TOP10
 
         agents, blast_radii, _warnings, scan_sources = await _run_scan_pipeline(config_path, image)
@@ -65,11 +66,12 @@ async def compliance_impl(
                     "atlas_tags": list(br.atlas_tags),
                     "nist_ai_rmf_tags": list(br.nist_ai_rmf_tags),
                     "owasp_mcp_tags": list(br.owasp_mcp_tags),
+                    "owasp_agentic_tags": list(getattr(br, "owasp_agentic_tags", [])),
                     "nist_800_53_tags": list(getattr(br, "nist_800_53_tags", [])),
                 }
             )
 
-        def _build_controls(catalog, tag_field, id_key):
+        def _build_controls(catalog, tag_field, id_key, *, scored: bool):
             controls = []
             for code, name in sorted(catalog.items()):
                 sev_bk = {"critical": 0, "high": 0, "medium": 0, "low": 0}
@@ -84,17 +86,17 @@ async def compliance_impl(
                             pkgs.add(br["package"])
                         for a in br.get("affected_agents", []):
                             ags.add(a)
-                # A control with no mapped finding is NOT a pass. These
-                # catalogues (OWASP LLM/MCP, ATLAS, NIST AI RMF) are all
-                # corrective/preventive: they are attested by the absence of an
-                # open weakness, and absence of a CVE is not proof the control
-                # is implemented. Scoring them as passes made a clean scan
-                # return "100% / pass" over 99 never-evaluated controls — the
-                # same false green /v1/compliance removed. Mirrors the API's
-                # not_evaluated semantics (see evidence/control_modes.py).
-                status = (
-                    "fail" if findings and (sev_bk["critical"] > 0 or sev_bk["high"] > 0) else "warning" if findings else "not_evaluated"
-                )
+                if not scored:
+                    status = "applicable" if findings else "not_applicable"
+                else:
+                    # A scored control with no mapped finding is NOT a pass.
+                    status = (
+                        "fail"
+                        if findings and (sev_bk["critical"] > 0 or sev_bk["high"] > 0)
+                        else "warning"
+                        if findings
+                        else "not_evaluated"
+                    )
                 controls.append(
                     {
                         id_key: code,
@@ -104,30 +106,39 @@ async def compliance_impl(
                         "severity_breakdown": sev_bk,
                         "affected_packages": sorted(pkgs),
                         "affected_agents": sorted(ags),
+                        "scored": scored,
                     }
                 )
             return controls
 
-        owasp = _build_controls(OWASP_LLM_TOP10, "owasp_tags", "code")
-        atlas = _build_controls(ATLAS_TECHNIQUES, "atlas_tags", "code")
-        nist = _build_controls(NIST_AI_RMF, "nist_ai_rmf_tags", "code")
-        owasp_mcp = _build_controls(OWASP_MCP_TOP10, "owasp_mcp_tags", "code")
+        owasp = _build_controls(OWASP_LLM_TOP10, "owasp_tags", "code", scored=False)
+        atlas = _build_controls(ATLAS_TECHNIQUES, "atlas_tags", "code", scored=False)
+        nist = _build_controls(NIST_AI_RMF, "nist_ai_rmf_tags", "code", scored=True)
+        owasp_mcp = _build_controls(OWASP_MCP_TOP10, "owasp_mcp_tags", "code", scored=False)
+        owasp_agentic = _build_controls(
+            OWASP_AGENTIC_TOP10,
+            "owasp_agentic_tags",
+            "code",
+            scored=False,
+        )
 
-        all_controls = owasp + atlas + nist + owasp_mcp
-        total = len(all_controls)
+        all_catalog_entries = owasp + atlas + nist + owasp_mcp + owasp_agentic
+        scored_controls = [control for control in all_catalog_entries if control["scored"]]
+        total = len(all_catalog_entries)
+        scored_total = len(scored_controls)
         # Same scorer as /v1/compliance, the per-framework route, the HTML
         # report and the evidence bundle. None of these catalogues carry
         # detective controls, so every evaluated control here is substantive.
         from agent_bom.evidence.scoring import score_compliance
 
         verdict = score_compliance(
-            passed=sum(1 for c in all_controls if c["status"] == "pass"),
-            warned=sum(1 for c in all_controls if c["status"] == "warning"),
-            failed=sum(1 for c in all_controls if c["status"] == "fail"),
+            passed=sum(1 for c in scored_controls if c["status"] == "pass"),
+            warned=sum(1 for c in scored_controls if c["status"] == "warning"),
+            failed=sum(1 for c in scored_controls if c["status"] == "fail"),
             has_evidence=has_evidence,
         )
         evaluated_controls = verdict.evaluated
-        not_evaluated_controls = total - evaluated_controls
+        not_evaluated_controls = scored_total - evaluated_controls
         score = verdict.score
 
         # Catalog-backed NIST SP 800-53 Rev 5 line (vendor-asserted), scored
@@ -148,12 +159,16 @@ async def compliance_impl(
                     "overall_score": score,
                     "overall_status": verdict.status,
                     "total_controls": total,
+                    "total_catalog_entries": len(all_catalog_entries),
+                    "scored_controls": scored_total,
+                    "unscored_catalog_entries": total - scored_total,
                     "evaluated_controls": evaluated_controls,
                     "not_evaluated_controls": not_evaluated_controls,
                     "owasp_llm_top10": owasp,
                     "mitre_atlas": atlas,
                     "nist_ai_rmf": nist,
                     "owasp_mcp_top10": owasp_mcp,
+                    "owasp_agentic_top10": owasp_agentic,
                     "nist_800_53_catalog": nist_800_53_catalog,
                 },
                 indent=2,

--- a/src/agent_bom/parsers/os_parsers.py
+++ b/src/agent_bom/parsers/os_parsers.py
@@ -413,6 +413,8 @@ def detect_os_type(root: Path = Path("/")) -> str | None:
                     "rocky",
                     "alma",
                     "almalinux",
+                    "amzn",
+                    "amazon",
                     "ol",
                     "opensuse",
                     "opensuse-leap",

--- a/src/agent_bom/secret_scanner.py
+++ b/src/agent_bom/secret_scanner.py
@@ -195,9 +195,18 @@ _ENTROPY_ASSIGN_RE = re.compile(
 )
 # Obvious non-secrets to skip even when assigned to a secret-named key.
 _ENTROPY_PLACEHOLDER_RE = re.compile(
-    r"(?i)^(?:your[_-]|xxx|placeholder|example|changeme|none|null|true|false|enabled|disabled|"
-    r"\$\{|\{\{|<[a-z]|/[a-z]|https?://|[a-z]+(?:[._-][a-z]+)+$)"
+    r"(?i)^(?:your[-_][a-z0-9_.-]+|x{3,}|placeholder(?:[-_][a-z0-9_.-]+)?|"
+    r"example(?:[-_][a-z0-9_.-]+)?|changeme(?:[-_]?\d*)?|none|null|true|false|"
+    r"enabled|disabled|\$\{[^}]*\}|\{\{[^}]*\}\}|<[a-z][^>]*>|/[a-z][^\s]*|"
+    r"https?://[^\s]+)$"
 )
+_ASSIGNED_VALUE_RE = re.compile(r"[=:]\s*['\"]?([^'\"\s,;#]+)")
+
+
+def _matched_assignment_is_placeholder(match: re.Match) -> bool:
+    """Return whether a secret-pattern match is an explicit sample value."""
+    assigned = _ASSIGNED_VALUE_RE.search(match.group(0))
+    return bool(assigned and _ENTROPY_PLACEHOLDER_RE.fullmatch(assigned.group(1)))
 
 
 def _shannon_entropy(value: str) -> float:
@@ -378,6 +387,8 @@ def _scan_file(file_path: Path, rel_path: str, *, detect_entropy: bool = False) 
         for name, pattern in CREDENTIAL_PATTERNS:
             match = pattern.search(line)
             if match:
+                if _matched_assignment_is_placeholder(match):
+                    break
                 # A secret-named variable assigned to a function/method call
                 # (e.g. OAuth token minting:
                 # `access_token = self.signing_key.sign(claims)`) is derived
@@ -403,7 +414,8 @@ def _scan_file(file_path: Path, rel_path: str, *, detect_entropy: bool = False) 
 
         # File-specific secret patterns (HIGH)
         for name, pattern in _FILE_SECRET_PATTERNS:
-            if pattern.search(line):
+            match = pattern.search(line)
+            if match and not _matched_assignment_is_placeholder(match):
                 findings.append(
                     SecretFinding(
                         file_path=rel_path,

--- a/tests/test_atlas_is_an_applicability_overlay.py
+++ b/tests/test_atlas_is_an_applicability_overlay.py
@@ -52,8 +52,16 @@ def test_control_frameworks_remain_scored() -> None:
 
     Unscoring everything would make the score vacuous rather than accurate.
     """
-    for slug in ("owasp-llm", "nist", "nist-800-53", "iso-27001", "soc2", "pci-dss"):
+    for slug in ("nist", "nist-800-53", "iso-27001", "soc2", "pci-dss"):
         assert _BY_SLUG[slug].scored is True, slug
+
+
+def test_risk_catalogs_are_applicability_overlays_not_control_scores() -> None:
+    """Top-risk catalogs identify applicable risks, not controls that passed."""
+    for slug in ("owasp-llm", "owasp-mcp", "owasp-agentic"):
+        metadata = _BY_SLUG[slug]
+        assert metadata.scored is False, slug
+        assert "not scored" in metadata.coverage.lower(), slug
 
 
 def test_overlay_coverage_text_says_it_is_not_scored() -> None:

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -138,9 +138,10 @@ def test_compliance_no_scans():
     assert data["aisvs_benchmark"]["benchmark"]["checks"] == []
     assert data["summary"]["aisvs_pass"] == 0
     assert data["summary"]["aisvs_fail"] == 0
-    # With no evidence, every control is not_assessed — not a trivial "pass".
+    # OWASP Top 10 rows are applicability overlays, so no evidence means the
+    # risks are not applicable — never a passing control claim.
     for c in data["owasp_llm_top10"]:
-        assert c["status"] == "not_assessed"
+        assert c["status"] == "not_applicable"
         assert c["findings"] == 0
     for metadata in TAG_MAPPED_FRAMEWORKS:
         assert len(data[metadata.output_key]) == metadata.control_count
@@ -347,18 +348,17 @@ def test_compliance_with_findings():
     assert data["scan_count"] == 1
     assert data["overall_status"] == "fail"  # HIGH severity → fail
 
-    # LLM05 should be fail (has HIGH severity finding)
+    # OWASP Top 10 identifies applicable risks; it does not assert a failed
+    # control. Severity remains available as evidence metadata.
     lmm05 = next(c for c in data["owasp_llm_top10"] if c["code"] == "LLM05")
-    assert lmm05["status"] == "fail"
+    assert lmm05["status"] == "applicable"
     assert lmm05["findings"] == 1
     assert "express" in lmm05["affected_packages"]
     assert "claude-desktop" in lmm05["affected_agents"]
 
-    # LLM01 should be pass (no findings)
+    # No observed finding means the risk is not applicable, not "passed".
     lmm01 = next(c for c in data["owasp_llm_top10"] if c["code"] == "LLM01")
-    # No findings map to this control — it is not_evaluated (no evidence), never a
-    # silent pass. Matches the narrative + CLI export.
-    assert lmm01["status"] == "not_evaluated"
+    assert lmm01["status"] == "not_applicable"
     assert lmm01["findings"] == 0
 
     _clear_jobs()
@@ -384,15 +384,15 @@ def test_compliance_severity_breakdown():
     data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
 
     lmm04 = next(c for c in data["owasp_llm_top10"] if c["code"] == "LLM04")
-    assert lmm04["status"] == "fail"
+    assert lmm04["status"] == "applicable"
     assert lmm04["severity_breakdown"]["critical"] == 1
     assert lmm04["severity_breakdown"]["high"] == 0
 
     _clear_jobs()
 
 
-def test_compliance_warning_status():
-    """MEDIUM-only findings produce warning (not fail) status."""
+def test_compliance_overlay_preserves_medium_severity_breakdown():
+    """An applicable risk keeps severity evidence without becoming a score."""
     _clear_jobs()
     _add_done_job(
         [
@@ -411,7 +411,7 @@ def test_compliance_warning_status():
     data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
 
     lmm05 = next(c for c in data["owasp_llm_top10"] if c["code"] == "LLM05")
-    assert lmm05["status"] == "warning"
+    assert lmm05["status"] == "applicable"
     assert lmm05["severity_breakdown"]["medium"] == 1
 
     _clear_jobs()
@@ -465,14 +465,9 @@ def test_compliance_summary_counts():
     data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
 
     s = data["summary"]
-    # Verify OWASP: 1 fail (LLM05), 9 pass
-    assert s["owasp_fail"] == 1
-    # The other 9 controls have no mapped findings → not_evaluated, not a silent
-    # pass (would otherwise inflate the score toward 100).
-    assert s["owasp_pass"] == 0
-    assert s["owasp_warn"] == 0
-    assert s["owasp_not_evaluated"] == 9
-    assert s["owasp_pass"] + s["owasp_warn"] + s["owasp_fail"] + s["owasp_not_evaluated"] == 10
+    assert s["owasp_applicable"] == 1
+    assert s["owasp_not_applicable"] == 9
+    assert s["owasp_applicable"] + s["owasp_not_applicable"] == 10
 
     _clear_jobs()
 
@@ -528,11 +523,8 @@ def test_compliance_summary_with_scan_counts_evaluated_controls():
     client = TestClient(app)
     data = client.get("/v1/compliance/summary", headers=_AUTH_HEADERS).json()
     assert data["scan_count"] == 1
-    assert data["summary"]["owasp_fail"] == 1
-    # Never-triggered controls are not_evaluated, not pass — so the evaluated
-    # split is surfaced even on a non-empty scan.
-    assert data["summary"]["owasp_pass"] == 0
-    assert data["summary"]["owasp_not_evaluated"] == 9
+    assert data["summary"]["owasp_applicable"] == 1
+    assert data["summary"]["owasp_not_applicable"] == 9
     _clear_jobs()
 
 

--- a/tests/test_compliance_report.py
+++ b/tests/test_compliance_report.py
@@ -451,7 +451,7 @@ def test_report_with_no_completed_scans_marks_controls_not_evaluated() -> None:
     assert body["scope"]["completed_scan_count"] == 0
     assert body["summary"]["pass"] == 0
     assert body["summary"]["not_evaluated"] == 1
-    assert body["summary"]["score"] == 0.0
+    assert body["summary"]["score"] is None
     control = body["controls"][0]
     assert control["source_status"] == "pass"
     assert control["status"] == "not_evaluated"
@@ -476,7 +476,7 @@ def test_report_with_missing_control_evidence_is_incomplete_not_pass() -> None:
     assert body["scope"]["completed_scan_count"] == 1
     assert body["summary"]["pass"] == 0
     assert body["summary"]["incomplete"] == 1
-    assert body["summary"]["score"] == 0.0
+    assert body["summary"]["score"] is None
     control = body["controls"][0]
     assert control["source_status"] == "pass"
     assert control["status"] == "incomplete"

--- a/tests/test_compliance_signing_disclosure.py
+++ b/tests/test_compliance_signing_disclosure.py
@@ -277,7 +277,7 @@ def test_ed25519_bundle_discloses_it_is_verifiable_and_still_verifies(ed25519_en
     ed25519_env.verify(bytes.fromhex(body["signature"]), canonical)
 
     tampered = json.loads(json.dumps(body))
-    tampered["summary"]["fail"] = 0
+    tampered["framework_label"] = f"{tampered['framework_label']} tampered"
     from agent_bom.api.compliance_signing import verify_compliance_bundle
 
     assert verify_compliance_bundle(tampered) is False
@@ -292,7 +292,7 @@ def test_tampered_bundle_rejected_under_every_signer(
     body = _fetch_bundle(seeded_client)
     assert verify_compliance_bundle(body) is True
     tampered = json.loads(json.dumps(body))
-    tampered["summary"]["fail"] = 0
+    tampered["framework_label"] = f"{tampered['framework_label']} tampered"
     assert verify_compliance_bundle(tampered) is False
 
 
@@ -380,7 +380,7 @@ def test_cli_refuses_to_trust_the_key_embedded_in_the_bundle(ed25519_env: Ed2551
 
 def test_cli_rejects_a_tampered_ed25519_bundle(ed25519_env: Ed25519PublicKey, seeded_client: TestClient, tmp_path) -> None:
     body = _fetch_bundle(seeded_client)
-    body["summary"]["fail"] = 0
+    body["framework_label"] = f"{body['framework_label']} tampered"
     bundle = _write_bundle(tmp_path, body)
     key_file = tmp_path / "pub.pem"
     key_file.write_text(_public_pem(ed25519_env))

--- a/tests/test_compliance_unrated_false_pass.py
+++ b/tests/test_compliance_unrated_false_pass.py
@@ -94,17 +94,16 @@ def test_api_all_unrated_control_is_not_evaluated_not_pass() -> None:
 
     llm05 = next(c for c in data["owasp_llm_top10"] if c["control_id"] == "LLM05")
     assert llm05["findings"] == 1
-    assert llm05["status"] == "not_evaluated"  # NOT "pass"
+    assert llm05["status"] == "applicable"
 
-    # No control passes (the only mapped one is unrated), so score is not inflated.
-    assert data["summary"]["owasp_pass"] == 0
-    assert data["summary"]["owasp_not_evaluated"] == 10
+    # Risk applicability is reported without contributing to the control score.
+    assert data["summary"]["owasp_applicable"] == 1
+    assert data["summary"]["owasp_not_applicable"] == 9
     assert data["overall_score"] == 0.0
     _clear_jobs()
 
 
-def test_api_rated_finding_unchanged() -> None:
-    """A rated (high) finding still fails — the fix only touches the all-unrated case."""
+def test_api_rated_finding_is_applicable_without_becoming_a_failed_control() -> None:
     _clear_jobs()
     _add_done_job(
         [
@@ -120,8 +119,8 @@ def test_api_rated_finding_unchanged() -> None:
     client = TestClient(app)
     data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
     llm05 = next(c for c in data["owasp_llm_top10"] if c["control_id"] == "LLM05")
-    assert llm05["status"] == "fail"
-    assert data["summary"]["owasp_fail"] == 1
+    assert llm05["status"] == "applicable"
+    assert data["summary"]["owasp_applicable"] == 1
     _clear_jobs()
 
 

--- a/tests/test_coverage_warning.py
+++ b/tests/test_coverage_warning.py
@@ -61,6 +61,19 @@ def _deb_packages(distro_version, count=8):
     ]
 
 
+def _rpm_packages(distro_name: str, distro_version: str, count: int = 8):
+    return [
+        Package(
+            name=f"rpm-pkg-{i}",
+            version="1.0-1",
+            ecosystem="rpm",
+            distro_name=distro_name,
+            distro_version=distro_version,
+        )
+        for i in range(count)
+    ]
+
+
 def test_uncovered_release_emits_warning(tmp_path):
     """A release with packages present but zero advisory rows (while the family
     is broadly covered) is flagged as an incomplete-coverage gap."""
@@ -99,6 +112,42 @@ def test_empty_db_no_false_positive(tmp_path):
     conn = init_db(tmp_path / "vulns.db")  # no rows
 
     warnings = detect_release_coverage_gaps(_deb_packages("10"), conn=conn)
+    conn.close()
+
+    assert warnings == []
+
+
+@pytest.mark.parametrize(
+    ("distro_name", "distro_version", "expected_release"),
+    [
+        ("amzn", "2023", "amazon-linux:2023"),
+        ("ol", "9.5", "oracle-linux:9"),
+        ("sles", "15.5", "sles:15"),
+    ],
+)
+def test_unsupported_rpm_advisory_family_never_looks_clean(tmp_path, distro_name, distro_version, expected_release):
+    """A known unsupported feed must warn even when the local DB is empty."""
+    conn = init_db(tmp_path / "vulns.db")
+
+    warnings = detect_release_coverage_gaps(
+        _rpm_packages(distro_name, distro_version),
+        conn=conn,
+    )
+    conn.close()
+
+    assert len(warnings) == 1
+    assert warnings[0]["release"] == expected_release
+    assert warnings[0]["reason"] == "advisory_source_unavailable"
+    assert "not a clean bill of health" in warnings[0]["detail"].lower()
+
+
+def test_supported_opensuse_release_is_not_marked_source_unavailable(tmp_path):
+    conn = init_db(tmp_path / "vulns.db")
+
+    warnings = detect_release_coverage_gaps(
+        _rpm_packages("opensuse-leap", "15.5"),
+        conn=conn,
+    )
     conn.close()
 
     assert warnings == []

--- a/tests/test_mcp_introspect.py
+++ b/tests/test_mcp_introspect.py
@@ -214,6 +214,26 @@ def test_tool_schema_resource_and_prompt_lint_findings():
     assert any("required-freeform-argument" in finding for finding in prompt_findings)
 
 
+def test_tool_schema_does_not_treat_ecosystem_as_a_system_prompt():
+    from agent_bom.mcp_introspect import _lint_tool_schema
+
+    tool = MCPTool(
+        name="lookup_package",
+        description="Look up a package",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "ecosystem": {
+                    "type": "string",
+                    "description": "Package ecosystem identifier",
+                }
+            },
+        },
+    )
+
+    assert not any("prompt-bearing-input" in finding for finding in _lint_tool_schema(tool))
+
+
 def test_server_introspection_captures_fingerprint_and_auth_mode():
     from agent_bom.mcp_introspect import ServerIntrospection
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -832,11 +832,13 @@ def test_compliance_no_agents(mock_pipeline):
     assert result["overall_score"] == 0.0
     assert result["overall_status"] == "no_data"
     assert result["evaluated_controls"] == 0
-    assert result["not_evaluated_controls"] == result["total_controls"]
+    assert result["not_evaluated_controls"] == result["scored_controls"]
+    assert result["unscored_catalog_entries"] > 0
     assert len(result["owasp_llm_top10"]) == 10
     assert len(result["mitre_atlas"]) >= 50
     assert len(result["nist_ai_rmf"]) == 14
-    assert all(control["status"] == "not_evaluated" for control in result["owasp_llm_top10"])
+    assert all(control["status"] == "not_applicable" for control in result["owasp_llm_top10"])
+    assert all(control["status"] == "not_evaluated" for control in result["nist_ai_rmf"])
 
 
 @patch("agent_bom.mcp_server._run_scan_pipeline")
@@ -883,9 +885,9 @@ def test_compliance_with_findings(mock_pipeline):
     assert result["overall_status"] == "fail"
     assert result["overall_score"] < 100.0
 
-    # LLM05 should be fail
+    # OWASP Top 10 is a risk-applicability overlay, not a passed/failed control.
     lmm05 = next(c for c in result["owasp_llm_top10"] if c["code"] == "LLM05")
-    assert lmm05["status"] == "fail"
+    assert lmm05["status"] == "applicable"
     assert lmm05["findings"] == 1
 
 

--- a/tests/test_mcp_tool_impls.py
+++ b/tests/test_mcp_tool_impls.py
@@ -587,10 +587,12 @@ async def test_compliance_impl_never_passes_controls_it_did_not_evaluate():
     assert data["overall_status"] == "no_data", "a clean scan read as a compliant estate"
     assert data["overall_score"] == 0.0, "no_data still carried a score"
     assert data["evaluated_controls"] == 0
-    assert data["not_evaluated_controls"] == data["total_controls"]
-    for line in ("owasp_llm_top10", "mitre_atlas", "nist_ai_rmf", "owasp_mcp_top10"):
+    assert data["not_evaluated_controls"] == data["scored_controls"]
+    assert data["unscored_catalog_entries"] > 0
+    for line in ("owasp_llm_top10", "mitre_atlas", "owasp_mcp_top10", "owasp_agentic_top10"):
         statuses = {c["status"] for c in data[line]}
-        assert statuses == {"not_evaluated"}, f"{line} asserted a status it never evaluated: {statuses}"
+        assert statuses == {"not_applicable"}, f"{line} asserted a risk with no evidence: {statuses}"
+    assert {control["status"] for control in data["nist_ai_rmf"]} == {"not_evaluated"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_tool_rules.py
+++ b/tests/test_mcp_tool_rules.py
@@ -121,6 +121,13 @@ class TestPromptPassthroughRule:
         )
         assert not [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-06-prompt-passthrough"]
 
+    def test_silent_when_description_only_contains_ecosystem(self) -> None:
+        tool = _tool(
+            "lookup_package",
+            ecosystem={"type": "string", "description": "Package ecosystem identifier"},
+        )
+        assert not [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-06-prompt-passthrough"]
+
 
 class TestWeakDescriptionRule:
     def test_fires_when_description_missing(self) -> None:

--- a/tests/test_os_distro_coverage.py
+++ b/tests/test_os_distro_coverage.py
@@ -308,6 +308,7 @@ def test_covered_os_distros_reads_from_db(tmp_db):
         ("almalinux", "rpm"),
         ("opensuse-leap", "rpm"),
         ("sles", "rpm"),
+        ("amzn", "rpm"),
         ("wolfi", "apk"),
         ("chainguard", "apk"),
     ],

--- a/tests/test_secret_scanner.py
+++ b/tests/test_secret_scanner.py
@@ -111,6 +111,28 @@ def test_scan_secrets_still_flags_literal_token_passed_to_a_call(tmp_path: Path)
     assert any(finding.secret_type == "AWS Access Key" and finding.severity == "critical" for finding in result.findings)
 
 
+def test_scan_secrets_ignores_explicit_placeholder_assignments(tmp_path: Path):
+    (tmp_path / ".env").write_text(
+        'DB_PASSWORD=changeme\nAUTH_TOKEN=your-token-here\nsecret_key = "placeholder-secret"\n',
+        encoding="utf-8",
+    )
+
+    result = scan_secrets(tmp_path)
+
+    assert result.total == 0
+
+
+def test_scan_secrets_does_not_suppress_real_assigned_secrets(tmp_path: Path):
+    (tmp_path / ".env").write_text(
+        "DB_PASSWORD=correct-horse-battery-staple\n",
+        encoding="utf-8",
+    )
+
+    result = scan_secrets(tmp_path)
+
+    assert any(finding.secret_type == ".env password" for finding in result.findings)
+
+
 def test_scan_secrets_warns_on_non_directory(tmp_path: Path):
     target = tmp_path / "not-a-dir.txt"
     target.write_text("hello", encoding="utf-8")


### PR DESCRIPTION
## Summary

- Treat OWASP LLM, MCP, and Agentic Top 10 entries as risk-applicability overlays instead of passed or failed controls, and align REST/MCP results with explicit scored versus unscored totals.
- Suppress only explicit secret placeholders while preserving real assigned passphrases; make MCP prompt heuristics token-aware so `ecosystem` is not classified as `system`.
- Emit structured advisory-source-unavailable evidence for Amazon Linux, Oracle Linux, and SLES inventories until dedicated verified feeds are supported.

## Verification

- `pytest` focused REST/MCP compliance, secret scanner, coverage, OS parser, and MCP-rule matrix: **391 passed**
- Narrow post-expansion regressions for unscored reports and signed-bundle tampering: **5 passed**
- `make preflight`: passed (OpenAPI, schemas, product surfaces, release consistency, metrics, accuracy, SDK patterns, SVG guards)
- Ruff check and format: passed
- mypy on seven affected source modules: passed
- exception-sanitization guard and `git diff --check`: passed

## Notes

- Existing control frameworks remain scored; only risk/technique applicability catalogs are unscored.
- Unsupported RPM families remain inventoried and explicitly partial. This change does not claim new advisory-feed coverage.
- PostgreSQL tenant-GUC hardening is intentionally excluded: PostgreSQL parameter `SET` privileges do not prevent an application role from changing an ordinary custom GUC, so a cosmetic grant/revoke would not establish the claimed boundary.
