### PR TITLE
fix(control-plane): preserve evidence integrity and write authorization

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260728_03_trusted_maintenance_rls.py
+++ b/deploy/supabase/postgres/alembic/versions/20260728_03_trusted_maintenance_rls.py
@@ -127,9 +127,7 @@ def _configure_runtime_passwords() -> None:
             # PostgreSQL utility statements do not accept bind parameters.
             # psycopg composition quotes the fixed allowlisted identifier and
             # secret literal without raw string interpolation.
-            driver_connection.execute(
-                sql.SQL("ALTER ROLE {} PASSWORD {}").format(sql.Identifier(role), sql.Literal(password))
-            )
+            driver_connection.execute(sql.SQL("ALTER ROLE {} PASSWORD {}").format(sql.Identifier(role), sql.Literal(password)))
         elif password is not None and not _bootstrap_password_was_applied(bind, role, password):
             _validate_existing_runtime_login(os.environ[url_name].strip(), password, role)
 
@@ -218,7 +216,7 @@ def upgrade() -> None:
     op.execute(
         """
         CREATE POLICY scan_dispatch_queue_tenant_isolation ON scan_dispatch_queue
-          FOR ALL TO agent_bom_app
+          FOR ALL
           USING (tenant_id = public.abom_current_tenant())
           WITH CHECK (tenant_id = public.abom_current_tenant())
         """

--- a/deploy/supabase/postgres/alembic/versions/20260818_01_hub_ledger_scan_id.py
+++ b/deploy/supabase/postgres/alembic/versions/20260818_01_hub_ledger_scan_id.py
@@ -1,0 +1,47 @@
+"""Materialise the Compliance Hub ledger scan key.
+
+The SQLite ledger already stores and indexes the scan/batch identifier.  The
+Postgres ledger still decoded ``payload`` for each filtered row, preventing an
+index-backed scan view at scale.  Add and backfill the additive column, then
+create the same partial tenant/scan index used by new installations.
+
+Revision ID: 20260818_01
+Revises: 20260812_01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260818_01"
+down_revision = "20260812_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE IF EXISTS compliance_hub_findings ADD COLUMN IF NOT EXISTS scan_id TEXT NOT NULL DEFAULT ''")
+    op.execute(
+        "UPDATE compliance_hub_findings SET scan_id = "
+        "COALESCE(NULLIF(payload->>'batch_id', ''), payload->>'scan_id', '') "
+        "WHERE scan_id = '' AND "
+        "COALESCE(NULLIF(payload->>'batch_id', ''), payload->>'scan_id', '') <> ''"
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_scan ON compliance_hub_findings(tenant_id, scan_id) WHERE scan_id <> ''")
+    # The original tenant policy named ``agent_bom_app`` before that optional
+    # runtime role necessarily existed, so a pristine Alembic-only database
+    # could fail mid-upgrade.  A role-neutral policy applies to every caller and
+    # still enforces the same tenant predicate; the separately gated maintenance
+    # policy remains the only bypass path.
+    op.execute("DROP POLICY IF EXISTS scan_dispatch_queue_tenant_isolation ON scan_dispatch_queue")
+    op.execute(
+        "CREATE POLICY scan_dispatch_queue_tenant_isolation ON scan_dispatch_queue "
+        "FOR ALL USING (tenant_id = public.abom_current_tenant()) "
+        "WITH CHECK (tenant_id = public.abom_current_tenant())"
+    )
+
+
+def downgrade() -> None:
+    # Additive and non-destructive: current writers address this column, so a
+    # rollback must leave it present to keep the running application writable.
+    return

--- a/deploy/supabase/postgres/alembic/versions/20260818_01_hub_ledger_scan_id.py
+++ b/deploy/supabase/postgres/alembic/versions/20260818_01_hub_ledger_scan_id.py
@@ -21,13 +21,17 @@ depends_on = None
 
 def upgrade() -> None:
     op.execute("ALTER TABLE IF EXISTS compliance_hub_findings ADD COLUMN IF NOT EXISTS scan_id TEXT NOT NULL DEFAULT ''")
-    op.execute(
-        "UPDATE compliance_hub_findings SET scan_id = "
-        "COALESCE(NULLIF(payload->>'batch_id', ''), payload->>'scan_id', '') "
-        "WHERE scan_id = '' AND "
-        "COALESCE(NULLIF(payload->>'batch_id', ''), payload->>'scan_id', '') <> ''"
-    )
-    op.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_scan ON compliance_hub_findings(tenant_id, scan_id) WHERE scan_id <> ''")
+    ledger_exists = op.get_bind().exec_driver_sql("SELECT to_regclass('public.compliance_hub_findings')").scalar()
+    if ledger_exists is not None:
+        op.execute(
+            "UPDATE compliance_hub_findings SET scan_id = "
+            "COALESCE(NULLIF(payload->>'batch_id', ''), payload->>'scan_id', '') "
+            "WHERE scan_id = '' AND "
+            "COALESCE(NULLIF(payload->>'batch_id', ''), payload->>'scan_id', '') <> ''"
+        )
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_scan ON compliance_hub_findings(tenant_id, scan_id) WHERE scan_id <> ''"
+        )
     # The original tenant policy named ``agent_bom_app`` before that optional
     # runtime role necessarily existed, so a pristine Alembic-only database
     # could fail mid-upgrade.  A role-neutral policy applies to every caller and

--- a/deploy/supabase/postgres/runtime-schema.sql
+++ b/deploy/supabase/postgres/runtime-schema.sql
@@ -173,14 +173,12 @@ ALTER TABLE scan_dispatch_queue ENABLE ROW LEVEL SECURITY;
 ALTER TABLE scan_dispatch_queue FORCE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS scan_dispatch_queue_tenant_isolation ON scan_dispatch_queue;
 DROP POLICY IF EXISTS scan_dispatch_queue_maintenance ON scan_dispatch_queue;
+CREATE POLICY scan_dispatch_queue_tenant_isolation ON scan_dispatch_queue
+  FOR ALL
+  USING (tenant_id = public.abom_current_tenant())
+  WITH CHECK (tenant_id = public.abom_current_tenant());
 DO $queue_rls$
 BEGIN
- IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname='agent_bom_app') THEN
-   CREATE POLICY scan_dispatch_queue_tenant_isolation ON scan_dispatch_queue
-     FOR ALL TO agent_bom_app
-     USING (tenant_id = public.abom_current_tenant())
-     WITH CHECK (tenant_id = public.abom_current_tenant());
- END IF;
  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname='agent_bom_rls_maintenance') THEN
    CREATE POLICY scan_dispatch_queue_maintenance ON scan_dispatch_queue
      FOR ALL TO agent_bom_rls_maintenance
@@ -205,7 +203,7 @@ CREATE INDEX IF NOT EXISTS idx_credential_refs_tenant_updated ON credential_refs
 -- Audit-chain checkpoint is separated from the append-only audit rows.
 CREATE TABLE IF NOT EXISTS audit_chain_checkpoint (tenant_id TEXT PRIMARY KEY,entry_count BIGINT NOT NULL DEFAULT 0,head_signature TEXT NOT NULL DEFAULT '',updated_at TEXT NOT NULL DEFAULT '');
 
-CREATE TABLE IF NOT EXISTS compliance_hub_findings (tenant_id TEXT NOT NULL,finding_id TEXT NOT NULL,ingested_at TEXT NOT NULL,source TEXT NOT NULL,applicable_frameworks_csv TEXT NOT NULL DEFAULT '',payload JSONB NOT NULL,ordinal BIGSERIAL NOT NULL,effective_reach_score DOUBLE PRECISION NOT NULL DEFAULT 0,origin TEXT NOT NULL DEFAULT '',severity TEXT NOT NULL DEFAULT '',severity_rank INTEGER NOT NULL DEFAULT 0,cvss_score DOUBLE PRECISION NOT NULL DEFAULT 0,PRIMARY KEY(tenant_id,finding_id));
+CREATE TABLE IF NOT EXISTS compliance_hub_findings (tenant_id TEXT NOT NULL,finding_id TEXT NOT NULL,ingested_at TEXT NOT NULL,source TEXT NOT NULL,applicable_frameworks_csv TEXT NOT NULL DEFAULT '',payload JSONB NOT NULL,ordinal BIGSERIAL NOT NULL,effective_reach_score DOUBLE PRECISION NOT NULL DEFAULT 0,origin TEXT NOT NULL DEFAULT '',severity TEXT NOT NULL DEFAULT '',severity_rank INTEGER NOT NULL DEFAULT 0,cvss_score DOUBLE PRECISION NOT NULL DEFAULT 0,scan_id TEXT NOT NULL DEFAULT '',PRIMARY KEY(tenant_id,finding_id));
 CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_order ON compliance_hub_findings(tenant_id,ordinal);
 CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin_reach ON compliance_hub_findings(tenant_id,origin,effective_reach_score DESC,ordinal);
 CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin ON compliance_hub_findings(tenant_id,origin);
@@ -216,6 +214,7 @@ CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_reach_all ON compliance_hub_f
 CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_cvss_all ON compliance_hub_findings(tenant_id,cvss_score DESC,ordinal);
 CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_severity_all ON compliance_hub_findings(tenant_id,severity_rank DESC,ordinal);
 CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_severity_ci ON compliance_hub_findings(tenant_id,LOWER(severity)) WHERE severity <> '';
+CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_scan ON compliance_hub_findings(tenant_id,scan_id) WHERE scan_id <> '';
 CREATE TABLE IF NOT EXISTS hub_findings_current (tenant_id TEXT NOT NULL,canonical_id TEXT NOT NULL,first_seen TEXT NOT NULL,last_seen TEXT NOT NULL,status TEXT NOT NULL DEFAULT 'open',severity TEXT NOT NULL DEFAULT '',severity_rank INTEGER NOT NULL DEFAULT 0,cvss_score DOUBLE PRECISION NOT NULL DEFAULT 0,effective_reach_score DOUBLE PRECISION NOT NULL DEFAULT 0,scan_count INTEGER NOT NULL DEFAULT 1,resolved_at TEXT,reopened_at TEXT,updated_at TEXT NOT NULL,payload JSONB NOT NULL,ledger_finding_id TEXT,origin TEXT NOT NULL DEFAULT '',scan_id TEXT NOT NULL DEFAULT '',ledger_ordinal BIGINT NOT NULL DEFAULT 9223372036854775807,PRIMARY KEY(tenant_id,canonical_id));
 CREATE TABLE IF NOT EXISTS hub_findings_current_observations (tenant_id TEXT NOT NULL,canonical_id TEXT NOT NULL,scan_id TEXT NOT NULL,observed_at TEXT NOT NULL,PRIMARY KEY(tenant_id,canonical_id,scan_id));
 CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_last_seen ON hub_findings_current(tenant_id,last_seen DESC);

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -447,7 +447,7 @@ def _redact_finding(payload: dict[str, Any]) -> dict[str, Any]:
         clean["id"] = str(payload["id"])
     if "source" not in clean and "source" in payload:
         clean["source"] = str(payload["source"])
-    for key in ("origin", "batch_id", "bulk_ordinal", "intel_ref", "framework_ref"):
+    for key in ("origin", "ingest_source", "batch_id", "bulk_ordinal", "intel_ref", "framework_ref"):
         if key not in clean and key in payload:
             clean[key] = payload[key]
     return clean
@@ -1476,7 +1476,8 @@ class InMemoryComplianceHubStore:
             if canonical_id in present_canonical_ids:
                 continue
             payload = row.get("payload") or {}
-            if scope_source is not None and str(payload.get("source") or "") != scope_source:
+            payload_scope = str(payload.get("ingest_source") or payload.get("source") or "")
+            if scope_source is not None and payload_scope != scope_source:
                 continue
             merged = dict(row)
             merged["status"] = "resolved"
@@ -1984,7 +1985,7 @@ class SQLiteComplianceHubStore:
                     str(payload.get("severity") or ""),
                     _severity_rank(payload),
                     _cvss_value(payload),
-                    str(payload.get("scan_id") or ""),
+                    str(payload.get("batch_id") or payload.get("scan_id") or ""),
                 )
             )
         existing_ids = self._existing_finding_ids(tenant_id, finding_ids)
@@ -2555,7 +2556,7 @@ class SQLiteComplianceHubStore:
         where = ["tenant_id = ?", "status IN ('open', 'reopened')"]
         params: list[Any] = [tenant_id]
         if scope_source is not None:
-            where.append("json_extract(payload, '$.source') = ?")
+            where.append("COALESCE(json_extract(payload, '$.ingest_source'), json_extract(payload, '$.source')) = ?")
             params.append(scope_source)
         where_sql = " AND ".join(where)
         rows = self._conn.execute(

--- a/src/agent_bom/api/hub_current_payload.py
+++ b/src/agent_bom/api/hub_current_payload.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any
 
-_OVERLAY_KEYS = ("origin", "batch_id", "scan_id", "source", "id", "canonical_id")
+_OVERLAY_KEYS = ("origin", "ingest_source", "batch_id", "scan_id", "source", "id", "canonical_id")
 
 
 def resolve_ledger_finding_id(payload: Mapping[str, Any], *, canonical_id: str = "") -> str:

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -386,6 +386,7 @@ class PostgresComplianceHubStore:
                     severity TEXT NOT NULL DEFAULT '',
                     severity_rank INTEGER NOT NULL DEFAULT 0,
                     cvss_score DOUBLE PRECISION NOT NULL DEFAULT 0,
+                    scan_id TEXT NOT NULL DEFAULT '',
                     PRIMARY KEY (tenant_id, finding_id)
                 )
                 """
@@ -439,6 +440,17 @@ class PostgresComplianceHubStore:
                 "UPDATE compliance_hub_findings SET cvss_score = COALESCE((payload->>'cvss_score')::float8, 0) "
                 "WHERE cvss_score = 0 AND COALESCE((payload->>'cvss_score')::float8, 0) <> 0",
             )
