### PR TITLE
fix(graph): require evidence for positive reachability

### DIFF
--- a/src/agent_bom/api/finding_reachability.py
+++ b/src/agent_bom/api/finding_reachability.py
@@ -87,8 +87,7 @@ def _path_has_reachability_evidence(path: AttackPath) -> bool:
     """
 
     return any(
-        (edge.value if isinstance(edge, RelationshipType) else _text(edge).lower()) in _REACHABILITY_EVIDENCE_EDGES
-        for edge in path.edges
+        (edge.value if isinstance(edge, RelationshipType) else _text(edge).lower()) in _REACHABILITY_EVIDENCE_EDGES for edge in path.edges
     )
 
 

--- a/src/agent_bom/api/finding_reachability.py
+++ b/src/agent_bom/api/finding_reachability.py
@@ -11,12 +11,26 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Mapping
 
+from agent_bom.graph.types import RelationshipType
+
 if TYPE_CHECKING:
     from agent_bom.api.graph_store import GraphStoreProtocol
     from agent_bom.graph.container import AttackPath
 
 
 MAX_FINDING_REACHABILITY_PATHS = 1000
+
+_REACHABILITY_EVIDENCE_EDGES = frozenset(
+    {
+        RelationshipType.EXPLOITABLE_VIA.value,
+        RelationshipType.EXPOSED_TO.value,
+        RelationshipType.INVOKED.value,
+        RelationshipType.CALLED.value,
+        RelationshipType.USED_CREDENTIAL.value,
+        RelationshipType.ACCESSED.value,
+        RelationshipType.DELEGATED_TO.value,
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,6 +75,21 @@ def _path_vulnerability_ids(path: AttackPath) -> set[str]:
     values.append(path.target)
     values.extend(path.hops)
     return {identifier for value in values if (identifier := _vulnerability_id(value)).startswith(("CVE-", "GHSA-", "MAL-"))}
+
+
+def _path_has_reachability_evidence(path: AttackPath) -> bool:
+    """Return whether a path contains an observed reachability edge.
+
+    Static inventory edges such as ``uses`` and ``depends_on`` describe useful
+    topology, but they do not prove that an agent can reach a vulnerable
+    component at runtime. Positive reachability requires an explicit exploit,
+    network-exposure, or runtime-execution relationship.
+    """
+
+    return any(
+        (edge.value if isinstance(edge, RelationshipType) else _text(edge).lower()) in _REACHABILITY_EVIDENCE_EDGES
+        for edge in path.edges
+    )
 
 
 def _row_node_ids(row: Mapping[str, Any]) -> set[str]:
@@ -149,6 +178,8 @@ def project_persisted_graph_reachability(
     paths_by_finding: dict[str, list[AttackPath]] = {}
     paths_by_vulnerability: dict[str, list[AttackPath]] = {}
     for path in paths:
+        if not _path_has_reachability_evidence(path):
+            continue
         for finding_id in set(path.finding_ids):
             paths_by_finding.setdefault(finding_id, []).append(path)
         for vulnerability_id in _path_vulnerability_ids(path):

--- a/tests/api/test_api_scan_findings_wiring.py
+++ b/tests/api/test_api_scan_findings_wiring.py
@@ -187,12 +187,14 @@ def test_scan_vuln_flows_to_findings_and_attack_paths(wired_client):
     path_vuln_ids = {vid for path in paths for vid in (path.get("vuln_ids") or [])}
     assert KNOWN_CVE in path_vuln_ids, f"known vuln missing from attack paths: {path_vuln_ids}"
 
-    matching_paths = [path for path in paths if KNOWN_CVE in (path.get("vuln_ids") or [])]
-    expected_min_hops = min(len(path["hops"]) - 1 for path in matching_paths)
     reachable = next(row for row in finding_rows if row.get("vulnerability_id") == KNOWN_CVE)
-    assert reachable["graph_reachable"] is True
-    assert reachable["graph_min_hop_distance"] == expected_min_hops
-    assert reachable["graph_reachable_from_agents"] == ["agent:demo-agent"]
+    # A derived agent -> server -> package -> CVE dependency chain is useful
+    # topology, but it is not evidence that the vulnerability is reachable at
+    # runtime. Keep the finding unknown until the path carries an explicit
+    # execution, network, or exploit edge.
+    assert reachable["graph_reachable"] is None
+    assert reachable["graph_min_hop_distance"] is None
+    assert reachable["graph_reachable_from_agents"] == []
 
     unassessed = next(row for row in finding_rows if row.get("vulnerability_id") == NON_OVERLAP_CVE)
     assert unassessed["graph_reachable"] is None
@@ -221,6 +223,7 @@ def test_findings_reachability_projection_is_tenant_scoped_and_bounded():
                 source="agent:reachable",
                 target=f"vuln:{KNOWN_CVE}",
                 hops=["agent:reachable", "server:demo", f"vuln:{KNOWN_CVE}"],
+                edges=["invoked", "vulnerable_to"],
                 vuln_ids=[KNOWN_CVE],
             )
             return "scan-alpha", "2026-07-27T00:00:00Z", [path], MAX_FINDING_REACHABILITY_PATHS + 1
@@ -250,6 +253,35 @@ def test_findings_reachability_projection_is_tenant_scoped_and_bounded():
     assert result.rows[0]["graph_min_hop_distance"] == 2
     assert result.rows[0]["graph_reachable_from_agents"] == ["agent:reachable"]
     assert result.rows[1]["graph_reachable"] is None
+
+
+def test_structural_dependency_path_does_not_assert_graph_reachability():
+    class StructuralGraphStore:
+        def attack_paths(self, **_kwargs):
+            path = AttackPath(
+                source="agent:structural",
+                target=f"vuln:{KNOWN_CVE}",
+                hops=[
+                    "agent:structural",
+                    "server:demo",
+                    "pkg:pypi:demo-lib@1.0.0",
+                    f"vuln:{KNOWN_CVE}",
+                ],
+                edges=["uses", "depends_on", "vulnerable_to"],
+                vuln_ids=[KNOWN_CVE],
+            )
+            return "scan-alpha", "2026-07-27T00:00:00Z", [path], 1
+
+    result = project_persisted_graph_reachability(
+        [{"id": "structural", "cve_id": KNOWN_CVE, "finding_node_id": f"vuln:{KNOWN_CVE}"}],
+        graph_store=StructuralGraphStore(),  # type: ignore[arg-type]
+        tenant_id="tenant-alpha",
+        scan_id="scan-alpha",
+    )
+
+    assert result.rows[0]["graph_reachable"] is None
+    assert result.rows[0]["graph_min_hop_distance"] is None
+    assert result.rows[0]["graph_reachable_from_agents"] == []
 
 
 def test_findings_read_survives_unavailable_graph_backend(wired_client, monkeypatch):


### PR DESCRIPTION
## Summary

- keep structural `uses -> depends_on -> vulnerable_to` paths available as graph topology without treating them as positive reachability evidence
- require an explicit exploit, network-exposure, or runtime-execution relationship before projecting `graph_reachable=true` onto findings
- lock CLI/API agreement with an end-to-end structural-path regression while retaining a positive explicit-runtime-evidence case

## Verification

- red regression: `uv run pytest -q tests/api/test_api_scan_findings_wiring.py -k 'scan_vuln_flows or findings_reachability_projection or structural_dependency_path'` (2 failed before the production fix)
- `uv run pytest -q tests/api/test_api_scan_findings_wiring.py` (6 passed)
- `uv run pytest -q tests/api/test_api_scan_findings_wiring.py tests/test_dependency_reach.py tests/test_blast_reachability_surfacing.py tests/test_ingested_reachability_needs_a_path.py tests/test_finding.py tests/test_core.py -k 'reachab or graph_reachable or dependency_reach or scan_vuln_flows or unavailable_graph_backend or backpressure'` (35 passed)
- `uv run ruff check src/agent_bom/api/finding_reachability.py tests/api/test_api_scan_findings_wiring.py`
- `uv run mypy src/agent_bom/api/finding_reachability.py`
- `make preflight`
- `git diff --check`

## Notes

- A real offline demo scan produced 15 structural dependency blast radii with `dependency_reachable=true` and `graph_reachable=null`; this change makes the persisted API projection preserve the same distinction.
- No API schema or generated artifact changes are required.
