### PR TITLE
fix(hooks): keep scan output in the terminal

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -27,7 +27,7 @@
     vulnerabilities; fail the commit on high-or-above severity findings.
   entry: agent-bom scan
   language: python
-  args: ["-p", ".", "--fail-on-severity", "high"]
+  args: ["-p", ".", "--format", "console", "--fail-on-severity", "high"]
   pass_filenames: false
   always_run: true
   minimum_pre_commit_version: "2.9.0"

--- a/tests/test_consumer_precommit_hooks.py
+++ b/tests/test_consumer_precommit_hooks.py
@@ -21,4 +21,4 @@ def test_dependency_hook_scans_only_the_downstream_repository() -> None:
 
     assert hook["pass_filenames"] is False
     assert hook["args"][:2] == ["-p", "."]
-    assert hook["args"][2:] == ["--fail-on-severity", "high"]
+    assert hook["args"][2:] == ["--format", "console", "--fail-on-severity", "high"]


### PR DESCRIPTION
## Summary

- force the downstream dependency hook to render its result in the terminal
- prevent an active JSON-output profile from dropping `agent-bom-report.json` into the consumer repository during every commit
- retain repository-only `-p .` scope and the existing high-severity failure gate

## Verification

- red regression: `tests/test_consumer_precommit_hooks.py` failed before the hook declared an explicit console format
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_consumer_precommit_hooks.py` (1 passed)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check tests/test_consumer_precommit_hooks.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff format --check tests/test_consumer_precommit_hooks.py`
- exact downstream `pre-commit try-repo` smoke passed in 8.27s against a repository containing only `requests==2.32.5`
- post-hook file check contained only `requirements.txt` and the explicitly relocated analytics database; no report artifact was written into the repository
- `git diff --check`

## Notes

- explicit user-selected scan formats and output paths remain unchanged; this only makes the consumer pre-commit integration non-polluting
