### PR TITLE
fix(scanners): report manifest coverage gaps

### DIFF
--- a/src/agent_bom/parsers/beam_parsers.py
+++ b/src/agent_bom/parsers/beam_parsers.py
@@ -7,6 +7,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from agent_bom.coverage import record_manifest_parse_warning
 from agent_bom.models import Package
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,11 @@ def parse_hex_packages(directory: Path) -> list[Package]:
         text = lockfile.read_text(encoding="utf-8", errors="replace")
     except Exception as exc:  # noqa: BLE001
         logger.debug("Could not read mix.lock at %s: %s", lockfile, exc)
+        record_manifest_parse_warning(
+            ecosystem="hex",
+            path=str(lockfile),
+            detail="mix.lock could not be read; Hex dependencies were not scanned",
+        )
         return []
 
     packages: list[Package] = []
@@ -65,6 +71,11 @@ def _load_pubspec_lock(lockfile: Path) -> dict[str, Any]:
         data = yaml.safe_load(lockfile.read_text(encoding="utf-8", errors="replace"))
     except Exception as exc:  # noqa: BLE001
         logger.debug("Could not parse pubspec.lock at %s: %s", lockfile, exc)
+        record_manifest_parse_warning(
+            ecosystem="pub",
+            path=str(lockfile),
+            detail="pubspec.lock could not be read or parsed; Pub dependencies were not scanned",
+        )
         return {}
     return data if isinstance(data, dict) else {}
 

--- a/src/agent_bom/parsers/compiled_parsers.py
+++ b/src/agent_bom/parsers/compiled_parsers.py
@@ -21,6 +21,7 @@ from typing import Optional
 
 import httpx
 
+from agent_bom.coverage import record_manifest_parse_warning
 from agent_bom.models import MCPServer, Package
 
 logger = logging.getLogger(__name__)
