### PR TITLE
fix(ui): clarify the demo journey on wide screens

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -359,7 +359,7 @@ export default function Dashboard() {
       <PageLaneHeader
         lane="command"
         title="Overview"
-        subtitle="Exec briefing: posture, open issues, compliance evidence, and live surfaces. Use Findings and Investigation for engineer drill-down."
+        subtitle="See what is exposed, why it matters, who should fix it, and whether the fix worked."
         scopeChip={
           <span className="inline-flex items-center rounded-full border border-sky-500/30 bg-sky-500/10 px-2.5 py-0.5 text-[11px] font-medium text-sky-700 dark:text-sky-200">
             {deploymentModeLabel(counts?.deployment_mode)} · {countActiveServices(counts?.services)} services live

--- a/ui/components/app-shell.tsx
+++ b/ui/components/app-shell.tsx
@@ -18,7 +18,7 @@ function ShellMain({ children }: { children: React.ReactNode }) {
       id="main-content"
       className={`min-h-screen pt-16 transition-[padding-left] duration-200 ${mainContentPaddingClass(collapsed)}`}
     >
-      <div className="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-6">{children}</div>
+      <div className="mx-auto w-full max-w-[1920px] px-4 py-6 sm:px-6 lg:px-8">{children}</div>
     </main>
   );
 }

--- a/ui/components/overview-cockpit.tsx
+++ b/ui/components/overview-cockpit.tsx
@@ -141,12 +141,16 @@ function derivePostureBlurb({
 
   if (hasOpen) {
     const sevBits = [
-      critical > 0 ? `${critical} critical` : null,
-      high > 0 ? `${high} high` : null,
+      critical > 0
+        ? `${critical.toLocaleString("en-US")} critical finding${critical === 1 ? "" : "s"}`
+        : null,
+      high > 0
+        ? `${high.toLocaleString("en-US")} high finding${high === 1 ? "" : "s"}`
+        : null,
     ].filter(Boolean);
     const sev = sevBits.join(" · ");
     if (openCves > 0) {
-      return `${openCves} open CVE${openCves === 1 ? "" : "s"}${sev ? ` · ${sev}` : ""} across connected surfaces.`;
+      return `${openCves.toLocaleString("en-US")} unique open CVE${openCves === 1 ? "" : "s"}${sev ? ` · ${sev}` : ""} across connected surfaces.`;
     }
     return `${sev} in the current snapshot.`;
   }
@@ -254,6 +258,10 @@ export function OverviewCockpit({
           defaultOpen
         >
           <FreshnessStatus latestScan={latestScan} scans={scans} loading={loading} />
+          <TeamOutcomeJourney
+            pathCount={exposurePaths.length > 0 ? exposurePaths.length : topPath ? 1 : 0}
+            urgentFindingCount={critical + high}
+          />
 
           {/* 1 — Posture headline + open issues by severity.
               Posture track is capped (minmax) so a long summary can't grow it
@@ -311,6 +319,92 @@ export function OverviewCockpit({
         />
       </section>
     </div>
+  );
+}
+
+function TeamOutcomeJourney({
+  pathCount,
+  urgentFindingCount,
+}: {
+  pathCount: number;
+  urgentFindingCount: number;
+}) {
+  const pathLabel = `${pathCount.toLocaleString("en-US")} ranked path${pathCount === 1 ? "" : "s"}`;
+  const urgentLabel = `${urgentFindingCount.toLocaleString("en-US")} critical/high finding${urgentFindingCount === 1 ? "" : "s"}`;
+
+  return (
+    <section
+      data-testid="overview-team-journey"
+      aria-labelledby="overview-team-journey-title"
+      className="mb-4 overflow-hidden rounded-xl border border-emerald-500/25 bg-gradient-to-r from-emerald-500/10 via-[color:var(--surface-muted)] to-sky-500/10"
+    >
+      <div className="flex flex-col gap-1 border-b border-[color:var(--border-subtle)] px-3 py-2.5 sm:flex-row sm:items-baseline sm:justify-between">
+        <h2
+          id="overview-team-journey-title"
+          className="text-sm font-semibold text-[color:var(--foreground)]"
+        >
+          Turn exposure into a verified fix
+        </h2>
+        <p className="text-[11px] text-[color:var(--text-tertiary)]">
+          One evidence chain from detection to closure
+        </p>
+      </div>
+      <div className="grid md:grid-cols-3">
+        <div className="px-3 py-3 md:border-r md:border-[color:var(--border-subtle)]">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-emerald-700 dark:text-emerald-300">
+            1 · Investigate
+          </p>
+          <p className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">
+            Prioritize reachable risk
+          </p>
+          <p className="mt-1 text-xs text-[color:var(--text-secondary)]">
+            Follow correlated paths from vulnerabilities to agents, tools, and secrets.
+          </p>
+          <Link
+            href="/security-graph"
+            aria-label={`Investigate ${pathLabel}`}
+            className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-emerald-600 hover:text-emerald-500"
+          >
+            Investigate {pathLabel} <ArrowRight className="h-3 w-3" />
+          </Link>
+        </div>
+        <div className="border-t border-[color:var(--border-subtle)] px-3 py-3 md:border-r md:border-t-0">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-sky-700 dark:text-sky-300">
+            2 · Remediate
+          </p>
+          <p className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">
+            Assign owner and SLA
+          </p>
+          <p className="mt-1 text-xs text-[color:var(--text-secondary)]">
+            Turn {urgentLabel} into accountable, prioritized work.
+          </p>
+          <Link
+            href="/remediation"
+            aria-label="Open remediation"
+            className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-emerald-600 hover:text-emerald-500"
+          >
+            Open remediation <ArrowRight className="h-3 w-3" />
+          </Link>
+        </div>
+        <div className="border-t border-[color:var(--border-subtle)] px-3 py-3 md:border-t-0">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-violet-700 dark:text-violet-300">
+            3 · Prove
+          </p>
+          <p className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">
+            Verify with new evidence
+          </p>
+          <p className="mt-1 text-xs text-[color:var(--text-secondary)]">
+            Re-scan after the fix and close only when canonical evidence confirms the risk is gone.
+          </p>
+          <Link
+            href="/remediation"
+            className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-emerald-600 hover:text-emerald-500"
+          >
+            Review verification queue <ArrowRight className="h-3 w-3" />
+          </Link>
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/ui/lib/exposure-path-graph-layout.ts
+++ b/ui/lib/exposure-path-graph-layout.ts
@@ -18,10 +18,10 @@ const COLUMN_GAP = 132;
 // boards). Long chains collapse their middle instead — see `shouldCollapsePath`.
 
 /**
- * Drawable board width at the widest desktop the app shell allows. The shell
- * caps content at `max-w-[1400px]` with `lg:px-8` (1400 - 2 x 32 = 1336 CSS px);
- * the command-center card spends 44px on `sm:p-5 sm:pl-6` and the board wrapper
- * another 24px on its `p-1` + `p-2` insets, leaving 1268px of board.
+ * Conservative drawable-board reference width. The app shell can now grow to
+ * 1920px on ultrawide displays, but the graph also renders in narrower
+ * master-detail panels. Keeping this reference at the proven 1400px-shell
+ * budget prevents layout decisions from becoming unreadable in those panels.
  */
 export const FIT_REFERENCE_WIDTH = 1268;
 

--- a/ui/tests/app-shell.test.tsx
+++ b/ui/tests/app-shell.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AppShell } from "@/components/app-shell";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
+vi.mock("@/components/auth-gate", () => ({
+  AuthGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/demo-estate-label", () => ({ DemoEstateLabel: () => null }));
+vi.mock("@/components/nav", () => ({ Nav: () => null }));
+
+describe("AppShell", () => {
+  it("uses the ultrawide workspace instead of leaving 1400px of content between symmetric gutters", () => {
+    render(
+      <AppShell>
+        <div>Workspace content</div>
+      </AppShell>,
+    );
+
+    const content = screen.getByText("Workspace content").parentElement;
+    expect(content).toHaveClass("w-full", "max-w-[1920px]");
+    expect(content).not.toHaveClass("max-w-[1400px]");
+  });
+});

--- a/ui/tests/overview-cockpit.test.tsx
+++ b/ui/tests/overview-cockpit.test.tsx
@@ -299,7 +299,38 @@ describe("OverviewCockpit", () => {
     );
 
     expect(screen.queryByText(/no vulnerabilities/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/78 open CVEs across connected surfaces/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/78 unique open CVEs across connected surfaces/i),
+    ).toBeInTheDocument();
+  });
+
+  it("distinguishes unique CVEs from finding instances in the posture headline", () => {
+    render(<OverviewCockpit {...baseProps} cves={799} critical={440} high={1337} />);
+
+    expect(
+      screen.getByText(
+        /799 unique open CVEs · 440 critical findings · 1,337 high findings across connected surfaces/i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/799 open CVEs · 440 critical · 1337 high/i)).not.toBeInTheDocument();
+  });
+
+  it("opens with a complete team journey from reachable risk to verified remediation", () => {
+    render(<OverviewCockpit {...baseProps} exposurePaths={[baseProps.topPath]} />);
+
+    const journey = screen.getByTestId("overview-team-journey");
+    expect(within(journey).getByText("Turn exposure into a verified fix")).toBeInTheDocument();
+    expect(within(journey).getByText("Prioritize reachable risk")).toBeInTheDocument();
+    expect(within(journey).getByText("Assign owner and SLA")).toBeInTheDocument();
+    expect(within(journey).getByText("Verify with new evidence")).toBeInTheDocument();
+    expect(within(journey).getByRole("link", { name: /Investigate 1 ranked path/i })).toHaveAttribute(
+      "href",
+      "/security-graph",
+    );
+    expect(within(journey).getByRole("link", { name: /Open remediation/i })).toHaveAttribute(
+      "href",
+      "/remediation",
+    );
   });
 
   it("shows the posture score as a percentage alongside the letter grade", () => {


### PR DESCRIPTION
## Summary

- expand the primary app workspace from 1400px to 1920px so ultrawide demo screens use the available canvas without horizontal overflow
- add a compact Investigate → Remediate → Prove outcome journey that explains how teams move from reachable risk to evidence-backed closure
- distinguish unique CVEs from finding instances in the posture headline and keep graph layout decisions conservative in narrower panels

## Why

The ultrawide demo left symmetric empty gutters and the overview presented metrics without a clear team outcome. The fixed shell cap caused the wasted space; the overview lacked an explicit bridge from attack-path prioritization to ownership, remediation, and re-verification.

## Verification

- `npm test -- --run tests/app-shell.test.tsx tests/overview-cockpit.test.tsx tests/overview-page-reconciliation.test.tsx` — 26 tests passed
- `npm run typecheck`
- `npm test -- --run` — 1,192 tests passed
- Node 24.15.0: `npm run verify:toolchain`
- Node 24.15.0: `npm run build` — 52 static pages generated
- targeted ESLint on all changed UI and test files
- `git diff --check`
- Playwright visual QA in dark and light themes at 2560×1440: 1920px shell, 1814px journey panel, 2560px document width, no horizontal overflow

## Notes

The screenshots validate the local build with the API configured to the public v0.101.0 demo. This PR does not claim the hosted demo is updated; hosted proof remains a separate post-deployment check. Graph/snapshot terminology and hierarchy will follow as the next scoped PR.