### PR TITLE
fix(sarif): preserve package manifest locations

### DIFF
--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -431,6 +431,30 @@ def _finding_artifact_uri(report: AIBOMReport, finding: Finding) -> str:
     return _to_relative_path("unknown", ecosystem=ecosystem)
 
 
+def _package_manifest_location(finding: Finding) -> tuple[str, int] | None:
+    """Return the canonical package declaration location carried by a finding."""
+    provenance = evidence(finding, "package_version_provenance", {})
+    if not isinstance(provenance, dict):
+        return None
+    entries = provenance.get("evidence")
+    if not isinstance(entries, list):
+        return None
+    ecosystem = package_ecosystem(finding) or None
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        path = entry.get("source_file") or entry.get("path")
+        line = entry.get("line")
+        if isinstance(path, str) and path and isinstance(line, int) and line > 0:
+            # Persisted version evidence intentionally reduces absolute paths to
+            # ``<path:basename>``. SARIF needs the safe basename as its artifact
+            # URI, never the original host path.
+            if path.startswith("<path:") and path.endswith(">"):
+                path = path[6:-1]
+            return _to_relative_path(path, ecosystem=ecosystem), line
+    return None
+
+
 def _agent_discovery_provenance_from_report(report: AIBOMReport, agent_names: list[str]) -> list[Any]:
     agents_by_name = {agent.name: agent for agent in report.agents}
     out: list[Any] = []