@@ -107,6 +108,11 @@ def verify_go_checksums(
                 sum_entries[f"{mod}@{ver}"] = h1
         except OSError as exc:
             logger.warning("Could not read go.sum at %s: %s", go_sum, exc)
+            record_manifest_parse_warning(
+                ecosystem="go",
+                path=str(go_sum),
+                detail="go.sum could not be read; Go checksum verification was not completed",
+            )
             return {}
 
     results: dict[str, str] = {}
@@ -408,7 +414,13 @@ def _parse_go_mod_requires(
 
     try:
         content = go_mod.read_text(encoding="utf-8", errors="replace")
-    except OSError:
+    except OSError as exc:
+        logger.debug("Could not read go.mod at %s: %s", go_mod, exc)
+        record_manifest_parse_warning(
+            ecosystem="go",
+            path=str(go_mod),
+            detail="go.mod could not be read; Go dependencies were not scanned",
+        )
         return direct, indirect, replace_map
 
     block_re = re.compile(r"require\s*\(([^)]+)\)", re.DOTALL)
@@ -467,7 +479,13 @@ def parse_go_workspace(directory: Path) -> list[Package]:
 
     try:
         content = go_work.read_text(encoding="utf-8", errors="replace")
-    except OSError:
+    except OSError as exc:
+        logger.debug("Could not read go.work at %s: %s", go_work, exc)
+        record_manifest_parse_warning(
+            ecosystem="go",
+            path=str(go_work),
+            detail="go.work could not be read; Go workspace dependencies were not scanned",
+        )
         return []
 
     # Parse "use ./module_path" directives (single-line and block forms)
@@ -609,7 +627,13 @@ def parse_go_packages(
         seen: set[tuple[str, str]] = set()
         try:
             lines = go_sum.read_text(encoding="utf-8", errors="replace").splitlines()
-        except OSError:
+        except OSError as exc:
+            logger.debug("Could not read go.sum at %s: %s", go_sum, exc)
+            record_manifest_parse_warning(
+                ecosystem="go",
+                path=str(go_sum),
+                detail="go.sum could not be read; Go dependencies were not scanned",
+            )
             return []
         for line in lines:
             parts = line.strip().split()
@@ -661,14 +685,12 @@ def _parse_pom_modules(root_dir: Path, depth: int = 0) -> list[Package]:
     try:
         tree = safe_xml_parse(str(pom))
         xml_root = tree.getroot()
-    except ET.ParseError as exc:
+    except (ET.ParseError, OSError) as exc:
         logger.debug("Failed to parse pom.xml in %s: %s", root_dir, exc)
-        from agent_bom.coverage import record_manifest_parse_warning
-
         record_manifest_parse_warning(
             ecosystem="maven",
             path=str(pom),
-            detail=f"pom.xml failed to parse ({exc}); Maven dependencies were not scanned",
+            detail="pom.xml could not be read or parsed; Maven dependencies were not scanned",
         )
         return []
 
@@ -838,7 +860,13 @@ def _parse_cargo_toml(cargo_toml: Path) -> list[Package]:
         import tomllib
 
         data = tomllib.loads(cargo_toml.read_text(encoding="utf-8", errors="replace"))
-    except (OSError, ValueError):
+    except (OSError, ValueError) as exc:
+        logger.debug("Could not parse Cargo.toml at %s: %s", cargo_toml, exc)
+        record_manifest_parse_warning(
+            ecosystem="cargo",
+            path=str(cargo_toml),
+            detail="Cargo.toml could not be read or parsed; Cargo dependencies were not scanned",
+        )
         return []
 
     pkgs: list[Package] = []
@@ -884,7 +912,17 @@ def parse_cargo_packages(directory: Path, *, resolve_versions: bool = False) -> 
     if cargo_lock.exists():
         current_name: Optional[str] = None
         current_version: Optional[str] = None
-        for raw_line in cargo_lock.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            cargo_lines = cargo_lock.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError as exc:
+            logger.debug("Could not read Cargo.lock at %s: %s", cargo_lock, exc)
+            record_manifest_parse_warning(
+                ecosystem="cargo",
+                path=str(cargo_lock),
+                detail="Cargo.lock could not be read; Cargo dependencies were not scanned",
+            )
+            cargo_lines = []
+        for raw_line in cargo_lines:
             stripped_line = raw_line.strip()
             if stripped_line.startswith('name = "'):
                 current_name = stripped_line.split('"')[1]
@@ -967,7 +1005,13 @@ def parse_gradle_packages(directory: Path) -> list[Package]:
         packages: list[Package] = []
         try:
             content = path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
+        except OSError as exc:
+            logger.debug("Could not read Gradle version catalog at %s: %s", path, exc)
+            record_manifest_parse_warning(
+                ecosystem="maven",
+                path=str(path),
+                detail="libs.versions.toml could not be read; Gradle catalog dependencies were not scanned",
+            )
             return []
 
         # Parse [versions] section — simple key = "value" pairs
@@ -1044,7 +1088,13 @@ def parse_gradle_packages(directory: Path) -> list[Package]:
         packages: list[Package] = []
         try:
             lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-        except OSError:
+        except OSError as exc:
+            logger.debug("Could not read Gradle lockfile at %s: %s", path, exc)
+            record_manifest_parse_warning(
+                ecosystem="maven",
+                path=str(path),
+                detail="gradle.lockfile could not be read; Gradle dependencies were not scanned",
+            )
             return []
         for line in lines:
             line = line.strip()
@@ -1066,7 +1116,13 @@ def parse_gradle_packages(directory: Path) -> list[Package]:
         packages: list[Package] = []
         try:
             content = path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
+        except OSError as exc:
+            logger.debug("Could not read Gradle build file at %s: %s", path, exc)
+            record_manifest_parse_warning(
+                ecosystem="maven",
+                path=str(path),
+                detail=f"{path.name} could not be read; Gradle dependencies were not scanned",
+            )
             return []
 
         # Match Kotlin DSL: configName("group:artifact:version")
@@ -1169,7 +1225,13 @@ def parse_conda_packages(directory: Path) -> list[Package]:
         pkgs: list[Package] = []
         try:
             content = path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
+        except OSError as exc:
+            logger.debug("Could not read Conda environment at %s: %s", path, exc)
+            record_manifest_parse_warning(
+                ecosystem="conda",
+                path=str(path),
+                detail=f"{path.name} could not be read; Conda dependencies were not scanned",
+            )
             return pkgs
 
         # Try YAML first; fall back to line-by-line
@@ -1178,7 +1240,15 @@ def parse_conda_packages(directory: Path) -> list[Package]:
             import yaml  # type: ignore[import-untyped]
 
             data = yaml.safe_load(content) or {}
-        except Exception:
+        except ImportError:
+            data = None
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Could not parse Conda environment at %s: %s", path, exc)
+            record_manifest_parse_warning(
+                ecosystem="conda",
+                path=str(path),
+                detail=f"{path.name} could not be parsed; Conda dependency coverage may be incomplete",
+            )
             data = None
 
         if data is not None:
@@ -1277,7 +1347,13 @@ def parse_conda_packages(directory: Path) -> list[Package]:
         pkgs: list[Package] = []
         try:
             content = path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
+        except OSError as exc:
+            logger.debug("Could not read Conda lockfile at %s: %s", path, exc)
+            record_manifest_parse_warning(
+                ecosystem="conda",
+                path=str(path),
+                detail="conda-lock.yml could not be read; Conda dependencies were not scanned",
+            )
             return pkgs
 
         data: dict | None = None
@@ -1285,7 +1361,15 @@ def parse_conda_packages(directory: Path) -> list[Package]:
             import yaml  # type: ignore[import-untyped]
 
             data = yaml.safe_load(content) or {}
-        except Exception:
+        except ImportError:
+            data = None
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Could not parse Conda lockfile at %s: %s", path, exc)
+            record_manifest_parse_warning(
+                ecosystem="conda",
+                path=str(path),
+                detail="conda-lock.yml could not be parsed; Conda dependencies were not scanned",
+            )
             data = None
 
         if data is None:

--- a/src/agent_bom/parsers/dotnet_parsers.py
+++ b/src/agent_bom/parsers/dotnet_parsers.py
@@ -13,6 +13,7 @@ import logging
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+from agent_bom.coverage import record_manifest_parse_warning
 from agent_bom.models import Package
 
 logger = logging.getLogger(__name__)
@@ -91,8 +92,13 @@ def _parse_nuget_lock_json(directory: Path) -> list[Package]:
                         is_direct=(dep_type == "Direct"),
                     )
                 )
-    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+    except (json.JSONDecodeError, KeyError, TypeError, OSError, UnicodeDecodeError) as exc:
         logger.debug("Failed to parse packages.lock.json at %s: %s", lock_file, exc)
+        record_manifest_parse_warning(
+            ecosystem="nuget",
+            path=str(lock_file),
+            detail="packages.lock.json could not be read or parsed; NuGet dependencies were not scanned",
+        )
 
     return packages
 
@@ -128,7 +134,12 @@ def _parse_csproj_files(directory: Path) -> list[Package]:
                         is_direct=True,
                     )
                 )
