### PR TITLE
feat(tenancy): add database binding authority

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260819_01_tenant_binding_authority.py
+++ b/deploy/supabase/postgres/alembic/versions/20260819_01_tenant_binding_authority.py
@@ -1,0 +1,118 @@
+"""Add the database-owned verifier for signed tenant-binding claims.
+
+The shared application role may set any two-part custom GUC, so
+``app.tenant_id`` cannot by itself be an identity boundary.  This migration
+adds the key authority and verifier needed for a later application rollout.
+It intentionally does not replace ``abom_current_tenant`` yet: issuers,
+database keys, and runtime session binding must be deployed and observed
+before RLS starts rejecting unsigned sessions.
+
+Revision ID: 20260819_01
+Revises: 20260818_01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260819_01"
+down_revision = "20260818_01"
+branch_labels = None
+depends_on = None
+
+
+_AUTHORITY_DDL = r"""
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS public.agent_bom_tenant_binding_keys (
+  key_id TEXT PRIMARY KEY CHECK (key_id ~ '^[0-9a-f]{64}$'),
+  key_material BYTEA NOT NULL CHECK (octet_length(key_material) >= 32),
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()
+);
+
+COMMENT ON TABLE public.agent_bom_tenant_binding_keys IS
+  'Schema-owner-only HMAC keys used to verify bounded tenant-binding claims';
+
+CREATE OR REPLACE FUNCTION public.abom_verify_tenant_binding_claim(
+  p_tenant_id TEXT,
+  p_issued_at BIGINT,
+  p_nonce TEXT,
+  p_signature TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+  v_now BIGINT := floor(extract(epoch FROM clock_timestamp()))::BIGINT;
+  v_canonical TEXT;
+  v_verified BOOLEAN := FALSE;
+BEGIN
+  IF p_tenant_id IS NULL
+     OR p_tenant_id = ''
+     OR p_tenant_id <> btrim(p_tenant_id)
+     OR lower(p_tenant_id) IN ('admin', 'analyst', 'viewer', 'system', '__system__')
+     OR p_issued_at IS NULL
+     OR p_issued_at > v_now + 30
+     OR p_issued_at < v_now - 30
+     OR p_nonce IS NULL
+     OR p_nonce !~ '^[0-9a-f]{32}$'
+     OR p_signature IS NULL
+     OR p_signature !~ '^[0-9a-f]{64}$'
+  THEN
+    RETURN FALSE;
+  END IF;
+
+  v_canonical := 'v1:' || encode(convert_to(p_tenant_id, 'UTF8'), 'hex')
+                 || ':' || p_issued_at::TEXT || ':' || p_nonce;
+
+  SELECT EXISTS (
+    SELECT 1
+      FROM public.agent_bom_tenant_binding_keys
+     WHERE enabled
+       AND encode(
+             public.hmac(convert_to(v_canonical, 'UTF8'), key_material, 'sha256'),
+             'hex'
+           ) = p_signature
+  )
+    INTO v_verified;
+
+  RETURN COALESCE(v_verified, FALSE);
+END
+$function$;
+
+REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.abom_verify_tenant_binding_claim(TEXT, BIGINT, TEXT, TEXT) FROM PUBLIC;
+
+DO $roles$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'agent_bom_app') THEN
+    EXECUTE 'REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM agent_bom_app';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.abom_verify_tenant_binding_claim(TEXT, BIGINT, TEXT, TEXT) TO agent_bom_app';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'agent_bom_readonly') THEN
+    EXECUTE 'REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM agent_bom_readonly';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'agent_bom_rls_maintenance') THEN
+    EXECUTE 'REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM agent_bom_rls_maintenance';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'agent_bom_maintenance') THEN
+    EXECUTE 'REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM agent_bom_maintenance';
+  END IF;
+END
+$roles$;
+"""
+
+
+def upgrade() -> None:
+    op.execute(_AUTHORITY_DDL)
+
+
+def downgrade() -> None:
+    # Forward-only: removing the verifier or its rotation keys before the
+    # application/RLS stages are rolled back would fail open or strand active
+    # sessions.  Preserve the authority and require an explicit forward fix.
+    raise NotImplementedError("tenant-binding authority downgrade is intentionally forward-only")

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -1487,6 +1487,81 @@ GRANT USAGE ON SCHEMA public TO agent_bom_readonly;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO agent_bom_readonly;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO agent_bom_readonly;
 
+-- Database-owned authority for short-lived tenant-binding claims. The shared
+-- application role can set arbitrary custom GUCs, but it cannot read or alter
+-- these HMAC keys. This mechanical stage adds verification only; the active
+-- tenant RLS helper is switched after every runtime issues these claims.
+CREATE TABLE IF NOT EXISTS public.agent_bom_tenant_binding_keys (
+    key_id TEXT PRIMARY KEY CHECK (key_id ~ '^[0-9a-f]{64}$'),
+    key_material BYTEA NOT NULL CHECK (octet_length(key_material) >= 32),
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()
+);
+
+CREATE OR REPLACE FUNCTION public.abom_verify_tenant_binding_claim(
+    p_tenant_id TEXT,
+    p_issued_at BIGINT,
+    p_nonce TEXT,
+    p_signature TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    v_now BIGINT := floor(extract(epoch FROM clock_timestamp()))::BIGINT;
+    v_canonical TEXT;
+    v_verified BOOLEAN := FALSE;
+BEGIN
+    IF p_tenant_id IS NULL
+       OR p_tenant_id = ''
+       OR p_tenant_id <> btrim(p_tenant_id)
+       OR lower(p_tenant_id) IN ('admin', 'analyst', 'viewer', 'system', '__system__')
+       OR p_issued_at IS NULL
+       OR p_issued_at > v_now + 30
+       OR p_issued_at < v_now - 30
+       OR p_nonce IS NULL
+       OR p_nonce !~ '^[0-9a-f]{32}$'
+       OR p_signature IS NULL
+       OR p_signature !~ '^[0-9a-f]{64}$'
+    THEN
+        RETURN FALSE;
+    END IF;
+
+    v_canonical := 'v1:' || encode(convert_to(p_tenant_id, 'UTF8'), 'hex')
+                   || ':' || p_issued_at::TEXT || ':' || p_nonce;
+
+    SELECT EXISTS (
+        SELECT 1
+          FROM public.agent_bom_tenant_binding_keys
+         WHERE enabled
+           AND encode(
+                 public.hmac(convert_to(v_canonical, 'UTF8'), key_material, 'sha256'),
+                 'hex'
+               ) = p_signature
+    ) INTO v_verified;
+
+    RETURN COALESCE(v_verified, FALSE);
+END
+$function$;
+
+REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.abom_verify_tenant_binding_claim(TEXT, BIGINT, TEXT, TEXT) FROM PUBLIC;
+
+DO $tenant_binding_roles$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'agent_bom_app') THEN
+        REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM agent_bom_app;
+        GRANT EXECUTE ON FUNCTION public.abom_verify_tenant_binding_claim(TEXT, BIGINT, TEXT, TEXT) TO agent_bom_app;
+    END IF;
+    REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM agent_bom_readonly;
+    REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM agent_bom_rls_maintenance;
+    REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM agent_bom_maintenance;
+END
+$tenant_binding_roles$;
+
 -- ══════════════════════════════════════════════════════════════════════════════
 -- TENANT ISOLATION: strip RLS-bypassing attributes from the app/admin role (#3665)
 -- ══════════════════════════════════════════════════════════════════════════════

--- a/deploy/supabase/postgres/runtime-schema.sql
+++ b/deploy/supabase/postgres/runtime-schema.sql
@@ -268,6 +268,88 @@ BEGIN
  END IF;
 END $grant$;
 
+-- Database-owned authority for short-lived tenant-binding claims. Runtime
+-- roles receive no table privileges; the app may call only the locked-down
+-- verifier. Active RLS continues using app.tenant_id until the later surface
+-- and lock-in stages deploy claim issuance everywhere.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE TABLE IF NOT EXISTS public.agent_bom_tenant_binding_keys (
+  key_id TEXT PRIMARY KEY CHECK (key_id ~ '^[0-9a-f]{64}$'),
+  key_material BYTEA NOT NULL CHECK (octet_length(key_material) >= 32),
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()
+);
+
+CREATE OR REPLACE FUNCTION public.abom_verify_tenant_binding_claim(
+  p_tenant_id TEXT,
+  p_issued_at BIGINT,
+  p_nonce TEXT,
+  p_signature TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+  v_now BIGINT := floor(extract(epoch FROM clock_timestamp()))::BIGINT;
+  v_canonical TEXT;
+  v_verified BOOLEAN := FALSE;
+BEGIN
+  IF p_tenant_id IS NULL
+     OR p_tenant_id = ''
+     OR p_tenant_id <> btrim(p_tenant_id)
+     OR lower(p_tenant_id) IN ('admin', 'analyst', 'viewer', 'system', '__system__')
+     OR p_issued_at IS NULL
+     OR p_issued_at > v_now + 30
+     OR p_issued_at < v_now - 30
+     OR p_nonce IS NULL
+     OR p_nonce !~ '^[0-9a-f]{32}$'
+     OR p_signature IS NULL
+     OR p_signature !~ '^[0-9a-f]{64}$'
+  THEN
+    RETURN FALSE;
+  END IF;
+
+  v_canonical := 'v1:' || encode(convert_to(p_tenant_id, 'UTF8'), 'hex')
+                 || ':' || p_issued_at::TEXT || ':' || p_nonce;
+
+  SELECT EXISTS (
+    SELECT 1
+      FROM public.agent_bom_tenant_binding_keys
+     WHERE enabled
+       AND encode(
+             public.hmac(convert_to(v_canonical, 'UTF8'), key_material, 'sha256'),
+             'hex'
+           ) = p_signature
+  ) INTO v_verified;
+
+  RETURN COALESCE(v_verified, FALSE);
+END
+$function$;
+
+REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.abom_verify_tenant_binding_claim(TEXT, BIGINT, TEXT, TEXT) FROM PUBLIC;
+
+DO $tenant_binding_roles$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname='agent_bom_app') THEN
+    EXECUTE 'REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM agent_bom_app';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.abom_verify_tenant_binding_claim(TEXT, BIGINT, TEXT, TEXT) TO agent_bom_app';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname='agent_bom_readonly') THEN
+    EXECUTE 'REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM agent_bom_readonly';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname='agent_bom_rls_maintenance') THEN
+    EXECUTE 'REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM agent_bom_rls_maintenance';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname='agent_bom_maintenance') THEN
+    EXECUTE 'REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM agent_bom_maintenance';
+  END IF;
+END
+$tenant_binding_roles$;
+
 -- Readiness markers: deliberately last.
 INSERT INTO control_plane_schema_versions(component,version,updated_at)
 SELECT component,1,now() FROM unnest(ARRAY[

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -7,6 +7,7 @@ against a real server instead of the MockConnection unit-test harness.
 
 from __future__ import annotations
 
+import hashlib
 import os
 from dataclasses import replace
 from uuid import uuid4
@@ -156,6 +157,74 @@ def test_postgres_app_cannot_self_authorize_maintenance_and_dispatch_claim_is_te
             store.delete(cross_write.job_id, tenant_id=tenant_id)
         finally:
             reset_current_tenant(cleanup_token)
+
+
+def test_postgres_tenant_binding_verifier_keeps_keys_out_of_the_app_role():
+    """A caller-settable GUC cannot substitute for a valid signed claim."""
+    import psycopg
+
+    from agent_bom.api.postgres_common import _get_pool
+    from agent_bom.api.tenant_binding import issue_tenant_binding_claim
+
+    admin_dsn = os.environ.get("AGENT_BOM_POSTGRES_ADMIN_URL", "").strip()
+    if not admin_dsn:
+        pytest.skip("AGENT_BOM_POSTGRES_ADMIN_URL is required to provision a rotation key")
+
+    key = uuid4().hex.encode("utf-8")
+    key_id = hashlib.sha256(key).hexdigest()
+    claim = issue_tenant_binding_claim("tenant-binding-contract", nonce=uuid4().hex, key=key)
+    stale_claim = issue_tenant_binding_claim(
+        claim.tenant_id,
+        issued_at=claim.issued_at - 31,
+        nonce=uuid4().hex,
+        key=key,
+    )
+
+    with psycopg.connect(admin_dsn) as admin:
+        admin.execute(
+            "INSERT INTO public.agent_bom_tenant_binding_keys(key_id, key_material) VALUES (%s, %s)",
+            (key_id, key),
+        )
+
+    try:
+        with _get_pool().connection() as conn:
+            privileges = conn.execute(
+                "SELECT "
+                "has_function_privilege(current_user, "
+                "'public.abom_verify_tenant_binding_claim(text,bigint,text,text)', 'EXECUTE'), "
+                "has_table_privilege(current_user, 'public.agent_bom_tenant_binding_keys', 'SELECT')"
+            ).fetchone()
+            assert privileges == (True, False)
+
+            with pytest.raises(psycopg.errors.InsufficientPrivilege):
+                conn.execute("SELECT key_id FROM public.agent_bom_tenant_binding_keys")
+            conn.rollback()
+
+            conn.execute("SELECT set_config('app.tenant_id', 'attacker-controlled', false)")
+            verified = conn.execute(
+                "SELECT current_setting('app.tenant_id'), "
+                "public.abom_verify_tenant_binding_claim(%s, %s, %s, %s), "
+                "public.abom_verify_tenant_binding_claim(%s, %s, %s, %s), "
+                "public.abom_verify_tenant_binding_claim(%s, %s, %s, %s)",
+                (
+                    claim.tenant_id,
+                    claim.issued_at,
+                    claim.nonce,
+                    claim.signature,
+                    "other-tenant",
+                    claim.issued_at,
+                    claim.nonce,
+                    claim.signature,
+                    stale_claim.tenant_id,
+                    stale_claim.issued_at,
+                    stale_claim.nonce,
+                    stale_claim.signature,
+                ),
+            ).fetchone()
+            assert verified == ("attacker-controlled", True, False, False)
+    finally:
+        with psycopg.connect(admin_dsn) as admin:
+            admin.execute("DELETE FROM public.agent_bom_tenant_binding_keys WHERE key_id = %s", (key_id,))
 
 
 def test_postgres_ticketing_store_real_dml_role_roundtrip_and_tenant_filter():

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -36,6 +36,7 @@ HUB_OBSERVATIONS_PARTITION = VERSIONS_DIR / "20260705_01_hub_observations_partit
 BOOTSTRAP = ALEMBIC_DIR / "bootstrap.py"
 RUNTIME_SCHEMA_SQL = POSTGRES_DIR / "runtime-schema.sql"
 HUB_LEDGER_SCAN_ID = VERSIONS_DIR / "20260818_01_hub_ledger_scan_id.py"
+TENANT_BINDING_AUTHORITY = VERSIONS_DIR / "20260819_01_tenant_binding_authority.py"
 
 # The fork-guard UNIQUE index is spelled differently in its two schema sources:
 # the dedicated migration concatenates two quoted Python string literals, while
@@ -47,7 +48,7 @@ _FORK_GUARD_INDEX_CANON = "createuniqueindexifnotexistsaudit_log_team_prevsig_un
 
 # The newest migration. One place to update when a revision lands, so the
 # single-head property and the head's identity do not drift apart.
-ALEMBIC_HEAD = "20260818_01"
+ALEMBIC_HEAD = "20260819_01"
 
 
 def _canonical_sql(text: str) -> str:
@@ -614,6 +615,49 @@ def test_trusted_maintenance_queue_policy_does_not_require_precreated_app_role()
     assert "CREATE POLICY scan_dispatch_queue_tenant_isolation" in forward
     forward_policy = forward.split("CREATE POLICY scan_dispatch_queue_tenant_isolation", 1)[1].split('"', 1)[0]
     assert "TO agent_bom_app" not in forward_policy
+
+
+def test_tenant_binding_authority_is_chained_secret_minimal_and_fail_closed() -> None:
+    """The DB verifier may authenticate claims without exposing its HMAC keys."""
+    sql = TENANT_BINDING_AUTHORITY.read_text()
+
+    assert re.search(r'revision\s*=\s*"20260819_01"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260818_01"', sql)
+    assert "CREATE EXTENSION IF NOT EXISTS pgcrypto" in sql
+    assert "CREATE TABLE IF NOT EXISTS public.agent_bom_tenant_binding_keys" in sql
+    assert "key_material BYTEA NOT NULL" in sql
+    assert "octet_length(key_material) >= 32" in sql
+    assert "CREATE OR REPLACE FUNCTION public.abom_verify_tenant_binding_claim" in sql
+    assert "SECURITY DEFINER" in sql
+    assert "SET search_path = pg_catalog" in sql
+    assert "clock_timestamp()" in sql
+    assert "p_issued_at > v_now + 30" in sql
+    assert "p_issued_at < v_now - 30" in sql
+    assert "p_nonce !~ '^[0-9a-f]{32}$'" in sql
+    assert "p_signature !~ '^[0-9a-f]{64}$'" in sql
+    assert "'v1:' || encode(convert_to(p_tenant_id, 'UTF8'), 'hex')" in sql
+    assert "public.hmac(convert_to(v_canonical, 'UTF8'), key_material, 'sha256')" in sql
+    assert "WHERE enabled" in sql
+    assert "REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM PUBLIC" in sql
+    assert "REVOKE ALL ON FUNCTION public.abom_verify_tenant_binding_claim(TEXT, BIGINT, TEXT, TEXT) FROM PUBLIC" in sql
+    for runtime_role in ("agent_bom_app", "agent_bom_readonly", "agent_bom_rls_maintenance", "agent_bom_maintenance"):
+        assert f"REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM {runtime_role}" in sql
+    assert "GRANT EXECUTE ON FUNCTION public.abom_verify_tenant_binding_claim" in sql
+    assert "raise NotImplementedError" in sql
+
+    # New-install and supplemental-schema paths must carry the same authority,
+    # but this mechanical stage deliberately leaves active RLS on app.tenant_id.
+    init_schema = (POSTGRES_DIR / "init.sql").read_text()
+    runtime_schema = RUNTIME_SCHEMA_SQL.read_text()
+    for schema in (init_schema, runtime_schema):
+        assert "CREATE TABLE IF NOT EXISTS public.agent_bom_tenant_binding_keys" in schema
+        assert "CREATE OR REPLACE FUNCTION public.abom_verify_tenant_binding_claim" in schema
+        assert "SECURITY DEFINER" in schema
+        assert "SET search_path = pg_catalog" in schema
+        assert "REVOKE ALL ON TABLE public.agent_bom_tenant_binding_keys FROM PUBLIC" in schema
+        assert "tenant_id = public.abom_current_tenant()" in schema
+
+    assert "COALESCE(NULLIF(current_setting('app.tenant_id', true), ''), 'default')" in init_schema
 
 
 def test_hub_ledger_scan_id_migration_skips_backfill_when_ledger_is_absent(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- add a migration-owned HMAC key authority for short-lived tenant-binding claims
- expose only a locked-down `SECURITY DEFINER` verifier to the shared application role; runtime roles cannot read or modify the keys
- keep active RLS on the existing helper until the application issuance and lock-in stages are deployed
- add text-level migration parity checks and a real Postgres app/admin role regression

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_postgres_migrations.py tests/test_tenant_binding.py` (39 passed)
- `AGENT_BOM_POSTGRES_URL=... AGENT_BOM_POSTGRES_ADMIN_URL=... AGENT_BOM_AUDIT_HMAC_KEY=... UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_postgres_integration.py -k tenant_binding_verifier` (1 passed against Postgres 16)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check deploy/supabase/postgres/alembic/versions/20260819_01_tenant_binding_authority.py tests/test_postgres_migrations.py tests/test_postgres_integration.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff format --check deploy/supabase/postgres/alembic/versions/20260819_01_tenant_binding_authority.py tests/test_postgres_migrations.py tests/test_postgres_integration.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight`
- `git diff --check`

## Notes

This is the mechanical stage of the tenant-identity boundary rollout. It adds no runtime fallback and does not yet change session binding or RLS behavior. The next stages provision/rotate database keys, issue claims on application transactions, and only then replace the legacy caller-settable tenant helper.