### PR TITLE
fix(release): restore CI and registry convergence

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -5,34 +5,10 @@ name: Publish to Registries
 #   SMITHERY_API_TOKEN  — Smithery service token (smithery.ai → API tokens)
 #   CLAWHUB_TOKEN       — ClawHub auth token (clawhub.ai → Settings)
 #
-# NOT wired, deliberately: a `SMITHERY_UPSTREAM_TOKEN` was once documented here
-# as the way to let Smithery's scanner authenticate against our MCP endpoint.
-# No such secret exists and nothing in this file ever read one, so the note
-# described a fix that was never implemented. The consequence is real: Smithery
-# cannot enumerate our tools, the release settles as AUTH_REQUIRED, and the
-# public catalog lists fewer tools than the server serves (36 of 77 as of
-# 0.99.0 — see the supply-chain-drift tracker).
-#
-# The AS-not-mounted half of this was FIXED in #4730 (shipped in 0.100.0) and
-# the note below is kept only because the conclusion changed. Measured against
-# the live endpoint on 2026-08-12, after 0.100.0 deployed:
-#
-#   /.well-known/oauth-protected-resource   -> 200
-#   /.well-known/oauth-authorization-server -> 200   (was 404)
-#   POST /oauth/register                    -> 201   (DCR works)
-#   POST /mcp  (no token)                   -> 401
-#
-# So discovery and dynamic client registration both work now. Smithery still
-# reports AUTH_REQUIRED, and the reason is one level further in: DCR issues a
-# PUBLIC client (`token_endpoint_auth_method: none`) with an empty scope, and
-# the only machine-usable grant, `client_credentials`, needs a client secret.
-# `authorization_code` needs a human at `/authorize`. An unattended scanner can
-# therefore register but can never obtain a token.
-#
-# That makes AUTH_REQUIRED the correct terminal state for an endpoint that
-# authenticates every request by design — not a bug awaiting a CI fix. Closing
-# it means deciding to issue scanners a scoped credential (a product decision),
-# so no step here may treat the resulting stale catalog as a release blocker.
+# The protected external endpoint publishes RFC 9728/8414 OAuth discovery and
+# a static MCP server card.  Smithery reserves Authorization for that OAuth
+# flow; do not replace it with a required bearer-token config field.  The
+# release is only fresh when the catalog converges to the released tool count.
 # Optional vars:
 #   SMITHERY_MCP_URL    — Public Streamable HTTP MCP endpoint for Smithery
 # Optional secret:
@@ -206,7 +182,7 @@ jobs:
               jq -e \
                 --arg version "$VERSION" \
                 --argjson tool_count "$EXPECTED_TOOL_COUNT" \
-                '.serverInfo.version == $version and (.tools | length) == $tool_count and all(.tools[]; (.name | type == "string") and (.inputSchema | type == "object"))' \
+                '.serverInfo.version == $version and (.authentication.required == true) and (.authentication.schemes | index("oauth2") != null) and (.tools | length) == $tool_count and all(.tools[]; (.name | type == "string") and (.inputSchema | type == "object"))' \
                 /tmp/smithery-server-card.json >/dev/null; then
               echo "Smithery server card matches v${VERSION} with ${EXPECTED_TOOL_COUNT} live tool schemas"
               exit 0
@@ -238,22 +214,7 @@ jobs:
               -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" \
               -F "payload={
                 \"type\": \"external\",
-                \"upstreamUrl\": \"${MCP_URL}\",
-                \"configSchema\": {
-                  \"type\": \"object\",
-                  \"properties\": {
-                    \"bearerToken\": {
-                      \"type\": \"string\",
-                      \"title\": \"Access token\",
-                      \"description\": \"Bearer token for the agent-bom MCP endpoint. Required — the endpoint authenticates every request and will not enumerate tools without it.\"
-                    },
-                    \"NVD_API_KEY\": {
-                      \"type\": \"string\",
-                      \"description\": \"NVD API key for higher rate limits on CVSS enrichment (optional)\"
-                    }
-                  },
-                  \"required\": [\"bearerToken\"]
-                }
+                \"upstreamUrl\": \"${MCP_URL}\"
               }")
 
             echo "Smithery attempt ${ATTEMPT}/3 — HTTP ${HTTP_STATUS}"
@@ -297,24 +258,7 @@ jobs:
                 echo "scan_status=SUCCESS" >> "$GITHUB_OUTPUT"
                 exit 0
                 ;;