-        except ET.ParseError as exc:
+        except (ET.ParseError, OSError) as exc:
             logger.debug("Failed to parse .csproj at %s: %s", csproj, exc)
+            record_manifest_parse_warning(
+                ecosystem="nuget",
+                path=str(csproj),
+                detail=f"{csproj.name} could not be read or parsed; NuGet project dependencies were not scanned",
+            )
 
     return packages

--- a/src/agent_bom/parsers/node_parsers.py
+++ b/src/agent_bom/parsers/node_parsers.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from urllib.parse import quote
 
 from agent_bom.checksums import parse_sri
+from agent_bom.coverage import record_manifest_parse_warning
 from agent_bom.models import MCPServer, Package
 from agent_bom.parsers.file_limits import read_json_limited, read_text_limited
 from agent_bom.traversal import iter_discovery_files
@@ -344,8 +345,6 @@ def parse_npm_packages(directory: Path) -> list[Package]:
         # deny the scanner. Degrade with a named coverage warning instead.
         except (json.JSONDecodeError, KeyError, OSError, UnicodeDecodeError) as exc:
             logger.debug("Failed to parse package-lock.json in %s: %s", directory, exc)
-            from agent_bom.coverage import record_manifest_parse_warning
-
             record_manifest_parse_warning(
                 ecosystem="npm",
                 path=str(lock_file),
@@ -402,8 +401,6 @@ def parse_npm_packages(directory: Path) -> list[Package]:
         # gap to report, never a scan-aborting exception.
         except (json.JSONDecodeError, KeyError, OSError, UnicodeDecodeError) as exc:
             logger.debug("Failed to parse package.json in %s: %s", directory, exc)
-            from agent_bom.coverage import record_manifest_parse_warning
-
             record_manifest_parse_warning(
                 ecosystem="npm",
                 path=str(directory / "package.json"),
@@ -501,6 +498,11 @@ def parse_yarn_lock(directory: Path) -> list[Package]:
                     current_names = []
     except Exception as exc:
         logger.debug("Failed to parse yarn.lock at %s: %s", lock_file, exc)
+        record_manifest_parse_warning(
+            ecosystem="npm",
+            path=str(lock_file),
+            detail="yarn.lock could not be read or parsed; Yarn dependencies were not scanned",
+        )
 
     return packages
 
@@ -558,6 +560,11 @@ def parse_pnpm_lock(directory: Path) -> list[Package]:
                 )
     except Exception as exc:
         logger.debug("Failed to parse pnpm-lock.yaml at %s: %s", lock_file, exc)
+        record_manifest_parse_warning(
+            ecosystem="npm",
+            path=str(lock_file),
+            detail="pnpm-lock.yaml could not be read or parsed; pnpm dependencies were not scanned",
+        )
 
     return packages
 
@@ -634,6 +641,11 @@ def parse_bun_packages(directory: Path) -> list[Package]:
                 )
     except Exception as exc:
         logger.debug("Failed to parse bun.lock at %s: %s", bun_lock, exc)
