### PR TITLE
fix(analysis): preserve reachability and coverage results

### DIFF
--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -95,6 +95,30 @@ _max_taint_depth = _python_max_taint_depth
 
 _ANALYZABLE_SUFFIXES = frozenset({".py", ".go", ".java", ".rb", ".php", ".swift", ".rs", ".cs", *_JS_TS_EXTS, *_KOTLIN_EXTS})
 
+# A bounded analysis must spend its budget on the files most likely to define
+# externally reachable agent/tool behavior. Lexical order alone excluded this
+# project's own ``mcp_server.py`` once the source tree exceeded ``_MAX_FILES``.
+_HIGH_SIGNAL_SOURCE_NAMES = frozenset(
+    {
+        "agent.py",
+        "app.py",
+        "cli.py",
+        "gateway.py",
+        "gateway_server.py",
+        "main.py",
+        "mcp_server.py",
+        "proxy.py",
+        "server.py",
+        "tools.py",
+    }
+)
+
+
+def _analysis_priority(project: Path, path: Path) -> tuple[int, str]:
+    """Rank public entrypoints ahead of helpers, then remain deterministic."""
+    relative = path.relative_to(project).as_posix()
+    return (0 if path.name.lower() in _HIGH_SIGNAL_SOURCE_NAMES else 1, relative)
+
 
 def project_has_analyzable_sources(project_path: str | Path) -> bool:
     """Return True when *project_path* contains AST-analyzable source files."""
@@ -222,24 +246,49 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
             continue
         swift_files.append(f)
 
