### PR TITLE
fix(operations): settle storage accounting and shard CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       docs: ${{ steps.classify.outputs.docs }}
       docs_only: ${{ steps.classify.outputs.docs_only }}
       endpoint: ${{ steps.classify.outputs.endpoint }}
+      graph_performance: ${{ steps.classify.outputs.graph_performance }}
       helm: ${{ steps.classify.outputs.helm }}
       postgres: ${{ steps.classify.outputs.postgres }}
       python: ${{ steps.classify.outputs.python }}
@@ -85,6 +86,7 @@ jobs:
           compose=false
           docs=false
           endpoint=false
+          graph_performance=false
           helm=false
           postgres=false
           # UI Validate boots a real Next.js standalone container and runs a
@@ -110,6 +112,12 @@ jobs:
           fi
           if printf '%s\n' "$changed" | grep -Eq '^(pyproject\.toml|uv\.lock|Dockerfile|\.github/actions/setup-python/)'; then
             alpine_full=true
+          fi
+          # The measured graph heap/scale assertion takes about six minutes by
+          # itself. Keep it out of the general correctness suite, but require it
+          # for graph implementation/tests and for changes to its CI contract.
+          if printf '%s\n' "$changed" | grep -Eq '^(src/agent_bom/(graph/|context_graph\.py$|graph_schema\.py$|db/graph_store\.py$)|tests/(graph/|test_(context_graph|graph_api|graph_schema|graph_store).*\.py$)|\.github/workflows/(ci|perf-scale-evidence)\.yml$|scripts/pytest_ci_plan\.py$|pyproject\.toml$)'; then
+            graph_performance=true
           fi
           # Strict docs build guard: any change to the MkDocs source tree, its
           # config, or the workflows that build/deploy it must prove
@@ -158,6 +166,7 @@ jobs:
             echo "compose=${compose}"
             echo "docs=${docs}"
             echo "endpoint=${endpoint}"
+            echo "graph_performance=${graph_performance}"
             echo "helm=${helm}"
             echo "postgres=${postgres}"
             echo "python=${python}"
@@ -173,6 +182,7 @@ jobs:
             echo "- Docs strict build required: \`${docs}\`"
             echo "- Documentation-only fast path: \`${docs_only}\`"
             echo "- Endpoint packaging required: \`${endpoint}\`"
+            echo "- Measured graph performance required: \`${graph_performance}\`"
             echo "- Helm profile validation required: \`${helm}\`"
             echo "- Real Postgres integration required: \`${postgres}\`"
             echo "- Python test suite required: \`${python}\`"
@@ -894,97 +904,70 @@ jobs:
           $version = uv run python -c "from agent_bom import __version__; print(__version__)"
           ./scripts/build-msi.ps1 -BundleDir $env:BUNDLE_DIR -OutputPath (Join-Path $env:RUNNER_TEMP "agent-bom-endpoint.msi") -Version $version -DryRun
 
-  # 3. Tests
-  test:
-    name: Test (Python ${{ matrix.python-version }})
+  # 3. Python correctness
+  # Fast changed-domain/product-boundary feedback starts package proof while
+  # the exhaustive PR shards continue in parallel. The small aggregator below
+  # preserves the branch-protection context `Test (Python 3.13)` and requires
+  # every applicable shard plus measured graph evidence.
+  test-smoke:
+    name: Python changed-domain and contract smoke
     runs-on: ubuntu-latest
-    # The Python 3.11 main-push lane also collects coverage and reached the
-    # former 25-minute ceiling twice at cd43aadee while 3.13/3.14 completed.
-    # Keep a bounded 35-minute budget so normal suite growth can finish while
-    # a genuinely hung run still releases the hosted runner promptly.
-    timeout-minutes: 35
+    timeout-minutes: 15
     permissions:
       contents: read
     needs: changes