+        record_manifest_parse_warning(
+            ecosystem="npm",
+            path=str(bun_lock),
+            detail="bun.lock could not be read or parsed; Bun dependencies were not scanned",
+        )
 
     return packages
 

--- a/src/agent_bom/parsers/php_parsers.py
+++ b/src/agent_bom/parsers/php_parsers.py
@@ -11,6 +11,7 @@ import json
 import logging
 from pathlib import Path
 
+from agent_bom.coverage import record_manifest_parse_warning
 from agent_bom.models import Package
 from agent_bom.parsers.file_limits import read_json_limited
 
@@ -37,6 +38,11 @@ def parse_composer_lock(directory: str | Path) -> list[Package]:
         data = read_json_limited(lockfile, encoding="utf-8", errors="replace")
     except (OSError, json.JSONDecodeError) as exc:
         logger.warning("Cannot read %s: %s", lockfile, exc)
+        record_manifest_parse_warning(
+            ecosystem="composer",
+            path=str(lockfile),
+            detail="composer.lock could not be read or parsed; Composer dependencies were not scanned",
+        )
         return []
 
     # Read direct deps from composer.json for is_direct marking
@@ -51,8 +57,13 @@ def parse_composer_lock(directory: str | Path) -> list[Package]:
                     if name == "php" or name.startswith("ext-"):
                         continue
                     direct_names.add(name.lower())
-        except (OSError, json.JSONDecodeError):
-            pass
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.debug("Cannot read %s for direct dependency attribution: %s", composer_json, exc)
+            record_manifest_parse_warning(
+                ecosystem="composer",
+                path=str(composer_json),
+                detail="composer.json could not be read or parsed; direct dependency attribution is incomplete",
+            )
 
     packages: list[Package] = []
     seen: set[tuple[str, str]] = set()
@@ -119,6 +130,11 @@ def parse_php_packages(directory: str | Path) -> list[Package]:
         data = read_json_limited(composer_json, encoding="utf-8", errors="replace")
     except (OSError, json.JSONDecodeError) as exc:
         logger.warning("Cannot read %s: %s", composer_json, exc)
+        record_manifest_parse_warning(
+            ecosystem="composer",
+            path=str(composer_json),
+            detail="composer.json could not be read or parsed; Composer dependencies were not scanned",
+        )
         return []
 
     packages = []

--- a/src/agent_bom/parsers/python_parsers.py
+++ b/src/agent_bom/parsers/python_parsers.py
@@ -12,6 +12,7 @@ import re
 import subprocess
 from pathlib import Path
 
+from agent_bom.coverage import record_manifest_parse_warning
 from agent_bom.models import Package
 from agent_bom.parsers.file_limits import read_json_limited, read_text_limited
 from agent_bom.version_utils import strip_pip_extras
@@ -148,8 +149,6 @@ def parse_poetry_lock(directory: Path) -> list[Package]:
             )
     except Exception as exc:
         logger.debug("Failed to parse poetry.lock at %s: %s", lock_file, exc)