-              # The agent-bom MCP endpoint authenticates every request — that is
-              # the point of it, and the published configSchema marks
-              # `bearerToken` as required so a Smithery user supplies their own.
-              # Smithery's scanner therefore cannot enumerate our tools, and
-              # reports AUTH_REQUIRED / AUTH_TIMEOUT. The RELEASE ITSELF
-              # succeeded; only the optional post-publish scan did not.
-              #
-              # Failing here failed the whole Publish to Registries job on every
-              # release and opened a release-blocker issue for a server that had
-              # in fact published. The alternative — handing a third-party
-              # scanner our production bearer token so it can pass — is not a
-              # trade worth making for a green check.
-              AUTH_REQUIRED|AUTH_TIMEOUT)
-                echo "::warning::Smithery published the release but could not scan it (${STATUS}); the endpoint requires a caller-supplied bearerToken by design"
-                echo "scan_status=${STATUS}" >> "$GITHUB_OUTPUT"
-                exit 0
-                ;;
-              FAILURE|FAILURE_SCAN|CANCELLED|INTERNAL_ERROR)
+              FAILURE|FAILURE_SCAN|AUTH_REQUIRED|AUTH_TIMEOUT|CANCELLED|INTERNAL_ERROR)
                 echo "::error::Smithery release did not complete successfully (${STATUS})"
                 exit 1
                 ;;
@@ -324,33 +268,13 @@ jobs:
           echo "::error::Smithery release did not finish before the verification timeout"
           exit 1
 
-      # The step above deliberately accepts AUTH_REQUIRED/AUTH_TIMEOUT as a
-      # terminal state, because our MCP endpoint authenticates every request and
-      # Smithery's scanner has no credential. This step then asserted a tool
-      # count that only a SUCCESSFUL scan can produce — so it re-created, one
-      # step later, exactly the failure the step above documents having fixed:
-      # a release-blocker issue on every release for a server that published
-      # correctly. The catalog cannot converge while the scan cannot run.
-      #
-      # So the assertion is now conditional on the scan having actually run. It
-      # stays a hard failure when Smithery reports SUCCESS — that is a real
-      # regression signal — and degrades to a warning when the scan was refused,
-      # where the stale count is already reported by the supply-chain-drift
-      # tracker. A gate that cannot pass is as dishonest as one that cannot fail.
       - name: Verify Smithery catalog inventory
         if: steps.smithery_config.outputs.enabled == 'true'
         env:
           EXPECTED_TOOL_COUNT: ${{ needs.release.outputs.tool_count }}
           VERSION: ${{ needs.release.outputs.version }}
-          SCAN_STATUS: ${{ steps.smithery_release.outputs.scan_status }}
         run: |
           set -euo pipefail
-          if [ "${SCAN_STATUS}" != "SUCCESS" ]; then
-            ACTUAL=$(curl -fsS --connect-timeout 10 --max-time 30 \
-              "https://api.smithery.ai/servers/agent-bom/agent-bom" | jq -er '.tools | length')
-            echo "::warning::Smithery scan was refused (${SCAN_STATUS:-unknown}); its catalog still advertises ${ACTUAL}/${EXPECTED_TOOL_COUNT} tools for v${VERSION}. Not failing the release — a scan that cannot run cannot converge. Tracked by the supply-chain-drift issue."
-            exit 0
-          fi
           for ATTEMPT in $(seq 1 12); do
             ACTUAL=$(curl -fsS --connect-timeout 10 --max-time 30 \
               "https://api.smithery.ai/servers/agent-bom/agent-bom" | jq -er '.tools | length')

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -23,8 +23,11 @@ publish URL or health endpoint.
 The primary SSE/streamable-http server is deployed on Railway at
 `https://agent-bom-mcp.up.railway.app` (automated via `deploy-mcp-sse.yml`).
 Secure remote deployments should set `AGENT_BOM_MCP_BEARER_TOKEN` in Railway
-service variables so the MCP transport starts with built-in Bearer auth. Keep TLS
-at your ingress or platform edge.
+service variables so the MCP transport starts with built-in authentication. The
+same protected origin publishes OAuth protected-resource/authorization-server
+discovery and a static MCP server card; Smithery uses that OAuth2 contract to
+index the catalog without receiving the deployment's bearer token. Keep TLS at
+your ingress or platform edge.
 
 The daily deployment-freshness workflow probes this protected Railway `/health`
 surface with the configured bearer token, and probes Smithery through
@@ -47,6 +50,10 @@ The `publish-registries.yml` workflow auto-publishes to Smithery on each release
 `SMITHERY_MCP_URL` is retained only for the external-upstream publish mode. It
 must never point at Smithery's hosted proxy URL. Freshness monitoring no longer
 depends on that variable; it uses the Smithery catalog API directly.