-    # The job itself runs unless the workflow is cancelled: "Test (Python
-    # 3.13)" is a REQUIRED context,
-    # and a matrix job skipped at job level never expands its matrix, so the
-    # required check would sit at "Expected" forever and block auto-merge.
-    # The heavy STEPS below skip instead when the classifier positively says
-    # the PR cannot affect Python (docs/UI/deploy-only); the job then reports
-    # success in seconds. Fail closed: a classifier failure runs the suite.
     if: ${{ !cancelled() }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # PRs run the mainstream interpreter only; pushes to main run the full
-        # matrix (plus coverage on 3.11 below). Interpreter-specific drift is
-        # rare and still caught on main within one merge — this keeps PR
-        # wall-clock near the 4-5 minute mark instead of ~10.
-        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.13"]') || fromJSON('["3.11", "3.13", "3.14"]') }}
     steps:
       - name: Documentation-only test skip
-        if: needs.changes.result == 'success' && needs.changes.outputs.docs_only == 'true'
-        run: echo "No Python test input changed; the test matrix is not required."
+        if: needs.changes.result == 'success' && needs.changes.outputs.python != 'true'
+        run: echo "No Python test input changed; smoke is not required."
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: >-
-          (github.event_name != 'pull_request' && github.event_name != 'push') ||
-          needs.changes.result != 'success' ||
-          needs.changes.outputs.python == 'true'
-
-      - uses: ./.github/actions/setup-python
-        if: >-
-          (github.event_name != 'pull_request' && github.event_name != 'push') ||
           needs.changes.result != 'success' ||
           needs.changes.outputs.python == 'true'
         with:
-          python-version: ${{ matrix.python-version }}
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-python
+        if: >-
+          needs.changes.result != 'success' ||
+          needs.changes.outputs.python == 'true'
+        with:
+          python-version: "3.13"
 
       - name: Install dependencies
         if: >-
-          (github.event_name != 'pull_request' && github.event_name != 'push') ||
           needs.changes.result != 'success' ||
           needs.changes.outputs.python == 'true'
         run: uv sync --frozen --extra dev --extra api --extra mcp-server
 
-      - name: Run tests
+      - name: Run changed-domain and cross-surface smoke
         if: >-
-          (github.event_name != 'pull_request' && github.event_name != 'push') ||
           needs.changes.result != 'success' ||
           needs.changes.outputs.python == 'true'
         run: |
-          # Keep PR matrix worker count bounded on hosted runners. `-n auto`
-          # can overcommit CPU/RAM enough for GitHub to terminate the runner
-          # before pytest prints a failure summary.
-          # 3.11 keeps 4 workers (passes, and fewer would risk the job
-          # timeout); 3.13/3.14 drop to 2 so the parallel run's peak RAM stays
-          # under the hosted-runner limit (4 heavy interpreters OOM the VM,
-          # surfacing as "runner received a shutdown signal" / exit 143).
-          # PRs run a single matrix job (3.13), so it gets 3 workers there —
-          # one below the OOM threshold observed at 4 — to cut PR wall-clock.
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            PYTEST_XDIST_WORKERS="${PYTEST_XDIST_WORKERS:-3}"
-          elif [ "${{ matrix.python-version }}" = "3.11" ]; then
-            PYTEST_XDIST_WORKERS="${PYTEST_XDIST_WORKERS:-4}"
+            mapfile -t CHANGED < <(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
+          elif [ -n "${{ github.event.before }}" ] && ! printf '%s' "${{ github.event.before }}" | grep -qE '^0+$'; then
+            mapfile -t CHANGED < <(git diff --name-only "${{ github.event.before }}" "$GITHUB_SHA")
           else
-            PYTEST_XDIST_WORKERS="${PYTEST_XDIST_WORKERS:-2}"
+            mapfile -t CHANGED < <(git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA")
           fi
-          # --durations=25 names the slowest tests in the log, so a run that
-          # drifts toward the job timeout comes with its own evidence.
-          if [ "${{ matrix.python-version }}" = "3.11" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
-            uv run pytest tests/ -v --tb=short --durations=25 --cov=agent_bom --cov-report=term-missing --cov-fail-under=75 -m "not network and not slow" -n "$PYTEST_XDIST_WORKERS" --dist worksteal
-          else
-            uv run pytest tests/ -q --tb=short --durations=25 -m "not network and not slow" -n "$PYTEST_XDIST_WORKERS" --dist worksteal
-          fi
+          mapfile -t TARGETED < <(uv run python scripts/pytest_ci_plan.py targeted --root . "${CHANGED[@]}")
+          SMOKE=(
+            tests/test_ci_workflow_contract.py
+            tests/test_cli_entry_points.py
+            tests/test_product_surface_contract.py
+            tests/api/test_api_scan_findings_wiring.py
+          )
+          mapfile -t TESTS < <(printf '%s\n' "${SMOKE[@]}" "${TARGETED[@]}" | sort -u)
+          uv run pytest "${TESTS[@]}" -q --tb=short --durations=15 -m "not network and not slow and not graph_performance" -n 2 --dist loadfile
 
       - name: Graph accuracy fixture guard (#2259)
-        # The graph tests are already part of the full test invocation above.
-        # Keep the cheap fixture check and re-baseline guidance without running
-        # the same 23 tests a second time.
         if: >-
           always() && (
-            (github.event_name != 'pull_request' && github.event_name != 'push') ||
             needs.changes.result != 'success' ||
             needs.changes.outputs.python == 'true'
           )
@@ -996,7 +979,6 @@ jobs:
         # Proves the scanner is alive, its rules fire on real SQL, and our own
         # migration files are clean (or surface known findings explicitly).
         if: >-
-          (github.event_name != 'pull_request' && github.event_name != 'push') ||
           needs.changes.result != 'success' ||
           needs.changes.outputs.python == 'true'
         run: |
@@ -1027,6 +1009,138 @@ jobs:
               raise SystemExit(1)
           print("OK")
           PYEOF
+
+  test-pr-shard:
+    name: Python correctness shard ${{ matrix.shard }} of 0-3
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    needs: changes
+    if: >-
+      github.event_name == 'pull_request' && !cancelled() && (
+        needs.changes.result != 'success' || needs.changes.outputs.python == 'true'
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev --extra api --extra mcp-server
+
+      - name: Run deterministic test shard
+        run: |
+          set -euo pipefail
+          mapfile -t TEST_FILES < <(uv run python scripts/pytest_ci_plan.py shard --index "${{ matrix.shard }}" --total 4 --root tests)
+          test "${#TEST_FILES[@]}" -gt 0
+          uv run pytest "${TEST_FILES[@]}" -q --tb=short --durations=25 -m "not network and not slow and not graph_performance" -n 2 --dist loadfile
+
+  test-main:
+    name: Full correctness (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    permissions:
+      contents: read
+    if: ${{ github.event_name != 'pull_request' && !cancelled() }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev --extra api --extra mcp-server
+
+      - name: Run full correctness suite
+        run: |
+          if [ "${{ matrix.python-version }}" = "3.11" ]; then
+            PYTEST_XDIST_WORKERS="${PYTEST_XDIST_WORKERS:-4}"
+            uv run pytest tests/ -v --tb=short --durations=25 --cov=agent_bom --cov-report=term-missing --cov-fail-under=75 -m "not network and not slow and not graph_performance" -n "$PYTEST_XDIST_WORKERS" --dist worksteal
+          else
+            PYTEST_XDIST_WORKERS="${PYTEST_XDIST_WORKERS:-2}"
+            uv run pytest tests/ -q --tb=short --durations=25 -m "not network and not slow and not graph_performance" -n "$PYTEST_XDIST_WORKERS" --dist worksteal
+          fi
+
+  graph-performance:
+    name: Graph performance
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    needs: changes
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Unrelated PR skip
+        if: >-
+          github.event_name == 'pull_request' &&
+          needs.changes.result == 'success' &&
+          needs.changes.outputs.graph_performance != 'true'
+        run: echo "No graph performance input changed; measured scale proof is not required."
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: >-
+          github.event_name != 'pull_request' ||
+          needs.changes.result != 'success' ||
+          needs.changes.outputs.graph_performance == 'true'
+
+      - uses: ./.github/actions/setup-python
+        if: >-
+          github.event_name != 'pull_request' ||
+          needs.changes.result != 'success' ||
+          needs.changes.outputs.graph_performance == 'true'
+        with:
+          python-version: "3.13"
+
+      - name: Install graph test dependencies
+        if: >-
+          github.event_name != 'pull_request' ||
+          needs.changes.result != 'success' ||
+          needs.changes.outputs.graph_performance == 'true'
+        run: uv sync --frozen --extra dev --extra graph
+
+      - name: Run measured graph scale assertion
+        if: >-
+          github.event_name != 'pull_request' ||
+          needs.changes.result != 'success' ||
+          needs.changes.outputs.graph_performance == 'true'
+        run: uv run pytest tests/graph/test_store_backed_build_wiring.py -q -m graph_performance
+
+  test:
+    name: Test (Python 3.13)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    needs: [changes, test-smoke, test-pr-shard, test-main, graph-performance]
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Require every applicable correctness lane
+        env:
+          SMOKE_RESULT: ${{ needs.test-smoke.result }}
+          PR_SHARDS_RESULT: ${{ needs.test-pr-shard.result }}
+          MAIN_RESULT: ${{ needs.test-main.result }}
+          GRAPH_RESULT: ${{ needs.graph-performance.result }}
+        run: |
+          set -euo pipefail
+          for result in "$SMOKE_RESULT" "$PR_SHARDS_RESULT" "$MAIN_RESULT" "$GRAPH_RESULT"; do
+            case "$result" in
+              success|skipped) ;;
+              *) echo "Required correctness lane ended with: $result" >&2; exit 1 ;;
+            esac
+          done
+          echo "All applicable Python correctness lanes passed."
 
   sdk-import-smoke:
     name: Extra-gated SDK import smoke
@@ -1531,10 +1645,11 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-    needs: [changes, security, lint, test]
-    # Build still runs when the classifier legitimately skipped the test
-    # suite (docs-only PRs); a failed or cancelled test still blocks it.
-    if: ${{ !cancelled() && needs.security.result == 'success' && needs.lint.result == 'success' && contains(fromJSON('["success", "skipped"]'), needs.test.result) }}
+    needs: [changes, security, lint, test-smoke]
+    # Package proof starts after the compact changed-domain/contract gate while
+    # exhaustive correctness shards continue in parallel. Branch protection
+    # still requires their `Test (Python 3.13)` aggregator before merge.
+    if: ${{ !cancelled() && needs.security.result == 'success' && needs.lint.result == 'success' && contains(fromJSON('["success", "skipped"]'), needs.test-smoke.result) }}
     steps:
       - name: Documentation-only package skip
         if: needs.changes.result == 'success' && needs.changes.outputs.docs_only == 'true'

--- a/.github/workflows/perf-scale-evidence.yml
+++ b/.github/workflows/perf-scale-evidence.yml
@@ -70,6 +70,9 @@ jobs:
             --summary-output /tmp/postgres-graph-explain.json
           uv run pytest tests/test_graph_benchmark_scaffold.py -q
 
+      - name: Run measured graph scale assertion
+        run: uv run pytest tests/graph/test_store_backed_build_wiring.py -q -m graph_performance
+
       - name: Upload result artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -345,6 +345,7 @@ filterwarnings = [
 markers = [
     "network: tests that require network access (OSV API)",
     "slow: slow tests (e.g. large-scale perf benchmarks) — opt-in only",
+    "graph_performance: measured graph scale assertions — graph changes, main, and scheduled evidence only",
     "live_cluster: tests that require a reachable local Kubernetes cluster (e.g. kind) — opt-in only",
     "real_vuln_db_sync: test drives sync_db itself; opts out of the autouse no-download patch",
 ]

--- a/scripts/check_product_surface_contract.py
+++ b/scripts/check_product_surface_contract.py
@@ -252,10 +252,10 @@ def main() -> int:
             "merge_group:",
             "python scripts/check_release_consistency.py",
             "python scripts/check_product_surface_contract.py",
-            "Test (Python ${{ matrix.python-version }})",
+            "Test (Python 3.13)",
             # PRs run 3.13 only; pushes to main must still exercise the full
             # advertised interpreter matrix.
-            'fromJSON(\'["3.11", "3.13", "3.14"]\')',
+            'python-version: ["3.11", "3.13", "3.14"]',
         ],
         failures,
     )

--- a/scripts/pytest_ci_plan.py
+++ b/scripts/pytest_ci_plan.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Build deterministic, exhaustive pytest plans for CI.
+
+The PR suite is split by test-file byte weight.  Every file is assigned to
+exactly one shard, while the largest files are greedily spread across runners.
+The changed-domain selector is intentionally conservative: it includes tests
+changed directly and tests whose basename matches a changed source/script
+module.  Cross-surface smoke tests are added by the workflow itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+
+def discover_test_files(root: Path) -> list[Path]:
+    """Return every pytest module below *root* in stable path order."""
+    return sorted(path for path in root.rglob("test_*.py") if path.is_file())
+
+
+def plan_shards(files: Iterable[Path], *, total: int) -> list[list[Path]]:
+    """Assign all files once using deterministic largest-first balancing."""
+    if total < 1:
+        raise ValueError("total shards must be positive")
+
+    shards: list[list[Path]] = [[] for _ in range(total)]
+    loads = [0] * total
+    weighted = sorted(files, key=lambda path: (-path.stat().st_size, path.as_posix()))
+    for path in weighted:
+        index = min(range(total), key=lambda candidate: (loads[candidate], candidate))
+        shards[index].append(path)
+        loads[index] += path.stat().st_size
+
+    return [sorted(shard) for shard in shards]
+
+
+def select_targeted_tests(*, changed_files: Iterable[Path], root: Path) -> list[Path]:
+    """Select directly changed tests and basename matches for source modules."""
+    test_root = root / "tests"
+    available = discover_test_files(test_root)
+    selected: set[Path] = set()
+
+    for changed in changed_files:
+        normalized = Path(changed.as_posix().lstrip("./"))
+        direct = root / normalized
+        if normalized.parts and normalized.parts[0] == "tests" and direct in available:
+            selected.add(direct)
+
+        if normalized.suffix != ".py" or normalized.name == "__init__.py":
+            continue
+        if not normalized.parts or normalized.parts[0] not in {"src", "scripts"}:
+            continue
+
+        expected = f"test_{normalized.stem}"
+        selected.update(candidate for candidate in available if candidate.stem == expected or candidate.stem.startswith(f"{expected}_"))
+
+    return sorted(selected)
+
+
+def _display(path: Path, *, base: Path) -> str:
+    try:
+        return path.relative_to(base).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    shard = subparsers.add_parser("shard", help="print one deterministic test shard")
+    shard.add_argument("--index", type=int, required=True, help="zero-based shard index")
+    shard.add_argument("--total", type=int, required=True, help="total shard count")
+    shard.add_argument("--root", type=Path, default=Path("tests"), help="test root")
+
+    targeted = subparsers.add_parser("targeted", help="print tests related to changed files")
+    targeted.add_argument("--root", type=Path, default=Path("."), help="repository root")
+    targeted.add_argument("changed_files", nargs="*", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    cwd = Path.cwd().resolve()
+    if args.command == "shard":
+        if args.index < 0 or args.index >= args.total:
+            raise SystemExit(f"shard index {args.index} is outside 0..{args.total - 1}")
+        files = discover_test_files(args.root.resolve())
+        selected = plan_shards(files, total=args.total)[args.index]
+    else:
+        selected = select_targeted_tests(changed_files=args.changed_files, root=args.root.resolve())
+
+    for path in selected:
+        print(_display(path.resolve(), base=cwd))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_bom/db/local_analytics.py
+++ b/src/agent_bom/db/local_analytics.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import uuid
+from contextlib import closing
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
@@ -263,7 +264,7 @@ class LocalAnalyticsStore:
         findings = list(_iter_findings(report_json))
         package_rows = list(_iter_packages(report_json))
 
-        with self._connect() as conn:
+        with closing(self._connect()) as conn:
             conn.execute(
                 """
                 INSERT INTO scan_runs(
@@ -334,7 +335,7 @@ class LocalAnalyticsStore:
 
     def list_scan_runs(self, *, limit: int = 20, tenant_id: str | None = None) -> list[dict[str, Any]]:
         """Return recent scan runs newest first."""
-        with self._connect() as conn:
+        with closing(self._connect()) as conn:
             tenant_filter = (tenant_id or "").strip()
             bounded_limit = max(1, int(limit))
             if tenant_filter:
@@ -366,7 +367,7 @@ class LocalAnalyticsStore:
 
     def storage_stats(self) -> dict[str, Any]:
         """Return bounded local-mirror usage without including deployment state."""
-        with self._connect() as conn:
+        with closing(self._connect()) as conn:
             row = conn.execute(
                 """
                 SELECT
@@ -405,7 +406,7 @@ class LocalAnalyticsStore:
     ) -> dict[str, Any]:
         """Plan or apply whole-run retention, optionally compacting SQLite."""
         bytes_before = self._storage_bytes()
-        with self._connect() as conn:
+        with closing(self._connect()) as conn:
             stale = plan_local_scan_prune(
                 conn,
                 max_events=max_runs,
@@ -435,7 +436,7 @@ class LocalAnalyticsStore:
         """Run a read query against the local analytics store."""
         if not sql.lstrip().lower().startswith("select"):
             raise ValueError("local analytics queries are read-only")
-        with self._connect() as conn:
+        with closing(self._connect()) as conn:
             rows = conn.execute(sql, tuple(params)).fetchall()
         return [dict(row) for row in rows]
 

--- a/tests/graph/test_store_backed_build_wiring.py
+++ b/tests/graph/test_store_backed_build_wiring.py
@@ -281,6 +281,7 @@ def _builder_peak(report: dict, *, store_backed: bool) -> tuple[int, int]:
     return peak, node_count
 
 
+@pytest.mark.graph_performance
 def test_store_backed_producer_peak_advantage_widens_with_scale() -> None:
     """The store-backed producer removes the dominant resident structures — the
     whole-node dict + adjacency / reverse-adjacency + dedup indexes — so its peak

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -135,7 +135,7 @@ def test_test_job_timeout_leaves_margin_over_observed_worst_case() -> None:
     ``cd43aadee`` while the 3.13 and 3.14 lanes completed successfully. A
     35-minute ceiling preserves a hard bound while allowing normal suite growth.
     """
-    assert _ci()["jobs"]["test"]["timeout-minutes"] == 35
+    assert _ci()["jobs"]["test-main"]["timeout-minutes"] == 35
 
 
 def test_version_alignment_fails_fast_when_uv_lock_is_stale() -> None:
@@ -167,14 +167,63 @@ def test_alpine_full_suite_uses_bounded_parallelism() -> None:
 
 def test_pull_request_pytest_reports_slowest_tests() -> None:
     """PR runs surface the slowest tests so timeout regressions have evidence."""
-    text = CI_WORKFLOW.read_text(encoding="utf-8")
-    run_tests = text.split("      - name: Run tests", 1)[1].split("      - name: Graph accuracy fixture guard", 1)[0]
+    jobs = _ci()["jobs"]
+    shard_run = next(step["run"] for step in jobs["test-pr-shard"]["steps"] if step.get("name") == "Run deterministic test shard")
+    main_run = next(step["run"] for step in jobs["test-main"]["steps"] if step.get("name") == "Run full correctness suite")
 
-    pytest_lines = [line.strip() for line in run_tests.splitlines() if "uv run pytest tests/" in line]
-    assert len(pytest_lines) == 2
-    assert all("--durations=25" in line for line in pytest_lines)
-    coverage_line = next(line for line in pytest_lines if "--cov=agent_bom" in line)
+    assert "--durations=25" in shard_run
+    assert "--durations=25" in main_run
+    coverage_line = next(line.strip() for line in main_run.splitlines() if "--cov=agent_bom" in line)
     assert "--cov-fail-under=75" in coverage_line
+
+
+def test_pull_request_correctness_is_sharded_behind_required_aggregator() -> None:
+    """PR correctness stays exhaustive without one serial 17-minute job."""
+    jobs = _ci()["jobs"]
+
+    shards = jobs["test-pr-shard"]
+    assert shards["strategy"]["matrix"]["shard"] == [0, 1, 2, 3]
+    shard_run = next(step["run"] for step in shards["steps"] if step.get("name") == "Run deterministic test shard")
+    assert "scripts/pytest_ci_plan.py shard" in shard_run
+    assert "not graph_performance" in shard_run
+
+    required = jobs["test"]
+    assert required["name"] == "Test (Python 3.13)"
+    assert "test-pr-shard" in required["needs"]
+    assert "graph-performance" in required["needs"]
+
+
+def test_python_smoke_gate_combines_changed_domain_and_cross_surface_contracts() -> None:
+    """Every Python PR gets quick relevant and product-boundary feedback."""
+    smoke = _ci()["jobs"]["test-smoke"]
+    run = next(step["run"] for step in smoke["steps"] if step.get("name") == "Run changed-domain and cross-surface smoke")
+
+    assert "scripts/pytest_ci_plan.py targeted" in run
+    assert "tests/test_cli_entry_points.py" in run
+    assert "tests/test_product_surface_contract.py" in run
+    assert "tests/api/test_api_scan_findings_wiring.py" in run
+
+
+def test_package_build_waits_for_smoke_not_long_correctness_shards() -> None:
+    """Wheel proof starts after fast correctness while shards continue in parallel."""
+    needs = _ci()["jobs"]["build"]["needs"]
+    assert "test-smoke" in needs
+    assert "test" not in needs
+
+
+def test_measured_graph_heap_assertion_has_dedicated_conditional_job() -> None:
+    """The six-minute scale assertion is required only on relevant PRs and main."""
+    workflow = _ci()
+    assert "graph_performance" in workflow["jobs"]["changes"]["outputs"]
+    graph_job = workflow["jobs"]["graph-performance"]
+    run = next(step["run"] for step in graph_job["steps"] if step.get("name") == "Run measured graph scale assertion")
+    assert "-m graph_performance" in run
+
+    graph_test = (ROOT / "tests" / "graph" / "test_store_backed_build_wiring.py").read_text(encoding="utf-8")
+    assert "@pytest.mark.graph_performance" in graph_test
+
+    nightly = (ROOT / ".github" / "workflows" / "perf-scale-evidence.yml").read_text(encoding="utf-8")
+    assert "-m graph_performance" in nightly
 
 
 def test_security_reuses_typescript_install_for_build() -> None:

--- a/tests/test_cli_report_query.py
+++ b/tests/test_cli_report_query.py
@@ -154,3 +154,55 @@ def test_report_prune_requires_apply_for_compaction(tmp_path):
 
     assert result.exit_code != 0
     assert "--compact requires --apply" in result.output
+
+
+def test_report_prune_compact_reports_settled_storage_bytes(tmp_path, monkeypatch):
+    db_path = tmp_path / "local.sqlite"
+    monkeypatch.setenv("AGENT_BOM_ANALYTICS_MAX_EVENTS", "100")
+    monkeypatch.setenv("AGENT_BOM_ANALYTICS_MAX_PACKAGES", "10000")
+    monkeypatch.setenv("AGENT_BOM_ANALYTICS_MAX_FINDINGS", "10000")
+    store = LocalAnalyticsStore(db_path)
+    padding = "x" * 2048
+    for run_index in range(4):
+        report = _scan_report()
+        report["scan_id"] = f"scan-{run_index}"
+        report["generated_at"] = f"2026-05-1{run_index}T16:00:00+00:00"
+        report["findings"] = [
+            {
+                "id": f"finding-{run_index}-{finding_index}",
+                "vulnerability_id": f"CVE-2026-{run_index:02d}{finding_index:04d}",
+                "package_name": "fastapi",
+                "package_version": "0.115.0",
+                "ecosystem": "pypi",
+                "severity": "high",
+                "description": padding,
+            }
+            for finding_index in range(400)
+        ]
+        store.record_scan_report(report, source="cli")
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "report",
+            "prune",
+            "--db",
+            str(db_path),
+            "--max-runs",
+            "1",
+            "--apply",
+            "--compact",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    settled_bytes = sum(
+        path.stat().st_size
+        for path in (db_path, db_path.with_name(f"{db_path.name}-wal"), db_path.with_name(f"{db_path.name}-shm"))
+        if path.exists()
+    )
+    assert payload["bytes_after"] == settled_bytes
+    assert payload["bytes_after"] < payload["bytes_before"]

--- a/tests/test_pytest_ci_plan.py
+++ b/tests/test_pytest_ci_plan.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.pytest_ci_plan import discover_test_files, plan_shards, select_targeted_tests
+
+
+def _write(path: Path, lines: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("x\n" * lines, encoding="utf-8")
+
+
+def test_shard_plan_is_deterministic_disjoint_and_complete(tmp_path: Path) -> None:
+    for index, lines in enumerate((200, 150, 120, 90, 70, 50, 30, 20, 10)):
+        _write(tmp_path / f"group_{index % 3}" / f"test_{index}.py", lines)
+
+    files = discover_test_files(tmp_path)
+    first = plan_shards(files, total=4)
+    second = plan_shards(files, total=4)
+
+    assert first == second
+    assert {path for shard in first for path in shard} == set(files)
+    assert sum(len(shard) for shard in first) == len(files)
+
+    loads = [sum(path.stat().st_size for path in shard) for shard in first]
+    largest = max(path.stat().st_size for path in files)
+    assert max(loads) - min(loads) <= largest
+
+
+def test_targeted_tests_include_changed_tests_and_source_name_matches(tmp_path: Path) -> None:
+    direct = tmp_path / "tests" / "test_direct.py"
+    matching = tmp_path / "tests" / "db" / "test_local_analytics.py"
+    unrelated = tmp_path / "tests" / "test_other.py"
+    for path in (direct, matching, unrelated):
+        _write(path, 1)
+
+    selected = select_targeted_tests(
+        changed_files=[Path("tests/test_direct.py"), Path("src/agent_bom/db/local_analytics.py")],
+        root=tmp_path,
+    )
+
+    assert selected == [matching, direct]


### PR DESCRIPTION
## Summary

- close local analytics SQLite connections deterministically and report settled database/WAL/SHM bytes after prune/compact
- split exhaustive Python PR correctness across four deterministic, byte-balanced test-file shards while retaining a fast changed-domain and cross-surface smoke gate
- preserve the required `Test (Python 3.13)` context as an aggregator over every applicable shard and measured graph proof
- isolate the measured graph heap/scale assertion to graph changes, `main`, and the weekly performance workflow; let package proof start after the fast smoke gate

## Verification

- `PYTHONPATH=src /Users/mohamedsaad/repos/Agent-Bom/.venv/bin/pytest -q tests/test_ci_workflow_contract.py tests/test_pytest_ci_plan.py tests/test_ci_retrigger_scripts.py tests/test_product_surface_contract.py tests/test_cli_entry_points.py tests/api/test_api_scan_findings_wiring.py tests/test_cli_report_query.py tests/test_local_analytics.py -m 'not network and not slow and not graph_performance' -n 2 --dist loadfile --durations=15` (108 passed)
- `PYTHONPATH=src /Users/mohamedsaad/repos/Agent-Bom/.venv/bin/pytest -q tests/graph/test_store_backed_build_wiring.py -m graph_performance --durations=5` (1 passed, 5 deselected; 90.21s)
- `actionlint .github/workflows/ci.yml .github/workflows/perf-scale-evidence.yml`
- Ruff check/format on changed Python files
- `UV_PROJECT_ENVIRONMENT=/Users/mohamedsaad/repos/Agent-Bom/.venv UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight`
- `git diff --check origin/main...HEAD`

## Notes

- no correctness test is dropped: the shard planner assigns every `test_*.py` file to exactly one shard; marker selection only moves the measured graph assertion to its dedicated job
- the four current partitions contain 303/303/305/304 files and differ by less than 300 bytes of source weight
- package proof can run alongside exhaustive shards, but merge remains blocked until the required correctness aggregator passes
- prune selection and retained scan data are unchanged; deployment and EKS state remain outside analytics accounting/deletion scope