-        from agent_bom.coverage import record_manifest_parse_warning
-
         record_manifest_parse_warning(
             ecosystem="pypi",
             path=str(lock_file),
@@ -212,8 +211,6 @@ def parse_uv_lock(directory: Path) -> list[Package]:
             )
     except Exception as exc:
         logger.debug("Failed to parse uv.lock at %s: %s", lock_file, exc)
-        from agent_bom.coverage import record_manifest_parse_warning
-
         record_manifest_parse_warning(
             ecosystem="pypi",
             path=str(lock_file),
@@ -279,6 +276,11 @@ def parse_conda_environment(directory: Path) -> list[Package]:
                         )
     except Exception as exc:
         logger.debug("Failed to parse conda environment at %s: %s", env_file, exc)
+        record_manifest_parse_warning(
+            ecosystem="conda",
+            path=str(env_file),
+            detail=f"{env_file.name} could not be read or parsed; Conda dependencies were not scanned",
+        )
 
     return packages
 
@@ -309,36 +311,44 @@ def parse_pip_packages(directory: Path) -> list[Package]:
     # Try requirements.txt
     req_file = directory / "requirements.txt"
     if req_file.exists():
-        for line in read_text_limited(req_file).splitlines():
-            line = line.strip()
-            if not line or line.startswith("#") or line.startswith("-"):
-                continue
-            # Git URL/SHA reference (``flask @ git+…@<sha>``): version can't be
-            # pinned from the ref, so flag it floating rather than dropping it.
-            git_pkg = _git_reference_package(line, is_direct=True)
-            if git_pkg is not None:
-                packages.append(git_pkg)
-                continue
-            # Parse name==version, name>=version, etc.
-            match = re.match(r"^([a-zA-Z0-9_.-]+(?:\[[^\]]+\])?)\s*([=<>!~]+)\s*([a-zA-Z0-9_.*+-]+)", line)
-            if match:
-                raw_name, operator, version = match.groups()
-                name, _ = strip_pip_extras(raw_name)
-                packages.append(_requirement_package(name, operator, version, is_direct=True))
-            else:
-                # Just a name, no version
-                name_match = re.match(r"^([a-zA-Z0-9_.-]+(?:\[[^\]]+\])?)", line)
-                if name_match:
-                    name, _ = strip_pip_extras(name_match.group(1))
-                    packages.append(
-                        Package(
-                            name=name,
-                            version="unknown",
-                            ecosystem="pypi",
-                            is_direct=True,
-                            reachability_evidence="declaration_only",
+        try:
+            for line in read_text_limited(req_file).splitlines():
+                line = line.strip()
+                if not line or line.startswith("#") or line.startswith("-"):
+                    continue
+                # Git URL/SHA reference (``flask @ git+…@<sha>``): version can't be
+                # pinned from the ref, so flag it floating rather than dropping it.
+                git_pkg = _git_reference_package(line, is_direct=True)
+                if git_pkg is not None:
+                    packages.append(git_pkg)
+                    continue
+                # Parse name==version, name>=version, etc.
+                match = re.match(r"^([a-zA-Z0-9_.-]+(?:\[[^\]]+\])?)\s*([=<>!~]+)\s*([a-zA-Z0-9_.*+-]+)", line)
+                if match:
+                    raw_name, operator, version = match.groups()
+                    name, _ = strip_pip_extras(raw_name)
+                    packages.append(_requirement_package(name, operator, version, is_direct=True))
+                else:
+                    # Just a name, no version
+                    name_match = re.match(r"^([a-zA-Z0-9_.-]+(?:\[[^\]]+\])?)", line)
+                    if name_match:
+                        name, _ = strip_pip_extras(name_match.group(1))
+                        packages.append(
+                            Package(
+                                name=name,
+                                version="unknown",
+                                ecosystem="pypi",
+                                is_direct=True,
+                                reachability_evidence="declaration_only",
+                            )
                         )
-                    )
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.debug("Failed to read requirements.txt in %s: %s", directory, exc)
+            record_manifest_parse_warning(
+                ecosystem="pypi",
+                path=str(req_file),
+                detail="requirements.txt could not be read; Python dependencies were not scanned",
+            )
 
     # Try Pipfile.lock
     pipfile_lock = directory / "Pipfile.lock"
@@ -358,8 +368,13 @@ def parse_pip_packages(directory: Path) -> list[Package]:
                                 is_direct=section == "default",
                             )
                         )
