### PR TITLE
fix(ui): focus the investigation demo journey

### DIFF
--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -684,147 +684,6 @@ function SecurityGraphPageContent() {
         </div>
       ) : null}
 
-      {/* "Should I deploy?" is a deliberate, occasional action. It does not earn
-          a permanent band of vertical space on every visit. */}
-      {!captureMode && (
-        <Collapsible
-          title="Should I deploy?"
-          subtitle="Check an agent, service, image, or package against this snapshot's exposure paths."
-          icon={Rocket}
-          defaultOpen={false}
-        >
-          <DeployGatePanel scanId={selectedScanId || undefined} />
-        </Collapsible>
-      )}
-
-      <Collapsible
-        title="Exposure paths"
-        subtitle="Agent-native exposure-path lens over persisted graph evidence."
-        icon={Route}
-        defaultOpen={false}
-      >
-        <ExposurePathLens scanId={selectedScanId || undefined} />
-      </Collapsible>
-
-      <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-3">
-              <div>
-                <p className="text-[11px] uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">Snapshot</p>
-                <h2 className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">
-                  {selectedSnapshot ? `Scan ${selectedSnapshot.scan_id.slice(0, 8)}…` : "No graph snapshot yet"}
-                </h2>
-                {selectedSnapshot && (
-                  <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
-                    {formatDate(selectedSnapshot.created_at)} · {selectedSnapshot.node_count} nodes · {selectedSnapshot.edge_count} edges
-                  </p>
-                )}
-                {selectedSnapshot && estateMode.large ? (
-                  <div className="mt-3 max-w-2xl rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-[color:var(--text-secondary)]">
-                    <p className="font-semibold text-amber-800 dark:text-amber-200">
-                      Large estate · {estateMode.summary}
-                    </p>
-                    <p className="mt-1 leading-relaxed">
-                      Start with ranked attack paths or clustered estate groups. Raw topology is available as a drill-down and may be dense.
-                    </p>
-                    <div className="mt-2 flex flex-wrap gap-2">
-                      <Link
-                        href={estateMode.clusteredHref}
-                        className="rounded-lg border border-amber-500/30 bg-[color:var(--surface)] px-2.5 py-1 font-medium text-[color:var(--foreground)]"
-                      >
-                        Explore clusters
-                      </Link>
-                      <Link
-                        href={estateMode.rawHref}
-                        className="rounded-lg px-2.5 py-1 text-[color:var(--text-secondary)] underline decoration-[color:var(--border-strong)] underline-offset-2"
-                      >
-                        Open raw topology
-                      </Link>
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-              {posture && (
-                <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2">
-                  <p className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">Posture</p>
-                  <div className="mt-1 flex items-baseline gap-2">
-                    <span className="font-mono text-xl font-semibold text-red-300">{posture.grade}</span>
-                    <span className="font-mono text-sm text-[color:var(--foreground)]">{posture.score}</span>
-                  </div>
-                </div>
-              )}
-            </div>
-            {loadingSnapshots && (
-              <span className="mt-2 inline-flex items-center gap-2 text-xs text-sky-400">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                loading snapshots
-              </span>
-            )}
-          </div>
-          {fixFirstView && (
-            <div className="flex flex-wrap gap-2 text-xs">
-              <QuickStat label="Matched paths" value={String(fixFirstView.summary.matched_paths)} tone="blue" />
-              <QuickStat label="Covered findings" value={String(fixFirstView.summary.covered_findings)} tone="amber" />
-              <QuickStat label="Highest risk" value={fixFirstView.summary.highest_risk.toFixed(1)} tone="red" />
-            </div>
-          )}
-        </div>
-
-        {snapshots.length > 0 ? (
-              <>
-                <div className="mt-4 flex flex-wrap gap-2">
-                  {displayedSnapshots.map((snapshot) => {
-                    const selected = snapshot.scan_id === selectedScanId;
-                    return (
-                      <button
-                        key={snapshot.scan_id}
-                        type="button"
-                        onClick={() => selectSnapshot(snapshot.scan_id)}
-                        className={`rounded-xl border px-3 py-2 text-left text-xs transition ${
-                          selected
-                            ? "border-emerald-700 bg-emerald-500/10 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-200"
-                            : "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[color:var(--text-secondary)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
-                        }`}
-                      >
-                        <div className="font-mono">{snapshot.scan_id.slice(0, 8)}…</div>
-                        <div className="mt-1 text-[11px] opacity-80">{snapshot.node_count} nodes</div>
-                      </button>
-                    );
-                  })}
-                </div>
-                {(hiddenSnapshotCount > 0 || showAllSnapshots) && (
-                  <button
-                    type="button"
-                    onClick={() => setShowAllSnapshots((current) => !current)}
-                    className="mt-3 rounded-lg border border-[color:var(--border-subtle)] px-3 py-1.5 text-xs text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
-                  >
-                    {showAllSnapshots
-                      ? "Show active snapshots"
-                      : `Show all ${snapshots.length} snapshots (${hiddenSnapshotCount} empty or older)`}
-                  </button>
-                )}
-              </>
-            ) : (
-              !loadingSnapshots && (
-                <div className="mt-4">
-                  <GraphEmptyState
-                    title="No persisted graph snapshots yet"
-                    detail="Run a scan first so the security graph can build historical attack-path views from persisted graph evidence."
-                    suggestions={[
-                      "Run a local scan with graph output enabled.",
-                      "Confirm the graph persistence backend is enabled.",
-                      "Open the full graph after the first snapshot appears.",
-                    ]}
-                    command="agent-bom scan -p . -f graph"
-                    actions={[{ label: "Run a scan", href: "/scan" }]}
-                  />
-                </div>
-              )
-            )}
-
-      </section>
-
       {loadingGraph ? (
         <section className="rounded-3xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
           <GraphPanelSkeleton
@@ -866,7 +725,7 @@ function SecurityGraphPageContent() {
             detail={`No persisted graph snapshot exists for scan ${focus.scanId}. The investigation did not substitute evidence from a different scan.`}
             suggestions={[
               "Run or re-sync the requested scan with graph persistence enabled.",
-              "Choose one of the available snapshots above to investigate older evidence explicitly.",
+              "Choose another scan under Evidence scope to investigate older evidence explicitly.",
               "Review the requested scan's findings while its graph snapshot is unavailable.",
             ]}
           />
@@ -1061,6 +920,128 @@ function SecurityGraphPageContent() {
           }
         />
       )}
+
+      <Collapsible
+        title="Evidence scope"
+        subtitle={selectedSnapshot
+          ? `Current scan evidence · ${formatDate(selectedSnapshot.created_at)} · ${selectedSnapshot.node_count} nodes · ${selectedSnapshot.edge_count} edges`
+          : "No persisted graph evidence selected."
+        }
+        icon={GitBranch}
+        defaultOpen={false}
+      >
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                Current scan evidence
+              </p>
+              <p className="mt-1 font-mono text-sm text-[color:var(--foreground)]">
+                {selectedSnapshot ? selectedSnapshot.scan_id : "No scan selected"}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs">
+              {posture ? <QuickStat label="Posture" value={`${posture.grade} ${posture.score}`} tone="red" /> : null}
+              {fixFirstView ? (
+                <>
+                  <QuickStat label="Matched paths" value={String(fixFirstView.summary.matched_paths)} tone="blue" />
+                  <QuickStat label="Covered findings" value={String(fixFirstView.summary.covered_findings)} tone="amber" />
+                  <QuickStat label="Highest risk" value={fixFirstView.summary.highest_risk.toFixed(1)} tone="red" />
+                </>
+              ) : null}
+            </div>
+          </div>
+
+          {loadingSnapshots ? (
+            <span className="inline-flex items-center gap-2 text-xs text-sky-400">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Loading scan evidence
+            </span>
+          ) : snapshots.length > 0 ? (
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                Manage snapshots
+              </p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {displayedSnapshots.map((snapshot) => {
+                  const selected = snapshot.scan_id === selectedScanId;
+                  return (
+                    <button
+                      key={snapshot.scan_id}
+                      type="button"
+                      onClick={() => selectSnapshot(snapshot.scan_id)}
+                      className={`rounded-xl border px-3 py-2 text-left text-xs transition ${
+                        selected
+                          ? "border-emerald-700 bg-emerald-500/10 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-200"
+                          : "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[color:var(--text-secondary)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
+                      }`}
+                    >
+                      <span className="block font-mono">{snapshot.scan_id.slice(0, 8)}…</span>
+                      <span className="mt-1 block text-[11px] opacity-80">{snapshot.node_count} nodes</span>
+                    </button>
+                  );
+                })}
+              </div>
+              {hiddenSnapshotCount > 0 || showAllSnapshots ? (
+                <button
+                  type="button"
+                  onClick={() => setShowAllSnapshots((current) => !current)}
+                  className="mt-3 rounded-lg border border-[color:var(--border-subtle)] px-3 py-1.5 text-xs text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
+                >
+                  {showAllSnapshots
+                    ? "Show active snapshots"
+                    : `Show all ${snapshots.length} snapshots (${hiddenSnapshotCount} empty or older)`}
+                </button>
+              ) : null}
+            </div>
+          ) : (
+            <GraphEmptyState
+              title="No persisted graph snapshots yet"
+              detail="Run a scan first so Investigation can rank paths from persisted graph evidence."
+              suggestions={[
+                "Run a local scan with graph output enabled.",
+                "Confirm the graph persistence backend is enabled.",
+              ]}
+              command="agent-bom scan -p . -f graph"
+              actions={[{ label: "Run a scan", href: "/scan" }]}
+            />
+          )}
+
+          {selectedSnapshot && estateMode.large ? (
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[color:var(--border-subtle)] pt-3 text-xs text-[color:var(--text-secondary)]">
+              <span>{estateMode.summary}. Use a focused lens before opening the full topology.</span>
+              <div className="flex flex-wrap gap-3">
+                <Link href={estateMode.clusteredHref} className="font-medium text-[color:var(--accent-mint)] hover:underline">
+                  Explore clusters
+                </Link>
+                <Link href={estateMode.rawHref} className="font-medium text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] hover:underline">
+                  Open raw topology
+                </Link>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </Collapsible>
+
+      {!captureMode ? (
+        <Collapsible
+          title="Should I deploy?"
+          subtitle="Check an agent, service, image, or package against the selected evidence scope."
+          icon={Rocket}
+          defaultOpen={false}
+        >
+          <DeployGatePanel scanId={selectedScanId || undefined} />
+        </Collapsible>
+      ) : null}
+
+      <Collapsible
+        title="Exposure paths"
+        subtitle="Broader agent-native exposure analysis over the selected evidence scope."
+        icon={Route}
+        defaultOpen={false}
+      >
+        <ExposurePathLens scanId={selectedScanId || undefined} />
+      </Collapsible>
     </div>
   );
 }

--- a/ui/components/finding-drawer.tsx
+++ b/ui/components/finding-drawer.tsx
@@ -64,7 +64,7 @@ export function FindingDrawer({
     <Drawer
       open
       onClose={onClose}
-      size="4xl"
+      size="2xl"
       ariaLabel={`Finding details for ${vuln.id}`}
       eyebrow={findingsDrawerEyebrow(lens)}
       title={<span className="break-all font-mono">{vuln.id}</span>}
@@ -127,62 +127,84 @@ function OverviewTab({ vuln, triage }: { vuln: EnrichedVuln; triage: FindingTria
   const published = vuln.published_at ?? vuln.published ?? vuln.nvd_published;
   const fixCandidates = vuln.remediation_items.filter((item) => item.fixed_version || item.command || item.verify_command);
   const version = cvssVersion(vuln.cvss_vector);
-  const cvssDetail = [version ? `v${version}` : "version unavailable", vuln.cvss_severity ?? "severity unavailable"].join(" · ");
+  const cvssDetail = [version ? `v${version}` : null, vuln.cvss_severity].filter(Boolean).join(" · ");
   const epssDetail = typeof vuln.epss_percentile === "number"
     ? `${vuln.epss_percentile.toFixed(1)}th percentile`
-    : "Percentile unavailable";
+    : undefined;
   const fixValue = vuln.current_version && vuln.fixed_version
     ? `${vuln.current_version} → ${vuln.fixed_version}`
     : vuln.fixed_version
       ? `Upgrade to ${vuln.fixed_version}`
-      : "Unavailable";
-  const stats: { label: string; value: string; detail?: string }[] = [
-    {
+      : null;
+  const stats: Array<{ label: string; value: string; detail?: string }> = [
+    typeof vuln.cvss_score === "number" ? {
       label: "CVSS",
-      value: typeof vuln.cvss_score === "number" ? vuln.cvss_score.toFixed(1) : "Unavailable",
-      detail: cvssDetail,
-    },
-    {
+      value: vuln.cvss_score.toFixed(1),
+      ...(cvssDetail ? { detail: cvssDetail } : {}),
+    } : null,
+    typeof vuln.epss_score === "number" ? {
       label: "EPSS",
-      value: typeof vuln.epss_score === "number" ? `${(vuln.epss_score * 100).toFixed(1)}%` : "Unavailable",
-      detail: epssDetail,
-    },
-    {
+      value: `${(vuln.epss_score * 100).toFixed(1)}%`,
+      ...(epssDetail ? { detail: epssDetail } : {}),
+    } : null,
+    typeof vuln.is_kev === "boolean" ? {
       label: "CISA KEV",
-      value: typeof vuln.is_kev === "boolean" ? (vuln.is_kev ? "Known exploited" : "Not listed") : "Unavailable",
-      detail: vuln.kev_date_added ? `Added ${formatDateOnly(vuln.kev_date_added)}` : "Catalog date unavailable",
-    },
-    { label: "Affected → fixed", value: fixValue },
-  ];
+      value: vuln.is_kev ? "Known exploited" : "Not listed",
+      ...(vuln.kev_date_added ? { detail: `Added ${formatDateOnly(vuln.kev_date_added)}` } : {}),
+    } : null,
+    fixValue ? { label: "Affected → fixed", value: fixValue } : null,
+  ].filter((stat): stat is { label: string; value: string; detail?: string } => stat !== null);
+  const workflowFacts = [
+    vuln.first_seen ? { label: "First seen", value: formatFindingTimestamp(vuln.first_seen) } : null,
+    vuln.last_observed || vuln.last_seen
+      ? { label: "Last observed", value: formatFindingTimestamp(vuln.last_observed ?? vuln.last_seen) }
+      : null,
+    vuln.lifecycle_status || triage?.queue_state
+      ? { label: "Status", value: vuln.lifecycle_status ? findingStatusLabel(vuln.lifecycle_status) : triage!.queue_state }
+      : null,
+    typeof vuln.occurrence_count === "number"
+      ? { label: "Occurrences", value: String(vuln.occurrence_count) }
+      : null,
+    vuln.owner || triage?.assignee ? { label: "Owner", value: vuln.owner || triage!.assignee! } : null,
+    vuln.sla_due_at ? { label: "SLA", value: formatFindingTimestamp(vuln.sla_due_at) } : null,
+  ].filter((fact): fact is { label: string; value: string } => fact !== null);
+  const intelligenceFacts = [
+    vuln.cvss_vector ? { label: "CVSS vector", value: vuln.cvss_vector } : null,
+    vuln.severity_source ? { label: "Severity source", value: vuln.severity_source } : null,
+    published ? { label: "Published", value: formatDateOnly(published) } : null,
+    vuln.modified_at ? { label: "Modified", value: formatDateOnly(vuln.modified_at) } : null,
+  ].filter((fact): fact is { label: string; value: string } => fact !== null);
+  const omittedFactCount = (4 - stats.length) + (6 - workflowFacts.length) + (4 - intelligenceFacts.length);
 
   return (
     <div className="space-y-3">
-      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-2 sm:grid-cols-2">
         {stats.map((stat) => (
           <DetailStat key={stat.label} label={stat.label} value={stat.value} detail={stat.detail} />
         ))}
       </div>
 
-      <Section title="Observation and workflow">
-        <div className="grid gap-x-5 gap-y-1.5 text-xs text-[color:var(--text-secondary)] sm:grid-cols-2 lg:grid-cols-3">
-          <KeyVal label="First seen" value={vuln.first_seen ? formatFindingTimestamp(vuln.first_seen) : "Unavailable"} />
-          <KeyVal label="Last observed" value={vuln.last_observed || vuln.last_seen ? formatFindingTimestamp(vuln.last_observed ?? vuln.last_seen) : "Unavailable"} />
-          <KeyVal label="Last scanned" value="Unavailable" />
-          <KeyVal label="Status" value={vuln.lifecycle_status ? findingStatusLabel(vuln.lifecycle_status) : triage?.queue_state ?? "Unavailable"} />
-          <KeyVal label="Occurrences" value={typeof vuln.occurrence_count === "number" ? String(vuln.occurrence_count) : "Unavailable"} />
-          <KeyVal label="Owner" value={vuln.owner || triage?.assignee || "Unavailable"} />
-          <KeyVal label="SLA" value={vuln.sla_due_at ? formatFindingTimestamp(vuln.sla_due_at) : "Unavailable"} />
-        </div>
-      </Section>
+      {omittedFactCount > 0 ? (
+        <p className="text-xs text-[color:var(--text-tertiary)]">
+          Source did not provide {omittedFactCount} optional intelligence or workflow fields; omitted instead of showing placeholder tiles.
+        </p>
+      ) : null}
 
-      <Section title="Security intelligence">
-        <div className="grid gap-x-5 gap-y-1.5 text-xs text-[color:var(--text-secondary)] sm:grid-cols-2">
-          <KeyVal label="CVSS vector" value={vuln.cvss_vector ?? "Unavailable"} />
-          <KeyVal label="Severity source" value={vuln.severity_source ?? "Unavailable"} />
-          <KeyVal label="Published" value={published ? formatDateOnly(published) : "Unavailable"} />
-          <KeyVal label="Modified" value={vuln.modified_at ? formatDateOnly(vuln.modified_at) : "Unavailable"} />
-        </div>
-      </Section>
+      {workflowFacts.length > 0 ? (
+        <Section title="Observation and workflow">
+          <div className="grid gap-x-5 gap-y-1.5 text-xs text-[color:var(--text-secondary)] sm:grid-cols-2">
+            {workflowFacts.map((fact) => <KeyVal key={fact.label} label={fact.label} value={fact.value} />)}
+          </div>
+        </Section>
+      ) : null}
+
+      {intelligenceFacts.length > 0 ? (
+        <Section title="Security intelligence">
+          <div className="grid gap-x-5 gap-y-1.5 text-xs text-[color:var(--text-secondary)] sm:grid-cols-2">
+            {intelligenceFacts.map((fact) => <KeyVal key={fact.label} label={fact.label} value={fact.value} />)}
+          </div>
+        </Section>
+      ) : null}
 
       <ReachBadges vuln={vuln} />
 

--- a/ui/components/risk-campaign-command-center.tsx
+++ b/ui/components/risk-campaign-command-center.tsx
@@ -381,8 +381,8 @@ function CampaignCard({
         </div>
       </div>
       {!workflowActionable ? (
-        <p role="status" className="risk-campaign-warning">
-          Workflow actions are paused until the complete campaign membership is available. No partial ticket or verification state will be written.
+        <p role="status" className="mt-2 text-xs text-[color:var(--status-warn)]">
+          Membership incomplete · workflow locked to prevent partial ticket or verification state.
         </p>
       ) : null}
       {editingAssignment ? (
@@ -602,6 +602,11 @@ export function RiskCampaignCommandCenter() {
   useEffect(() => { void load(); }, [load]);
 
   const campaignFindingCount = useMemo(() => campaigns.reduce((sum, campaign) => sum + campaign.finding_count, 0), [campaigns]);
+  const workflowSummary = useMemo(() => ({
+    assigned: campaigns.filter((campaign) => Boolean(campaign.owner)).length,
+    withSla: campaigns.filter((campaign) => Boolean(campaign.sla_due_at)).length,
+    awaitingProof: campaigns.filter((campaign) => campaign.verification_status !== "verified").length,
+  }), [campaigns]);
   const visibleCampaigns = useMemo(
     () => campaigns.slice(0, visibleCampaignCount),
     [campaigns, visibleCampaignCount],
@@ -622,7 +627,20 @@ export function RiskCampaignCommandCenter() {
         <div>
           <div className="risk-campaign-kicker">Prioritized remediation</div>
           <h2 id="risk-campaigns-title" className="risk-page-title">Risk campaigns</h2>
-          <p className="risk-page-copy">{campaigns.length} campaigns cluster {campaignFindingCount} finding{campaignFindingCount === 1 ? "" : "s"} into owner-ready work. Start with the highest-priority campaign, opened below.</p>
+          <p className="risk-page-copy">
+            Start with {campaigns[0]!.title}. {campaigns.length} prioritized action{campaigns.length === 1 ? "" : "s"} cover{campaigns.length === 1 ? "s" : ""} {campaignFindingCount} finding{campaignFindingCount === 1 ? "" : "s"} in the current evidence window.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2 text-xs" aria-label="Remediation workflow summary">
+            <span className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1.5">
+              {workflowSummary.assigned} assigned
+            </span>
+            <span className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1.5">
+              {workflowSummary.withSla} with SLA
+            </span>
+            <span className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1.5">
+              {workflowSummary.awaitingProof} awaiting proof
+            </span>
+          </div>
         </div>
         <div className="flex flex-wrap gap-2 text-xs">
           <Link href="/security-graph" className="risk-campaign-investigate">Open investigation</Link>

--- a/ui/e2e/security-graph-cockpit.spec.ts
+++ b/ui/e2e/security-graph-cockpit.spec.ts
@@ -457,7 +457,12 @@ test(`large estates lead with non-overlapping clusters in ${theme}`, async ({ pa
   await page.goto("/security-graph");
   await page.waitForLoadState("networkidle");
 
-  await expect(page.getByText("Large estate · 1,241 nodes")).toBeVisible();
+  const evidenceScope = page.getByRole("button", { name: /Evidence scope/ });
+  await expect(evidenceScope).toHaveAttribute("aria-expanded", "false");
+  await evidenceScope.click();
+  await expect(
+    page.getByText("1,241 nodes. Use a focused lens before opening the full topology."),
+  ).toBeVisible();
   await expect(page.getByRole("link", { name: "Explore clusters" })).toHaveAttribute(
     "href",
     "/graph?scan=scan-cockpit-fixture&rollup=1",

--- a/ui/scripts/capture-product-proof.mjs
+++ b/ui/scripts/capture-product-proof.mjs
@@ -1623,6 +1623,42 @@ async function installRoutes(page) {
     limit: 1000,
     offset: 0,
   }));
+  await page.route("**/v1/fleet/endpoints?**", (route) => fulfill(route, {
+    endpoints: [
+      {
+        endpoint_id: "workstation-01",
+        tenant_id: "default",
+        platform: { system: "Darwin", release: "15.6", machine: "arm64" },
+        counts: {
+          applications: 42,
+          processes: 118,
+          services: 16,
+          listeners: 9,
+          containers: 6,
+          images: 11,
+        },
+        collector_status: {
+          applications: "complete",
+          processes: "complete",
+          services: "complete",
+          listeners: "complete",
+          containers: "complete",
+          images: "complete",
+        },
+        collector_messages: {},
+        privacy: { process_arguments_collected: false, environment_values_collected: false },
+        completeness: "complete",
+        last_scan_id: SCAN_ID,
+        observed_at: CREATED_AT,
+        updated_at: CREATED_AT,
+      },
+    ],
+    count: 1,
+    total: 1,
+    limit: 25,
+    offset: 0,
+    has_more: false,
+  }));
   await page.route("**/v1/fleet/stats", (route) => fulfill(route, {
     total: fleetAgents.length,
     by_state: fleetAgents.reduce((acc, item) => {
@@ -2114,7 +2150,7 @@ async function main() {
     const page = await newCapturePage(CAPTURE_THEME, { width: 1440, height: 980 });
 
     await capture(page, "/?capture=1", "dashboard-live.png", undefined, {
-      expectedText: [/Overview/i, /Risk posture/i, /15 open CVEs/i],
+      expectedText: [/Overview/i, /Risk posture/i, /15 unique open CVEs/i],
       expectedApiPaths: ["/v1/posture/counts", "/v1/overview"],
     });
     await capture(page, "/?capture=1", "dashboard-paths-live.png", async (dashboardPage) => {
@@ -2342,7 +2378,7 @@ async function main() {
 
     const lightPage = await newCapturePage("light", { width: 1440, height: 980 });
     await capture(lightPage, "/?capture=1", "dashboard-light-live.png", undefined, {
-      expectedText: [/Overview/i, /Risk posture/i, /15 open CVEs/i],
+      expectedText: [/Overview/i, /Risk posture/i, /15 unique open CVEs/i],
       expectedApiPaths: ["/v1/posture/counts", "/v1/overview"],
     });
     await capture(lightPage, "/security-graph?capture=1", "security-graph-light-live.png", async (securityGraphPage) => {
@@ -2363,7 +2399,7 @@ async function main() {
 
     const mobilePage = await newCapturePage("dark", { width: 390, height: 844 });
     await capture(mobilePage, "/?capture=1", "dashboard-mobile-live.png", undefined, {
-      expectedText: [/Overview/i, /Risk posture/i, /15 open CVEs/i],
+      expectedText: [/Overview/i, /Risk posture/i, /15 unique open CVEs/i],
       expectedApiPaths: ["/v1/posture/counts", "/v1/overview"],
     });
     await capture(mobilePage, "/security-graph?capture=1", "security-graph-mobile-live.png", async (securityGraphPage) => {

--- a/ui/tests/demo-investigation-contract.test.ts
+++ b/ui/tests/demo-investigation-contract.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const page = readFileSync(join(process.cwd(), "app/security-graph/page.tsx"), "utf8");
+
+describe("investigation demo hierarchy", () => {
+  it("puts the ranked decision workspace before secondary evidence controls", () => {
+    const workspace = page.indexOf("<InvestigationPathWorkspace");
+    const evidenceScope = page.indexOf('title="Evidence scope"');
+    const deployGate = page.indexOf('title="Should I deploy?"');
+    const exposureLens = page.indexOf('title="Exposure paths"');
+
+    expect(workspace).toBeGreaterThan(-1);
+    expect(evidenceScope).toBeGreaterThan(workspace);
+    expect(deployGate).toBeGreaterThan(workspace);
+    expect(exposureLens).toBeGreaterThan(workspace);
+  });
+
+  it("describes snapshots as supporting evidence instead of the page identity", () => {
+    expect(page).toContain("Evidence scope");
+    expect(page).toContain("Current scan evidence");
+    expect(page).toContain("Manage snapshots");
+    expect(page).not.toContain(">Snapshot</p>");
+    expect(page).not.toContain("Large estate ·");
+  });
+});

--- a/ui/tests/findings-page.test.tsx
+++ b/ui/tests/findings-page.test.tsx
@@ -109,6 +109,10 @@ describe("FindingsPage", () => {
       expect.stringContaining("/security-graph"),
     );
     expect(within(drawer).queryByRole("tab", { name: "Exposure path" })).not.toBeInTheDocument();
+    expect(drawer.querySelector("aside")).toHaveClass("max-w-2xl");
+    expect(within(drawer).queryByText("Unavailable")).not.toBeInTheDocument();
+    expect(within(drawer).queryByText("Last scanned")).not.toBeInTheDocument();
+    expect(within(drawer).getByText(/Source did not provide/i)).toBeInTheDocument();
 
     const closeButtons = within(drawer).getAllByRole("button", { name: "Close" });
     fireEvent.click(closeButtons.at(-1)!);
@@ -227,10 +231,10 @@ describe("FindingsPage", () => {
     expect(within(drawer).getByText("Known exploited")).toBeInTheDocument();
     expect(within(drawer).getByText(/First seen/i)).toBeInTheDocument();
     expect(within(drawer).getByText(/Last observed/i)).toBeInTheDocument();
-    expect(within(drawer).getByText(/Last scanned/i)).toBeInTheDocument();
+    expect(within(drawer).queryByText(/Last scanned/i)).not.toBeInTheDocument();
     expect(within(drawer).getByText("5.3 → 6.0.2")).toBeInTheDocument();
     expect(within(drawer).getByText("security-platform")).toBeInTheDocument();
-    expect(within(drawer).getByLabelText(/SLA: unavailable/i)).toBeInTheDocument();
+    expect(within(drawer).queryByLabelText(/SLA: unavailable/i)).not.toBeInTheDocument();
 
     fireEvent.click(within(drawer).getByRole("tab", { name: "Evidence" }));
     expect(within(drawer).getByRole("link", { name: /OSV/i })).toHaveAttribute(

--- a/ui/tests/risk-campaign-command-center.test.tsx
+++ b/ui/tests/risk-campaign-command-center.test.tsx
@@ -142,7 +142,12 @@ describe("RiskCampaignCommandCenter", () => {
 
     const title = await screen.findByText(response.campaigns[0]!.title);
     expect(title.closest("details")).toHaveAttribute("open");
-    expect(screen.getByText(/Start with the highest-priority campaign/i)).toBeInTheDocument();
+    expect(screen.getByText(/Start with Upgrade openssl to 3.0.14/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 prioritized action covers 2 findings/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 assigned/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 with SLA/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 awaiting proof/i)).toBeInTheDocument();
+    expect(screen.queryByText(/campaigns cluster/i)).not.toBeInTheDocument();
   });
 
   it("progressively discloses large campaign queues", async () => {
@@ -253,7 +258,7 @@ describe("RiskCampaignCommandCenter", () => {
 
     render(<RiskCampaignCommandCenter />);
 
-    expect(await screen.findByText(/Workflow actions are paused/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Membership incomplete · workflow locked/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Create campaign tickets/i })).toBeDisabled();
     expect(screen.getByRole("button", { name: /Sync tickets/i })).toBeDisabled();
     expect(screen.getByLabelText(/Campaign state/i)).toBeDisabled();


### PR DESCRIPTION
## Summary

- Put the ranked attack-path decision workspace first on Investigation and move scan selection, estate controls, deployment checks, and broader exposure analysis into secondary evidence sections.
- Tighten the finding drawer so it shows sourced facts without placeholder-heavy tiles, then make Remediation open with the highest-priority action and assignment/SLA/proof readiness.
- Repair the deterministic product-proof fixture so the current dashboard copy and Fleet endpoint surface are covered by dark, light, and mobile captures.

## Consolidated demo observations

1. Ranked paths render before scan metadata.
2. The attack-path graph remains the primary Investigation identity.
3. Snapshot terminology becomes Evidence scope.
4. Evidence scope is collapsed by default.
5. Current scan provenance remains visible in the collapsed summary.
6. Snapshot switching is grouped under Manage snapshots.
7. Large-estate guidance is demoted from a dominant warning card.
8. Cluster drill-down remains available.
9. Raw-topology drill-down remains available.
10. Matched-path, covered-finding, and highest-risk metrics remain available in scope.
11. Posture remains available in scope.
12. The deployment gate moves below the decision workspace.
13. The broader exposure lens moves below the decision workspace.
14. Missing-snapshot guidance points to Evidence scope.
15. The finding drawer uses a narrower readable width.
16. Missing CVSS, EPSS, KEV, and fix tiles are omitted.
17. The unsourced Last scanned placeholder is removed.
18. Missing workflow and intelligence fields are summarized once.
19. Remediation opens with the highest-priority action and evidence-window coverage.
20. Remediation shows assigned, SLA, and proof progression while incomplete membership uses a compact fail-closed lock message.

## Verification

- `/opt/homebrew/opt/node@24/bin/node scripts/verify-toolchain.mjs`
- `/opt/homebrew/opt/node@24/bin/npm run typecheck`
- `/opt/homebrew/opt/node@24/bin/npm test -- --run` — 192 files, 1,194 tests passed
- `/opt/homebrew/opt/node@24/bin/npm run build` — 52 routes generated
- `/opt/homebrew/opt/node@24/bin/npm run lint -- app/security-graph/page.tsx components/finding-drawer.tsx components/risk-campaign-command-center.tsx tests/demo-investigation-contract.test.ts tests/findings-page.test.tsx tests/risk-campaign-command-center.test.tsx`
- `/opt/homebrew/opt/node@24/bin/npm run lint -- scripts/capture-product-proof.mjs`
- `PATH=/opt/homebrew/opt/node@24/bin:/opt/homebrew/bin:/usr/bin:/bin /opt/homebrew/opt/node@24/bin/node scripts/capture-product-proof.mjs` — 20 dark/light/mobile captures completed
- `git diff --check`

## Notes

- The default machine Node 25.9.0 is outside the repository constraint; all Node validation used supported Node 24.18.0 with npm 10.9.7.
- Main has a separate Python 3.11 CI regression tracked by #4855. This PR does not touch that backend test path.
- These are 20 concrete demo observations consolidated into one UI PR; they map to partially open audit areas and should not be counted as 20 independently closed top-level audit findings until merge and CI verification.