### PR TITLE
fix(cli): reject invalid operator inputs

### DIFF
--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -110,6 +110,13 @@ def main(ctx: click.Context, profile: str | None, agent_mode: bool):
     if profile:
         import os as _os
 
+        from agent_bom.cli._profiles import load_active_profile
+
+        try:
+            load_active_profile(profile)
+        except click.ClickException as exc:
+            raise click.BadParameter(str(exc), param_hint="'--profile'") from exc
+
         _os.environ["AGENT_BOM_PROFILE"] = profile
     if agent_mode:
         import os as _os

--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -280,6 +280,9 @@ def run_local_discovery(
                 mcp_servers=[sbom_server],
             )
             ctx.agents.append(sbom_agent)
+        except json.JSONDecodeError:
+            con.print("\n  [red]SBOM error: input is not valid JSON.[/red]")
+            sys.exit(1)
         except (FileNotFoundError, ValueError) as e:
             con.print(f"\n  [red]SBOM error: {e}[/red]")
             sys.exit(1)

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -356,6 +356,18 @@ def test_sbom_missing_file_is_usage_error():
     assert "does not exist" in result.output
 
 
+def test_sbom_invalid_json_reports_stable_input_error(tmp_path):
+    bad_sbom = tmp_path / "bad.sbom.json"
+    bad_sbom.write_text("not-json")
+
+    result = CliRunner().invoke(main, ["sbom", str(bad_sbom), "--offline"])
+
+    assert result.exit_code == 1
+    assert "SBOM error: input is not valid JSON" in result.output
+    assert "Expecting value" not in result.output
+    assert "line 1 column 1" not in result.output
+
+
 def test_check_quiet_suppresses_scan_chatter(monkeypatch):
     async def _scan_packages(pkgs, **_kwargs):
         import agent_bom.scanners as scanners

--- a/tests/test_cli_profiles.py
+++ b/tests/test_cli_profiles.py
@@ -59,6 +59,29 @@ tenant_id = "team-a"
     assert "Available profiles: dev, prod" in message
 
 
+def test_top_level_profile_option_rejects_unknown_profile(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+[profiles.dev]
+tenant_id = "default"
+
+[profiles.prod]
+tenant_id = "team-a"
+"""
+    )
+    monkeypatch.setenv("AGENT_BOM_CONFIG", str(config_path))
+    monkeypatch.delenv("AGENT_BOM_PROFILE", raising=False)
+
+    result = CliRunner().invoke(main, ["--profile", "totally-bogus", "where"])
+
+    assert result.exit_code == 2
+    assert "Invalid value for '--profile'" in result.output
+    assert "Profile 'totally-bogus' was not found" in result.output
+    assert "Available profiles: dev, prod" in result.output
+    assert "MCP config locations" not in result.output
+
+
 def test_scan_profile_defaults_do_not_override_explicit_cli_flags(monkeypatch, tmp_path):
     config_path = tmp_path / "config.toml"
     config_path.write_text(


### PR DESCRIPTION
## Summary

- validate an explicitly selected CLI profile before running the requested command
- report missing profiles as a usage error with the configured alternatives
- replace raw JSON-decoder details for invalid SBOM input with a stable operator-facing error

## Verification

- red regression: `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_cli_profiles.py::test_top_level_profile_option_rejects_unknown_profile tests/test_cli_check.py::test_sbom_invalid_json_reports_stable_input_error` (2 failed before implementation)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_cli_profiles.py tests/test_cli_check.py tests/test_cli_entry_points.py tests/test_sbom.py tests/test_sbom_ingestion.py` (139 passed)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check src/agent_bom/cli/__init__.py src/agent_bom/cli/agents/_discovery.py tests/test_cli_profiles.py tests/test_cli_check.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff format --check src/agent_bom/cli/__init__.py src/agent_bom/cli/agents/_discovery.py tests/test_cli_profiles.py tests/test_cli_check.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/cli/__init__.py src/agent_bom/cli/agents/_discovery.py`
- `SKIP=mypy UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pre-commit run --files src/agent_bom/cli/__init__.py src/agent_bom/cli/agents/_discovery.py tests/test_cli_profiles.py tests/test_cli_check.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight`
- original CLI repros: unknown profile exits 2 before `where`; invalid SBOM JSON exits 1 without decoder coordinates
- `git diff --check`

## Notes

- `-q` / `--quiet` already exists on the SBOM and scan surfaces and is intentionally unchanged.