-        except (json.JSONDecodeError, KeyError) as exc:
+        except (json.JSONDecodeError, KeyError, OSError, UnicodeDecodeError) as exc:
             logger.debug("Failed to parse Pipfile.lock in %s: %s", directory, exc)
+            record_manifest_parse_warning(
+                ecosystem="pypi",
+                path=str(pipfile_lock),
+                detail="Pipfile.lock could not be read or parsed; Python dependencies were not scanned",
+            )
 
     # Try pyproject.toml
     pyproject = directory / "pyproject.toml"
@@ -400,8 +415,6 @@ def parse_pip_packages(directory: Path) -> list[Package]:
                         )
         except Exception as e:
             logger.debug(f"Failed to parse pyproject.toml at {pyproject}: {e}")
-            from agent_bom.coverage import record_manifest_parse_warning
-
             record_manifest_parse_warning(
                 ecosystem="pypi",
                 path=str(pyproject),
@@ -492,8 +505,13 @@ def parse_pip_compile_inputs(directory: Path) -> list[Package]:
         try:
             in_lines = in_file.read_text(encoding="utf-8").splitlines()
             packages.extend(_parse_requirements_lines(in_lines, is_direct=True))
-        except OSError as exc:
+        except (OSError, UnicodeDecodeError) as exc:
             logger.debug("Failed to read %s: %s", in_file, exc)
+            record_manifest_parse_warning(
+                ecosystem="pypi",
+                path=str(in_file),
+                detail=f"{in_file.name} could not be read; pip-compile dependencies were not scanned",
+            )
 
     # constraints.txt — version pins for transitive deps; not direct installs
     constraints_file = directory / "constraints.txt"
@@ -501,8 +519,13 @@ def parse_pip_compile_inputs(directory: Path) -> list[Package]:
         try:
             c_lines = constraints_file.read_text(encoding="utf-8").splitlines()
             packages.extend(_parse_requirements_lines(c_lines, is_direct=False))
-        except OSError as exc:
+        except (OSError, UnicodeDecodeError) as exc:
             logger.debug("Failed to read %s: %s", constraints_file, exc)
+            record_manifest_parse_warning(
+                ecosystem="pypi",
+                path=str(constraints_file),
+                detail="constraints.txt could not be read; constrained Python dependencies were not scanned",
+            )
 
     return packages
 

--- a/src/agent_bom/parsers/ruby_parsers.py
+++ b/src/agent_bom/parsers/ruby_parsers.py
@@ -11,6 +11,7 @@ import logging
 import re
 from pathlib import Path
 
+from agent_bom.coverage import record_manifest_parse_warning
 from agent_bom.models import Package
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,11 @@ def parse_gemfile_lock(directory: str | Path) -> list[Package]:
         content = lockfile.read_text(encoding="utf-8", errors="replace")
     except OSError as exc:
         logger.warning("Cannot read %s: %s", lockfile, exc)
+        record_manifest_parse_warning(
+            ecosystem="rubygems",
+            path=str(lockfile),
+            detail="Gemfile.lock could not be read; Ruby dependencies were not scanned",
+        )
         return []
 
     packages: list[Package] = []
@@ -61,8 +67,13 @@ def parse_gemfile_lock(directory: str | Path) -> list[Package]:
             # Match: gem "name" or gem 'name'
             for m in re.finditer(r"""gem\s+["']([^"']+)["']""", gf_content):
                 direct_names.add(m.group(1).strip())
-        except OSError:
-            pass
+        except OSError as exc:
+            logger.debug("Cannot read %s for direct dependency attribution: %s", gemfile, exc)
+            record_manifest_parse_warning(
+                ecosystem="rubygems",
+                path=str(gemfile),
+                detail="Gemfile could not be read; direct dependency attribution is incomplete",
+            )
 
     # Parse the GEM specs section
     in_gem_section = False
@@ -148,6 +159,11 @@ def parse_ruby_packages(directory: str | Path) -> list[Package]:
         content = gemfile.read_text(encoding="utf-8", errors="replace")
     except OSError as exc:
         logger.warning("Cannot read %s: %s", gemfile, exc)
+        record_manifest_parse_warning(
+            ecosystem="rubygems",
+            path=str(gemfile),
+            detail="Gemfile could not be read; Ruby dependencies were not scanned",
+        )
         return []
 
     packages = []

--- a/src/agent_bom/parsers/swift_parsers.py
+++ b/src/agent_bom/parsers/swift_parsers.py
@@ -10,6 +10,7 @@ import json
 import logging
 from pathlib import Path
 
+from agent_bom.coverage import record_manifest_parse_warning
 from agent_bom.models import Package
 
 logger = logging.getLogger(__name__)
@@ -58,6 +59,11 @@ def parse_package_resolved(directory: str | Path) -> list[Package]:
         data = json.loads(resolved.read_text(encoding="utf-8", errors="replace"))
     except (OSError, json.JSONDecodeError) as exc:
         logger.warning("Cannot read %s: %s", resolved, exc)
+        record_manifest_parse_warning(
+            ecosystem="swift",
+            path=str(resolved),
+            detail=f"{resolved.name} could not be read or parsed; Swift dependencies were not scanned",
+        )
         return []
 
     packages: list[Package] = []

--- a/tests/test_manifest_parser_coverage.py
+++ b/tests/test_manifest_parser_coverage.py
@@ -1,0 +1,153 @@
+"""Manifest parser failures become structured coverage gaps, never false-clean scans."""
+
+from __future__ import annotations
+
+import builtins
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from agent_bom.parsers.beam_parsers import parse_hex_packages, parse_pub_packages
+from agent_bom.parsers.compiled_parsers import (
+    parse_cargo_packages,
+    parse_conda_packages,
+    parse_go_packages,
+    parse_go_workspace,
+    parse_gradle_packages,
+    parse_maven_packages,
+)
+from agent_bom.parsers.dotnet_parsers import parse_nuget_packages
+from agent_bom.parsers.node_parsers import parse_bun_packages, parse_pnpm_lock, parse_yarn_lock
+from agent_bom.parsers.php_parsers import parse_composer_lock, parse_php_packages
+from agent_bom.parsers.python_parsers import parse_conda_environment, parse_pip_compile_inputs, parse_pip_packages
+from agent_bom.parsers.ruby_parsers import parse_gemfile_lock, parse_ruby_packages
+from agent_bom.parsers.swift_parsers import parse_package_resolved
+from agent_bom.scanners import state as scanner_state
+
+Parser = Callable[[Path], list]
+
+
+@pytest.fixture(autouse=True)
+def _reset_coverage_warnings():
+    scanner_state.consume_coverage_warnings()
+    yield
+    scanner_state.consume_coverage_warnings()
+
+
+def _go_packages(directory: Path) -> list:
+    return parse_go_packages(directory, verify_checksums=False)
+
+
+_READ_FAILURE_CASES: list[tuple[str, str, Parser]] = [
+    ("yarn.lock", "npm", parse_yarn_lock),
+    ("pnpm-lock.yaml", "npm", parse_pnpm_lock),
+    ("bun.lock", "npm", parse_bun_packages),
+    ("requirements.txt", "pypi", parse_pip_packages),
+    ("Pipfile.lock", "pypi", parse_pip_packages),
+    ("requirements.in", "pypi", parse_pip_compile_inputs),
+    ("constraints.txt", "pypi", parse_pip_compile_inputs),
+    ("environment.yml", "conda", parse_conda_environment),
+    ("environment.yaml", "conda", parse_conda_packages),
+    ("mix.lock", "hex", parse_hex_packages),
+    ("pubspec.lock", "pub", parse_pub_packages),
+    ("packages.lock.json", "nuget", parse_nuget_packages),
+    ("Sample.csproj", "nuget", parse_nuget_packages),
+    ("composer.lock", "composer", parse_composer_lock),
+    ("composer.json", "composer", parse_php_packages),
+    ("Gemfile.lock", "rubygems", parse_gemfile_lock),
+    ("Gemfile", "rubygems", parse_ruby_packages),
+    ("Package.resolved", "swift", parse_package_resolved),
+    ("go.work", "go", parse_go_workspace),
+    ("go.mod", "go", _go_packages),
+    ("go.sum", "go", _go_packages),
+    ("pom.xml", "maven", parse_maven_packages),
+    ("Cargo.lock", "cargo", parse_cargo_packages),
+    ("Cargo.toml", "cargo", parse_cargo_packages),
+    ("gradle/libs.versions.toml", "maven", parse_gradle_packages),
+    ("gradle.lockfile", "maven", parse_gradle_packages),
+    ("build.gradle", "maven", parse_gradle_packages),
+    ("build.gradle.kts", "maven", parse_gradle_packages),
+    ("conda-lock.yml", "conda", parse_conda_packages),
+]
+
+
+@pytest.mark.parametrize(("relative_path", "ecosystem", "parser"), _READ_FAILURE_CASES)
+def test_manifest_read_failure_records_named_coverage_gap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    relative_path: str,
+    ecosystem: str,
+    parser: Parser,
+) -> None:
+    target = tmp_path / relative_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("placeholder", encoding="utf-8")
+
+    original_path_open = Path.open
+    original_builtin_open = builtins.open
+
+    def denied_path_open(self: Path, *args, **kwargs):
+        if self == target:
+            raise OSError("simulated unreadable manifest")
+        return original_path_open(self, *args, **kwargs)
+
+    def denied_builtin_open(file, *args, **kwargs):
+        if Path(file) == target:
+            raise OSError("simulated unreadable manifest")
+        return original_builtin_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", denied_path_open)
+    monkeypatch.setattr(builtins, "open", denied_builtin_open)
+
+    assert parser(tmp_path) == []
+    warnings = scanner_state.consume_coverage_warnings()
+    assert len(warnings) == 1, warnings
+    assert warnings[0]["reason"] == "manifest_parse_error"
+    assert warnings[0]["ecosystem"] == ecosystem
+    assert target.name in warnings[0]["release"]
+    assert "simulated unreadable manifest" not in warnings[0]["detail"]
+
+
+def _scan_dir_to_json(directory: Path, output: Path) -> dict:
+    from click.testing import CliRunner
+
+    from agent_bom.cli import main
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "scan",
+            str(directory),
+            "--offline",
+            "--no-auto-update-db",
+            "--format",
+            "json",
+            "--output",
+            str(output),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1, result.output
+    assert output.exists(), result.output
+    return json.loads(output.read_text(encoding="utf-8"))
+
+
+def test_non_npm_manifest_warning_reaches_partial_scan_artifact(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "composer.lock").write_text("{not-json", encoding="utf-8")
+
+    payload = _scan_dir_to_json(project, tmp_path / "report.json")
+
+    parse_errors = [warning for warning in payload["coverage_warnings"] if warning["reason"] == "manifest_parse_error"]
+    assert any(warning["ecosystem"] == "composer" for warning in parse_errors), parse_errors
+    assert payload["scan_run"]["outcome"] == "partial"
+
+
+def test_empty_project_does_not_invent_manifest_coverage_gaps(tmp_path: Path) -> None:
+    assert parse_php_packages(tmp_path) == []
+    assert parse_go_packages(tmp_path, verify_checksums=False) == []
+    assert parse_gradle_packages(tmp_path) == []
+    assert scanner_state.consume_coverage_warnings() == []