+            # Keep the append ledger filterable without decoding every JSONB
+            # payload.  ``batch_id`` is the canonical ingest snapshot key; a
+            # direct ``scan_id`` remains supported for scan-produced rows.
+            conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN IF NOT EXISTS scan_id TEXT NOT NULL DEFAULT ''")
+            _run_gated_backfill(
+                conn,
+                "compliance_hub_findings.scan_id",
+                "UPDATE compliance_hub_findings SET scan_id = "
+                "COALESCE(NULLIF(payload->>'batch_id', ''), payload->>'scan_id', '') "
+                "WHERE scan_id = '' AND COALESCE(NULLIF(payload->>'batch_id', ''), payload->>'scan_id', '') <> ''",
+            )
             self._migrate_primary_key(conn)
             conn.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_order ON compliance_hub_findings(tenant_id, ordinal)")
             conn.execute("DROP INDEX IF EXISTS idx_hub_findings_tenant_reach")
@@ -491,6 +503,9 @@ class PostgresComplianceHubStore:
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_severity_ci "
                 "ON compliance_hub_findings(tenant_id, LOWER(severity)) WHERE severity <> ''"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_scan ON compliance_hub_findings(tenant_id, scan_id) WHERE scan_id <> ''"
             )
             _ensure_tenant_rls(conn, "compliance_hub_findings", "tenant_id")
             from agent_bom.api.finding_lifecycle import (
@@ -682,6 +697,7 @@ class PostgresComplianceHubStore:
                 str(payload.get("severity") or ""),
                 _severity_rank(payload),
                 _cvss_value(payload),
+                str(payload.get("batch_id") or payload.get("scan_id") or ""),
             )
             for finding_id, frameworks_csv, payload in rows_to_insert
         ]
