### PR TITLE
fix(scanner): suppress verified false positives

### DIFF
--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -533,6 +533,18 @@ def _ingest_osv_file(conn: sqlite3.Connection, content: bytes, filename: str) ->
         _logger.debug("Skipping invalid JSON: %s", filename)
         return 0
 
+    # OSV keeps withdrawn records in its feed so downstream databases can
+    # retract advisories they ingested before the withdrawal. Merely skipping
+    # the new payload leaves the stale vulnerability and package ranges active
+    # forever. Remove the exact advisory ID before returning; affected rows are
+    # deleted explicitly as well as by the schema's cascade so this helper stays
+    # correct for callers using an externally-created SQLite connection.
+    vuln_id = data.get("id", "")
+    if vuln_id and data.get("withdrawn"):
+        conn.execute("DELETE FROM affected WHERE vuln_id = ?", (vuln_id,))
+        conn.execute("DELETE FROM vulns WHERE id = ?", (vuln_id,))
+        return 0
+
     parsed = _parse_osv_entry(data)
     if parsed is None:
         return 0

--- a/src/agent_bom/malicious.py
+++ b/src/agent_bom/malicious.py
@@ -138,7 +138,13 @@ _POPULAR_PACKAGES: dict[str, frozenset[str]] = {
 # campaigns, so exempting that shape would trade a false positive for a false
 # negative. Names only land here once the upstream project is confirmed.
 _KNOWN_LEGITIMATE: dict[str, frozenset[str]] = {
-    "npm": frozenset(),
+    "npm": frozenset(
+        {
+            # Independent React-compatible UI framework, published by the
+            # Preact project as a first-class public npm package.
+            "preact",
+        }
+    ),
     "pypi": frozenset(
         {
             # The httpx successor, by httpx's own author (github.com/pydantic/httpx2).
@@ -288,6 +294,13 @@ def check_dependency_confusion(package: "Package") -> str | None:
     """
     name = package.name.lower()
     eco = package.ecosystem.lower()
+
+    # Go dependencies use origin-qualified module paths rather than unscoped
+    # public-registry names. Tokens such as ``go-internal`` are normal project
+    # names there and do not establish the PyPI/npm shadowing condition this
+    # heuristic is designed to detect.
+    if eco in {"go", "golang"}:
+        return None
 
     # Scoped npm packages from known orgs are safe
     if eco == "npm" and any(name.startswith(scope) for scope in _SAFE_NPM_SCOPES):

--- a/tests/test_dependency_confusion.py
+++ b/tests/test_dependency_confusion.py
@@ -100,6 +100,13 @@ def test_public_cloud_and_telemetry_namespaces_not_flagged_as_confusion():
     assert check_dependency_confusion(_pkg("ts-api-utils", "npm")) is None
 
 
+def test_go_module_path_not_flagged_as_dependency_confusion():
+    # Go module paths are origin-qualified, so a legitimate ``-internal``
+    # suffix is not evidence that an unscoped public-registry name shadows a
+    # private dependency.
+    assert check_dependency_confusion(_pkg("github.com/rogpeppe/go-internal", "go", "1.14.1")) is None
+
+
 def test_weak_internal_suffix_flagged_when_version_unresolved():
     pkg = _pkg("mycompany-platform", version="unknown")
     result = check_dependency_confusion(pkg)

--- a/tests/test_local_vuln_db.py
+++ b/tests/test_local_vuln_db.py
@@ -361,6 +361,20 @@ def test_parse_osv_entry_withdrawn_skipped():
     assert _parse_osv_entry(data) is None
 
 
+def test_ingest_osv_withdrawal_removes_previously_stored_advisory(tmp_db):
+    data = _make_osv_entry()
+    content = json.dumps(data).encode()
+    assert _ingest_osv_file(tmp_db, content, "CVE-2024-OSV-TEST.json") == 1
+    assert tmp_db.execute("SELECT 1 FROM vulns WHERE id = ?", (data["id"],)).fetchone() is not None
+    assert tmp_db.execute("SELECT 1 FROM affected WHERE vuln_id = ?", (data["id"],)).fetchone() is not None
+
+    data["withdrawn"] = "2024-06-01T00:00:00Z"
+    assert _ingest_osv_file(tmp_db, json.dumps(data).encode(), "CVE-2024-OSV-TEST.json") == 0
+
+    assert tmp_db.execute("SELECT 1 FROM vulns WHERE id = ?", (data["id"],)).fetchone() is None
+    assert tmp_db.execute("SELECT 1 FROM affected WHERE vuln_id = ?", (data["id"],)).fetchone() is None
+
+
 def test_parse_osv_entry_missing_id_skipped():
     assert _parse_osv_entry({"summary": "no id"}) is None
 

--- a/tests/test_malicious.py
+++ b/tests/test_malicious.py
@@ -120,6 +120,12 @@ def test_typosquat_known_legitimate_successor_not_flagged():
     assert check_typosquat("langchainhub", "pypi") is None
 
 
+def test_typosquat_known_legitimate_preact_not_flagged():
+    # Preact is an independently maintained, public npm package. Its name is
+    # intentionally React-compatible, not a misspelling of ``react``.
+    assert check_typosquat("preact", "npm") is None
+
+
 def test_typosquat_numeric_suffix_still_flagged():
     # Guards the allowlist against being "simplified" into a rule that exempts
     # every trailing-digit name. `requests2`/`requests3` were real typosquat


### PR DESCRIPTION
## Summary

- exempt the verified `preact` npm project from typosquat detection
- avoid applying PyPI/npm dependency-confusion naming heuristics to origin-qualified Go module paths
- retract previously stored vulnerability ranges when OSV publishes a withdrawn advisory

## Verification

- `PYTHONPATH=src /Users/mohamedsaad/repos/Agent-Bom/.venv/bin/pytest -q tests/test_malicious.py tests/test_dependency_confusion.py tests/test_local_vuln_db.py` (128 passed)
- Ruff check and format check on the five changed files
- targeted mypy on `src/agent_bom/malicious.py` and `src/agent_bom/db/sync.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight`
- changed-file pre-commit hooks
- `PYTHONPATH=src /Users/mohamedsaad/repos/Agent-Bom/.venv/bin/agent-bom scan --demo --offline --format json` (complete report; expected nonzero vulnerability verdict)
- `git diff --check`

## Notes

- detection remains fail-closed for unverified near-neighbor package names and unresolved private-style npm/PyPI names
- withdrawal handling deletes only the exact OSV advisory ID and its affected ranges