### PR DESCRIPTION
## Summary

- Convert silent manifest read and parse failures into structured `manifest_parse_error` coverage warnings across Node, Python, Go, Maven/Gradle, Cargo, Conda, NuGet, Composer, RubyGems, Swift, Hex, and Pub inputs.
- Preserve graceful scanning while making incomplete dependency extraction produce a partial scan artifact and non-zero scan verdict instead of a false-clean result.
- Keep report details operator-readable without copying raw exception text into the artifact, with a parameterized regression matrix for 29 concrete failure paths.

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_manifest_parser_coverage.py tests/test_node_manifest_read_failures.py tests/test_bun_nuget_pipcompile_parsers.py tests/test_beam_parsers.py tests/test_go_integrity.py tests/test_gradle_conda_parsers.py tests/test_php_parser.py tests/test_ruby_parsers.py tests/test_swift_parser.py tests/test_yarn_lock.py` — 150 passed
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_manifest_parser_coverage.py` — 31 passed
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check ...` — passed for all touched parser and regression-test files
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom` — no issues in 860 source files
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python scripts/check_exception_sanitization.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight`
- `git diff --check`

## Notes

- An optional full `pytest -q` run was stopped after 1,973 passed and 16 skipped while a long-running graph scale test was executing; it is not reported as a completed green suite.
- The 29 cases are concrete parser coverage observations consolidated into one mechanical expansion PR. They are not counted as 29 independently closed top-level audit findings until merge and release verification.