+
+Do not add the upstream bearer token to Smithery `configSchema`. Smithery
+reserves the `Authorization` header for OAuth, and the release workflow treats
+OAuth/auth-timeout status or a stale catalog count as publication failure.
 
 ### Verification
 

--- a/site-docs/integrations/smithery.md
+++ b/site-docs/integrations/smithery.md
@@ -11,6 +11,11 @@ catalog entry is considered live when Smithery's catalog API lists
 inventory. Smithery-hosted remotes are OAuth-gated by Smithery, so they do not
 expose agent-bom's raw `/health` route.
 
+The external Streamable HTTP release is separate from the managed stdio manifest
+below. It advertises OAuth2 through the public server card and OAuth discovery;
+the release does not ask users or Smithery to supply the deployment's bearer
+token as session configuration.
+
 ## Why two naming conventions exist
 
 agent-bom standardises on `AGENT_BOM_*` snake-case environment variables across CLI,

--- a/src/agent_bom/backpressure.py
+++ b/src/agent_bom/backpressure.py
@@ -133,10 +133,13 @@ _CONTROLLERS_LOCK = Lock()
 # deep ``?sort=cvss`` read at millions of rows can legitimately take several
 # seconds. Below the generic 2500ms budget a single well-behaved deep read
 # would trip the shared cooldown and 429-storm every reader — shedding under
-# normal single-user load, not overload. Give it headroom above its honest
-# latency; the concurrency limit still sheds a genuine pile-up of concurrent
-# deep reads (the event-loop-starvation case this guard exists to prevent).
-_DEFAULT_P99_THRESHOLD_MS: dict[str, int] = {"graph": 12_000, "findings": 12_000}
+# normal single-user load, not overload. Main CI measured the seeded large
+# estate facet read at 17.5 seconds; a 12-second threshold therefore accumulated
+# honest reads until the process-wide circuit opened and rejected a later
+# request. Give the findings path measured headroom while the concurrency limit
+# still sheds a genuine pile-up of deep reads (the event-loop-starvation case
+# this guard exists to prevent).
+_DEFAULT_P99_THRESHOLD_MS: dict[str, int] = {"graph": 12_000, "findings": 30_000}
 _GENERIC_P99_THRESHOLD_MS = 2500
 
 

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -608,7 +608,11 @@ def build_server_card(*, auth_required: bool = False) -> dict[str, Any]:
     card["serverInfo"] = {"name": card["name"], "version": card["version"]}
     card["authentication"] = {
         "required": auth_required,
-        "schemes": ["bearer"] if auth_required else [],
+        # The protected remote exposes RFC 9728/8414 discovery, dynamic client
+        # registration, PKCE authorization and token endpoints.  Marketplaces
+        # must discover that OAuth flow rather than ask users for an opaque
+        # upstream bearer token as session configuration.
+        "schemes": ["oauth2"] if auth_required else [],
     }
     return card
 

--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -85,6 +85,25 @@ async def test_backpressure_records_normal_path_posture() -> None:
 
 
 @pytest.mark.asyncio
+async def test_findings_backpressure_budget_covers_the_measured_demo_read() -> None:
+    """A valid large-estate read must not become process-wide overload.
+
+    Main CI measured the seeded findings facet request at 17.5 seconds.  The
+    old 12-second default accumulated those honest reads across the process and
+    opened the shared findings circuit, so the next unrelated list request was
+    rejected with 429.  Keep headroom above the measured cold read while the
+    concurrency ceiling continues to shed an actual pile-up.
+    """
+    async with adaptive_backpressure("findings"):
+        await asyncio.sleep(0)
+
+    posture = describe_backpressure_posture()
+    findings = next(path for path in posture["paths"] if path["path"] == "findings")
+
+    assert findings["p99_threshold_ms"] >= 30_000
+
+
+@pytest.mark.asyncio
 async def test_backpressure_rejects_when_concurrency_is_saturated(monkeypatch) -> None:
     monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_GRAPH_CONCURRENCY", "1")
 

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -17,20 +17,17 @@ VIEWER: dict[str, str] = {}
 
 
 @pytest.fixture()
-def _degraded_findings_backpressure():
-    """Model the stale process state that caused main CI's 429 regression."""
+def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path):
     from agent_bom.backpressure import _controller_for, reset_backpressure_for_tests
 