@@ -599,7 +623,8 @@ def _cve_sarif_result(
     if exposure_chain:
         message_text += f" Exposure path: {exposure_chain}. Blast radius: {exposure_path_blast_summary(exposure_path)}."
 
-    config_path = _finding_artifact_uri(report, finding)
+    manifest_location = _package_manifest_location(finding)
+    config_path, start_line = manifest_location or (_finding_artifact_uri(report, finding), 1)
     fp_input = f"{rule_id}:{pkg_name}:{pkg_version}:{config_path}"
     kind = "informational" if sev == Severity.NONE else "fail"
     result: dict = {
@@ -607,12 +632,12 @@ def _cve_sarif_result(
         "level": level,
         "kind": kind,
         "message": {"text": sanitize_advisory_text("title", message_text, fallback=f"{rule_id} package vulnerability")},
-        **_sarif_fingerprint_fields(stable_input=fp_input, artifact_uri=config_path, start_line=1),
+        **_sarif_fingerprint_fields(stable_input=fp_input, artifact_uri=config_path, start_line=start_line),
         "locations": [
             {
                 "physicalLocation": {
                     "artifactLocation": {"uri": config_path, "uriBaseId": "%SRCROOT%"},
-                    "region": {"startLine": 1, "startColumn": 1},
+                    "region": {"startLine": start_line, "startColumn": 1},
                 },
             }
         ],

--- a/src/agent_bom/parsers/node_parsers.py
+++ b/src/agent_bom/parsers/node_parsers.py
@@ -40,6 +40,42 @@ def _npm_purl(name: str, version: str) -> str:
     return f"pkg:npm/{name}@{version}"
 
 
+def _json_object_property_line(text: str, object_name: str, property_name: str) -> int | None:
+    """Return an exact property line inside one top-level JSON object."""
+    object_match = re.search(rf"{re.escape(json.dumps(object_name))}\s*:\s*\{{", text)
+    if object_match is None:
+        return None
+    opening_brace = text.find("{", object_match.start())
+    depth = 0
+    in_string = False
+    escaped = False
+    closing_brace = len(text)
+    for index in range(opening_brace, len(text)):
+        character = text[index]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+        elif character == "{":
+            depth += 1
+        elif character == "}":
+            depth -= 1
+            if depth == 0:
+                closing_brace = index
+                break
+    object_text = text[opening_brace + 1 : closing_brace]
+    property_match = re.search(rf"(?m)^[ \t]*{re.escape(json.dumps(property_name))}[ \t]*:", object_text)
+    if property_match is not None:
+        return text.count("\n", 0, opening_brace + 1 + property_match.start()) + 1
+    return None
+
+
 def _resolve_npx_cached_version(name: str) -> tuple[str, Path] | None:
     """Return an exact package version from npm's local npx cache, if present."""
     cache_root = Path(os.environ.get("npm_config_cache") or Path.home() / ".npm")
@@ -366,7 +402,9 @@ def parse_npm_packages(directory: Path) -> list[Package]:
     # Fallback to package.json only
     elif (directory / "package.json").exists():
         try:
-            pkg_data = read_json_limited(directory / "package.json")
+            package_json = directory / "package.json"
+            package_json_text = read_text_limited(package_json)
+            pkg_data = json.loads(package_json_text)
             for dep_type in ("dependencies", "devDependencies"):
                 for name, version_spec in pkg_data.get(dep_type, {}).items():
                     declared_version = str(version_spec)
@@ -375,6 +413,15 @@ def parse_npm_packages(directory: Path) -> list[Package]:
                     resolved_version = None
                     version_confidence = None
                     version_evidence: list[dict] = []
+                    line_number = _json_object_property_line(package_json_text, dep_type, name)
+                    if line_number is not None:
+                        version_evidence.append(
+                            {
+                                "type": "manifest",
+                                "source_file": str(package_json),
+                                "line": line_number,
+                            }
+                        )
                     if workspace_resolution:
                         version, declared_version = workspace_resolution
                         version_source = "workspace"

--- a/src/agent_bom/parsers/python_parsers.py
+++ b/src/agent_bom/parsers/python_parsers.py
@@ -42,6 +42,18 @@ def _looks_like_git_requirement(url: str) -> bool:
     return lowered.startswith(("git+", "git@", "git://")) or "git+" in lowered
 
 
+def _with_manifest_location(package: Package, path: Path, line: int) -> Package:
+    """Attach the declaration location used by machine-readable outputs."""
+    package.version_evidence.append(
+        {
+            "type": "manifest",
+            "source_file": str(path),
+            "line": line,
+        }
+    )
+    return package
+
+
 def _requirement_package(name: str, operator: str, version: str, *, is_direct: bool) -> Package:
     """Build a Package for a ``name<op>version`` declaration line.
 
@@ -312,34 +324,44 @@ def parse_pip_packages(directory: Path) -> list[Package]:
     req_file = directory / "requirements.txt"
     if req_file.exists():
         try:
-            for line in read_text_limited(req_file).splitlines():
-                line = line.strip()
+            for line_number, raw_line in enumerate(read_text_limited(req_file).splitlines(), start=1):
+                line = raw_line.strip()
                 if not line or line.startswith("#") or line.startswith("-"):
                     continue
                 # Git URL/SHA reference (``flask @ git+…@<sha>``): version can't be
                 # pinned from the ref, so flag it floating rather than dropping it.
                 git_pkg = _git_reference_package(line, is_direct=True)
                 if git_pkg is not None:
-                    packages.append(git_pkg)
+                    packages.append(_with_manifest_location(git_pkg, req_file, line_number))
                     continue
                 # Parse name==version, name>=version, etc.
                 match = re.match(r"^([a-zA-Z0-9_.-]+(?:\[[^\]]+\])?)\s*([=<>!~]+)\s*([a-zA-Z0-9_.*+-]+)", line)
                 if match:
                     raw_name, operator, version = match.groups()
                     name, _ = strip_pip_extras(raw_name)
-                    packages.append(_requirement_package(name, operator, version, is_direct=True))
+                    packages.append(
+                        _with_manifest_location(
+                            _requirement_package(name, operator, version, is_direct=True),
+                            req_file,
+                            line_number,
+                        )
+                    )
                 else:
                     # Just a name, no version
                     name_match = re.match(r"^([a-zA-Z0-9_.-]+(?:\[[^\]]+\])?)", line)
                     if name_match:
                         name, _ = strip_pip_extras(name_match.group(1))
                         packages.append(
-                            Package(
-                                name=name,
-                                version="unknown",
-                                ecosystem="pypi",
-                                is_direct=True,
-                                reachability_evidence="declaration_only",
+                            _with_manifest_location(
+                                Package(
+                                    name=name,
+                                    version="unknown",
+                                    ecosystem="pypi",
+                                    is_direct=True,
+                                    reachability_evidence="declaration_only",
+                                ),
+                                req_file,
+                                line_number,
                             )
                         )
         except (OSError, UnicodeDecodeError) as exc:

--- a/tests/test_output_cov.py
+++ b/tests/test_output_cov.py
@@ -415,6 +415,19 @@ class TestToSarif:
         assert props["package_version_provenance"]["confidence"] == "exact"
         assert props["agent_discovery_provenance"][0]["collector"] == "cmdb-export"
 
+    def test_cve_result_uses_package_manifest_location(self, tmp_path):
+        requirements = tmp_path / "requirements.txt"
+        requirements.write_text("flask==0.12.2\njinja2==2.10\npyyaml==5.3\n")
+        pkg = _make_pkg(name="pyyaml", version="5.3", ecosystem="pypi")
+        pkg.version_evidence = [{"type": "manifest", "source_file": str(requirements), "line": 3}]
+        br = _make_blast_radius(pkg=pkg)
+
+        result = to_sarif(_make_report(blast_radii=[br]))["runs"][0]["results"][0]
+        physical = result["locations"][0]["physicalLocation"]
+
+        assert physical["artifactLocation"]["uri"] == "requirements.txt"
+        assert physical["region"]["startLine"] == 3
+
 
 # ── to_cyclonedx ─────────────────────────────────────────────────────────────
 

--- a/tests/test_parser_interop.py
+++ b/tests/test_parser_interop.py
@@ -101,6 +101,29 @@ class TestPoetryLock:
         assert pkgs[0].is_direct is True
 
 
+def test_requirements_packages_preserve_manifest_locations(tmp_path):
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("flask==0.12.2\n# retained comment\npyyaml==5.3\n")
+
+    packages = {package.name: package for package in parse_pip_packages(tmp_path)}
+
+    assert packages["flask"].version_evidence == [{"type": "manifest", "source_file": str(requirements), "line": 1}]
+    assert packages["pyyaml"].version_evidence == [{"type": "manifest", "source_file": str(requirements), "line": 3}]
+
+
+def test_package_json_packages_preserve_manifest_locations(tmp_path):
+    package_json = tmp_path / "package.json"
+    package_json.write_text(
+        '{\n  "name": "demo",\n  "scripts": {"axios": "not-a-dependency"},\n  "dependencies": {\n'
+        '    "axios": "1.0.0",\n    "lodash": "4.17.20"\n  }\n}\n'
+    )
+
+    packages = {package.name: package for package in parse_npm_packages(tmp_path)}
+
+    assert packages["axios"].version_evidence == [{"type": "manifest", "source_file": str(package_json), "line": 5}]
+    assert packages["lodash"].version_evidence == [{"type": "manifest", "source_file": str(package_json), "line": 6}]
+
+
 # ── uv.lock ──────────────────────────────────────────────────────────────────
 
 UV_LOCK = textwrap.dedent("""\


### PR DESCRIPTION
## Summary

- preserve exact declaration lines from `requirements.txt` and dependency sections in `package.json`
- project package provenance into SARIF artifact locations and line-sensitive fingerprints without exposing absolute host paths
- keep JSON dependency matching scoped to the correct object so same-named script keys cannot supply false locations

## Verification

- red regression: three focused tests failed before implementation because package declarations carried no manifest location and SARIF fell back to `unknown:1`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_parser_interop.py tests/test_output_cov.py tests/test_asset_discovery_provenance.py tests/test_sarif_schema_2_1_0.py` (136 passed)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_parser_interop.py tests/test_output_cov.py tests/test_cli_scan.py tests/test_sarif_schema_2_1_0.py -k 'manifest_location or package_json or requirements or sarif'` (27 passed, 229 deselected)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check src/agent_bom/output/sarif.py src/agent_bom/parsers/node_parsers.py src/agent_bom/parsers/python_parsers.py tests/test_output_cov.py tests/test_parser_interop.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff format --check src/agent_bom/output/sarif.py src/agent_bom/parsers/node_parsers.py src/agent_bom/parsers/python_parsers.py tests/test_output_cov.py tests/test_parser_interop.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/output/sarif.py src/agent_bom/parsers/node_parsers.py src/agent_bom/parsers/python_parsers.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight`
- original six-line manifest repro: PyYAML findings resolved to `requirements.txt:3`, LangChain to `requirements.txt:5`, Requests to `requirements.txt:6`; npm findings resolved to Axios/Lodash/Minimist lines 5/6/7
- `git diff --check`

## Notes

- persisted sanitized paths are unwrapped only to their basename for SARIF; absolute source paths are not restored or emitted
- this closes the manifest-location defect only; broader SARIF rule-description and rule-ID consolidation concerns remain separate
