### PR TITLE
fix(scan): cover sensitive files and truncated pickles

### DIFF
--- a/src/agent_bom/model_files.py
+++ b/src/agent_bom/model_files.py
@@ -370,6 +370,22 @@ MODEL_FLAG_PROMOTIONS: dict[str, dict] = {
         ),
         "requires_signature_policy": False,
     },
+    "TRUNCATED_PICKLE_UNSCANNED": {
+        "detector": "pickletools-static-disassembly",
+        "finding_type": "MODEL_INTEGRITY",
+        "default_severity": "HIGH",
+        "title": "Model artifact opcode scan incomplete",
+        "is_malicious": False,
+        "malicious_reason": None,
+        "cwe_ids": ["CWE-502"],
+        "risk_score": 6.5,
+        "remediation": (
+            "The pickle opcode walk stopped before the complete stream was inspected. Raise "
+            "AGENT_BOM_PICKLE_MAX_OPCODES when the opcode bound was reached, or replace an incomplete "
+            "artifact with a trusted safetensors/ONNX distribution and scan it again."
+        ),
+        "requires_signature_policy": False,
+    },
     "PICKLE_SCAN_ERROR": {
         "detector": "pickletools-static-disassembly",
         "finding_type": "MODEL_INTEGRITY",

--- a/src/agent_bom/model_pickle_scan.py
+++ b/src/agent_bom/model_pickle_scan.py
@@ -224,7 +224,9 @@ class PickleScanResult:
            also failed to read keeps its HIGH signal instead of collapsing to
            a LOW scan error (which the finding promoter treats as coverage
            loss, not as evasion).
-        3. ``error`` — the scan could not complete.
+        3. ``truncated`` — the opcode bound or an incomplete stream stopped
+           analysis before a complete verdict was possible.
+        4. ``error`` — the scan could not complete.
         """
         if self.verdict in {"malicious", "suspicious"}:
             location = f" (zip member {self.member})" if self.member else ""
@@ -259,6 +261,18 @@ class PickleScanResult:
                     "disassembled and the remainder was NOT scanned. Padding a pickle past the "
                     "cap is a known evasion — treat as suspicious; prefer safetensors/ONNX or "
                     "raise AGENT_BOM_PICKLE_MAX_BYTES to scan it fully."
+                ),
+            }
+        if self.truncated:
+            location = f" (zip member {self.member})" if self.member else ""
+            return {
+                "severity": "HIGH",
+                "type": "TRUNCATED_PICKLE_UNSCANNED",
+                "description": (
+                    f"Pickle opcode analysis{location} stopped before the stream was fully inspected "
+                    f"after {self.opcodes_scanned} opcode(s). The remaining payload is unverified and "
+                    "must not be treated as clean; raise AGENT_BOM_PICKLE_MAX_OPCODES when the opcode "
+                    "bound was reached, or replace the incomplete artifact and scan again."
                 ),
             }
         if self.verdict == "error":

--- a/src/agent_bom/secret_scanner.py
+++ b/src/agent_bom/secret_scanner.py
@@ -98,6 +98,11 @@ _SCAN_EXTENSIONS = frozenset(
         ".ps1",
         ".md",
         ".txt",
+        # Private keys and certificate bundles commonly carry one of these
+        # suffixes. Excluding them made the scanner blind to the credential
+        # format it already knows how to detect.
+        ".pem",
+        ".key",
     }
 )
 
@@ -321,6 +326,11 @@ def _should_scan(path: Path) -> bool:
     if path.name.startswith("test_") or path.name.endswith("_test.py"):
         return False
     if path.name in _SCAN_FILENAMES:
+        return True
+    # SSH keys and credential stores are frequently extensionless (id_rsa,
+    # credentials, token, ...). Content patterns decide whether they contain a
+    # secret; the absence of a suffix must not exclude them before inspection.
+    if not path.suffix:
         return True
     return path.suffix.lower() in _SCAN_EXTENSIONS
 

--- a/tests/test_model_pickle_scan.py
+++ b/tests/test_model_pickle_scan.py
@@ -203,6 +203,34 @@ def test_opcode_bound_enforced(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     assert res.truncated
 
 
+def test_opcode_bound_emits_unscanned_tail_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Hitting the opcode bound is partial analysis, never a clean verdict."""
+    monkeypatch.setenv("AGENT_BOM_PICKLE_MAX_OPCODES", "3")
+    p = tmp_path / "bounded.pkl"
+    p.write_bytes(pickle.dumps(list(range(1000))))
+
+    flags, results = scan_pickle_file_flags(p)
+
+    assert results[0].truncated is True
+    assert "TRUNCATED_PICKLE_UNSCANNED" in {flag["type"] for flag in flags}
+
+
+def test_opcode_bound_becomes_canonical_integrity_finding(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The incomplete disassembly must survive model inventory and promotion."""
+    from agent_bom.finding import FindingType
+    from agent_bom.model_files import model_file_findings
+
+    monkeypatch.setenv("AGENT_BOM_PICKLE_MAX_OPCODES", "3")
+    p = tmp_path / "bounded.pkl"
+    p.write_bytes(pickle.dumps(list(range(1000))))
+
+    models, _ = scan_model_files(tmp_path)
+    findings = model_file_findings(models)
+
+    assert any(finding.finding_type == FindingType.MODEL_INTEGRITY for finding in findings)
+    assert any("opcode" in finding.description.lower() for finding in findings)
+
+
 def test_wired_into_scan_model_files(tmp_path: Path):
     """A normal model scan now reports the malicious-pickle finding end-to-end."""
     (tmp_path / "model.pkl").write_bytes(_malicious_bytes())

--- a/tests/test_sensitive_file_candidate_coverage.py
+++ b/tests/test_sensitive_file_candidate_coverage.py
@@ -1,0 +1,46 @@
+"""Credential-bearing files must enter the secret scanner candidate set."""
+
+from pathlib import Path
+
+import pytest
+
+from agent_bom.secret_scanner import scan_secrets
+
+# Real-shaped only after Python joins the fragments, so the regression tests
+# credential detection without committing a token-shaped literal.
+LEAKED_KEY = "AKIA" + "IOSFODNN7" + "EXAMPLE"
+
+SENSITIVE_FILENAMES = (
+    "server.pem",
+    "client.pem",
+    "signing.pem",
+    "tls.pem",
+    "private.pem",
+    "server.key",
+    "client.key",
+    "signing.key",
+    "tls.key",
+    "private.key",
+    "id_rsa",
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "identity",
+    "private_key",
+    "signing_key",
+    "credentials",
+    "secrets",
+    "token",
+)
+
+
+@pytest.mark.parametrize("filename", SENSITIVE_FILENAMES)
+def test_sensitive_file_is_scanned_for_credential_material(tmp_path: Path, filename: str) -> None:
+    target = tmp_path / filename
+    target.write_text(f"AWS_ACCESS_KEY_ID={LEAKED_KEY}\n", encoding="utf-8")
+
+    result = scan_secrets(tmp_path)
+
+    assert result.files_scanned == 1
+    assert result.to_dict()["complete"] is True
+    assert any(finding.file_path == filename and finding.secret_type == "AWS Access Key" for finding in result.findings)


### PR DESCRIPTION
## Summary

- scan .pem, .key, and extensionless files so private-key and credential material reaches the existing content detectors
- fail closed when pickle opcode analysis stops before the full stream is inspected, then promote that signal to a canonical model-integrity finding
- add 22 regressions covering 20 sensitive filenames plus flag and finding propagation for opcode-bounded pickle scans

## Verification

- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_secret_scanner.py tests/test_secret_scanner_entropy.py tests/test_secret_scanner_never_reports_a_silent_clean.py tests/test_secret_scanner_worktree_pruning.py tests/test_posture_signal_surfacing.py tests/test_model_pickle_scan.py tests/test_model_files.py tests/test_sensitive_file_candidate_coverage.py (116 passed)
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check src/agent_bom/secret_scanner.py src/agent_bom/model_pickle_scan.py src/agent_bom/model_files.py tests/test_sensitive_file_candidate_coverage.py tests/test_model_pickle_scan.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/secret_scanner.py src/agent_bom/model_pickle_scan.py src/agent_bom/model_files.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python scripts/check_exception_sanitization.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python scripts/check_package_layout.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run agent-bom scan --demo --offline --format json --output /tmp/agent-bom-next-scan.json (complete report, 24 findings; expected exit 1 policy verdict for the curated malicious package)

## Notes

- The previous main-branch CI regression issue is closed, and current main post-merge security checks are green.