+    # Model the stale process state that caused main CI's 429 regression. Keep
+    # this proof inside the exported fixture so modules that import only
+    # ``demo_estate_client`` do not lose one of its private dependencies.
     reset_backpressure_for_tests()
     controller = _controller_for("findings")
     controller.open_until_monotonic = time.monotonic() + 60
     controller.last_trigger_reason = "p99_latency_threshold"
-    yield
-    reset_backpressure_for_tests()
 
-
-@pytest.fixture()
-def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path, _degraded_findings_backpressure):
     monkeypatch.setenv("AGENT_BOM_DEMO_ESTATE", "1")
     monkeypatch.setenv("AGENT_BOM_DB", str(tmp_path / "demo-estate.db"))
     monkeypatch.setenv("AGENT_BOM_GRAPH_DB", str(tmp_path / "demo-graph.db"))
@@ -40,7 +37,6 @@ def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path, _degraded_find
     from agent_bom.api import stores as api_stores
     from agent_bom.api.compliance_hub_store import set_compliance_hub_store
     from agent_bom.api.findings_count_cache import reset_findings_count_cache
-    from agent_bom.backpressure import reset_backpressure_for_tests
 
     api_server._runtime_api_key_seeded = False
     api_server._shutting_down = False

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import time
 from collections import Counter
 from datetime import datetime, timedelta, timezone
 
@@ -16,7 +17,20 @@ VIEWER: dict[str, str] = {}
 
 
 @pytest.fixture()
-def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path):
+def _degraded_findings_backpressure():
+    """Model the stale process state that caused main CI's 429 regression."""
+    from agent_bom.backpressure import _controller_for, reset_backpressure_for_tests
+
+    reset_backpressure_for_tests()
+    controller = _controller_for("findings")
+    controller.open_until_monotonic = time.monotonic() + 60
+    controller.last_trigger_reason = "p99_latency_threshold"
+    yield
+    reset_backpressure_for_tests()
+
+
+@pytest.fixture()
+def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path, _degraded_findings_backpressure):
     monkeypatch.setenv("AGENT_BOM_DEMO_ESTATE", "1")
     monkeypatch.setenv("AGENT_BOM_DB", str(tmp_path / "demo-estate.db"))
     monkeypatch.setenv("AGENT_BOM_GRAPH_DB", str(tmp_path / "demo-graph.db"))
@@ -26,6 +40,7 @@ def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path):
     from agent_bom.api import stores as api_stores
     from agent_bom.api.compliance_hub_store import set_compliance_hub_store
     from agent_bom.api.findings_count_cache import reset_findings_count_cache
+    from agent_bom.backpressure import reset_backpressure_for_tests
 
     api_server._runtime_api_key_seeded = False
     api_server._shutting_down = False
@@ -36,6 +51,10 @@ def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path):
     api_stores._graph_store = None
     set_compliance_hub_store(None)
     reset_findings_count_cache()
+    # Each TestClient instance represents a fresh API process.  The adaptive
+    # controllers are process-global, so reset them at that lifecycle boundary
+    # instead of carrying latency/cooldown state across randomized test apps.
+    reset_backpressure_for_tests()
 
     try:
         with TestClient(api_server.app) as client:
@@ -45,6 +64,7 @@ def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path):
         api_stores._graph_store = original_graph_store
         set_compliance_hub_store(original_hub_store)
         reset_findings_count_cache()
+        reset_backpressure_for_tests()
         # The proxy alert/metric ring buffers and the firewall decision store are
         # process-global; the demo bootstrap seeds them, so clear them here to
         # keep the seeded gateway feed from leaking into later tests.

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -471,7 +471,7 @@ def test_live_server_card_exposes_exact_mcp_tool_schemas():
 
     assert response.status_code == 200
     card = response.json()
-    assert card["authentication"] == {"required": True, "schemes": ["bearer"]}
+    assert card["authentication"] == {"required": True, "schemes": ["oauth2"]}
     assert len(card["tools"]) == len(_SERVER_CARD_TOOLS)
     assert all(isinstance(tool.get("inputSchema"), dict) for tool in card["tools"])
     assert all(tool["inputSchema"].get("additionalProperties") is False for tool in card["tools"])
@@ -746,19 +746,10 @@ def test_smithery_publish_is_gated_on_server_card_and_catalog_parity():
     assert "Validate Smithery public server card" in workflow
     assert "(.tools | length) == $tool_count" in workflow
     assert '(.inputSchema | type == "object")' in workflow
+    assert '(.authentication.schemes | index("oauth2") != null)' in workflow
     assert "Wait for Smithery release" in workflow