@@ -691,8 +707,8 @@ class PostgresComplianceHubStore:
                     """
                     INSERT INTO compliance_hub_findings
                         (tenant_id, finding_id, ingested_at, source, applicable_frameworks_csv, payload,
-                         effective_reach_score, origin, severity, severity_rank, cvss_score)
-                    VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s, %s)
+                         effective_reach_score, origin, severity, severity_rank, cvss_score, scan_id)
+                    VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s, %s, %s)
                     ON CONFLICT (tenant_id, finding_id) DO UPDATE SET
                         ingested_at = EXCLUDED.ingested_at,
                         source = EXCLUDED.source,
@@ -702,7 +718,8 @@ class PostgresComplianceHubStore:
                         origin = EXCLUDED.origin,
                         severity = EXCLUDED.severity,
                         severity_rank = EXCLUDED.severity_rank,
-                        cvss_score = EXCLUDED.cvss_score
+                        cvss_score = EXCLUDED.cvss_score,
+                        scan_id = EXCLUDED.scan_id
                     """,
                     insert_params,
                 )
@@ -802,10 +819,10 @@ class PostgresComplianceHubStore:
             # Filter on the materialised severity STRING (exact, lowercased) so
             # every backend agrees; ``severity_rank`` collapses info==low and is
             # kept for ORDER BY only (#3192).
-            where.append("LOWER(severity) = %s")
+            where.append("severity <> '' AND LOWER(severity) = %s")
             params.append(severity.lower())
         if scan_id is not None:
-            where.append("payload->>'scan_id' = %s")
+            where.append("scan_id = %s AND scan_id <> ''")
             params.append(scan_id)
         where_sql = " AND ".join(where)
         order_sql = _postgres_order_clause(sort)
@@ -1451,7 +1468,7 @@ class PostgresComplianceHubStore:
         where = ["tenant_id = %s", "status IN ('open', 'reopened')"]
         params: list[Any] = [tenant_id]
         if scope_source is not None:
-            where.append("payload->>'source' = %s")
+            where.append("COALESCE(payload->>'ingest_source', payload->>'source') = %s")
             params.append(scope_source)
         where_sql = " AND ".join(where)
         total = 0

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -2498,6 +2498,12 @@ async def ingest_compliance_findings(request: Request) -> dict:
 
     payloads = [f.to_dict() for f in findings]
     for payload in payloads:
+        # Preserve the parser's semantic finding source (for example
+        # ``EXTERNAL``) separately from the durable import stream used to scope
+        # absent reconciliation.  Conflating the two made a CSV/SARIF
+        # reconcile report success while resolving zero prior findings.
+        payload["ingest_source"] = fmt
+        payload["origin"] = "bulk_ingest"
         frameworks = payload.get("applicable_frameworks")
         if isinstance(frameworks, list):
             payload["applicable_frameworks"] = [normalize_framework_slug(str(slug)) for slug in frameworks if slug]

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -2291,7 +2291,11 @@ def _resolve_bulk_findings_total(
             return bulk_total, False
         cached = get_cached_total(key)
         if cached is not None:
-            return cached, True
+            # Cache entries are populated only from an exact store COUNT.  A
+            # normal request reusing that value remains complete; labelling it
+            # approximate made the campaign workflow reject a second request
+            # as provisional even though the underlying membership was exact.
+            return cached, False
         return bulk_total, False
 
     if offset == 0 and bulk_total is not None:

--- a/src/agent_bom/findings_push.py
+++ b/src/agent_bom/findings_push.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from agent_bom.finding import FindingType
 from agent_bom.models import Package, Severity
 
 
@@ -41,6 +42,7 @@ def packages_to_bulk_findings(
                     "fixed_version": vuln.fixed_version,
                     "cvss_score": vuln.cvss_score,
                     "is_kev": bool(vuln.is_kev),
+                    "finding_type": FindingType.CVE.value,
                     "source": source,
                     "origin": "bulk_ingest",
                 }

--- a/tests/test_compliance_hub_api.py
+++ b/tests/test_compliance_hub_api.py
@@ -152,6 +152,41 @@ def test_ingest_csv_classifies_cve_rows():
     assert body["ingested"] == 1
 
 
+def test_ingest_reconcile_absent_uses_the_import_stream_not_parser_source():
+    """A second import must resolve rows absent from the same format stream.
+
+    Parser findings use the semantic source ``EXTERNAL``.  Reconciliation is
+    scoped to the import stream (``csv``/``sarif``/...), so those two concepts
+    must not be conflated or an apparently successful reconcile resolves zero
+    findings.
+    """
+    client = _client()
+    first = client.post(
+        "/v1/compliance/ingest",
+        json={"format": "csv", "content": "Title,Severity\nkept,high\ndropped,medium\n"},
+    )
+    assert first.status_code == 201, first.text
+
+    second = client.post(
+        "/v1/compliance/ingest",
+        json={
+            "format": "csv",
+            "content": "Title,Severity\nkept,high\n",
+            "reconcile_absent": True,
+            "observed_at": "2026-08-18T12:00:00Z",
+        },
+    )
+    assert second.status_code == 201, second.text
+    assert second.json()["reconciled"] == 1
+
+    resolved = client.get("/v1/findings", params={"status": "resolved", "limit": 50})
+    assert resolved.status_code == 200, resolved.text
+    rows = resolved.json()["findings"]
+    assert len(rows) == 1
+    assert rows[0]["title"] == "dropped"
+    assert rows[0]["source"] == "EXTERNAL"
+
+
 # ─── GET /v1/compliance/hub/findings ─────────────────────────────────────────
 
 
@@ -327,9 +362,9 @@ def test_list_hub_findings_cursor_crosses_native_prefix_into_durable_rows():
         "native_scan",
         "native_scan",
         "native_scan",
-        "durable_hub",
-        "durable_hub",
-        "durable_hub",
+        "bulk_ingest",
+        "bulk_ingest",
+        "bulk_ingest",
     ]
 
 

--- a/tests/test_findings_push.py
+++ b/tests/test_findings_push.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from agent_bom.finding_scope import domain_for_row
 from agent_bom.findings_push import load_push_findings, load_push_findings_file, packages_to_bulk_findings
 from agent_bom.parsers.external_scanners import parse_trivy_json
 from tests.test_external_scanners import TRIVY_BASIC
@@ -17,6 +18,8 @@ def test_packages_to_bulk_findings_projects_scanner_rows() -> None:
     assert findings
     assert findings[0]["source"] == "trivy-ci"
     assert findings[0]["origin"] == "bulk_ingest"
+    assert findings[0]["finding_type"] == "CVE"
+    assert domain_for_row(findings[0]) == "vuln"
     assert findings[0]["package_name"] == packages[0].name
     assert findings[0]["vulnerability_id"]
 

