### PR TITLE
fix(parser): support pnpm root workspaces

### DIFF
--- a/src/agent_bom/parsers/node_parsers.py
+++ b/src/agent_bom/parsers/node_parsers.py
@@ -66,13 +66,25 @@ def _resolve_npx_cached_version(name: str) -> tuple[str, Path] | None:
 
 
 def _coerce_workspace_patterns(value: object) -> list[str]:
+    items: list[object]
     if isinstance(value, list):
-        return [str(item).strip() for item in value if str(item).strip()]
-    if isinstance(value, dict):
+        items = value
+    elif isinstance(value, dict):
         packages = value.get("packages")
         if isinstance(packages, list):
-            return [str(item).strip() for item in packages if str(item).strip()]
-    return []
+            items = packages
+        else:
+            return []
+    else:
+        return []
+
+    patterns: list[str] = []
+    for item in items:
+        if item is None:
+            continue
+        pattern = str(item).strip()
+        patterns.append("." if pattern in {"", ".", "./"} else pattern)
+    return patterns
 
 
 def _workspace_root_for(directory: Path) -> Path | None:
@@ -102,9 +114,7 @@ def _workspace_package_versions(root: str) -> dict[str, str]:
 
             data = yaml.safe_load(read_text_limited(pnpm_workspace)) or {}
             if isinstance(data, dict):
-                packages = data.get("packages")
-                if isinstance(packages, list):
-                    patterns.extend(str(item).strip() for item in packages if str(item).strip())
+                patterns.extend(_coerce_workspace_patterns(data.get("packages")))
         except Exception as exc:
             logger.debug("Failed to parse pnpm workspace at %s: %s", pnpm_workspace, exc)
 
@@ -123,7 +133,9 @@ def _workspace_package_versions(root: str) -> dict[str, str]:
             continue
 
         package_jsons: list[Path] = []
-        if "**" in pattern:
+        if pattern == ".":
+            package_jsons.append(root_pkg_json)
+        elif "**" in pattern:
             recursive_suffix = "/**"
             if pattern.endswith(recursive_suffix) and pattern.count("**") == 1:
                 base = workspace_root / pattern[: -len(recursive_suffix)].rstrip("/")

--- a/tests/test_parser_interop.py
+++ b/tests/test_parser_interop.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import textwrap
 
+import pytest
+
 from agent_bom.parsers import (
     parse_conda_environment,
     parse_npm_packages,
@@ -344,6 +346,29 @@ def test_package_json_resolves_workspace_dependencies(tmp_path):
     assert by_name["@repo/eslint-config"].version == "0.0.0"
     assert by_name["next"].version == "16.2.6"
     assert by_name["typescript"].version == "5.9.3"
+
+
+@pytest.mark.parametrize("root_pattern", [".", "./", ""])
+def test_package_json_resolves_root_workspace_pattern(tmp_path, root_pattern):
+    (tmp_path / "pnpm-workspace.yaml").write_text(f'packages:\n  - "{root_pattern}"\n')
+    (tmp_path / "package.json").write_text(
+        textwrap.dedent("""\
+            {
+              "name": "@repo/root",
+              "version": "1.2.3",
+              "dependencies": {
+                "@repo/root": "workspace:*"
+              }
+            }
+        """)
+    )
+
+    by_name = {pkg.name: pkg for pkg in parse_npm_packages(tmp_path)}
+
+    assert by_name["@repo/root"].version == "1.2.3"
+    assert by_name["@repo/root"].version_source == "workspace"
+    assert by_name["@repo/root"].declared_version == "workspace:*"
+    assert by_name["@repo/root"].resolved_version == "1.2.3"
 
 
 # ── ECOSYSTEM_MAP includes conda ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- normalize pnpm and npm workspace root tokens (`.`, `./`, and an explicit empty token) before package discovery
- resolve root workspace metadata directly from `workspace_root/package.json` instead of passing the root token to `Path.glob`
- preserve workspace pattern deduplication, package bounds, and workspace version provenance

## Verification

- red regression on Python 3.13.5: `ValueError: Unacceptable pattern: PosixPath('.')`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_parser_interop.py` (35 passed)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check src/agent_bom/parsers/node_parsers.py tests/test_parser_interop.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff format --check src/agent_bom/parsers/node_parsers.py tests/test_parser_interop.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/parsers/node_parsers.py`
- `SKIP=mypy UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pre-commit run --files src/agent_bom/parsers/node_parsers.py tests/test_parser_interop.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run agent-bom scan -p <two-file-root-workspace> --offline -f json` (complete; one npm package resolved with `workspace_manifest` evidence; zero warnings)
- `git diff --check`

## Notes

Python 3.13 rejects `Path.glob('.')`. Legal pnpm configurations containing `packages: ['.']` therefore aborted the full scan before any artifact was produced. Root workspace entries now take the direct manifest path while non-root patterns continue through the existing bounded discovery logic.
