### PR TITLE
fix(ast): report partial source coverage

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-16",
+  "generated_on": "2026-08-18",
   "version": "0.101.0",
   "metrics": [
     {
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 860,
+      "value": 861,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-16`
+- Generated on: `2026-08-18`
 - Version: `0.101.0`
 
 | Metric | Value | Source | Notes |
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 48 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 860 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 861 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/ast/js_ts/facade.py
+++ b/src/agent_bom/ast/js_ts/facade.py
@@ -19,6 +19,7 @@ import re
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
+from agent_bom.ast.source_reader import read_source_for_analysis
 from agent_bom.ast_models import CallEdge, DependencySymbolReach, DetectedGuardrail, ExtractedPrompt, FlowFinding, ToolSignature
 from agent_bom.ast_signal_utils import _GUARDRAIL_CALL_PATTERNS, _balanced_segment, check_prompt_risks, classify_prompt_type
 from agent_bom.ast_source_mask import mask_line_comments_and_strings
@@ -660,12 +661,8 @@ def scan_js_ts_file(
     JSTSAstAnalysis | None,
 ]:
     """Extract prompt/tool/guardrail/dangerous-call signals from JS/TS source files."""
-    try:
-        source = file_path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return [], [], [], [], [], [], None
-
-    if len(source) > _MAX_FILE_SIZE:
+    source = read_source_for_analysis(file_path, rel_path, scanner="ast-js-ts", max_size=_MAX_FILE_SIZE)
+    if source is None:
         return [], [], [], [], [], [], None
 
     prompts: list[ExtractedPrompt] = []

--- a/src/agent_bom/ast/kotlin/analyzer.py
+++ b/src/agent_bom/ast/kotlin/analyzer.py
@@ -34,6 +34,7 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from agent_bom.ast.source_reader import read_source_for_analysis
 from agent_bom.ast_models import (
     CallEdge,
     DependencySymbolReach,
@@ -463,12 +464,8 @@ def scan_kotlin_file(
     _KotlinFileAnalysis | None,
 ]:
     """Extract MCP/tool signals and call sites from Kotlin source files."""
-    try:
-        source = file_path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return [], [], [], [], [], [], None
-
-    if len(source) > _MAX_FILE_SIZE:
+    source = read_source_for_analysis(file_path, rel_path, scanner="ast-kotlin", max_size=_MAX_FILE_SIZE)
+    if source is None:
         return [], [], [], [], [], [], None
 
     scope_match = _KOTLIN_SCOPE_RE.search(mask_line_comments_and_strings(source))

--- a/src/agent_bom/ast/source_reader.py
+++ b/src/agent_bom/ast/source_reader.py
@@ -1,0 +1,37 @@
+"""Bounded source reads that preserve honest AST scan coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_bom.coverage import record_scan_input_warning
+
+
+def read_source_for_analysis(
+    file_path: Path,
+    rel_path: str,
+    *,
+    scanner: str,
+    max_size: int,
+) -> str | None:
+    """Read one source file or record why AST analysis is partial."""
+    try:
+        source = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        record_scan_input_warning(
+            scanner=scanner,
+            path=rel_path,
+            reason="source_read_error",
+            detail="Source file could not be read; AST analysis is incomplete.",
+        )
+        return None
+
+    if len(source) > max_size:
+        record_scan_input_warning(
+            scanner=scanner,
+            path=rel_path,
+            reason="source_size_limit",
+            detail=f"Source file exceeds the {max_size:,}-character AST analysis limit.",
+        )
+        return None
+    return source

--- a/src/agent_bom/ast_csharp.py
+++ b/src/agent_bom/ast_csharp.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from agent_bom.ast.source_reader import read_source_for_analysis
 from agent_bom.ast_models import (
     CallEdge,
     DependencySymbolReach,
@@ -409,12 +410,8 @@ def scan_csharp_file(
     _CSharpFileAnalysis | None,
 ]:
     """Extract MCP/tool signals and call sites from C# source files."""
-    try:
-        source = file_path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return [], [], [], [], [], [], None
-
-    if len(source) > _MAX_FILE_SIZE:
+    source = read_source_for_analysis(file_path, rel_path, scanner="ast-csharp", max_size=_MAX_FILE_SIZE)
+    if source is None:
         return [], [], [], [], [], [], None
 
     class_match = _CS_CLASS_RE.search(source)

--- a/src/agent_bom/ast_go.py
+++ b/src/agent_bom/ast_go.py
@@ -6,6 +6,7 @@ import re
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
+from agent_bom.ast.source_reader import read_source_for_analysis
 from agent_bom.ast_models import (
     CallEdge,
     DependencySymbolReach,
@@ -971,12 +972,8 @@ def scan_go_file(
     _GoFileAnalysis | None,
 ]:
     """Extract prompt/tool/guardrail/dangerous-call signals from Go source files."""
-    try:
-        source = file_path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return [], [], [], [], [], [], None
-
-    if len(source) > _MAX_FILE_SIZE:
+    source = read_source_for_analysis(file_path, rel_path, scanner="ast-go", max_size=_MAX_FILE_SIZE)
+    if source is None:
         return [], [], [], [], [], [], None
 
     prompts: list[ExtractedPrompt] = []

--- a/src/agent_bom/ast_java.py
+++ b/src/agent_bom/ast_java.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from agent_bom.ast.source_reader import read_source_for_analysis
 from agent_bom.ast_models import (
     CallEdge,
     DependencySymbolReach,
@@ -449,12 +450,8 @@ def scan_java_file(
     _JavaFileAnalysis | None,
 ]:
     """Extract MCP/tool signals and call sites from Java source files."""
-    try:
-        source = file_path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return [], [], [], [], [], [], None
-
-    if len(source) > _MAX_FILE_SIZE:
+    source = read_source_for_analysis(file_path, rel_path, scanner="ast-java", max_size=_MAX_FILE_SIZE)
+    if source is None:
         return [], [], [], [], [], [], None
 
     class_match = _JAVA_CLASS_RE.search(source)

--- a/src/agent_bom/ast_php.py
+++ b/src/agent_bom/ast_php.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from agent_bom.ast.source_reader import read_source_for_analysis
 from agent_bom.ast_models import (
     CallEdge,
     DependencySymbolReach,
@@ -410,12 +411,8 @@ def scan_php_file(
     list[CallEdge],
     _PhpFileAnalysis | None,
 ]:
-    try:
-        source = file_path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return [], [], [], [], [], [], None
-
-    if len(source) > _MAX_FILE_SIZE:
+    source = read_source_for_analysis(file_path, rel_path, scanner="ast-php", max_size=_MAX_FILE_SIZE)
+    if source is None:
         return [], [], [], [], [], [], None
 
     class_match = _PHP_CLASS_RE.search(source)

--- a/src/agent_bom/ast_python_analysis.py
+++ b/src/agent_bom/ast_python_analysis.py
@@ -7,6 +7,7 @@ import os
 import re
 from pathlib import Path
 
+from agent_bom.ast.source_reader import read_source_for_analysis
 from agent_bom.ast_models import (
     CallEdge,
     ControlFlowEdge,
@@ -760,12 +761,8 @@ def _analyze_file(
     list[FlowFinding],
 ]:
     """Analyze a single Python file with full AST parsing."""
-    try:
-        source = file_path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return [], [], [], [], [], []
-
-    if len(source) > _MAX_FILE_SIZE:
+    source = read_source_for_analysis(file_path, rel_path, scanner="ast-python", max_size=_MAX_FILE_SIZE)
+    if source is None:
         return [], [], [], [], [], []
 
     try:

--- a/src/agent_bom/ast_ruby.py
+++ b/src/agent_bom/ast_ruby.py
@@ -20,6 +20,7 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from agent_bom.ast.source_reader import read_source_for_analysis
 from agent_bom.ast_models import (
     CallEdge,
     DependencySymbolReach,
@@ -536,12 +537,8 @@ def scan_ruby_file(
     _RubyFileAnalysis | None,
 ]:
     """Extract MCP/tool signals and call sites from Ruby source files."""
-    try:
-        source = file_path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return [], [], [], [], [], [], None
-
-    if len(source) > _MAX_FILE_SIZE:
+    source = read_source_for_analysis(file_path, rel_path, scanner="ast-ruby", max_size=_MAX_FILE_SIZE)
+    if source is None:
         return [], [], [], [], [], [], None
 
     class_match = _RUBY_CLASS_RE.search(source)

--- a/src/agent_bom/ast_rust.py
+++ b/src/agent_bom/ast_rust.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from agent_bom.ast.source_reader import read_source_for_analysis
 from agent_bom.ast_models import (
     CallEdge,
     DependencySymbolReach,
@@ -373,12 +374,8 @@ def scan_rust_file(
     _RustFileAnalysis | None,
 ]:
     """Extract MCP/tool signals and call sites from Rust source files."""
-    try:
-        source = file_path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return [], [], [], [], [], [], None
-
-    if len(source) > _MAX_FILE_SIZE:
+    source = read_source_for_analysis(file_path, rel_path, scanner="ast-rust", max_size=_MAX_FILE_SIZE)
+    if source is None:
         return [], [], [], [], [], [], None
 
     module_name = Path(rel_path).stem

--- a/src/agent_bom/ast_swift.py
+++ b/src/agent_bom/ast_swift.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from agent_bom.ast.source_reader import read_source_for_analysis
 from agent_bom.ast_models import (
     CallEdge,
     DependencySymbolReach,
@@ -558,12 +559,8 @@ def scan_swift_file(
     list[CallEdge],
     _SwiftFileAnalysis | None,
 ]:
-    try:
-        source = file_path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return [], [], [], [], [], [], None
-
-    if len(source) > _MAX_FILE_SIZE:
+    source = read_source_for_analysis(file_path, rel_path, scanner="ast-swift", max_size=_MAX_FILE_SIZE)
+    if source is None:
         return [], [], [], [], [], [], None
 
     scope_name = Path(rel_path).stem

--- a/src/agent_bom/coverage.py
+++ b/src/agent_bom/coverage.py
@@ -94,6 +94,31 @@ def record_manifest_parse_warning(*, ecosystem: str, path: str, detail: str) -> 
         pass
 
 
+def record_scan_input_warning(*, scanner: str, path: str, reason: str, detail: str) -> None:
+    """Record a structured warning when a scanner cannot inspect an input.
+
+    Best-effort scanners should continue past one unreadable or deliberately
+    bounded input, but that branch must not be indistinguishable from a clean
+    analysis. The warning is intentionally free of raw exception text so scan
+    artifacts cannot expose local paths, credentials, or platform details.
+    """
+    warning = CoverageWarning(
+        ecosystem=scanner,
+        release=f"{scanner}:{path}",
+        reason=reason,
+        detail=detail,
+        package_count=0,
+        advisory_rows=0,
+    )
+    _logger.warning("Input not scanned (%s/%s): %s", scanner, path, detail)
+    try:
+        from agent_bom.scanners.state import record_coverage_warning
+
+        record_coverage_warning(warning.to_dict())
+    except Exception:  # noqa: BLE001 - warning surfacing must never break a scan
+        pass
+
+
 def covered_os_distros(conn: sqlite3.Connection) -> list[str]:
     """Return the OS-distro families the local DB actually carries advisories for.
 

--- a/src/agent_bom/evidence/scan_run.py
+++ b/src/agent_bom/evidence/scan_run.py
@@ -173,9 +173,10 @@ def effective_scan_run(report: Any) -> ScanRun:
         source = str(warning.get("ecosystem") or "vulnerability-data")
         release = str(warning.get("release") or "unknown release")
         detail = str(warning.get("detail") or warning.get("reason") or "Vulnerability coverage is incomplete")
+        issue_code = "scanner_coverage_gap" if source.startswith("ast-") else "vulnerability_coverage_gap"
         run.add_issue(
             ScanIssue(
-                code="vulnerability_coverage_gap",
+                code=issue_code,
                 stage="scanning",
                 source=source,
                 message=f"{release}: {detail}",

--- a/tests/test_ast_source_coverage.py
+++ b/tests/test_ast_source_coverage.py
@@ -1,0 +1,156 @@
+"""Regression coverage for AST inputs that were previously false-clean."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from agent_bom.ast.js_ts.facade import scan_js_ts_file
+from agent_bom.ast.kotlin.analyzer import scan_kotlin_file
+from agent_bom.ast_csharp import scan_csharp_file
+from agent_bom.ast_go import scan_go_file
+from agent_bom.ast_java import scan_java_file
+from agent_bom.ast_php import scan_php_file
+from agent_bom.ast_python_analysis import _analyze_file
+from agent_bom.ast_ruby import scan_ruby_file
+from agent_bom.ast_rust import scan_rust_file
+from agent_bom.ast_swift import scan_swift_file
+from agent_bom.evidence.scan_run import ScanOutcome, effective_scan_run, vulnerability_coverage_incomplete
+from agent_bom.models import AIBOMReport
+from agent_bom.scanners.state import consume_coverage_warnings, reset_scan_warnings
+
+_MAX_AST_SOURCE_SIZE = 512 * 1024
+
+
+def _go(path: Path, rel_path: str) -> tuple:
+    return scan_go_file(path, rel_path)
+
+
+def _csharp(path: Path, rel_path: str) -> tuple:
+    return scan_csharp_file(path, rel_path, nuget_map={})
+
+
+def _ruby(path: Path, rel_path: str) -> tuple:
+    return scan_ruby_file(path, rel_path, gem_map={})
+
+
+def _java(path: Path, rel_path: str) -> tuple:
+    return scan_java_file(path, rel_path, maven_map={})
+
+
+def _php(path: Path, rel_path: str) -> tuple:
+    return scan_php_file(path, rel_path, package_map={})
+
+
+def _python(path: Path, rel_path: str) -> tuple:
+    return _analyze_file(path, rel_path)
+
+
+def _swift(path: Path, rel_path: str) -> tuple:
+    return scan_swift_file(path, rel_path, package_map={})
+
+
+def _rust(path: Path, rel_path: str) -> tuple:
+    return scan_rust_file(path, rel_path)
+
+
+def _kotlin(path: Path, rel_path: str) -> tuple:
+    return scan_kotlin_file(path, rel_path, maven_map={})
+
+
+def _js_ts(path: Path, rel_path: str) -> tuple:
+    return scan_js_ts_file(path, rel_path)
+
+
+_AST_SCANNERS: tuple[tuple[str, str, Callable[[Path, str], tuple]], ...] = (
+    ("ast-go", "go", _go),
+    ("ast-csharp", "cs", _csharp),
+    ("ast-ruby", "rb", _ruby),
+    ("ast-java", "java", _java),
+    ("ast-php", "php", _php),
+    ("ast-python", "py", _python),
+    ("ast-swift", "swift", _swift),
+    ("ast-rust", "rs", _rust),
+    ("ast-kotlin", "kt", _kotlin),
+    ("ast-js-ts", "ts", _js_ts),
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_coverage_state() -> None:
+    reset_scan_warnings()
+    yield
+    reset_scan_warnings()
+
+
+@pytest.mark.parametrize(("scanner", "extension", "run_scan"), _AST_SCANNERS)
+def test_unreadable_ast_source_records_partial_coverage_without_exception_text(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scanner: str,
+    extension: str,
+    run_scan: Callable[[Path, str], tuple],
+) -> None:
+    rel_path = f"src/unreadable.{extension}"
+
+    def _unreadable(*args: object, **kwargs: object) -> str:
+        raise OSError("sentinel-private-read-detail")
+
+    monkeypatch.setattr(Path, "read_text", _unreadable)
+    run_scan(tmp_path / f"unreadable.{extension}", rel_path)
+
+    assert consume_coverage_warnings() == [
+        {
+            "ecosystem": scanner,
+            "release": f"{scanner}:{rel_path}",
+            "reason": "source_read_error",
+            "detail": "Source file could not be read; AST analysis is incomplete.",
+            "package_count": 0,
+            "advisory_rows": 0,
+        }
+    ]
+
+
+@pytest.mark.parametrize(("scanner", "extension", "run_scan"), _AST_SCANNERS)
+def test_oversized_ast_source_records_partial_coverage(
+    tmp_path: Path,
+    scanner: str,
+    extension: str,
+    run_scan: Callable[[Path, str], tuple],
+) -> None:
+    rel_path = f"src/oversized.{extension}"
+    source = tmp_path / f"oversized.{extension}"
+    source.write_text("x" * (_MAX_AST_SOURCE_SIZE + 1), encoding="utf-8")
+
+    run_scan(source, rel_path)
+
+    assert consume_coverage_warnings() == [
+        {
+            "ecosystem": scanner,
+            "release": f"{scanner}:{rel_path}",
+            "reason": "source_size_limit",
+            "detail": "Source file exceeds the 524,288-character AST analysis limit.",
+            "package_count": 0,
+            "advisory_rows": 0,
+        }
+    ]
+
+
+def test_ast_warning_marks_run_partial_without_invalidating_vulnerability_coverage() -> None:
+    warning = {
+        "ecosystem": "ast-python",
+        "release": "ast-python:src/agent.py",
+        "reason": "source_read_error",
+        "detail": "Source file could not be read; AST analysis is incomplete.",
+        "package_count": 0,
+        "advisory_rows": 0,
+    }
+    report = AIBOMReport(coverage_warnings=[warning])
+
+    run = effective_scan_run(report)
+
+    assert run.outcome is ScanOutcome.PARTIAL
+    assert [issue.code for issue in run.issues] == ["scanner_coverage_gap"]
+    assert vulnerability_coverage_incomplete(report) is False


### PR DESCRIPTION
## Summary

- replace silent unreadable and over-limit source returns across 10 AST language analyzers with one bounded source-reader contract
- emit sanitized structured coverage warnings so incomplete AST analysis marks the overall scan partial without invalidating the separate vulnerability-coverage lane
- add a 20-case regression matrix covering both failure branches for Go, C#, Ruby, Java, PHP, Python, Swift, Rust, Kotlin, and JavaScript/TypeScript
- regenerate the owned product-metrics snapshot for the new Python module

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_ast_analyzer.py tests/test_ast_cli_gate.py tests/test_ast_flow_finding_promotion.py tests/test_ast_js_ts_package.py tests/test_ast_multilang_tool_detection.py tests/test_ast_reach_masking.py tests/test_ast_source_coverage.py tests/test_ast_swift.py tests/test_ast_symbol_reach_guards.py tests/test_ast_tool_detection_precision.py tests/test_js_ts_ast.py tests/test_sast.py tests/test_sast_surface_contract.py` — 303 passed, 1 skipped
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_ast_source_coverage.py tests/test_coverage_warning.py` — 38 passed
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check src tests/test_ast_source_coverage.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python scripts/check_exception_sanitization.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight`
- `git diff --check`

## Notes

- Best-effort scanning still continues past one unreadable or bounded source file.
- Coverage artifacts contain generic operator guidance and never include raw exception text.