--- a/tests/test_postgres_ledger_scan_filter.py
+++ b/tests/test_postgres_ledger_scan_filter.py
@@ -1,0 +1,89 @@
+"""Postgres ledger filter parity and migration contracts.
+
+SQLite already materialises ``scan_id`` on the append ledger.  These contracts
+keep Postgres from falling back to per-row JSONB extraction, and require the
+forward migration/runtime bootstrap to stay aligned for existing and new
+installations.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+
+from agent_bom.api import postgres_compliance_hub as hub_module
+from agent_bom.api.postgres_compliance_hub import PostgresComplianceHubStore
+
+ROOT = Path(__file__).parent.parent
+MIGRATION = ROOT / "deploy/supabase/postgres/alembic/versions/20260818_01_hub_ledger_scan_id.py"
+RUNTIME_SCHEMA = ROOT / "deploy/supabase/postgres/runtime-schema.sql"
+
+
+class _Rows:
+    def __init__(self, rows: list[tuple[object, ...]]) -> None:
+        self._rows = rows
+
+    def fetchone(self) -> tuple[object, ...] | None:
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self) -> list[tuple[object, ...]]:
+        return self._rows
+
+
+class _ReadConnection:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[object, ...] | None]] = []
+
+    def execute(self, sql: str, params: tuple[object, ...] | None = None) -> _Rows:
+        self.executed.append((sql, params))
+        return _Rows([(0,)] if "COUNT(*)" in sql else [])
+
+
+def test_postgres_ledger_filters_use_materialized_partial_indexes(monkeypatch) -> None:
+    conn = _ReadConnection()
+
+    @contextmanager
+    def _connection(_pool):
+        yield conn
+
+    monkeypatch.setattr(hub_module, "_tenant_connection", _connection)
+    monkeypatch.setattr(hub_module, "hydrate_finding_payloads_postgres", lambda _conn, _tenant, payloads: payloads)
+    store = object.__new__(PostgresComplianceHubStore)
+    store._pool = object()
+
+    rows, total = store.list_page(
+        "tenant-a",
+        limit=25,
+        severity="HIGH",
+        scan_id="scan-42",
+    )
+
+    assert rows == [] and total == 0
+    normalized = [" ".join(sql.split()) for sql, _params in conn.executed]
+    assert normalized
+    for sql in normalized:
+        assert "severity <> '' AND LOWER(severity) = %s" in sql
+        assert "scan_id = %s AND scan_id <> ''" in sql
+        assert "payload->>'scan_id'" not in sql
+
+
+def test_postgres_ledger_scan_id_is_forward_migrated_and_bootstrapped() -> None:
+    assert MIGRATION.exists(), "released databases need a forward migration for the materialized scan_id"
+    migration = MIGRATION.read_text()
+    runtime = RUNTIME_SCHEMA.read_text()
+
+    for sql in (migration, runtime):
+        assert "scan_id TEXT NOT NULL DEFAULT ''" in sql
+        assert "idx_hub_findings_tenant_scan" in sql
+        assert "WHERE scan_id <> ''" in sql
+
+    assert "COALESCE(NULLIF(payload->>'batch_id', ''), payload->>'scan_id', '')" in migration
+
+
+def test_postgres_ledger_write_materializes_batch_or_scan_id() -> None:
+    source = (ROOT / "src/agent_bom/api/postgres_compliance_hub.py").read_text()
+    insert_start = source.index("INSERT INTO compliance_hub_findings")
+    insert = source[insert_start : source.index("ON CONFLICT", insert_start)]
+
+    assert "scan_id" in insert
+    assert 'payload.get("batch_id") or payload.get("scan_id")' in source

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -616,6 +616,36 @@ def test_trusted_maintenance_queue_policy_does_not_require_precreated_app_role()
     assert "TO agent_bom_app" not in forward_policy
 
 
+def test_hub_ledger_scan_id_migration_skips_backfill_when_ledger_is_absent() -> None:
+    """A pristine Alembic path may not provision the optional ledger table."""
+    migration = _load_module(HUB_LEDGER_SCAN_ID, "hub_ledger_scan_id_pristine")
+    statements: list[str] = []
+    probes: list[str] = []
+
+    class _MissingRelationResult:
+        @staticmethod
+        def scalar() -> None:
+            return None
+
+    class _PristineBind:
+        @staticmethod
+        def exec_driver_sql(statement: str) -> _MissingRelationResult:
+            probes.append(statement)
+            return _MissingRelationResult()
+
+    migration.op = SimpleNamespace(
+        get_bind=lambda: _PristineBind(),
+        execute=statements.append,
+    )
+
+    migration.upgrade()
+
+    assert probes == ["SELECT to_regclass('public.compliance_hub_findings')"]
+    assert any("ALTER TABLE IF EXISTS compliance_hub_findings" in statement for statement in statements)
+    assert not any("UPDATE compliance_hub_findings" in statement for statement in statements)
+    assert not any("idx_hub_findings_tenant_scan" in statement for statement in statements)
+
+
 def test_trusted_maintenance_migration_preserves_explicit_superuser_acknowledgement(monkeypatch) -> None:
     """The dev escape hatch must not grant the app maintenance-marker membership."""
     monkeypatch.setitem(sys.modules, "alembic", SimpleNamespace(op=SimpleNamespace()))

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -616,8 +616,9 @@ def test_trusted_maintenance_queue_policy_does_not_require_precreated_app_role()
     assert "TO agent_bom_app" not in forward_policy
 
 
-def test_hub_ledger_scan_id_migration_skips_backfill_when_ledger_is_absent() -> None:
+def test_hub_ledger_scan_id_migration_skips_backfill_when_ledger_is_absent(monkeypatch) -> None:
     """A pristine Alembic path may not provision the optional ledger table."""
+    monkeypatch.setitem(sys.modules, "alembic", SimpleNamespace(op=SimpleNamespace()))
     migration = _load_module(HUB_LEDGER_SCAN_ID, "hub_ledger_scan_id_pristine")
     statements: list[str] = []
     probes: list[str] = []

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -35,6 +35,7 @@ AUDIT_FORK_GUARD_INDEX = VERSIONS_DIR / "20260719_01_audit_fork_guard_index.py"
 HUB_OBSERVATIONS_PARTITION = VERSIONS_DIR / "20260705_01_hub_observations_partition.py"
 BOOTSTRAP = ALEMBIC_DIR / "bootstrap.py"
 RUNTIME_SCHEMA_SQL = POSTGRES_DIR / "runtime-schema.sql"
+HUB_LEDGER_SCAN_ID = VERSIONS_DIR / "20260818_01_hub_ledger_scan_id.py"
 
 # The fork-guard UNIQUE index is spelled differently in its two schema sources:
 # the dedicated migration concatenates two quoted Python string literals, while
@@ -46,7 +47,7 @@ _FORK_GUARD_INDEX_CANON = "createuniqueindexifnotexistsaudit_log_team_prevsig_un
 
 # The newest migration. One place to update when a revision lands, so the
 # single-head property and the head's identity do not drift apart.
-ALEMBIC_HEAD = "20260812_01"
+ALEMBIC_HEAD = "20260818_01"
 
 
 def _canonical_sql(text: str) -> str:
@@ -595,6 +596,24 @@ def test_trusted_maintenance_migration_is_forward_only_and_preserves_queue_rows(
         "DELETE FROM scan_dispatch_queue",
     ):
         assert destructive not in sql
+
+
+def test_trusted_maintenance_queue_policy_does_not_require_precreated_app_role() -> None:
+    """Alembic must upgrade an empty database before runtime roles exist."""
+    sql = TRUSTED_MAINTENANCE_RLS.read_text()
+    policy = sql.split("CREATE POLICY scan_dispatch_queue_tenant_isolation", 1)[1].split('"""', 1)[0]
+    assert "TO agent_bom_app" not in policy
+    assert "tenant_id = public.abom_current_tenant()" in policy
+
+    runtime = RUNTIME_SCHEMA_SQL.read_text()
+    runtime_policy = runtime.split("CREATE POLICY scan_dispatch_queue_tenant_isolation", 1)[1].split(";", 1)[0]
+    assert "TO agent_bom_app" not in runtime_policy
+
+    forward = HUB_LEDGER_SCAN_ID.read_text()
+    assert "DROP POLICY IF EXISTS scan_dispatch_queue_tenant_isolation" in forward
+    assert "CREATE POLICY scan_dispatch_queue_tenant_isolation" in forward
+    forward_policy = forward.split("CREATE POLICY scan_dispatch_queue_tenant_isolation", 1)[1].split('"', 1)[0]
+    assert "TO agent_bom_app" not in forward_policy
 
 
 def test_trusted_maintenance_migration_preserves_explicit_superuser_acknowledgement(monkeypatch) -> None:

--- a/tests/test_risk_campaigns.py
+++ b/tests/test_risk_campaigns.py
@@ -561,6 +561,21 @@ def test_campaign_api_derives_from_bulk_findings_spine() -> None:
     body = response.json()
     assert body["count"] == 2
     assert {campaign["source"] for campaign in body["campaigns"]} == {"canonical_findings_spine"}
+    assert body["membership_complete"] is True
+    assert body["truncated"] is False
+
+    campaign = body["campaigns"][0]
+    updated = client.patch(
+        f"/v1/campaigns/{campaign['id']}",
+        json={
+            "version": campaign["version"],
+            "owner": "security-platform",
+            "state": "in_progress",
+        },
+        headers=_headers(tenant="default"),
+    )
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["owner"] == "security-platform"
 
 
 def test_findings_window_excludes_old_completed_scan_but_keeps_recent_bulk() -> None:

--- a/ui/app/fleet/page.tsx
+++ b/ui/app/fleet/page.tsx
@@ -42,6 +42,7 @@ import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
 import { useChartTheme } from "@/lib/theme-colors";
 import { EndpointFleetPanel } from "@/components/endpoint-fleet-panel";