-    py_files = py_files[:_MAX_FILES]
-    js_ts_files = js_ts_files[: max(0, _MAX_FILES - len(py_files))]
-    go_files = go_files[: max(0, _MAX_FILES - len(py_files) - len(js_ts_files))]
-    remaining = max(0, _MAX_FILES - len(py_files) - len(js_ts_files) - len(go_files))
-    rust_files = rust_files[:remaining]
-    java_files = java_files[: max(0, remaining - len(rust_files))]
-    csharp_files = csharp_files[: max(0, remaining - len(rust_files) - len(java_files))]
-    ruby_files = ruby_files[: max(0, remaining - len(rust_files) - len(java_files) - len(csharp_files))]
-    php_files = php_files[: max(0, remaining - len(rust_files) - len(java_files) - len(csharp_files) - len(ruby_files))]
-    swift_files = swift_files[
-        : max(0, remaining - len(rust_files) - len(java_files) - len(csharp_files) - len(ruby_files) - len(php_files))
-    ]
-    kotlin_files = kotlin_files[
-        : max(
-            0,
-            remaining - len(rust_files) - len(java_files) - len(csharp_files) - len(ruby_files) - len(php_files) - len(swift_files),
+    file_groups = (
+        py_files,
+        js_ts_files,
+        go_files,
+        rust_files,
+        java_files,
+        csharp_files,
+        ruby_files,
+        php_files,
+        swift_files,
+        kotlin_files,
+    )
+    eligible_count = sum(len(group) for group in file_groups)
+    selected = set(
+        sorted((path for group in file_groups for path in group), key=lambda path: _analysis_priority(project, path))[:_MAX_FILES]
+    )
+    (
+        py_files,
+        js_ts_files,
+        go_files,
+        rust_files,
+        java_files,
+        csharp_files,
+        ruby_files,
+        php_files,
+        swift_files,
+        kotlin_files,
+    ) = tuple([path for path in group if path in selected] for group in file_groups)
+    if eligible_count > len(selected):
+        warning = f"AST analysis stopped at {len(selected)} of {eligible_count} eligible source files"
+        result.warnings.append(warning)
+        from agent_bom.scanners.state import record_coverage_warning
+
+        record_coverage_warning(
+            {
+                "ecosystem": "ast-analysis",
+                "release": "ast-analysis:project-file-budget",
+                "reason": "source_file_limit",
+                "detail": f"{warning}.",
+                "package_count": 0,
+                "advisory_rows": 0,
+            }
         )
-    ]
     result.files_analyzed = (
         len(py_files)
         + len(js_ts_files)

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -2553,8 +2553,19 @@ def scan(
                             f"{_n_guards} guardrails, {_n_tools} tools" + (f" [red]({_n_risky} risky prompts)[/red]" if _n_risky else "")
                         )
                     _scan_sources.append("ast_analysis")
-            except Exception:
-                pass  # AST analysis not available
+            except Exception as exc:  # noqa: BLE001
+                from agent_bom.security import sanitize_error
+
+                logger.debug("AST analysis unavailable: %s", sanitize_error(exc, generic=True))
+                report.scan_run.add_issue(
+                    ScanIssue(
+                        code="scanner_unavailable",
+                        stage="scanning",
+                        source="ast-analysis",
+                        message="AST analysis could not complete.",
+                        affects_coverage=True,
+                    )
+                )
 
     # ── Step 1n: Secret scanning (auto-detect in project) ──────────
     if not skill_only and not no_discover and project and not dry_run:
@@ -2562,15 +2573,44 @@ def scan(
             from agent_bom.secret_scanner import scan_secrets as _scan_secrets
 
             _secret_result = _scan_secrets(project)
-            if _secret_result.total > 0:
+            if _secret_result.total > 0 or _secret_result.warnings:
                 report.ai_inventory_data = report.ai_inventory_data or {}
                 report.ai_inventory_data["secrets"] = _secret_result.to_dict()
+                _scan_sources.append("secret_scan")
+            if _secret_result.total > 0:
                 con.print(
                     f"  [red]![/red] Secrets: {_secret_result.total} hardcoded secrets/PII found ({_secret_result.critical_count} critical)"
                 )
-                _scan_sources.append("secret_scan")
-        except Exception:
-            pass  # Secret scanning not available
+            for _secret_warning in _secret_result.warnings:
+                report.scan_run.add_issue(
+                    ScanIssue(
+                        code="scanner_coverage_gap",
+                        stage="scanning",
+                        source="secret-scan",
+                        message=f"Secret scan incomplete: {_secret_warning}",
+                        affects_coverage=True,
+                    )
+                )
+        except Exception as exc:  # noqa: BLE001
+            from agent_bom.security import sanitize_error
+
+            logger.debug("Secret scanning unavailable: %s", sanitize_error(exc, generic=True))
+            report.scan_run.add_issue(
+                ScanIssue(
+                    code="scanner_unavailable",
+                    stage="scanning",
+                    source="secret-scan",
+                    message="Secret scanning could not complete.",
+                    affects_coverage=True,
+                )
+            )
+
+    # AST source-budget diagnostics are recorded after the early scanner-state
+    # drain above. Fold that late evidence into the report at the last producer
+    # boundary so JSON/SARIF and the process exit all see the same outcome.
+    for _warning in consume_coverage_warnings():
+        if str(_warning.get("release", "")) not in {str(w.get("release", "")) for w in report.coverage_warnings}:
+            report.coverage_warnings.append(_warning)
 
     if report.model_files or report.model_provenance or report.model_hash_verification_data:
         from agent_bom.model_files import evaluate_model_provenance_policy, summarize_model_supply_chain

--- a/src/agent_bom/graph/blast_reach.py
+++ b/src/agent_bom/graph/blast_reach.py
@@ -100,6 +100,8 @@ def apply_dependency_reachability_to_blast_radii(
 def apply_symbol_reachability_to_blast_radii(
     blast_radii: list["BlastRadius"],
     ast_result: "ASTAnalysisResult",
+    *,
+    rescore: bool = True,
 ) -> int:
     """Join CVE affected-symbols to AST symbol reach on each BlastRadius row.
 
@@ -114,8 +116,11 @@ def apply_symbol_reachability_to_blast_radii(
     whose symbols were not individually captured reports ``package_reachable``
     rather than ``unreachable``.
 
-    Returns the count of rows whose signal was populated. Best-effort: any
-    failure downgrades to a no-op rather than failing the scan.
+    Returns the count of rows whose signal was populated. Scores are
+    recalculated by default so the report cannot carry a post-analysis verdict
+    beside a pre-analysis score; callers that are deliberately batching score
+    calculation may opt out with ``rescore=False``. Best-effort: any failure
+    downgrades to a no-op rather than failing the scan.
     """
     if not blast_radii or ast_result is None:
         return 0
@@ -152,6 +157,8 @@ def apply_symbol_reachability_to_blast_radii(
             continue
         br.symbol_reachability = signal.state
         br.reachable_affected_symbols = list(signal.matched_symbols)
+        if rescore:
+            br.calculate_risk_score()
         stamped += 1
 
     return stamped

--- a/tests/test_ast_source_coverage.py
+++ b/tests/test_ast_source_coverage.py
@@ -154,3 +154,39 @@ def test_ast_warning_marks_run_partial_without_invalidating_vulnerability_covera
     assert run.outcome is ScanOutcome.PARTIAL
     assert [issue.code for issue in run.issues] == ["scanner_coverage_gap"]
     assert vulnerability_coverage_incomplete(report) is False
+
+
+def test_project_file_budget_prioritizes_entrypoints_and_records_partial_coverage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import agent_bom.ast_analyzer as ast_analyzer
+
+    monkeypatch.setattr(ast_analyzer, "_MAX_FILES", 2)
+    for index in range(3):
+        (tmp_path / f"a_regular_{index}.py").write_text(
+            f"def helper_{index}():\n    return {index}\n",
+            encoding="utf-8",
+        )
+    late = tmp_path / "zzzz"
+    late.mkdir()
+    (late / "mcp_server.py").write_text(
+        "from mcp.server.fastmcp import FastMCP\nmcp = FastMCP('late')\n\n@mcp.tool()\ndef late_tool() -> str:\n    return 'ok'\n",
+        encoding="utf-8",
+    )
+
+    result = ast_analyzer.analyze_project(tmp_path)
+
+    assert result.files_analyzed == 2
+    assert any(tool.name == "late_tool" and tool.file_path == "zzzz/mcp_server.py" for tool in result.tools)
+    assert result.warnings == ["AST analysis stopped at 2 of 4 eligible source files"]
+    assert consume_coverage_warnings() == [
+        {
+            "ecosystem": "ast-analysis",
+            "release": "ast-analysis:project-file-budget",
+            "reason": "source_file_limit",
+            "detail": "AST analysis stopped at 2 of 4 eligible source files.",
+            "package_count": 0,
+            "advisory_rows": 0,
+        }
+    ]

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1429,6 +1429,98 @@ def test_scan_warning_is_preserved_in_json_and_marks_partial(monkeypatch, tmp_pa
     assert payload["warnings"] == ["package lookup coverage degraded"]
 
 
+def test_zero_finding_partial_secret_scan_is_preserved_and_fails_closed(monkeypatch, tmp_path):
+    from agent_bom.secret_scanner import SecretScanResult
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "app.py").write_text("VALUE = 1\n", encoding="utf-8")
+    output = tmp_path / "secret-partial.json"
+    monkeypatch.setattr(
+        "agent_bom.secret_scanner.scan_secrets",
+        lambda *_args, **_kwargs: SecretScanResult(files_scanned=2, warnings=["Stopped at 2 files"]),
+    )
+
+    result = _run(
+        [
+            "scan",
+            str(project),
+            "--no-scan",
+            "--offline",
+            "--no-auto-update-db",
+            "--format",
+            "json",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["ai_inventory"]["secrets"]["total"] == 0
+    assert payload["ai_inventory"]["secrets"]["warnings"] == ["Stopped at 2 files"]
+    assert "secret_scan" in payload["scan_sources"]
+    assert payload["scan_run"]["outcome"] == "partial"
+    assert payload["scan_run"]["issues"] == [
+        {
+            "code": "scanner_coverage_gap",
+            "stage": "scanning",
+            "source": "secret-scan",
+            "message": "Secret scan incomplete: Stopped at 2 files",
+            "severity": "warning",
+            "affects_coverage": True,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("patch_target", "source"),
+    [
+        ("agent_bom.ast_analyzer.analyze_project", "ast-analysis"),
+        ("agent_bom.secret_scanner.scan_secrets", "secret-scan"),
+    ],
+)
+def test_project_scanner_exception_is_sanitized_and_marks_partial(monkeypatch, tmp_path, patch_target, source):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "app.py").write_text("VALUE = 1\n", encoding="utf-8")
+    output = tmp_path / f"{source}-partial.json"
+    private_detail = "sentinel-private-scanner-detail"
+
+    def _fail(*_args, **_kwargs):
+        raise RuntimeError(private_detail)
+
+    monkeypatch.setattr(patch_target, _fail)
+    result = _run(
+        [
+            "scan",
+            str(project),
+            "--no-scan",
+            "--offline",
+            "--no-auto-update-db",
+            "--format",
+            "json",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    matching = [issue for issue in payload["scan_run"]["issues"] if issue["source"] == source]
+    assert matching == [
+        {
+            "code": "scanner_unavailable",
+            "stage": "scanning",
+            "source": source,
+            "message": f"{'AST analysis' if source == 'ast-analysis' else 'Secret scanning'} could not complete.",
+            "severity": "warning",
+            "affects_coverage": True,
+        }
+    ]
+    assert private_detail not in json.dumps(payload)
+
+
 def test_scan_expands_local_docker_mcp_image():
     from agent_bom.cli.agents import _expand_docker_mcp_packages
     from agent_bom.models import MCPServer, Package, TransportType

--- a/tests/test_reachability_cve.py
+++ b/tests/test_reachability_cve.py
@@ -465,10 +465,23 @@ def _ast_result_with_get() -> ASTAnalysisResult:
 
 def test_wiring_stamps_function_reachable_on_python_row() -> None:
     br = _python_br(["get"])
+    original_score = br.calculate_risk_score()
     stamped = apply_symbol_reachability_to_blast_radii([br], _ast_result_with_get())
     assert stamped == 1
     assert br.symbol_reachability == FUNCTION_REACHABLE
     assert br.reachable_affected_symbols == ["get"]
+    assert br.risk_score > original_score
+
+
+def test_wiring_can_stamp_without_rescoring() -> None:
+    br = _python_br(["get"])
+    original_score = br.calculate_risk_score()
+
+    stamped = apply_symbol_reachability_to_blast_radii([br], _ast_result_with_get(), rescore=False)
+
+    assert stamped == 1
+    assert br.symbol_reachability == FUNCTION_REACHABLE
+    assert br.risk_score == original_score
 
 
 def test_wiring_stamps_function_reachable_from_built_vulnerability_model() -> None:


### PR DESCRIPTION
## Summary

- recalculate blast-radius risk after symbol reachability changes the verdict, with an explicit opt-out for batched callers
- prioritize public agent and MCP entrypoints within the bounded AST source budget and persist a partial-coverage signal when eligible files exceed that budget
- retain zero-finding secret-scan warnings and convert AST or secret-scanner failures into sanitized coverage issues

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_reachability_cve.py tests/test_ast_source_coverage.py tests/test_cli_scan.py` (189 passed)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check ...`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff format --check ...`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/graph/blast_reach.py src/agent_bom/ast_analyzer.py src/agent_bom/cli/agents/scan_cmd.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight`
- changed-file pre-commit hooks passed before rebase
- `git diff --check`

## Notes

- the scanner remains bounded at 500 source files, but entrypoint priority prevents lexical ordering from excluding the externally reachable server surface
- bounded AST or secret evidence is fail-closed as partial coverage; security findings remain separate from scan-execution quality
- blocked registry DNS produced unresolved-future diagnostics during the focused test run without failing any affected test