-    # The terminal statuses are split deliberately (#4687). Our MCP endpoint
-    # authenticates every request by design and the published configSchema marks
-    # `bearerToken` required, so Smithery's scanner CANNOT enumerate our tools
-    # and settles the release as AUTH_REQUIRED. The release itself succeeded;
-    # only the optional post-publish scan did not. Treating that as fatal failed
-    # every release and auto-opened a release-blocker for a server that had in
-    # fact published.
-    assert "AUTH_REQUIRED|AUTH_TIMEOUT" in workflow, "auth statuses must be handled as their own non-fatal case"
-    assert "FAILURE|FAILURE_SCAN|CANCELLED|INTERNAL_ERROR" in workflow, "real failures must still fail the job"
-    # Guard the split itself: if AUTH_REQUIRED is ever folded back in with the
-    # fatal statuses, releases start failing again for a publish that worked.
-    assert "FAILURE_SCAN|AUTH_REQUIRED" not in workflow, "AUTH_REQUIRED must not be grouped with the fatal statuses"
+    assert "FAILURE|FAILURE_SCAN|AUTH_REQUIRED|AUTH_TIMEOUT|CANCELLED|INTERNAL_ERROR" in workflow
+    assert "caller-supplied bearerToken by design" not in workflow
     assert "Verify Smithery catalog inventory" in workflow
     assert 'if [ "$ACTUAL" = "$EXPECTED_TOOL_COUNT" ]; then' in workflow
 
@@ -1008,24 +999,11 @@ def test_mcp_registry_descriptions_are_bounded():
     assert not too_long, f"registry descriptions exceed {MCP_REGISTRY_DESCRIPTION_MAX_CHARS} chars: {too_long[:5]}"
 
 
-def test_smithery_release_declares_the_upstream_credential():
-    """Smithery cannot enumerate an endpoint it has no credential for.
-
-    The agent-bom MCP endpoint authenticates every request. Smithery reads the
-    public server card (which advertises all 77 tools) but its live connection
-    401s, so the release settles as ``AUTH_REQUIRED`` and the public catalog
-    listed 36 of 77 — the tools it could reach without one.
-
-    Publishing the credential requirement in ``configSchema`` is what lets a
-    connection be established with a scoped, revocable token instead of opening
-    the endpoint anonymously.
-    """
+def test_smithery_release_uses_oauth_discovery_not_bearer_config():
+    """The external release must not replace OAuth with user token config."""
     workflow = (ROOT / ".github" / "workflows" / "publish-registries.yml").read_text()
 
-    assert "bearerToken" in workflow, "the release must declare the upstream credential"
-    assert '\\"required\\": [\\"bearerToken\\"]' in workflow, (
-        "the token must be required — an optional credential leaves the catalog "
-        "enumerating anonymously, which is the state that produced 36 of 77 tools"
-    )
+    assert "bearerToken" not in workflow
+    assert '\\"configSchema\\"' not in workflow
     # The endpoint must never be published as open in place of supplying a token.
     assert "--allow-insecure-no-auth" not in workflow


### PR DESCRIPTION
## Summary

- isolate adaptive findings backpressure at API test lifecycles and give the measured 17.5-second large-estate read a 30-second budget, preventing process-global 429 leakage across randomized CI tests
- publish the protected external MCP endpoint through its existing OAuth discovery/server-card contract instead of a required bearer-token session field
- fail registry publication when OAuth discovery, Smithery scanning, or the 81-tool catalog convergence does not complete

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run --python 3.11 pytest -q tests/test_demo_estate_bootstrap.py::test_demo_estate_finding_counts_reconcile_across_tile_list_and_facet --randomly-seed=4071394739 -vv` (1 passed)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_mcp_oauth_authorization_server.py tests/test_mcp_catalog_drift.py tests/test_deployment.py tests/test_backpressure.py` (87 passed)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check ...` and `ruff format --check ...`
- targeted mypy for both changed source modules
- `python scripts/lint_release_workflow.py .github/workflows/publish-registries.yml`
- `python scripts/check_workflow_timeouts.py`
- `python scripts/check_public_docs_hygiene.py`
- `uv run mkdocs build --strict`
- `make preflight`
- `git diff --check`

## Notes

- Closes #4883.
- Addresses #4722. The automated drift tracker should remain open until a post-merge registry publish verifies the Smithery catalog at 81/81 tools.
- Authentication remains required. The change uses the already-mounted OAuth authorization server and does not disclose or distribute the deployment bearer token.
- The changed-file pre-commit run passed every applicable hook except repository-wide mypy, which reports 41 pre-existing errors in unrelated API/graph modules; targeted mypy for the changed source files passes.