+import { useAuthState } from "@/components/auth-provider";
 
 function downloadJson(data: unknown, filename: string) {
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
@@ -94,6 +95,8 @@ function trustTextColor(score: number): string {
 // ─── Page ───────────────────────────────────────────────────────────────────
 
 export default function FleetPage() {
+  const { hasCapability } = useAuthState();
+  const canManageFleet = hasCapability("fleet.manage");
   const chart = useChartTheme();
   const [agents, setAgents] = useState<FleetAgent[]>([]);
   const [stats, setStats] = useState<FleetStatsResponse | null>(null);
@@ -169,6 +172,7 @@ export default function FleetPage() {
   }, [search, stateFilter]);
 
   const handleSync = async () => {
+    if (!canManageFleet) return;
     setSyncing(true);
     try {
       await api.syncFleet();
@@ -179,12 +183,14 @@ export default function FleetPage() {
   };
 
   const handleStateChange = async (agentId: string, newState: FleetLifecycleState) => {
+    if (!canManageFleet) return;
     if (!confirm(`Change this agent state to ${newState}?`)) return;
     await api.updateFleetState(agentId, newState);
     void load();
   };
 
   const handleQuarantine = async (agentId: string, agentName: string) => {
+    if (!canManageFleet) return;
     if (
       !confirm(
         `Quarantine "${agentName}" and enforce a gateway DENY policy for its identity?\n\n` +
@@ -250,7 +256,8 @@ export default function FleetPage() {
           )}
           <button
             onClick={handleSync}
-            disabled={syncing}
+            disabled={syncing || !canManageFleet}
+            title={!canManageFleet ? "Admin role required to sync fleet state" : undefined}
             className="flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
           >
             <RefreshCw className={`w-4 h-4 ${syncing ? "animate-spin" : ""}`} />
@@ -519,6 +526,8 @@ export default function FleetPage() {
                         {transitions?.map((t) => (
                           <button
                             key={t}
+                            disabled={!canManageFleet}
+                            title={!canManageFleet ? "Admin role required to change fleet state" : undefined}
                             onClick={(e) => {
                               e.stopPropagation();
                               void handleStateChange(agent.agent_id, t);
@@ -538,8 +547,12 @@ export default function FleetPage() {
                             e.stopPropagation();
                             void handleQuarantine(agent.agent_id, agent.name);
                           }}
-                          disabled={quarantiningId === agent.agent_id}
-                          title="Quarantine this agent and enforce a gateway DENY policy for its identity"
+                          disabled={!canManageFleet || quarantiningId === agent.agent_id}
+                          title={
+                            !canManageFleet
+                              ? "Admin role required to quarantine agents"
+                              : "Quarantine this agent and enforce a gateway DENY policy for its identity"
+                          }
                           className="flex items-center gap-1.5 rounded-md border border-red-500/30 dark:border-red-800 bg-red-500/10 dark:bg-red-950/40 px-3 py-1.5 text-xs font-medium text-red-700 dark:text-red-300 transition-colors hover:bg-red-500/10 dark:hover:bg-red-900/40 disabled:opacity-50"
                           data-testid="fleet-quarantine-deny"
                         >

--- a/ui/components/finding-drawer.tsx
+++ b/ui/components/finding-drawer.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import { ExternalLink, FileSearch, Loader2 } from "lucide-react";
 
 import { severityColor, type FindingTriageDecision, type FindingTriageItem, type FindingTriageJustification } from "@/lib/api";
+import { useAuthState } from "@/components/auth-provider";
 import { buildFindingInvestigationHref } from "@/lib/finding-investigation-href";
 import { buildWhyItMatters } from "@/lib/finding-why-matters";
 import { Drawer } from "@/components/drawer";
@@ -51,6 +52,8 @@ export function FindingDrawer({
   onClose: () => void;
   lens?: FindingsLens | undefined;
 }) {
+  const { hasCapability } = useAuthState();
+  const canManageExceptions = hasCapability("exceptions.manage");
   const [tab, setTab] = useState<TabKey>(lens === "trust" ? "evidence" : "overview");
 
   useEffect(() => {
@@ -108,6 +111,7 @@ export function FindingDrawer({
           triageBusy={triageBusy}
           onTriageDecision={onTriageDecision}
           lens={lens}
+          canTriage={canManageExceptions}
         />
       ) : null}
     </Drawer>
@@ -456,6 +460,7 @@ function TriageTab({
   triageBusy,
   onTriageDecision,
   lens,
+  canTriage,
 }: {
   vuln: EnrichedVuln;
   triage: FindingTriageItem | undefined;
@@ -466,6 +471,7 @@ function TriageTab({
     justification?: FindingTriageJustification,
   ) => void;
   lens: FindingsLens;
+  canTriage: boolean;
 }) {
   return (
     <div className="space-y-4">
@@ -495,10 +501,13 @@ function TriageTab({
           <p className="mt-3 text-xs text-[color:var(--text-tertiary)]">No triage item recorded for this finding/package pair.</p>
         )}
         <div className="mt-4 flex flex-wrap gap-2">
-          <TriageButton label="Investigate" busy={triageBusy} disabled={Boolean(triage)} onClick={() => onTriageDecision(vuln, "under_investigation")} />
-          <TriageButton label="Affected" busy={triageBusy} onClick={() => onTriageDecision(vuln, "affected")} />
-          <TriageButton label="Not affected" busy={triageBusy} tone="green" onClick={() => onTriageDecision(vuln, "not_affected", "vulnerable_code_not_in_execute_path")} />
+          <TriageButton label="Investigate" busy={triageBusy} disabled={!canTriage || Boolean(triage)} onClick={() => onTriageDecision(vuln, "under_investigation")} />
+          <TriageButton label="Affected" busy={triageBusy} disabled={!canTriage} onClick={() => onTriageDecision(vuln, "affected")} />
+          <TriageButton label="Not affected" busy={triageBusy} disabled={!canTriage} tone="green" onClick={() => onTriageDecision(vuln, "not_affected", "vulnerable_code_not_in_execute_path")} />
         </div>
+        {!canTriage ? (
+          <p className="mt-2 text-xs text-[color:var(--text-tertiary)]">Contributor role required to update triage.</p>
+        ) : null}
       </Panel>
 
       <div className="flex flex-wrap gap-2">

--- a/ui/components/findings-queue.tsx
+++ b/ui/components/findings-queue.tsx
@@ -3,6 +3,7 @@
 import { ChevronDown, ChevronRight, ChevronUp, ExternalLink } from "lucide-react";
 import { useLayoutEffect, useState } from "react";
 
+import { useAuthState } from "@/components/auth-provider";
 import { severityColor, severityDot, type FindingTriageItem } from "@/lib/api";
 import type { FindingsLens } from "@/lib/findings-lens";
 import type { EnrichedVuln, SortKey } from "@/lib/findings-view";
@@ -131,6 +132,8 @@ export function FindingsQueueTable({
   lens?: FindingsLens;
   triageByKey?: ReadonlyMap<string, FindingTriageItem>;
 }) {
+  const { hasCapability } = useAuthState();
+  const canManageExceptions = hasCapability("exceptions.manage");
   const compactLayout = useCompactFindingsLayout();
   const emptyLabel =
     lens === "trust"
@@ -153,6 +156,7 @@ export function FindingsQueueTable({
               suppressed={suppressed.has(vuln.id)}
               onSelect={() => onSelect(rowKey)}
               onMarkFP={() => onMarkFP(vuln.id, vuln.packages[0] ?? "")}
+              canMarkFalsePositive={canManageExceptions}
             />
           );
         })}
@@ -216,6 +220,7 @@ export function FindingsQueueTable({
                       suppressed={suppressed.has(v.id)}
                       onSelect={() => onSelect(rowKey)}
                       onMarkFP={() => onMarkFP(v.id, v.packages[0] ?? "")}
+                      canMarkFalsePositive={canManageExceptions}
                     />
                   </>
                 )}
@@ -259,6 +264,7 @@ function MobileFindingCard({
   suppressed,
   onSelect,
   onMarkFP,
+  canMarkFalsePositive,
 }: {
   vuln: EnrichedVuln;
   lens: FindingsLens;
@@ -267,6 +273,7 @@ function MobileFindingCard({
   suppressed: boolean;
   onSelect: () => void;
   onMarkFP: () => void;
+  canMarkFalsePositive: boolean;
 }) {
   const controls = controlLabels(vuln);
   const evidenceSources = vuln.sources.filter((source) => source !== "finding");
@@ -361,6 +368,8 @@ function MobileFindingCard({
             <button
               type="button"
               onClick={onMarkFP}
+              disabled={!canMarkFalsePositive}
+              title={!canMarkFalsePositive ? "Contributor role required to mark false positives" : undefined}
               className="rounded-md border border-[var(--border-subtle)] px-2.5 py-1.5 text-xs text-[var(--text-secondary)]"
             >
               Mark false positive
@@ -460,12 +469,14 @@ function EngineeringCells({
   suppressed,
   onSelect,
   onMarkFP,
+  canMarkFalsePositive,
 }: {
   vuln: EnrichedVuln;
   triage: FindingTriageItem | undefined;
   suppressed: boolean;
   onSelect: () => void;
   onMarkFP: () => void;
+  canMarkFalsePositive: boolean;
 }) {
   const verifyCommand = vuln.remediation_items.find((item) => item.verify_command)?.verify_command;
   const sla = formatSlaDue(vuln.sla_due_at);
@@ -553,7 +564,9 @@ function EngineeringCells({
                 event.stopPropagation();
                 onMarkFP();
               }}
-              className="px-1 text-[11px] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
+              disabled={!canMarkFalsePositive}
+              title={!canMarkFalsePositive ? "Contributor role required to mark false positives" : undefined}
+              className="px-1 text-[11px] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] disabled:cursor-not-allowed disabled:opacity-50"
             >
               Mark false positive
             </button>

--- a/ui/components/integrations/reports-panel.tsx
+++ b/ui/components/integrations/reports-panel.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Download, FileDown, Loader2, Play } from "lucide-react";
 
 import { api, formatDate, type ReportJobRecord, type ReportSort } from "@/lib/api";
+import { useAuthState } from "@/components/auth-provider";
 import { DataTable, type DataTableColumn } from "@/components/data-table";
 import {
   Field,
@@ -30,6 +31,8 @@ function isTerminal(status: string): boolean {
 }
 
 export function ReportsPanel() {
+  const { hasCapability } = useAuthState();
+  const canCreateReports = hasCapability("scan.run");
   // No server-side list endpoint exists for reports, so we track the jobs
   // created in this session and poll each until it reaches a terminal state.
   const [jobs, setJobs] = useState<ReportJobRecord[]>([]);
@@ -60,6 +63,7 @@ export function ReportsPanel() {
   }, [poll]);
 
   const create = async () => {
+    if (!canCreateReports) return;
     setCreating(true);
     setNotice(null);
     try {
@@ -219,7 +223,13 @@ export function ReportsPanel() {
             </select>
           </Field>
         </div>
-        <PanelButton tone="primary" type="submit" disabled={creating} data-testid="report-create-submit">
+        <PanelButton
+          tone="primary"
+          type="submit"
+          disabled={creating || !canCreateReports}
+          title={!canCreateReports ? "Contributor role required to queue exports" : undefined}
+          data-testid="report-create-submit"
+        >
           {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
           Queue export
         </PanelButton>

--- a/ui/tests/findings-page.test.tsx
+++ b/ui/tests/findings-page.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import FindingsPage from "@/app/findings/page";
 
-const { apiMock, navigationState } = vi.hoisted(() => ({
+const { apiMock, navigationState, authState } = vi.hoisted(() => ({
   apiMock: {
     listFindings: vi.fn(),
     listFindingTriage: vi.fn(),
@@ -13,6 +13,7 @@ const { apiMock, navigationState } = vi.hoisted(() => ({
     getPostureCounts: vi.fn(),
   },
   navigationState: { query: "" },
+  authState: { canManageExceptions: true },
 }));
 
 vi.mock("next/navigation", () => ({
@@ -32,6 +33,13 @@ vi.mock("@/lib/api", async () => {
     api: apiMock,
   };
 });
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuthState: () => ({
+    session: { auth_required: true, role: authState.canManageExceptions ? "analyst" : "viewer" },
+    hasCapability: (capability: string) => capability === "exceptions.manage" && authState.canManageExceptions,
+  }),
+}));
 
 const canonicalFinding = {
   id: "finding-1",
@@ -57,6 +65,7 @@ const canonicalFinding = {
 
 describe("FindingsPage", () => {
   beforeEach(() => {
+    authState.canManageExceptions = true;
     navigationState.query = "";
     apiMock.listFindings.mockReset();
     apiMock.listFindingTriage.mockReset();
@@ -107,6 +116,20 @@ describe("FindingsPage", () => {
     await waitFor(() => {
       expect(screen.queryByRole("dialog", { name: "Finding details for CVE-2026-1234" })).not.toBeInTheDocument();
     });
+  });
+
+  it("renders exception and triage writes disabled for a viewer", async () => {
+    authState.canManageExceptions = false;
+    render(<FindingsPage />);
+
+    expect(await screen.findByText("CVE-2026-1234")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Mark false positive" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Open details for CVE-2026-1234" }));
+    const drawer = await screen.findByRole("dialog", { name: "Finding details for CVE-2026-1234" });
+    fireEvent.click(within(drawer).getByRole("tab", { name: "Triage" }));
+    expect(within(drawer).getByRole("button", { name: "Investigate" })).toBeDisabled();
+    expect(within(drawer).getByRole("button", { name: "Affected" })).toBeDisabled();
+    expect(within(drawer).getByRole("button", { name: "Not affected" })).toBeDisabled();
   });
 
   it("uses the persisted package identity when an older finding has no asset object", async () => {

--- a/ui/tests/fleet-page.test.tsx
+++ b/ui/tests/fleet-page.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import FleetPage from "@/app/fleet/page";
+
+const { apiMock, authState } = vi.hoisted(() => ({
+  apiMock: {
+    listFleet: vi.fn(),
+    getFleetStats: vi.fn(),
+    syncFleet: vi.fn(),
+    updateFleetState: vi.fn(),
+    quarantineFleetAgent: vi.fn(),
+  },
+  authState: { canManageFleet: false },
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, api: apiMock, formatDate: (value: string) => value };
+});
+vi.mock("@/components/auth-provider", () => ({
+  useAuthState: () => ({
+    session: { auth_required: true, role: authState.canManageFleet ? "admin" : "viewer" },
+    hasCapability: (capability: string) => capability === "fleet.manage" && authState.canManageFleet,
+  }),
+}));
+vi.mock("@/hooks/use-deployment-context", () => ({ useDeploymentContext: () => ({ counts: null }) }));
+vi.mock("@/lib/theme-colors", () => ({
+  useChartTheme: () => ({
+    severity: { unrated: "#777" },
+    status: { warn: "#f90", success: "#0a0", danger: "#d00" },
+    text: "#aaa",
+    border: "#444",
+    tooltip: { bg: "#111", border: "#444", text: "#fff" },
+  }),
+}));
+vi.mock("@/components/endpoint-fleet-panel", () => ({ EndpointFleetPanel: () => <div /> }));
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  BarChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Bar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Cell: () => null,
+}));
+
+const AGENT = {
+  agent_id: "agent-1",
+  name: "Developer laptop",
+  agent_type: "desktop",
+  lifecycle_state: "discovered",
+  trust_score: 42,
+  trust_factors: {},
+  server_count: 1,
+  package_count: 2,
+  credential_count: 0,
+  vuln_count: 1,
+  owner: "platform",
+  environment: "dev",
+  last_discovery: "2026-08-18T00:00:00Z",
+  config_path: null,
+};
+
+describe("FleetPage protected actions", () => {
+  beforeEach(() => {
+    authState.canManageFleet = false;
+    Object.values(apiMock).forEach((mock) => mock.mockReset());
+    apiMock.listFleet.mockResolvedValue({ agents: [AGENT], total: 1 });
+    apiMock.getFleetStats.mockResolvedValue({
+      total: 1,
+      by_state: { discovered: 1 },
+      low_trust_count: 1,
+      avg_trust_score: 42,
+    });
+  });
+
+  it("keeps sync, lifecycle, and quarantine controls disabled for viewers", async () => {
+    render(<FleetPage />);
+    expect(screen.getByRole("button", { name: "Sync Now" })).toBeDisabled();
+    const row = await screen.findByRole("button", { name: /Developer laptop/ });
+    fireEvent.click(row);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Pending Review" })).toBeDisabled());
+    expect(screen.getByTestId("fleet-quarantine-deny")).toBeDisabled();
+  });
+});

--- a/ui/tests/integrations-reports-panel.test.tsx
+++ b/ui/tests/integrations-reports-panel.test.tsx
@@ -3,15 +3,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ReportsPanel } from "@/components/integrations/reports-panel";
 
-const { apiMock } = vi.hoisted(() => ({
+const { apiMock, authState } = vi.hoisted(() => ({
   apiMock: {
     createReportJob: vi.fn(),
     getReportJob: vi.fn(),
     downloadReportArtifact: vi.fn(),
   },
+  authState: { canCreate: true },
 }));
 
 vi.mock("@/lib/api", () => ({ api: apiMock, formatDate: (s: string) => s }));
+vi.mock("@/components/auth-provider", () => ({
+  useAuthState: () => ({
+    session: { auth_required: true, role: authState.canCreate ? "analyst" : "viewer" },
+    hasCapability: (capability: string) => capability === "scan.run" && authState.canCreate,
+  }),
+}));
 
 const PENDING = {
   job_id: "job-abcdef12",
@@ -31,6 +38,7 @@ const PENDING = {
 const DONE = { ...PENDING, status: "done", row_count: 128, download_token: "test", download_token_header: "X-Agent-Bom-Download-Token" };
 
 beforeEach(() => {
+  authState.canCreate = true;
   Object.values(apiMock).forEach((fn) => fn.mockReset());
   URL.createObjectURL = vi.fn(() => "blob:mock");
   URL.revokeObjectURL = vi.fn();
@@ -41,6 +49,12 @@ afterEach(() => {
 });
 
 describe("ReportsPanel", () => {
+  it("keeps export creation read-only for viewers", () => {
+    authState.canCreate = false;
+    render(<ReportsPanel />);
+    expect(screen.getByTestId("report-create-submit")).toBeDisabled();
+  });
+
   it("queues an export and shows the job row", async () => {
     apiMock.createReportJob.mockResolvedValue(PENDING);
     render(<ReportsPanel />);


### PR DESCRIPTION
## Summary

- preserve semantic finding domains and import-source reconciliation across bulk findings and compliance ingestion
- make Postgres ledger scan filtering materialized, indexed, migration-safe, and consistent with SQLite; keep pristine Alembic queue policy creation role-independent
- restore exact campaign membership on cached counts and disable viewer-only write controls across findings, reports, and fleet workflows

## Verification

- `uv run pytest -q ...` — 316 passed, 4 skipped across affected persistence, migration, findings, and campaign suites
- supported Node 24.18.0 / npm 10.9.7 — typecheck, focused ESLint, 190 Vitest files / 1,189 tests, and 52-route production build
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src/agent_bom`
- `uv run python scripts/check_exception_sanitization.py`
- `make preflight`
- Postgres 16 migration-only/bootstrap schema parity with pgcrypto and pg_trgm

## Notes

- Changes were developed contract-first; regressions failed before each implementation and passed afterward.
- The disposable Postgres container was stopped and verified absent after testing.
- A broader live audit-posture test requires the deployment's dedicated NOSUPERUSER/NOBYPASSRLS maintenance role and was not counted as green.