### PR TITLE
fix(integrity): align grouped findings and evidence persistence

### DIFF
--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -380,10 +380,13 @@ CREATE TABLE IF NOT EXISTS trend_history (
     medium        INTEGER NOT NULL DEFAULT 0,
     low           INTEGER NOT NULL DEFAULT 0,
     posture_score REAL NOT NULL DEFAULT 0,
-    posture_grade TEXT NOT NULL DEFAULT ''
+    posture_grade TEXT NOT NULL DEFAULT '',
+    scan_id       TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_trend_history_team_ts ON trend_history(team_id, timestamp DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_trend_history_team_scan
+    ON trend_history(team_id, scan_id) WHERE scan_id IS NOT NULL;
 
 -- ── Tables: Scan Schedules ────────────────────────────────────────────────────
 

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 864,
+      "value": 865,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 48 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 864 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 865 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -18056,6 +18056,18 @@
             }
           },
           {
+            "description": "Group vulnerability occurrences by advisory and package while preserving asset-scoped rows",
+            "in": "query",
+            "name": "group_occurrences",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Group vulnerability occurrences by advisory and package while preserving asset-scoped rows",
+              "title": "Group Occurrences",
+              "type": "boolean"
+            }
+          },
+          {
             "description": "Compliance framework drill-through, e.g. soc2 / nist-csf (compliance section id)",
             "in": "query",
             "name": "framework",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -12167,6 +12167,17 @@ paths:
           - type: 'null'
           description: Only known-exploited (KEV) findings, or only non-KEV when false
           title: Kev
+      - description: Group vulnerability occurrences by advisory and package while
+          preserving asset-scoped rows
+        in: query
+        name: group_occurrences
+        required: false
+        schema:
+          default: false
+          description: Group vulnerability occurrences by advisory and package while
+            preserving asset-scoped rows
+          title: Group Occurrences
+          type: boolean
       - description: Compliance framework drill-through, e.g. soc2 / nist-csf (compliance
           section id)
         in: query

--- a/src/agent_bom/api/finding_cursor.py
+++ b/src/agent_bom/api/finding_cursor.py
@@ -85,6 +85,39 @@ def decode_finding_cursor(cursor: str, *, expected_sort: str) -> tuple[float, st
 
 
 _MERGED_SCAN_CURSOR_MARKER = "merge1"
+_GROUP_CURSOR_MARKER = "group1"
+
+
+def encode_finding_group_cursor(*, sort: str, offset: int) -> str:
+    """Encode the next offset in the fully materialized issue-group list."""
+    payload = {
+        "t": _GROUP_CURSOR_MARKER,
+        "sort": sort if sort in _ALLOWED_SORTS else "effective_reach",
+        "offset": max(0, int(offset)),
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def decode_finding_group_cursor(cursor: str, *, expected_sort: str) -> int | None:
+    """Decode an issue-group cursor, returning ``None`` for another cursor type."""
+    try:
+        padded = cursor + "=" * (-len(cursor) % 4)
+        raw = base64.urlsafe_b64decode(padded.encode()).decode()
+        payload = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(payload, dict) or payload.get("t") != _GROUP_CURSOR_MARKER:
+        return None
+    if str(payload.get("sort") or "") != expected_sort:
+        raise ValueError("Cursor sort mismatch")
+    try:
+        offset = int(payload.get("offset") or 0)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Invalid grouped findings cursor") from exc
+    if offset < 0:
+        raise ValueError("Invalid grouped findings cursor")
+    return offset
 
 
 def encode_merged_scan_cursor(*, sort: str, scan_index: int, bulk_cursor: str) -> str:

--- a/src/agent_bom/api/inventory_service.py
+++ b/src/agent_bom/api/inventory_service.py
@@ -224,6 +224,8 @@ async def build_summary(
 
     return {
         "schema_version": "inventory.summary.v1",
+        "scope": "unified_graph_estate",
+        "count_definition": ("typed graph nodes excluding finding entity types in the selected tenant and scan snapshot"),
         "tenant_id": tenant_id,
         "scan_id": stats.get("scan_id", scan_id or ""),
         "total_assets": total_assets,
@@ -317,6 +319,8 @@ async def build_asset_list(
         has_more = bool(next_cursor) if cursor else offset + len(rows) < total
         return {
             "schema_version": "inventory.assets.v1",
+            "scope": "unified_graph_estate",
+            "count_definition": ("typed graph nodes excluding finding entity types in the selected tenant and scan snapshot"),
             "tenant_id": tenant_id,
             "assets": rows,
             "filters": {
@@ -384,6 +388,8 @@ async def build_asset_list(
         has_more = bool(next_cursor_out)
     return {
         "schema_version": "inventory.assets.v1",
+        "scope": "unified_graph_estate",
+        "count_definition": ("typed graph nodes excluding finding entity types in the selected tenant and scan snapshot"),
         "tenant_id": tenant_id,
         "assets": page_rows,
         "filters": {

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -1475,6 +1475,16 @@ def _run_scan_sync(job: ScanJob) -> None:
                         _record_graph_persistence(job, status="failed", lock=lock)
                         with lock:
                             job.progress.append("Graph persistence failed; scan evidence remains available")
+                    from agent_bom.api.trend_recording import record_scan_trend_best_effort
+
+                    if record_scan_trend_best_effort(
+                        report_json,
+                        tenant_id=job.tenant_id or "default",
+                        scan_id=job.job_id,
+                        completed_at=job.completed_at,
+                    ):
+                        with lock:
+                            job.progress.append("Posture trend recorded")
                 pipeline.complete_step("output", "Report ready")
                 return
 
@@ -1776,6 +1786,16 @@ def _run_scan_sync(job: ScanJob) -> None:
             job.status = JobStatus.DONE
 
         if side_effects_enabled:
+            from agent_bom.api.trend_recording import record_scan_trend_best_effort
+
+            if record_scan_trend_best_effort(
+                report_json,
+                tenant_id=job.tenant_id or "default",
+                scan_id=job.job_id,
+                completed_at=job.completed_at or report_json.get("generated_at"),
+            ):
+                with lock:
+                    job.progress.append("Posture trend recorded")
             try:
                 pipeline.update_step("output", "Persisting unified graph...")
                 _persist_graph_snapshot(job, report_json, lock=lock)

--- a/src/agent_bom/api/postgres_audit.py
+++ b/src/agent_bom/api/postgres_audit.py
@@ -608,10 +608,15 @@ class PostgresTrendStore:
                     medium INTEGER NOT NULL DEFAULT 0,
                     low INTEGER NOT NULL DEFAULT 0,
                     posture_score REAL NOT NULL DEFAULT 0,
-                    posture_grade TEXT NOT NULL DEFAULT ''
+                    posture_grade TEXT NOT NULL DEFAULT '',
+                    scan_id TEXT
                 )
             """)
+            conn.execute("ALTER TABLE trend_history ADD COLUMN IF NOT EXISTS scan_id TEXT")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_trend_history_team_ts ON trend_history(team_id, timestamp DESC)")
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_trend_history_team_scan ON trend_history(team_id, scan_id) WHERE scan_id IS NOT NULL"
+            )
             _ensure_tenant_rls(conn, "trend_history", "team_id")
             conn.commit()
 
@@ -619,8 +624,17 @@ class PostgresTrendStore:
         with _tenant_connection(self._pool) as conn:
             conn.execute(
                 """INSERT INTO trend_history
-                   (timestamp, team_id, total_vulns, critical, high, medium, low, posture_score, posture_grade)
-                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                   (timestamp, team_id, total_vulns, critical, high, medium, low, posture_score, posture_grade, scan_id)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                   ON CONFLICT (team_id, scan_id) WHERE scan_id IS NOT NULL DO UPDATE SET
+                     timestamp = EXCLUDED.timestamp,
+                     total_vulns = EXCLUDED.total_vulns,
+                     critical = EXCLUDED.critical,
+                     high = EXCLUDED.high,
+                     medium = EXCLUDED.medium,
+                     low = EXCLUDED.low,
+                     posture_score = EXCLUDED.posture_score,
+                     posture_grade = EXCLUDED.posture_grade""",
                 (
                     point.timestamp,
                     _current_tenant.get(),
@@ -631,6 +645,7 @@ class PostgresTrendStore:
                     point.low,
                     point.posture_score,
                     point.posture_grade,
+                    point.scan_id,
                 ),
             )
             conn.commit()
@@ -642,7 +657,7 @@ class PostgresTrendStore:
         try:
             with _tenant_connection(self._pool) as conn:
                 rows = conn.execute(
-                    "SELECT timestamp, total_vulns, critical, high, medium, low, posture_score, posture_grade "
+                    "SELECT timestamp, total_vulns, critical, high, medium, low, posture_score, posture_grade, scan_id "
                     "FROM trend_history ORDER BY timestamp DESC LIMIT %s",
                     (limit,),
                 ).fetchall()
@@ -660,6 +675,7 @@ class PostgresTrendStore:
                 posture_score=row[6],
                 posture_grade=row[7],
                 tenant_id=tenant_id or _current_tenant.get(),
+                scan_id=row[8] if len(row) > 8 else None,
             )
             for row in rows
         ]

--- a/src/agent_bom/api/routes/assets.py
+++ b/src/agent_bom/api/routes/assets.py
@@ -16,6 +16,10 @@ from agent_bom.api.tenancy import require_request_tenant_id
 router = APIRouter()
 _logger = logging.getLogger(__name__)
 
+_ASSET_SCOPE = "vulnerability_asset_lifecycle"
+_ASSET_COUNT_DEFINITION = "tracked vulnerability-package records after lifecycle filters; not unified estate assets"
+_ASSET_STATS_COUNT_DEFINITION = "tracked vulnerability-package records across lifecycle states; not unified estate assets"
+
 
 @router.get("/assets", tags=["assets"])
 async def list_assets(
@@ -39,6 +43,9 @@ async def list_assets(
             stats = tracker.stats()
             mttr = tracker.mttr_days()
         return {
+            "schema_version": "vulnerability-assets.v1",
+            "scope": _ASSET_SCOPE,
+            "count_definition": _ASSET_COUNT_DEFINITION,
             "assets": assets,
             "count": len(assets),
             "stats": stats,
@@ -47,6 +54,9 @@ async def list_assets(
     except Exception:
         _logger.exception("Failed to list assets")
         return {
+            "schema_version": "vulnerability-assets.v1",
+            "scope": _ASSET_SCOPE,
+            "count_definition": _ASSET_COUNT_DEFINITION,
             "assets": [],
             "count": 0,
             "stats": {},
@@ -64,10 +74,19 @@ async def get_asset_stats(request: Request) -> dict:
         with AssetTracker(tenant_id=require_request_tenant_id(request)) as tracker:
             stats = tracker.stats()
             mttr = tracker.mttr_days()
-        return {"stats": stats, "mttr_days": mttr}
+        return {
+            "schema_version": "vulnerability-assets.stats.v1",
+            "scope": _ASSET_SCOPE,
+            "count_definition": _ASSET_STATS_COUNT_DEFINITION,
+            "stats": stats,
+            "mttr_days": mttr,
+        }
     except Exception:
         _logger.exception("Failed to get asset stats")
         return {
+            "schema_version": "vulnerability-assets.stats.v1",
+            "scope": _ASSET_SCOPE,
+            "count_definition": _ASSET_STATS_COUNT_DEFINITION,
             "stats": {},
             "mttr_days": None,
             "error": "Asset tracker unavailable",

--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -789,6 +789,14 @@ def _persist_connection_report(
         # instead of minting an orphan result row.
         scan_job = queued_job
         scan_job.result = report_json
+    from agent_bom.api.trend_recording import record_scan_trend_best_effort
+
+    record_scan_trend_best_effort(
+        report_json,
+        tenant_id=tenant_id,
+        scan_id=scan_job.job_id,
+        completed_at=now,
+    )
     _persist_graph_snapshot(scan_job, report_json)
     return str(scan_job.job_id)
 

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -84,7 +84,7 @@ from agent_bom.api.stores import (
 from agent_bom.api.tenancy import require_body_tenant_match, require_request_tenant_id
 from agent_bom.api.tenant_quota import enforce_active_scan_quota, enforce_retained_jobs_quota, tenant_quota_guard
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
-from agent_bom.canonical_ids import canonical_finding_id
+from agent_bom.canonical_ids import canonical_finding_id, canonical_id
 from agent_bom.finding_scope import (
     FINDING_SEVERITY_FILTERS,
     FindingClass,
@@ -1976,6 +1976,17 @@ _ALLOWED_FINDING_STATUSES = ("open", "resolved", "all")
 _DEFAULT_FINDING_STATUS = "open"
 _ALLOWED_FINDING_SEVERITIES = FINDING_SEVERITY_FILTERS
 
+
+def _normalize_finding_sort(sort: str) -> str:
+    sort_key = sort.lower().strip() if isinstance(sort, str) else "effective_reach"
+    if sort_key not in _ALLOWED_FINDING_SORTS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"invalid sort '{sort}'; accepted values: {', '.join(_ALLOWED_FINDING_SORTS)}",
+        )
+    return sort_key
+
+
 _FRESHNESS_BUCKETS = ("last_24_hours", "last_7_days", "last_30_days", "older", "unavailable")
 _FACET_SCAN_BUDGET = 50_000
 _FACET_DEADLINE_SECONDS = 1.5
@@ -2584,6 +2595,10 @@ async def list_findings(
     status: Annotated[str, Query(max_length=16)] = _DEFAULT_FINDING_STATUS,
     finding_class: FindingClass | None = None,
     kev: Annotated[bool | None, Query(description="Only known-exploited (KEV) findings, or only non-KEV when false")] = None,
+    group_occurrences: Annotated[
+        bool,
+        Query(description="Group vulnerability occurrences by advisory and package while preserving asset-scoped rows"),
+    ] = False,
     framework: Annotated[
         str | None,
         Query(max_length=64, description="Compliance framework drill-through, e.g. soc2 / nist-csf (compliance section id)"),
@@ -2620,8 +2635,9 @@ async def list_findings(
     """
     try:
         async with adaptive_backpressure("findings"):
+            implementation = _list_finding_groups_impl if group_occurrences else _list_findings_impl
             return await anyio.to_thread.run_sync(
-                _list_findings_impl,
+                implementation,
                 request,
                 q,
                 severity,
@@ -2705,13 +2721,8 @@ def _list_findings_impl(
     # window at scale. ``window_days=0`` widens to all history (#4009).
     resolved_window = time_window.normalize_window_days(window_days)
     window_since = time_window.window_since_iso(resolved_window)
-    sort_key = sort.lower().strip() if isinstance(sort, str) else "effective_reach"
-    if sort_key not in _ALLOWED_FINDING_SORTS:
-        # Silently falling back masked typos as "wrong order"; reject clearly.
-        raise HTTPException(
-            status_code=422,
-            detail=f"invalid sort '{sort}'; accepted values: {', '.join(_ALLOWED_FINDING_SORTS)}",
-        )
+    # Silently falling back masked typos as "wrong order"; reject clearly.
+    sort_key = _normalize_finding_sort(sort)
     try:
         severity = canonical_finding_severity_filter(severity)
     except ValueError:
@@ -3140,6 +3151,214 @@ def _list_findings_impl(
             },
             "completeness": facet_completeness,
         }
+    return envelope
+
+
+_FINDING_GROUP_MAX_OCCURRENCES = 50_000
+_FINDING_GROUP_OCCURRENCE_SAMPLE = 25
+
+
+def _finding_group_identity(row: dict[str, Any]) -> tuple[str, str]:
+    """Return the canonical aggregate identity without changing occurrence IDs."""
+    supplied_id = str(row.get("finding_group_id") or "").strip()
+    supplied_key = str(row.get("finding_group_key") or "").strip()
+    if supplied_id and supplied_key:
+        return supplied_id, supplied_key
+
+    vulnerability_id = _row_vuln_id(row).lower()
+    if vulnerability_id:
+        group_key = f"vulnerability:{vulnerability_id}:{_package_base_name(row).lower()}"
+    else:
+        group_key = f"occurrence:{_finding_identity(row)}"
+    return supplied_id or canonical_id("finding-group", group_key), supplied_key or group_key
+
+
+def _finding_occurrence_summary(row: dict[str, Any]) -> dict[str, Any]:
+    """Project the bounded fields needed to expand a grouped issue row."""
+    return {
+        key: row.get(key)
+        for key in (
+            "finding_id",
+            "occurrence_id",
+            "canonical_id",
+            "asset",
+            "severity",
+            "package_version",
+            "scan_id",
+            "status",
+            "owner",
+            "sla_due_at",
+            "last_seen",
+            "last_observed",
+            "graph_reachable",
+            "graph_min_hop_distance",
+        )
+        if row.get(key) is not None
+    }
+
+
+def _list_finding_groups_impl(
+    request: Request,
+    q: str | None,
+    severity: str | None,
+    scan_id: str | None,
+    sort: str,
+    limit: int,
+    offset: int,
+    cursor: str | None,
+    approximate_total: bool,
+    provider: str | None = None,
+    account: str | None = None,
+    environment: str | None = None,
+    domain: str | None = None,
+    window_days: int | None = None,
+    status: str = _DEFAULT_FINDING_STATUS,
+    finding_class: str | None = None,
+    kev: bool | None = None,
+    include_facets: bool = False,
+    framework: str | None = None,
+    control: str | None = None,
+    owner: str | None = None,
+    sla: str | None = None,
+) -> dict[str, Any]:
+    """Build a bounded server-side issue queue over canonical occurrence rows.
+
+    Raw ``GET /v1/findings`` remains the authoritative per-asset workflow
+    surface. This view walks that exact filtered queue, groups only rows sharing
+    the canonical asset-independent issue identity, and returns bounded
+    occurrence summaries for expansion. A row-budget hit is explicit partial
+    evidence; it is never described as a complete group count.
+    """
+    from agent_bom.api.finding_cursor import decode_finding_group_cursor, encode_finding_group_cursor
+
+    sort_key = _normalize_finding_sort(sort)
+    if cursor:
+        try:
+            group_offset = decode_finding_group_cursor(cursor, expected_sort=sort_key)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="Invalid grouped findings cursor") from exc
+        if group_offset is None:
+            raise HTTPException(status_code=400, detail="Cursor is not valid for grouped findings")
+    else:
+        group_offset = offset
+
+    rows: list[dict[str, Any]] = []
+    source_cursor: str | None = None
+    first_page: dict[str, Any] | None = None
+    warnings: list[str] = []
+    while len(rows) < _FINDING_GROUP_MAX_OCCURRENCES:
+        page = _list_findings_impl(
+            request,
+            q,
+            # Severity is applied after grouping so the issue histogram remains
+            # self-excluding. Otherwise two asset occurrences of one advisory
+            # would be presented as two separate severity-filter counts.
+            None,
+            scan_id,
+            sort_key,
+            min(1000, _FINDING_GROUP_MAX_OCCURRENCES - len(rows)),
+            0,
+            source_cursor,
+            True,
+            provider,
+            account,
+            environment,
+            domain,
+            window_days,
+            status,
+            finding_class,
+            kev,
+            include_facets and first_page is None,
+            framework,
+            control,
+            owner,
+            sla,
+        )
+        if first_page is None:
+            first_page = page
+        page_rows = page.get("findings")
+        if isinstance(page_rows, list):
+            rows.extend(row for row in page_rows if isinstance(row, dict))
+        warnings.extend(str(item) for item in page.get("warnings", []) if str(item))
+        source_cursor = str(page.get("next_cursor") or "") or None
+        if not source_cursor:
+            break
+
+    grouped: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        group_id, group_key = _finding_group_identity(row)
+        group = grouped.get(group_id)
+        if group is None:
+            representative = dict(row)
+            representative["finding_group_id"] = group_id
+            representative["finding_group_key"] = group_key
+            representative["occurrence_count"] = 0
+            representative["occurrences"] = []
+            representative["occurrences_truncated"] = False
+            grouped[group_id] = representative
+            group = representative
+        group["occurrence_count"] = int(group["occurrence_count"]) + 1
+        occurrences = group["occurrences"]
+        if isinstance(occurrences, list) and len(occurrences) < _FINDING_GROUP_OCCURRENCE_SAMPLE:
+            occurrences.append(_finding_occurrence_summary(row))
+        else:
+            group["occurrences_truncated"] = True
+
+    all_groups = list(grouped.values())
+    grouped_severity_counts = {key: 0 for key in ("critical", "high", "medium", "low", "info", "unknown")}
+    for group in all_groups:
+        grouped_severity_counts[_normalize_facet_severity(group.get("severity"))] += 1
+    normalized_severity = severity.strip().lower() if severity and severity.strip() else None
+    groups = [
+        group
+        for group in all_groups
+        if normalized_severity is None or _normalize_facet_severity(group.get("severity")) == normalized_severity
+    ]
+    truncated = source_cursor is not None
+    if truncated:
+        warnings.append("Issue grouping stopped after 50,000 occurrence rows; group and occurrence counts are lower bounds.")
+    page_groups = groups[group_offset : group_offset + limit]
+    next_offset = group_offset + len(page_groups)
+    next_cursor = ""
+    if next_offset < len(groups):
+        next_cursor = encode_finding_group_cursor(sort=sort_key, offset=next_offset)
+
+    filters = dict(first_page.get("filters") or {}) if first_page else {}
+    filters["group_occurrences"] = True
+    if normalized_severity is not None:
+        filters["severity"] = normalized_severity
+    envelope = finding_list_envelope(
+        findings=page_groups,
+        total=len(groups),
+        limit=limit,
+        offset=0 if cursor else offset,
+        sort=sort_key,
+        scan_id=scan_id,
+        cursor=cursor or "",
+        next_cursor=next_cursor,
+        filters=filters,
+        warnings=list(dict.fromkeys(warnings)),
+        total_approximate=truncated,
+        source="scan_and_current_ingest_finding_groups",
+        scope="tenant current-state issue groups over asset-scoped occurrences",
+    )
+    envelope["grouping"] = {
+        "status": "partial" if truncated else "complete",
+        "scanned_occurrences": len(rows),
+        "scan_budget": _FINDING_GROUP_MAX_OCCURRENCES,
+        "occurrence_total": sum(int(group.get("occurrence_count") or 0) for group in groups),
+        "occurrence_sample_limit": _FINDING_GROUP_OCCURRENCE_SAMPLE,
+    }
+    if first_page:
+        if "window" in first_page:
+            envelope["window"] = first_page["window"]
+            envelope["count_metadata"]["window"] = first_page["window"]
+        for key in ("facets", "facets_approximate", "facet_metadata", "scope_completeness"):
+            if key in first_page:
+                envelope[key] = first_page[key]
+        if include_facets:
+            envelope.setdefault("facets", {})["severity"] = grouped_severity_counts
+            envelope["facet_metadata"]["severity_basis"] = "canonical issue groups"
     return envelope
 
 

--- a/src/agent_bom/api/trend_recording.py
+++ b/src/agent_bom/api/trend_recording.py
@@ -1,0 +1,102 @@
+"""Canonical scan-result to posture-trend persistence boundary."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from agent_bom.baseline import TrendPoint
+from agent_bom.security import sanitize_error
+
+_logger = logging.getLogger(__name__)
+_SEVERITIES = ("critical", "high", "medium", "low")
+
+
+def _vulnerability_severities(result: Mapping[str, Any]) -> list[str]:
+    severities: list[str] = []
+    packages = result.get("packages")
+    if isinstance(packages, list):
+        for package in packages:
+            if not isinstance(package, Mapping):
+                continue
+            vulnerabilities = package.get("vulnerabilities")
+            if not isinstance(vulnerabilities, list):
+                continue
+            for vulnerability in vulnerabilities:
+                if isinstance(vulnerability, Mapping):
+                    severities.append(str(vulnerability.get("severity") or "unknown").strip().lower())
+    if severities:
+        return severities
+    blast_radius = result.get("blast_radius") or result.get("blast_radii")
+    if isinstance(blast_radius, list):
+        for finding in blast_radius:
+            if isinstance(finding, Mapping):
+                severities.append(str(finding.get("severity") or "unknown").strip().lower())
+    return severities
+
+
+def trend_point_from_scan_result(
+    result: Mapping[str, Any],
+    *,
+    tenant_id: str,
+    scan_id: str | None = None,
+    completed_at: str | None = None,
+) -> TrendPoint | None:
+    """Build one honest, retry-safe trend point from canonical scan JSON."""
+    scorecard = result.get("posture_scorecard")
+    if not isinstance(scorecard, Mapping) or bool(scorecard.get("no_data")):
+        return None
+    grade = str(scorecard.get("grade") or "").strip().upper()
+    if not grade or grade == "N/A":
+        return None
+    try:
+        score = float(scorecard["score"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    resolved_scan_id = str(scan_id or result.get("scan_id") or "").strip()
+    if not resolved_scan_id:
+        return None
+    timestamp = str(completed_at or result.get("generated_at") or "").strip()
+    if not timestamp:
+        return None
+    severities = _vulnerability_severities(result)
+    counts = {severity: severities.count(severity) for severity in _SEVERITIES}
+    return TrendPoint(
+        timestamp=timestamp,
+        total_vulns=len(severities),
+        critical=counts["critical"],
+        high=counts["high"],
+        medium=counts["medium"],
+        low=counts["low"],
+        posture_score=score,
+        posture_grade=grade,
+        tenant_id=str(tenant_id or "default"),
+        scan_id=resolved_scan_id,
+    )
+
+
+def record_scan_trend_best_effort(
+    result: Mapping[str, Any],
+    *,
+    tenant_id: str,
+    scan_id: str | None = None,
+    completed_at: str | None = None,
+) -> bool:
+    """Persist one trend point; return whether a gradable point was recorded."""
+    point = trend_point_from_scan_result(
+        result,
+        tenant_id=tenant_id,
+        scan_id=scan_id,
+        completed_at=completed_at,
+    )
+    if point is None:
+        return False
+    try:
+        from agent_bom.api.stores import _get_trend_store
+
+        _get_trend_store().record(point)
+    except Exception as exc:  # noqa: BLE001 - trend history must not fail a completed scan
+        _logger.warning("Posture trend persistence skipped: %s", sanitize_error(exc, generic=True))
+        return False
+    return True

--- a/src/agent_bom/baseline.py
+++ b/src/agent_bom/baseline.py
@@ -172,7 +172,15 @@ class InMemoryTrendStore:
 
     def record(self, point: TrendPoint) -> None:
         with self._lock:
-            self._points.append(point)
+            if point.scan_id:
+                for index, existing in enumerate(self._points):
+                    if existing.idempotency_key == point.idempotency_key:
+                        self._points[index] = point
+                        break
+                else:
+                    self._points.append(point)
+            else:
+                self._points.append(point)
             if len(self._points) > self._MAX_POINTS:
                 self._points = self._points[-self._MAX_POINTS :]
 
@@ -208,19 +216,34 @@ class SQLiteTrendStore:
             medium INTEGER NOT NULL DEFAULT 0,
             low INTEGER NOT NULL DEFAULT 0,
             posture_score REAL NOT NULL DEFAULT 0,
-            posture_grade TEXT NOT NULL DEFAULT ''
+            posture_grade TEXT NOT NULL DEFAULT '',
+            scan_id TEXT
         )""")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_trend_ts ON trend_history(timestamp)")
         cols = {row[1] for row in self._conn.execute("PRAGMA table_info(trend_history)").fetchall()}
         if "tenant_id" not in cols:
             self._conn.execute("ALTER TABLE trend_history ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'")
+        if "scan_id" not in cols:
+            self._conn.execute("ALTER TABLE trend_history ADD COLUMN scan_id TEXT")
+        self._conn.execute(
+            "DELETE FROM trend_history WHERE scan_id IS NOT NULL AND id NOT IN "
+            "(SELECT MAX(id) FROM trend_history WHERE scan_id IS NOT NULL GROUP BY tenant_id, scan_id)"
+        )
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_trend_tenant_ts ON trend_history(tenant_id, timestamp)")
+        self._conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_trend_tenant_scan ON trend_history(tenant_id, scan_id) WHERE scan_id IS NOT NULL"
+        )
         self._conn.commit()
 
     def record(self, point: TrendPoint) -> None:
         self._conn.execute(
-            "INSERT INTO trend_history (timestamp, tenant_id, total_vulns, critical, high, medium, low, posture_score, posture_grade) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO trend_history "
+            "(timestamp, tenant_id, total_vulns, critical, high, medium, low, posture_score, posture_grade, scan_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT (tenant_id, scan_id) WHERE scan_id IS NOT NULL DO UPDATE SET "
+            "timestamp = excluded.timestamp, total_vulns = excluded.total_vulns, critical = excluded.critical, "
+            "high = excluded.high, medium = excluded.medium, low = excluded.low, "
+            "posture_score = excluded.posture_score, posture_grade = excluded.posture_grade",
             (
                 point.timestamp,
                 point.tenant_id,
@@ -231,6 +254,7 @@ class SQLiteTrendStore:
                 point.low,
                 point.posture_score,
                 point.posture_grade,
+                point.scan_id,
             ),
         )
         self._conn.commit()
@@ -238,13 +262,13 @@ class SQLiteTrendStore:
     def get_history(self, limit: int = 30, tenant_id: str | None = None) -> list[TrendPoint]:
         if tenant_id is None:
             rows = self._conn.execute(
-                "SELECT timestamp, total_vulns, critical, high, medium, low, posture_score, posture_grade, tenant_id "
+                "SELECT timestamp, total_vulns, critical, high, medium, low, posture_score, posture_grade, tenant_id, scan_id "
                 "FROM trend_history ORDER BY timestamp DESC LIMIT ?",
                 (limit,),
             ).fetchall()
         else:
             rows = self._conn.execute(
-                "SELECT timestamp, total_vulns, critical, high, medium, low, posture_score, posture_grade, tenant_id "
+                "SELECT timestamp, total_vulns, critical, high, medium, low, posture_score, posture_grade, tenant_id, scan_id "
                 "FROM trend_history WHERE tenant_id = ? ORDER BY timestamp DESC LIMIT ?",
                 (tenant_id, limit),
             ).fetchall()
@@ -259,6 +283,7 @@ class SQLiteTrendStore:
                 posture_score=r[6],
                 posture_grade=r[7],
                 tenant_id=r[8] if len(r) > 8 else "default",
+                scan_id=r[9] if len(r) > 9 else None,
             )
             for r in rows
         ]

--- a/src/agent_bom/cloud/aws_cis_benchmark.py
+++ b/src/agent_bom/cloud/aws_cis_benchmark.py
@@ -66,6 +66,17 @@ from .base import CloudDiscoveryError
 
 logger = logging.getLogger(__name__)
 
+_AWS_RETRY_CONFIG = {"max_attempts": 5, "mode": "adaptive"}
+
+
+def _aws_client_config() -> Any | None:
+    """Return the bounded adaptive retry policy when botocore is available."""
+    try:
+        from botocore.config import Config
+    except ImportError:
+        return None
+    return Config(retries=_AWS_RETRY_CONFIG)
+
 
 def _safe_error_evidence(prefix: str, error_code: str) -> str:
     """Build client-safe evidence text without leaking raw exception details."""
@@ -1744,6 +1755,49 @@ def _check_3_11(cloudtrail_client: Any) -> CISCheckResult:
 _MONITORING_SECTION = "4 - Monitoring"
 
 
+def _require_targeting_alarm(
+    result: CISCheckResult,
+    logs_client: Any,
+    cloudwatch_client: Any,
+    *,
+    matches_filter: Callable[[str], bool],
+) -> CISCheckResult:
+    """Require a usable metric transform and an alarm targeting its metric."""
+    try:
+        paginator = logs_client.get_paginator("describe_metric_filters")
+        transforms: list[tuple[str, str]] = []
+        for page in paginator.paginate():
+            for metric_filter in page.get("metricFilters", []):
+                pattern = str(metric_filter.get("filterPattern", ""))
+                if not matches_filter(pattern):
+                    continue
+                for transform in metric_filter.get("metricTransformations", []):
+                    metric_name = str(transform.get("metricName", "")).strip()
+                    namespace = str(transform.get("metricNamespace", "")).strip()
+                    if metric_name and namespace:
+                        transforms.append((metric_name, namespace))
+        if not transforms:
+            result.status = CheckStatus.FAIL
+            result.evidence = "A matching metric filter exists, but it has no usable metric transformation."
+            return result
+        for metric_name, namespace in dict.fromkeys(transforms):
+            response = cloudwatch_client.describe_alarms_for_metric(
+                MetricName=metric_name,
+                Namespace=namespace,
+            )
+            if response.get("MetricAlarms", []):
+                result.evidence = f"{result.evidence.rstrip('.')} and a targeting CloudWatch alarm exists."
+                return result
+        result.status = CheckStatus.FAIL
+        result.evidence = "A matching metric filter exists, but no CloudWatch alarm targets its metric."
+    except Exception as exc:
+        error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
+        logger.debug("Could not verify metric alarm: %s (%s)", type(exc).__name__, error_code)
+        result.status = CheckStatus.ERROR
+        result.evidence = _safe_error_evidence("Could not query metric filters and alarms.", error_code)
+    return result
+
+
 def _check_4_3(logs_client: Any, cloudwatch_client: Any) -> CISCheckResult:
     """CIS 4.3 — Metric filter and alarm for root account usage."""
     result = CISCheckResult(
@@ -1800,7 +1854,7 @@ def _check_4_3(logs_client: Any, cloudwatch_client: Any) -> CISCheckResult:
     return result
 
 
-def _check_4_4(logs_client: Any) -> CISCheckResult:
+def _check_4_4(logs_client: Any, cloudwatch_client: Any = None) -> CISCheckResult:
     """CIS 4.4 — Metric filter and alarm for IAM policy changes."""
     result = CISCheckResult(
         check_id="4.4",
@@ -1851,10 +1905,17 @@ def _check_4_4(logs_client: Any) -> CISCheckResult:
         logger.debug("Could not check metric filters: %s (%s)", exc, error_code)
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not query metric filters: {error_code or exc}"
+    if result.status is CheckStatus.PASS:
+        return _require_targeting_alarm(
+            result,
+            logs_client,
+            cloudwatch_client,
+            matches_filter=lambda pattern: sum(1 for event in iam_event_names if event in pattern) >= 3,
+        )
     return result
 
 
-def _check_4_5(logs_client: Any, cloudtrail_client: Any) -> CISCheckResult:
+def _check_4_5(logs_client: Any, cloudtrail_client: Any, cloudwatch_client: Any = None) -> CISCheckResult:
     """CIS 4.5 — Metric filter and alarm for CloudTrail config changes."""
     result = CISCheckResult(
         check_id="4.5",
@@ -1904,10 +1965,17 @@ def _check_4_5(logs_client: Any, cloudtrail_client: Any) -> CISCheckResult:
         logger.debug("Could not check metric filters: %s (%s)", exc, error_code)
         result.status = CheckStatus.ERROR
         result.evidence = _safe_error_evidence("Could not query metric filters.", error_code)
+    if result.status is CheckStatus.PASS:
+        return _require_targeting_alarm(
+            result,
+            logs_client,
+            cloudwatch_client,
+            matches_filter=lambda pattern: sum(1 for event in ct_event_names if event in pattern) >= 3,
+        )
     return result
 
 
-def _check_4_1(logs_client: Any) -> CISCheckResult:
+def _check_4_1(logs_client: Any, cloudwatch_client: Any = None) -> CISCheckResult:
     """CIS 4.1 — Metric filter and alarm for unauthorized API calls."""
     result = CISCheckResult(
         check_id="4.1",
@@ -1938,10 +2006,17 @@ def _check_4_1(logs_client: Any) -> CISCheckResult:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not query metric filters: {error_code or exc}"
+    if result.status is CheckStatus.PASS:
+        return _require_targeting_alarm(
+            result,
+            logs_client,
+            cloudwatch_client,
+            matches_filter=lambda pattern: any(token.lower() in pattern.lower() for token in patterns),
+        )
     return result
 
 
-def _check_4_2(logs_client: Any) -> CISCheckResult:
+def _check_4_2(logs_client: Any, cloudwatch_client: Any = None) -> CISCheckResult:
     """CIS 4.2 — Metric filter and alarm for console sign-in without MFA."""
     result = CISCheckResult(
         check_id="4.2",
@@ -1972,10 +2047,17 @@ def _check_4_2(logs_client: Any) -> CISCheckResult:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not query metric filters: {error_code or exc}"
+    if result.status is CheckStatus.PASS:
+        return _require_targeting_alarm(
+            result,
+            logs_client,
+            cloudwatch_client,
+            matches_filter=lambda pattern: all(token.lower() in pattern.lower() for token in patterns),
+        )
     return result
 
 
-def _check_4_6(logs_client: Any) -> CISCheckResult:
+def _check_4_6(logs_client: Any, cloudwatch_client: Any = None) -> CISCheckResult:
     """CIS 4.6 — Metric filter and alarm for console auth failures."""
     result = CISCheckResult(
         check_id="4.6",
@@ -2006,10 +2088,17 @@ def _check_4_6(logs_client: Any) -> CISCheckResult:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not query metric filters: {error_code or exc}"
+    if result.status is CheckStatus.PASS:
+        return _require_targeting_alarm(
+            result,
+            logs_client,
+            cloudwatch_client,
+            matches_filter=lambda pattern: all(token.lower() in pattern.lower() for token in patterns),
+        )
     return result
 
 
-def _check_4_7(logs_client: Any) -> CISCheckResult:
+def _check_4_7(logs_client: Any, cloudwatch_client: Any = None) -> CISCheckResult:
     """CIS 4.7 — Metric filter and alarm for CMK disable or deletion."""
     result = CISCheckResult(
         check_id="4.7",
@@ -2041,10 +2130,17 @@ def _check_4_7(logs_client: Any) -> CISCheckResult:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not query metric filters: {error_code or exc}"
+    if result.status is CheckStatus.PASS:
+        return _require_targeting_alarm(
+            result,
+            logs_client,
+            cloudwatch_client,
+            matches_filter=lambda pattern: any(event in pattern for event in kms_event_names),
+        )
     return result
 
 
-def _check_4_8(logs_client: Any) -> CISCheckResult:
+def _check_4_8(logs_client: Any, cloudwatch_client: Any = None) -> CISCheckResult:
     """CIS 4.8 — Metric filter and alarm for S3 bucket policy changes."""
     result = CISCheckResult(
         check_id="4.8",
@@ -2086,10 +2182,17 @@ def _check_4_8(logs_client: Any) -> CISCheckResult:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not query metric filters: {error_code or exc}"
+    if result.status is CheckStatus.PASS:
+        return _require_targeting_alarm(
+            result,
+            logs_client,
+            cloudwatch_client,
+            matches_filter=lambda pattern: sum(1 for event in s3_event_names if event in pattern) >= 3,
+        )
     return result
 
 
-def _check_4_9(logs_client: Any) -> CISCheckResult:
+def _check_4_9(logs_client: Any, cloudwatch_client: Any = None) -> CISCheckResult:
     """CIS 4.9 — Metric filter and alarm for AWS Config changes."""
     result = CISCheckResult(
         check_id="4.9",
@@ -2126,10 +2229,17 @@ def _check_4_9(logs_client: Any) -> CISCheckResult:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not query metric filters: {error_code or exc}"
+    if result.status is CheckStatus.PASS:
+        return _require_targeting_alarm(
+            result,
+            logs_client,
+            cloudwatch_client,
+            matches_filter=lambda pattern: sum(1 for event in config_event_names if event in pattern) >= 2,
+        )
     return result
 
 
-def _check_4_10(logs_client: Any) -> CISCheckResult:
+def _check_4_10(logs_client: Any, cloudwatch_client: Any = None) -> CISCheckResult:
     """CIS 4.10 — Metric filter and alarm for security group changes."""
     result = CISCheckResult(
         check_id="4.10",
@@ -2168,10 +2278,17 @@ def _check_4_10(logs_client: Any) -> CISCheckResult:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not query metric filters: {error_code or exc}"
+    if result.status is CheckStatus.PASS:
+        return _require_targeting_alarm(
+            result,
+            logs_client,
+            cloudwatch_client,
+            matches_filter=lambda pattern: sum(1 for event in sg_event_names if event in pattern) >= 3,
+        )
     return result
 
 
-def _check_4_11(logs_client: Any) -> CISCheckResult:
+def _check_4_11(logs_client: Any, cloudwatch_client: Any = None) -> CISCheckResult:
     """CIS 4.11 — Metric filter and alarm for NACL changes."""
     result = CISCheckResult(
         check_id="4.11",
@@ -2210,10 +2327,17 @@ def _check_4_11(logs_client: Any) -> CISCheckResult:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not query metric filters: {error_code or exc}"
+    if result.status is CheckStatus.PASS:
+        return _require_targeting_alarm(
+            result,
+            logs_client,
+            cloudwatch_client,
+            matches_filter=lambda pattern: sum(1 for event in nacl_event_names if event in pattern) >= 3,
+        )
     return result
 
 
-def _check_4_12(logs_client: Any) -> CISCheckResult:
+def _check_4_12(logs_client: Any, cloudwatch_client: Any = None) -> CISCheckResult:
     """CIS 4.12 — Metric filter and alarm for network gateway changes."""
     result = CISCheckResult(
         check_id="4.12",
@@ -2252,10 +2376,17 @@ def _check_4_12(logs_client: Any) -> CISCheckResult:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not query metric filters: {error_code or exc}"
+    if result.status is CheckStatus.PASS:
+        return _require_targeting_alarm(
+            result,
+            logs_client,
+            cloudwatch_client,
+            matches_filter=lambda pattern: sum(1 for event in gw_event_names if event in pattern) >= 3,
+        )
     return result
 
 
-def _check_4_13(logs_client: Any) -> CISCheckResult:
+def _check_4_13(logs_client: Any, cloudwatch_client: Any = None) -> CISCheckResult:
     """CIS 4.13 — Metric filter and alarm for route table changes."""
     result = CISCheckResult(
         check_id="4.13",
@@ -2295,10 +2426,17 @@ def _check_4_13(logs_client: Any) -> CISCheckResult:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not query metric filters: {error_code or exc}"
+    if result.status is CheckStatus.PASS:
+        return _require_targeting_alarm(
+            result,
+            logs_client,
+            cloudwatch_client,
+            matches_filter=lambda pattern: sum(1 for event in rt_event_names if event in pattern) >= 3,
+        )
     return result
 
 
-def _check_4_14(logs_client: Any) -> CISCheckResult:
+def _check_4_14(logs_client: Any, cloudwatch_client: Any = None) -> CISCheckResult:
     """CIS 4.14 — Metric filter and alarm for VPC changes."""
     result = CISCheckResult(
         check_id="4.14",
@@ -2342,10 +2480,17 @@ def _check_4_14(logs_client: Any) -> CISCheckResult:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not query metric filters: {error_code or exc}"
+    if result.status is CheckStatus.PASS:
+        return _require_targeting_alarm(
+            result,
+            logs_client,
+            cloudwatch_client,
+            matches_filter=lambda pattern: sum(1 for event in vpc_event_names if event in pattern) >= 3,
+        )
     return result
 
 
-def _check_4_15(logs_client: Any) -> CISCheckResult:
+def _check_4_15(logs_client: Any, cloudwatch_client: Any = None) -> CISCheckResult:
     """CIS 4.15 — Metric filter and alarm for AWS Organizations changes."""
     result = CISCheckResult(
         check_id="4.15",
@@ -2385,6 +2530,13 @@ def _check_4_15(logs_client: Any) -> CISCheckResult:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
         result.evidence = _safe_error_evidence("Could not query metric filters.", error_code)
+    if result.status is CheckStatus.PASS:
+        return _require_targeting_alarm(
+            result,
+            logs_client,
+            cloudwatch_client,
+            matches_filter=lambda pattern: sum(1 for event in org_event_names if event in pattern) >= 2,
+        )
     return result
 
 
@@ -2764,6 +2916,8 @@ _CHECKS: list[tuple[str, Callable]] = [
     ("ec2", _check_5_6),
 ]
 
+_MONITORING_ALARM_CHECKS = {check_fn for service, check_fn in _CHECKS if service == "logs"}
+
 # Checks that need special handling (multiple clients or account_id)
 _SPECIAL_CHECKS: list[tuple[str, Callable]] = [
     ("account", _check_1_1),  # needs account client
@@ -2832,8 +2986,12 @@ def run_benchmark(
 
     # Get account ID for the report
     account_id = ""
+    client_config = _aws_client_config()
     try:
-        sts = session.client("sts", region_name=resolved_region)
+        sts_kwargs = {"region_name": resolved_region}
+        if client_config is not None:
+            sts_kwargs["config"] = client_config
+        sts = session.client("sts", **sts_kwargs)
         account_id = sts.get_caller_identity()["Account"]
     except Exception as exc:
         # Account ID lookup is non-fatal; continue with empty value
@@ -2853,7 +3011,10 @@ def run_benchmark(
 
     def _get_client(svc: str) -> Any:
         if svc not in clients:
-            clients[svc] = session.client(svc, region_name=resolved_region)
+            client_kwargs = {"region_name": resolved_region}
+            if client_config is not None:
+                client_kwargs["config"] = client_config
+            clients[svc] = session.client(svc, **client_kwargs)
         return clients[svc]
 
     def _extract_check_id(fn: Callable) -> str:
@@ -2894,7 +3055,8 @@ def run_benchmark(
 
     # Standard checks (single client)
     for service, check_fn in _CHECKS:
-        _run_check(_extract_check_id(check_fn), check_fn, _get_client(service))
+        args = (_get_client(service), _get_client("cloudwatch")) if check_fn in _MONITORING_ALARM_CHECKS else (_get_client(service),)
+        _run_check(_extract_check_id(check_fn), check_fn, *args)
 
     # Special checks requiring multiple clients, account_id, or no client
     _run_check("1.1", _check_1_1, _get_client("account"))
@@ -2907,7 +3069,7 @@ def run_benchmark(
     _run_check("3.6", _check_3_6, _get_client("s3"), _get_client("cloudtrail"))
     _run_check("3.9", _check_3_9, _get_client("ec2"))
     _run_check("4.3", _check_4_3, _get_client("logs"), _get_client("cloudwatch"))
-    _run_check("4.5", _check_4_5, _get_client("logs"), _get_client("cloudtrail"))
+    _run_check("4.5", _check_4_5, _get_client("logs"), _get_client("cloudtrail"), _get_client("cloudwatch"))
     _run_check("4.16", _check_4_16, _get_client("securityhub"))
 
     if not account_id:

--- a/src/agent_bom/discovery/config_parsers.py
+++ b/src/agent_bom/discovery/config_parsers.py
@@ -12,14 +12,14 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Mapping, Optional
 
 import toml  # type: ignore[import-untyped]
 import yaml  # type: ignore[import-untyped]
 from rich.console import Console
 from rich.markup import escape
 
-from agent_bom.models import MCPServer, MCPTool, TransportType
+from agent_bom.models import CredentialIdentityBinding, MCPServer, MCPTool, TransportType
 from agent_bom.security import (
     SecurityError,
     sanitize_env_vars,
@@ -53,6 +53,46 @@ def _auto_approved_tool_names(value: object) -> list[str]:
         return []
     names = {item.strip() for item in value[:256] if isinstance(item, str) and item.strip() and len(item.strip()) <= 200}
     return sorted(names)
+
+
+def _explicit_identity_bindings(value: object, *, credential_refs: set[str]) -> list[CredentialIdentityBinding]:
+    """Parse bounded, explicit credential-to-identity evidence.
+
+    The credential slot must exist in the same server definition.  Provider and
+    identity are declarative non-secret metadata; provenance is derived from the
+    parser contract rather than trusting an arbitrary caller label.
+    """
+    if not isinstance(value, list):
+        return []
+    bindings: list[CredentialIdentityBinding] = []
+    seen: set[tuple[str, str]] = set()
+    for item in value[:64]:
+        if not isinstance(item, Mapping):
+            continue
+        credential_ref = str(item.get("credentialRef") or item.get("credential_ref") or "").strip()
+        identity_id = str(item.get("identityCanonicalId") or item.get("identity_canonical_id") or "").strip()
+        provider = str(item.get("provider") or "").strip()
+        if (
+            credential_ref not in credential_refs
+            or not identity_id
+            or len(credential_ref) > 200
+            or len(identity_id) > 512
+            or len(provider) > 64
+        ):
+            continue
+        key = (credential_ref, identity_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        bindings.append(
+            CredentialIdentityBinding(
+                credential_ref=credential_ref,
+                identity_canonical_id=identity_id,
+                evidence_source="mcp-config:identityBindings",
+                provider=provider or None,
+            )
+        )
+    return bindings
 
 
 # ---------------------------------------------------------------------------
@@ -144,6 +184,10 @@ def parse_mcp_config(config_data: dict, config_path: str) -> list[MCPServer]:
         # ✅ Security: redact credential values before storing in MCPServer
         # Only env var NAMES appear in reports — values are replaced with ***REDACTED***
         env = sanitize_env_vars(raw_env) if isinstance(raw_env, dict) else {}
+        identity_bindings = _explicit_identity_bindings(
+            server_def.get("identityBindings", server_def.get("identity_bindings")),
+            credential_refs=set(env),
+        )
 
         auto_approved = _auto_approved_tool_names(server_def.get("autoApprove", server_def.get("auto_approve")))
         security_warnings: list[str] = []
@@ -174,6 +218,7 @@ def parse_mcp_config(config_data: dict, config_path: str) -> list[MCPServer]:
             tools=[MCPTool(name=tool_name, description="Tool configured for automatic approval") for tool_name in auto_approved],
             config_path=config_path,
             security_warnings=security_warnings,
+            identity_bindings=identity_bindings,
         )
 
         # Detect privilege indicators from command/args

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -388,6 +388,43 @@ def build_unified_graph_from_report(
                             },
                         )
                     )
+                for binding in srv_dict.get("identity_bindings", []):
+                    if not isinstance(binding, Mapping) or binding.get("credential_ref") != env_key:
+                        continue
+                    identity_id = sanitize_text(str(binding.get("identity_canonical_id") or "").strip())
+                    evidence_source = sanitize_text(str(binding.get("evidence_source") or "").strip())
+                    if not identity_id or not evidence_source:
+                        continue
+                    provider = sanitize_text(str(binding.get("provider") or "").strip().lower())
+                    graph.add_node(
+                        UnifiedNode(
+                            id=identity_id,
+                            entity_type=EntityType.MANAGED_IDENTITY,
+                            label=identity_id.rsplit(":", 1)[-1],
+                            attributes={
+                                "canonical_id": identity_id,
+                                "provider": provider,
+                                "evidence_source": evidence_source,
+                                "credential_ref": env_key,
+                            },
+                            data_sources=[data_source_tag, evidence_source],
+                            dimensions=NodeDimensions(cloud_provider=provider),
+                        )
+                    )
+                    graph.add_edge(
+                        UnifiedEdge(
+                            source=cred_id,
+                            target=identity_id,
+                            relationship=RelationshipType.AUTHENTICATES_AS,
+                            evidence={
+                                "source": evidence_source,
+                                "credential_ref": env_key,
+                                "mapping_method": "explicit_identity_binding",
+                                "confidence": "high",
+                            },
+                            confidence=1.0,
+                        )
+                    )
 
     for vuln_node_id, srv_id, pkg_id, package_evidence, severity in pending_exploitable_edges:
         _add_exploitable_via_edges(

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -1099,6 +1099,7 @@ def to_json(report: AIBOMReport) -> dict:
                         "mcp_version": server.mcp_version,
                         "has_credentials": server.has_credentials,
                         "credential_env_vars": server.credential_names,
+                        "identity_bindings": [binding.to_dict() for binding in server.identity_bindings],
                         "registry_verified": server.registry_verified,
                         "registry_badge": "verified" if server.registry_verified else "unknown",
                         "security_blocked": server.security_blocked,

--- a/tests/api/test_api_finding_groups.py
+++ b/tests/api/test_api_finding_groups.py
@@ -1,0 +1,157 @@
+"""Server-backed issue grouping preserves asset-scoped finding occurrences."""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+from agent_bom.api.server import app, set_job_store
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import _get_store
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+    set_job_store(InMemoryJobStore())
+
+
+def _finding(asset_identifier: str, *, severity: str = "high") -> dict[str, object]:
+    return Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(
+            name="requests",
+            asset_type="package",
+            identifier=asset_identifier,
+        ),
+        severity=severity,
+        cve_id="CVE-2026-1000",
+    ).to_dict()
+
+
+def test_findings_group_view_preserves_and_expands_asset_occurrences() -> None:
+    tenant = "finding-groups"
+    set_job_store(InMemoryJobStore())
+    job = ScanJob(job_id="scan-groups", tenant_id=tenant, created_at="2026-08-20T12:00:00Z", request=ScanRequest())
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-08-20T12:01:00Z"
+    job.result = {
+        "findings": [
+            _finding("pkg:pypi/requests@2.0.0?image=api"),
+            _finding("pkg:pypi/requests@2.0.0?image=worker"),
+        ]
+    }
+    _get_store().put(job)
+    client = TestClient(app)
+    headers = proxy_headers(role="analyst", tenant=tenant)
+
+    raw = client.get("/v1/findings?limit=10&window_days=0", headers=headers).json()
+    grouped = client.get(
+        "/v1/findings?group_occurrences=true&limit=10&window_days=0",
+        headers=headers,
+    ).json()
+
+    assert raw["count"] == 2
+    assert grouped["count"] == 1
+    assert grouped["total"] == 1
+    assert grouped["filters"]["group_occurrences"] is True
+    row = grouped["findings"][0]
+    assert row["occurrence_count"] == 2
+    assert row["occurrences_truncated"] is False
+    assert {item["finding_id"] for item in row["occurrences"]} == {
+        raw["findings"][0]["finding_id"],
+        raw["findings"][1]["finding_id"],
+    }
+    # Public responses intentionally omit raw asset identifiers, but the two
+    # opaque asset identities remain distinct and joinable.
+    assert len({item["asset"]["stable_id"] for item in row["occurrences"]}) == 2
+
+
+def test_findings_group_view_paginates_groups_without_collapsing_advisories() -> None:
+    tenant = "finding-group-pages"
+    set_job_store(InMemoryJobStore())
+    job = ScanJob(job_id="scan-group-pages", tenant_id=tenant, created_at="2026-08-20T12:00:00Z", request=ScanRequest())
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-08-20T12:01:00Z"
+    rows = []
+    for cve in ("CVE-2026-1000", "CVE-2026-2000"):
+        finding = Finding(
+            finding_type=FindingType.CVE,
+            source=FindingSource.MCP_SCAN,
+            asset=Asset(name="requests", asset_type="package", identifier=f"pkg:pypi/requests@2.0.0?cve={cve}"),
+            severity="high",
+            cve_id=cve,
+        )
+        rows.append(finding.to_dict())
+    job.result = {"findings": rows}
+    _get_store().put(job)
+    client = TestClient(app)
+    headers = proxy_headers(role="analyst", tenant=tenant)
+
+    first = client.get(
+        "/v1/findings?group_occurrences=true&limit=1&window_days=0",
+        headers=headers,
+    ).json()
+    second = client.get(
+        f"/v1/findings?group_occurrences=true&limit=1&window_days=0&cursor={first['next_cursor']}",
+        headers=headers,
+    ).json()
+
+    assert first["total"] == 2
+    assert first["has_more"] is True
+    assert first["next_cursor"]
+    assert second["has_more"] is False
+    assert {first["findings"][0]["cve_id"], second["findings"][0]["cve_id"]} == {
+        "CVE-2026-1000",
+        "CVE-2026-2000",
+    }
+
+
+def test_findings_group_view_facets_count_issue_groups_not_occurrences() -> None:
+    tenant = "finding-group-facets"
+    set_job_store(InMemoryJobStore())
+    job = ScanJob(job_id="scan-group-facets", tenant_id=tenant, created_at="2026-08-20T12:00:00Z", request=ScanRequest())
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-08-20T12:01:00Z"
+    job.result = {
+        "findings": [
+            _finding("pkg:pypi/requests@2.0.0?image=api", severity="high"),
+            _finding("pkg:pypi/requests@2.0.0?image=worker", severity="high"),
+            {
+                **_finding("pkg:pypi/requests@2.0.0?image=batch", severity="critical"),
+                "cve_id": "CVE-2026-2000",
+            },
+        ]
+    }
+    _get_store().put(job)
+    client = TestClient(app)
+    headers = proxy_headers(role="analyst", tenant=tenant)
+
+    grouped = client.get(
+        "/v1/findings?group_occurrences=true&include_facets=true&limit=10&window_days=0",
+        headers=headers,
+    ).json()
+    critical = client.get(
+        "/v1/findings?group_occurrences=true&include_facets=true&severity=critical&limit=10&window_days=0",
+        headers=headers,
+    ).json()
+
+    assert grouped["total"] == 2
+    assert grouped["facets"]["severity"] == {
+        "critical": 1,
+        "high": 1,
+        "medium": 0,
+        "low": 0,
+        "info": 0,
+        "unknown": 0,
+    }
+    # Severity facets are self-excluding so changing the active band does not
+    # make the other issue counts disappear.
+    assert critical["total"] == 1
+    assert critical["facets"]["severity"] == grouped["facets"]["severity"]

--- a/tests/api/test_api_pipeline_findings_surface.py
+++ b/tests/api/test_api_pipeline_findings_surface.py
@@ -114,3 +114,26 @@ def test_pipeline_surfaces_mcp_tool_rule_finding_end_to_end(tmp_path, monkeypatc
     findings = job.result.get("findings", [])
     mcp = [f for f in findings if isinstance(f.get("evidence"), dict) and f["evidence"].get("mcp_tool_rule")]
     assert mcp, "hosted scan must surface MCP tool-rule findings in job.result['findings']"
+
+
+def test_pipeline_records_one_scan_backed_trend_point(tmp_path, monkeypatch):
+    """A completed scan invokes the canonical, retry-safe trend boundary."""
+    _patch_scan(monkeypatch)
+    calls: list[tuple[dict, dict]] = []
+
+    def _record(result, **kwargs):
+        calls.append((result, kwargs))
+        return True
+
+    monkeypatch.setattr("agent_bom.api.trend_recording.record_scan_trend_best_effort", _record)
+
+    job = _scan_job(_empty_inventory(tmp_path))
+    _run_scan_sync(job)
+
+    assert job.status == JobStatus.DONE, job.result
+    assert len(calls) == 1
+    result, metadata = calls[0]
+    assert result is job.result
+    assert metadata["tenant_id"] == "default"
+    assert metadata["scan_id"] == job.job_id
+    assert metadata["completed_at"]

--- a/tests/api/test_api_tenant_isolation.py
+++ b/tests/api/test_api_tenant_isolation.py
@@ -992,10 +992,16 @@ async def test_asset_routes_are_tenant_scoped(tmp_path, monkeypatch):
 
         req = _request("tenant-alpha")
         data = await asset_routes.list_assets(req)
+        assert data["schema_version"] == "vulnerability-assets.v1"
+        assert data["scope"] == "vulnerability_asset_lifecycle"
+        assert data["count_definition"] == ("tracked vulnerability-package records after lifecycle filters; not unified estate assets")
         assert data["count"] == 1
         assert [asset["vuln_id"] for asset in data["assets"]] == ["CVE-alpha"]
 
         stats = await asset_routes.get_asset_stats(req)
+        assert stats["schema_version"] == "vulnerability-assets.stats.v1"
+        assert stats["scope"] == "vulnerability_asset_lifecycle"
+        assert stats["count_definition"] == ("tracked vulnerability-package records across lifecycle states; not unified estate assets")
         assert stats["stats"]["total"] == 1
         assert stats["stats"]["critical_open"] == 1
     finally:

--- a/tests/api/test_api_trend_recording.py
+++ b/tests/api/test_api_trend_recording.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from agent_bom.api.trend_recording import trend_point_from_scan_result
+
+
+def test_trend_point_uses_canonical_scan_result_and_vulnerability_counts() -> None:
+    point = trend_point_from_scan_result(
+        {
+            "scan_id": "scan-123",
+            "generated_at": "2026-08-20T12:00:00Z",
+            "posture_scorecard": {"grade": "C", "score": 72.5, "no_data": False},
+            "packages": [
+                {
+                    "name": "alpha",
+                    "version": "1.0.0",
+                    "vulnerabilities": [
+                        {"id": "CVE-1", "severity": "critical"},
+                        {"id": "CVE-2", "severity": "high"},
+                    ],
+                },
+                {
+                    "name": "beta",
+                    "version": "2.0.0",
+                    "vulnerabilities": [
+                        {"id": "CVE-3", "severity": "medium"},
+                        {"id": "CVE-4", "severity": "low"},
+                    ],
+                },
+            ],
+        },
+        tenant_id="tenant-a",
+    )
+
+    assert point is not None
+    assert point.idempotency_key == "tenant-a:scan-123"
+    assert point.total_vulns == 4
+    assert (point.critical, point.high, point.medium, point.low) == (1, 1, 1, 1)
+    assert point.posture_score == 72.5
+
+
+def test_trend_point_rejects_ungraded_or_identity_free_results() -> None:
+    assert (
+        trend_point_from_scan_result(
+            {"scan_id": "scan-123", "posture_scorecard": {"grade": "N/A", "score": 0, "no_data": True}},
+            tenant_id="tenant-a",
+        )
+        is None
+    )
+    assert (
+        trend_point_from_scan_result(
+            {"posture_scorecard": {"grade": "A", "score": 95, "no_data": False}},
+            tenant_id="tenant-a",
+        )
+        is None
+    )

--- a/tests/test_aws_cis_benchmark.py
+++ b/tests/test_aws_cis_benchmark.py
@@ -80,6 +80,20 @@ from agent_bom.cloud.aws_cis_benchmark import (
 # ---------------------------------------------------------------------------
 
 
+def _targeting_alarm_for(logs_client: MagicMock) -> MagicMock:
+    """Attach one usable metric transformation and return its targeting alarm client."""
+    pages = logs_client.get_paginator.return_value.paginate.return_value
+    for page in pages:
+        for metric_filter in page.get("metricFilters", []):
+            metric_filter.setdefault(
+                "metricTransformations",
+                [{"metricName": "SecurityEvents", "metricNamespace": "Security"}],
+            )
+    cloudwatch = MagicMock()
+    cloudwatch.describe_alarms_for_metric.return_value = {"MetricAlarms": [{"AlarmName": "SecurityEventsAlarm"}]}
+    return cloudwatch
+
+
 def _iam_client(**overrides) -> MagicMock:
     """Create a mock IAM client with sensible defaults."""
     client = MagicMock()
@@ -1135,7 +1149,7 @@ class TestCheck44:
             }
         ]
         client.get_paginator.return_value = paginator
-        result = _check_4_4(client)
+        result = _check_4_4(client, _targeting_alarm_for(client))
         assert result.status == CheckStatus.PASS
         assert result.check_id == "4.4"
 
@@ -1185,7 +1199,7 @@ class TestCheck45:
             }
         ]
         logs.get_paginator.return_value = paginator
-        result = _check_4_5(logs, ct)
+        result = _check_4_5(logs, ct, _targeting_alarm_for(logs))
         assert result.status == CheckStatus.PASS
         assert result.check_id == "4.5"
 
@@ -1929,7 +1943,7 @@ class TestCheck41:
         paginator = MagicMock()
         paginator.paginate.return_value = [{"metricFilters": [{"filterPattern": "{ $.errorCode = AccessDenied }"}]}]
         client.get_paginator.return_value = paginator
-        result = _check_4_1(client)
+        result = _check_4_1(client, _targeting_alarm_for(client))
         assert result.status == CheckStatus.PASS
         assert result.check_id == "4.1"
 
@@ -1956,7 +1970,7 @@ class TestCheck42:
             {"metricFilters": [{"filterPattern": '{ $.eventName = ConsoleLogin && $.additionalEventData.MFAUsed != "Yes" }'}]}
         ]
         client.get_paginator.return_value = paginator
-        result = _check_4_2(client)
+        result = _check_4_2(client, _targeting_alarm_for(client))
         assert result.status == CheckStatus.PASS
         assert result.check_id == "4.2"
 
@@ -1991,7 +2005,7 @@ class TestCheck46:
             {"metricFilters": [{"filterPattern": '{ $.eventName = ConsoleLogin && $.errorMessage = "Failed authentication" }'}]}
         ]
         client.get_paginator.return_value = paginator
-        result = _check_4_6(client)
+        result = _check_4_6(client, _targeting_alarm_for(client))
         assert result.status == CheckStatus.PASS
         assert result.check_id == "4.6"
 
@@ -2017,7 +2031,7 @@ class TestCheck47:
             {"metricFilters": [{"filterPattern": "{ $.eventName = DisableKey || $.eventName = ScheduleKeyDeletion }"}]}
         ]
         client.get_paginator.return_value = paginator
-        result = _check_4_7(client)
+        result = _check_4_7(client, _targeting_alarm_for(client))
         assert result.status == CheckStatus.PASS
         assert result.check_id == "4.7"
 
@@ -2051,7 +2065,7 @@ class TestCheck48:
             }
         ]
         client.get_paginator.return_value = paginator
-        result = _check_4_8(client)
+        result = _check_4_8(client, _targeting_alarm_for(client))
         assert result.status == CheckStatus.PASS
         assert result.check_id == "4.8"
 
@@ -2086,7 +2100,7 @@ class TestCheck49:
             }
         ]
         client.get_paginator.return_value = paginator
-        result = _check_4_9(client)
+        result = _check_4_9(client, _targeting_alarm_for(client))
         assert result.status == CheckStatus.PASS
         assert result.check_id == "4.9"
 
@@ -2122,7 +2136,7 @@ class TestCheck410:
             }
         ]
         client.get_paginator.return_value = paginator
-        result = _check_4_10(client)
+        result = _check_4_10(client, _targeting_alarm_for(client))
         assert result.status == CheckStatus.PASS
         assert result.check_id == "4.10"
 
@@ -2158,7 +2172,7 @@ class TestCheck411:
             }
         ]
         client.get_paginator.return_value = paginator
-        result = _check_4_11(client)
+        result = _check_4_11(client, _targeting_alarm_for(client))
         assert result.status == CheckStatus.PASS
         assert result.check_id == "4.11"
 
@@ -2194,7 +2208,7 @@ class TestCheck412:
             }
         ]
         client.get_paginator.return_value = paginator
-        result = _check_4_12(client)
+        result = _check_4_12(client, _targeting_alarm_for(client))
         assert result.status == CheckStatus.PASS
         assert result.check_id == "4.12"
 
@@ -2228,7 +2242,7 @@ class TestCheck413:
             }
         ]
         client.get_paginator.return_value = paginator
-        result = _check_4_13(client)
+        result = _check_4_13(client, _targeting_alarm_for(client))
         assert result.status == CheckStatus.PASS
         assert result.check_id == "4.13"
 
@@ -2258,7 +2272,7 @@ class TestCheck414:
             }
         ]
         client.get_paginator.return_value = paginator
-        result = _check_4_14(client)
+        result = _check_4_14(client, _targeting_alarm_for(client))
         assert result.status == CheckStatus.PASS
         assert result.check_id == "4.14"
 
@@ -2294,7 +2308,7 @@ class TestCheck415:
             }
         ]
         client.get_paginator.return_value = paginator
-        result = _check_4_15(client)
+        result = _check_4_15(client, _targeting_alarm_for(client))
         assert result.status == CheckStatus.PASS
         assert result.check_id == "4.15"
 

--- a/tests/test_aws_cis_scope_truth.py
+++ b/tests/test_aws_cis_scope_truth.py
@@ -15,14 +15,18 @@ from agent_bom.cloud import aws_cis_benchmark as cis
 def _install_boto_modules(monkeypatch) -> None:
     boto3 = types.ModuleType("boto3")
     botocore = types.ModuleType("botocore")
+    botocore.__path__ = []  # type: ignore[attr-defined]
+    config = types.ModuleType("botocore.config")
     exceptions = types.ModuleType("botocore.exceptions")
 
     class ClientError(Exception):
         pass
 
     exceptions.ClientError = ClientError
+    config.Config = MagicMock(side_effect=lambda **kwargs: types.SimpleNamespace(**kwargs))
     monkeypatch.setitem(sys.modules, "boto3", boto3)
     monkeypatch.setitem(sys.modules, "botocore", botocore)
+    monkeypatch.setitem(sys.modules, "botocore.config", config)
     monkeypatch.setitem(sys.modules, "botocore.exceptions", exceptions)
 
 
@@ -124,6 +128,18 @@ def test_check_coverage_error_marks_complete_scope_partial(monkeypatch) -> None:
     assert any("coverage" in warning.lower() for warning in report.warnings)
 
 
+def test_benchmark_clients_use_adaptive_retry_budget(monkeypatch) -> None:
+    _install_boto_modules(monkeypatch)
+    monkeypatch.setattr(cis, "_CHECKS", [("ec2", _passing_check)])
+    monkeypatch.setattr(cis, "_SPECIAL_CHECKS", [])
+    session = _session()
+
+    cis.run_benchmark(session=session, checks=["5.2"], region_scope_complete=True)
+
+    ec2_call = next(call for call in session.client.call_args_list if call.args == ("ec2",))
+    assert ec2_call.kwargs["config"].retries == {"max_attempts": 5, "mode": "adaptive"}
+
+
 def test_root_usage_check_receives_logs_and_cloudwatch_clients(monkeypatch) -> None:
     _install_boto_modules(monkeypatch)
     monkeypatch.setattr(cis, "_CHECKS", [])
@@ -154,6 +170,36 @@ def test_root_usage_check_receives_logs_and_cloudwatch_clients(monkeypatch) -> N
 
     assert report.checks[0].status is cis.CheckStatus.PASS
     cloudwatch.describe_alarms_for_metric.assert_called_once_with(MetricName="RootUsage", Namespace="Security")
+
+
+@pytest.mark.parametrize(
+    ("check", "pattern"),
+    [
+        (cis._check_4_1, "UnauthorizedAccess AccessDenied"),
+        (cis._check_4_4, "DeleteGroupPolicy PutRolePolicy CreatePolicy"),
+    ],
+)
+def test_monitoring_checks_cannot_pass_without_a_targeting_alarm(check, pattern: str) -> None:
+    logs = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = [
+        {
+            "metricFilters": [
+                {
+                    "filterPattern": pattern,
+                    "metricTransformations": [{"metricName": "SecurityEvents", "metricNamespace": "Security"}],
+                }
+            ]
+        }
+    ]
+    logs.get_paginator.return_value = paginator
+    cloudwatch = MagicMock()
+    cloudwatch.describe_alarms_for_metric.return_value = {"MetricAlarms": []}
+
+    result = check(logs, cloudwatch)
+
+    assert result.status is cis.CheckStatus.FAIL
+    assert "alarm" in result.evidence.lower()
 
 
 def test_failed_region_enumeration_marks_regional_pass_unknown(monkeypatch) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -159,6 +159,61 @@ def test_parse_empty_config():
     assert len(servers) == 0
 
 
+def test_parse_mcp_config_preserves_only_explicit_credential_identity_bindings():
+    """Credential names alone never imply a cloud identity relationship."""
+    config = {
+        "mcpServers": {
+            "deploy": {
+                "command": "node",
+                "args": ["deploy-agent.js"],
+                "env": {"AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/deploy"},
+                "identityBindings": [
+                    {
+                        "credentialRef": "AWS_ROLE_ARN",
+                        "identityCanonicalId": "managed_identity:aws:123456789012:role/deploy",
+                        "evidenceSource": "mcp-config:identityBindings",
+                        "provider": "AWS",
+                    },
+                    {
+                        "credentialRef": "MISSING",
+                        "identityCanonicalId": "managed_identity:aws:123456789012:role/missing",
+                        "evidenceSource": "mcp-config:identityBindings",
+                    },
+                    {"credentialRef": "AWS_ROLE_ARN"},
+                ],
+            }
+        }
+    }
+
+    [server] = parse_mcp_config(config, "/tmp/mcp.json")
+
+    assert [binding.to_dict() for binding in server.identity_bindings] == [
+        {
+            "credential_ref": "AWS_ROLE_ARN",
+            "identity_canonical_id": "managed_identity:aws:123456789012:role/deploy",
+            "evidence_source": "mcp-config:identityBindings",
+            "provider": "aws",
+        }
+    ]
+
+
+def test_parse_mcp_config_does_not_infer_identity_from_environment_names():
+    [server] = parse_mcp_config(
+        {
+            "mcpServers": {
+                "deploy": {
+                    "command": "node",
+                    "args": ["deploy-agent.js"],
+                    "env": {"AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/deploy"},
+                }
+            }
+        },
+        "/tmp/mcp.json",
+    )
+
+    assert server.identity_bindings == []
+
+
 # ─── Parser Tests ───────────────────────────────────────────────────────────
 
 

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -114,6 +114,39 @@ class TestBuildUnifiedGraphFromReport:
         names = {a.label for a in agents}
         assert names == {"claude-desktop", "cursor"}
 
+    def test_explicit_credential_identity_binding_joins_cloud_identity(self):
+        report = _minimal_report()
+        server = report["agents"][0]["mcp_servers"][0]
+        server["identity_bindings"] = [
+            {
+                "credential_ref": "GITHUB_TOKEN",
+                "identity_canonical_id": "managed_identity:github:app/deployer",
+                "evidence_source": "mcp-config",
+                "provider": "github",
+            }
+        ]
+
+        graph = build_unified_graph_from_report(report)
+        credential = next(
+            node
+            for node in graph.nodes_by_type(EntityType.CREDENTIAL)
+            if node.label == "GITHUB_TOKEN" and node.attributes["server"].endswith(":mcp-fs")
+        )
+        identity = graph.get_node("managed_identity:github:app/deployer")
+
+        assert identity is not None
+        assert identity.entity_type is EntityType.MANAGED_IDENTITY
+        assert identity.attributes["evidence_source"] == "mcp-config"
+        assert any(
+            edge.source == credential.id and edge.target == identity.id and edge.relationship is RelationshipType.AUTHENTICATES_AS
+            for edge in graph.edges
+        )
+
+    def test_credential_slots_do_not_infer_cloud_identity_without_binding(self):
+        graph = build_unified_graph_from_report(_minimal_report())
+
+        assert graph.nodes_by_type(EntityType.MANAGED_IDENTITY) == []
+
     def test_agent_environment_lands_on_dimensions_and_stack(self):
         report = _minimal_report()
         report["agents"][0]["environment"] = "production"

--- a/tests/test_integrity_foundation.py
+++ b/tests/test_integrity_foundation.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from agent_bom.baseline import TrendPoint
+from agent_bom.baseline import InMemoryTrendStore, SQLiteTrendStore, TrendPoint
 from agent_bom.finding import Asset, Finding, FindingSource, FindingType
-from agent_bom.models import CredentialIdentityBinding, MCPServer
+from agent_bom.models import Agent, AgentType, AIBOMReport, CredentialIdentityBinding, MCPServer
+from agent_bom.output.json_fmt import to_json
 
 
 def _finding(*, asset_id: str, cve_id: str = "CVE-2026-1000") -> Finding:
@@ -56,6 +57,45 @@ def test_trend_point_exposes_idempotent_scan_key() -> None:
     assert point.to_dict()["scan_id"] == "scan-123"
 
 
+def _trend_point(*, score: float = 70.0) -> TrendPoint:
+    return TrendPoint(
+        scan_id="scan-123",
+        timestamp="2026-08-20T12:00:00Z",
+        total_vulns=4,
+        critical=1,
+        high=1,
+        medium=1,
+        low=1,
+        posture_score=score,
+        posture_grade="C",
+        tenant_id="tenant-a",
+    )
+
+
+def test_inmemory_trend_store_upserts_scan_backed_points() -> None:
+    store = InMemoryTrendStore()
+
+    store.record(_trend_point(score=70.0))
+    store.record(_trend_point(score=80.0))
+
+    history = store.get_history(tenant_id="tenant-a")
+    assert len(history) == 1
+    assert history[0].scan_id == "scan-123"
+    assert history[0].posture_score == 80.0
+
+
+def test_sqlite_trend_store_upserts_and_round_trips_scan_id(tmp_path) -> None:
+    store = SQLiteTrendStore(str(tmp_path / "trends.db"))
+
+    store.record(_trend_point(score=70.0))
+    store.record(_trend_point(score=80.0))
+
+    history = store.get_history(tenant_id="tenant-a")
+    assert len(history) == 1
+    assert history[0].scan_id == "scan-123"
+    assert history[0].posture_score == 80.0
+
+
 def test_mcp_server_accepts_only_explicit_identity_bindings() -> None:
     binding = CredentialIdentityBinding(
         credential_ref="AWS_ROLE_ARN",
@@ -72,3 +112,21 @@ def test_mcp_server_accepts_only_explicit_identity_bindings() -> None:
         "evidence_source": "mcp-config",
         "provider": "aws",
     }
+
+
+def test_explicit_identity_bindings_survive_canonical_json_projection() -> None:
+    binding = CredentialIdentityBinding(
+        credential_ref="AWS_ROLE_ARN",
+        identity_canonical_id="managed_identity:aws:role/deployer",
+        evidence_source="mcp-config",
+        provider="aws",
+    )
+    server = MCPServer(name="deploy", env={"AWS_ROLE_ARN": "***"}, identity_bindings=[binding])
+    report = AIBOMReport(
+        scan_id="scan-123",
+        agents=[Agent(name="operator", agent_type=AgentType.CUSTOM, config_path="", mcp_servers=[server])],
+    )
+
+    payload = to_json(report)
+
+    assert payload["agents"][0]["mcp_servers"][0]["identity_bindings"] == [binding.to_dict()]

--- a/tests/test_inventory_assets.py
+++ b/tests/test_inventory_assets.py
@@ -111,6 +111,8 @@ def test_summary_counts_assets_by_type_and_group_excluding_findings(inventory_st
     assert resp.status_code == 200
     body = resp.json()
     assert body["schema_version"] == "inventory.summary.v1"
+    assert body["scope"] == "unified_graph_estate"
+    assert body["count_definition"] == ("typed graph nodes excluding finding entity types in the selected tenant and scan snapshot")
     # 16 non-finding nodes seeded; the vulnerability is not an asset.
     assert body["total_assets"] == 16
     assert body["finding_count"] == 1
@@ -142,6 +144,8 @@ def test_list_returns_asset_rows_and_excludes_findings(inventory_store):
     assert resp.status_code == 200
     body = resp.json()
     assert body["schema_version"] == "inventory.assets.v1"
+    assert body["scope"] == "unified_graph_estate"
+    assert body["count_definition"] == ("typed graph nodes excluding finding entity types in the selected tenant and scan snapshot")
     types = {row["type"] for row in body["assets"]}
     assert "vulnerability" not in types
     assert {"agent", "cloud_resource", "account", "role", "user"} <= types

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -123,6 +123,12 @@ def test_audit_and_trend_tables_exist_with_rls():
     assert "CREATE POLICY trend_history_tenant_isolation ON trend_history" in SQL
 
 
+def test_trend_history_has_retry_safe_scan_identity():
+    assert "scan_id" in _columns_for("trend_history")
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS idx_trend_history_team_scan" in SQL
+    assert "ON trend_history(team_id, scan_id) WHERE scan_id IS NOT NULL" in SQL
+
+
 def test_remaining_tenant_tables_have_rls():
     for table in ("findings", "agents", "policy_results", "job_queue"):
         assert f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY" in SQL

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -237,7 +237,7 @@ class MockConnection:
                 cursor.rows = [(tenant_id, row[8]) for tenant_id, row in latest.items()]
             elif "from trend_history" in sql_lower:
                 rows = list(self._store.get("trend_history", {}).values())
-                cursor.rows = [(r[0], r[2], r[3], r[4], r[5], r[6], r[7], r[8]) for r in rows]
+                cursor.rows = [(r[0], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9]) for r in rows]
             elif "from scan_schedules" in sql_lower:
                 rows = list(self._store.get("scan_schedules", {}).values())
                 if params:
@@ -1073,6 +1073,7 @@ def test_postgres_trend_store_roundtrip(mock_pool):
         low=4,
         posture_score=82.5,
         posture_grade="B",
+        scan_id="scan-1",
     )
     store.record(point)
     mock_pool._conn._store.setdefault("trend_history", {})["2026-01-01T00:00:00Z"] = (
@@ -1085,10 +1086,12 @@ def test_postgres_trend_store_roundtrip(mock_pool):
         point.low,
         point.posture_score,
         point.posture_grade,
+        point.scan_id,
     )
     history = store.get_history()
     assert len(history) == 1
     assert history[0].posture_grade == "B"
+    assert history[0].scan_id == "scan-1"
 
 
 # ─── Pool / Config ────────────────────────────────────────────────────────────

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -122,7 +122,9 @@ function collectUnifiedFindings(findings: UnifiedFinding[]): EnrichedVuln[] {
     ]);
     return {
       id: findingLabel,
-      finding_id: finding.id,
+      finding_id: finding.finding_id ?? finding.id,
+      finding_group_id: finding.finding_group_id,
+      finding_group_key: finding.finding_group_key,
       node_id: finding.node_id ?? undefined,
       finding_node_id: finding.finding_node_id ?? undefined,
       entity_type: finding.entity_type ?? undefined,
@@ -200,6 +202,8 @@ function collectUnifiedFindings(findings: UnifiedFinding[]): EnrichedVuln[] {
       scan_count: finding.scan_count,
       last_observed: finding.last_observed ?? finding.last_seen ?? undefined,
       occurrence_count: finding.occurrence_count ?? finding.scan_count,
+      occurrences: finding.occurrences,
+      occurrences_truncated: finding.occurrences_truncated,
       remediation_versions: finding.remediation_versions ?? undefined,
       provenance: finding.provenance ?? undefined,
       owner: finding.owner ?? undefined,
@@ -594,6 +598,7 @@ function FindingsPage() {
           ...(!currentCursor ? { offset: (page - 1) * PAGE_SIZE } : {}),
           ...(currentCursor ? { cursor: currentCursor } : {}),
           approximateTotal: true,
+          groupOccurrences: true,
           includeFacets: true,
           windowDays,
         });
@@ -776,7 +781,7 @@ function FindingsPage() {
         title="Findings"
         subtitle={findingsPageSubtitle(
           lens,
-          `${findingsTotalLabel}${findingsTotal == null ? "" : " findings"}`,
+          `${findingsTotalLabel}${findingsTotal == null ? "" : " issues"}`,
           paramScan
             ? `from scan ${paramScan.slice(0, 8)}.`
             : `current state across completed scans · ${findingsWindowLabel}.`,
@@ -924,7 +929,7 @@ function FindingsPage() {
                   {findingsQueueTitle(lens)}
                 </span>
                 <span aria-hidden="true">·</span>
-                <span>{displayed.length} on this page</span>
+                <span>{displayed.length} issues on this page</span>
                 <span aria-hidden="true">·</span>
                 <span>{PAGE_SIZE} per page</span>
               </p>
@@ -1203,7 +1208,7 @@ function FindingsPage() {
             totalPages={totalPages}
             totalItems={findingsTotal}
             hasMore={hasMoreFindings}
-            itemLabel={findingsTotalApproximate ? "findings (approx.)" : "findings"}
+            itemLabel={findingsTotalApproximate ? "issues (approx.)" : "issues"}
             onPrevious={() => setPage((p) => Math.max(1, p - 1))}
             onNext={() => {
               if (nextFindingsCursor) {

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -12,6 +12,7 @@ import {
   formatDate,
   type PostureCountsResponse,
   type ComplianceResponse,
+  type TrendsResponse,
 } from "@/lib/api";
 import { ActivityFeed } from "@/components/activity-feed";
 import {
@@ -63,6 +64,7 @@ export default function Dashboard() {
   const [posture, setPosture] = useState<PostureResponse | null>(null);
   const [overview, setOverview] = useState<OverviewResponse | null>(null);
   const [compliance, setCompliance] = useState<ComplianceResponse | null>(null);
+  const [trends, setTrends] = useState<TrendsResponse | null>(null);
   const [postureOverviewLoading, setPostureOverviewLoading] = useState(true);
   // Local display-format override; falls back to the persisted per-tenant
   // config carried on the overview posture. Toggling persists via the API (#3940).
@@ -88,10 +90,29 @@ export default function Dashboard() {
       },
       () => {},
     );
+    void api.getTrends(2).then(
+      (value) => {
+        if (!cancelled) setTrends(value);
+      },
+      () => {},
+    );
     return () => {
       cancelled = true;
     };
   }, []);
+
+  const postureTrend = useMemo(() => {
+    const current = trends?.data_points?.[0];
+    const previous = trends?.data_points?.[1];
+    if (!current || !previous) return null;
+    const delta = current.posture_score - previous.posture_score;
+    return {
+      direction: delta > 0 ? "improved" as const : delta < 0 ? "worsened" as const : "unchanged" as const,
+      delta,
+      previousScore: previous.posture_score,
+      points: trends?.count ?? trends.data_points.length,
+    };
+  }, [trends]);
 
   useEffect(() => {
     let cancelled = false;
@@ -408,6 +429,7 @@ export default function Dashboard() {
         scoreBreakdown={scoreBreakdown}
         onScoreFormatChange={handleScoreFormatChange}
         postureSummary={overview?.posture.summary ?? posture?.summary}
+        postureTrend={postureTrend}
         critical={criticalCount}
         high={highCount}
         kev={summaryReady ? displayedKevCount : null}

--- a/ui/components/compliance-control-drawer.tsx
+++ b/ui/components/compliance-control-drawer.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { Package, Server, X } from "lucide-react";
+import { useState } from "react";
+import { Package, Server } from "lucide-react";
 
-import { useEscToClose } from "@/hooks/use-esc-to-close";
+import { DetailTabs } from "@/components/detail-tabs";
+import { Drawer } from "@/components/drawer";
 import {
   controlStatusLabel,
   evidenceReasonCta,
@@ -24,87 +26,69 @@ export function ComplianceControlDrawer({
   catalogName?: string | undefined;
   onClose: () => void;
 }) {
-  useEscToClose(true, onClose);
+  const [tab, setTab] = useState<"overview" | "evidence" | "actions">("overview");
   const name = catalogName ?? control.name;
   const sev = control.severity_breakdown;
   const unscored = isControlUnscored(control.status);
   const reasonLabel = evidenceReasonLabel(control.evidence_reason);
   const reasonCta = unscored ? evidenceReasonCta(control.evidence_reason) : null;
 
-  return (
-    <div
-      className="fixed inset-0 z-[80] flex justify-end bg-black/45 backdrop-blur-sm"
-      role="dialog"
-      aria-modal="true"
-      aria-label={`Control details for ${control.code}`}
+  const statusPill = (
+    <span
+      className={`rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
+        control.status === "pass"
+          ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300"
+          : control.status === "warning"
+            ? "bg-yellow-500/15 text-yellow-700 dark:text-yellow-300"
+            : unscored
+              ? "bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]"
+              : "bg-red-500/15 text-red-700 dark:text-red-300"
+      }`}
     >
-      <button
-        type="button"
-        className="absolute inset-0 cursor-default"
-        aria-label="Close control details"
-        onClick={onClose}
+      {controlStatusLabel(control.status)}
+    </span>
+  );
+
+  return (
+    <Drawer
+      open
+      onClose={onClose}
+      size="xl"
+      ariaLabel={`Control details for ${control.code}`}
+      eyebrow={frameworkLabel}
+      title={<span><span className="font-mono">{control.code}</span> · {name}</span>}
+      subtitle={`${control.findings} finding${control.findings === 1 ? "" : "s"} mapped to this control.`}
+      headerAside={statusPill}
+    >
+      <DetailTabs
+        tabs={[
+          { key: "overview", label: "Overview" },
+          { key: "evidence", label: "Evidence" },
+          { key: "actions", label: "Actions" },
+        ] as const}
+        value={tab}
+        onChange={setTab}
+        ariaLabel="Control detail views"
       />
-      <aside className="relative h-full w-full max-w-xl overflow-y-auto border-l border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-2xl">
-        <div className="mb-4 flex items-start justify-between gap-4 border-b border-[color:var(--border-subtle)] pb-4">
-          <div className="min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
-              {frameworkLabel}
-            </p>
-            <div className="mt-2 flex flex-wrap items-center gap-2">
-              <span className="font-mono text-sm font-semibold text-[color:var(--foreground)]">
-                {control.code}
-              </span>
-              <span
-                className={`rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
-                  control.status === "pass"
-                    ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300"
-                    : control.status === "warning"
-                      ? "bg-yellow-500/15 text-yellow-700 dark:text-yellow-300"
-                      : unscored
-                        ? "bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]"
-                        : "bg-red-500/15 text-red-700 dark:text-red-300"
-                }`}
-              >
-                {controlStatusLabel(control.status)}
-              </span>
-            </div>
-            <h2 className="mt-2 text-base font-medium leading-snug text-[color:var(--foreground)]">
-              {name}
-            </h2>
-            {unscored ? (
-              // Provenance for a control the scan couldn't grade: state WHY, and
-              // (when a missing input is implied) offer the next step. Never
-              // imply a source is connected/disconnected — "no observed signal"
-              // is an honest statement of absence.
-              <div className="mt-2" data-testid="control-unscored-provenance">
-                <p className="text-sm text-[color:var(--text-secondary)]">
-                  Not evaluated{reasonLabel ? ` — ${reasonLabel.toLowerCase()}` : ""}.
-                </p>
-                {reasonCta ? (
-                  <Link
-                    href={reasonCta.href}
-                    className="mt-2 inline-flex items-center rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-1.5 text-xs font-medium text-[color:var(--accent)] transition hover:bg-[color:var(--accent-soft-hover)]"
-                    data-testid="control-evidence-cta"
-                  >
-                    {reasonCta.label}
-                  </Link>
-                ) : null}
-              </div>
-            ) : (
-              <p className="mt-2 text-sm text-[color:var(--text-secondary)]">
-                {control.findings} finding{control.findings === 1 ? "" : "s"} mapped to this control.
+
+      {tab === "overview" ? (
+        <div>
+          {unscored ? (
+            <div className="mb-4" data-testid="control-unscored-provenance">
+              <p className="text-sm text-[color:var(--text-secondary)]">
+                Not evaluated{reasonLabel ? ` — ${reasonLabel.toLowerCase()}` : ""}.
               </p>
-            )}
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-2 text-[color:var(--text-secondary)] transition-colors hover:text-[color:var(--foreground)]"
-            aria-label="Close control drawer"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
+              {reasonCta ? (
+                <Link
+                  href={reasonCta.href}
+                  className="mt-2 inline-flex items-center rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-1.5 text-xs font-medium text-[color:var(--accent)] transition hover:bg-[color:var(--accent-soft-hover)]"
+                  data-testid="control-evidence-cta"
+                >
+                  {reasonCta.label}
+                </Link>
+              ) : null}
+            </div>
+          ) : null}
 
         {(sev.critical ?? 0) + (sev.high ?? 0) + (sev.medium ?? 0) + (sev.low ?? 0) > 0 ? (
           <div className="mb-4 grid grid-cols-2 gap-2 sm:grid-cols-4">
@@ -129,6 +113,11 @@ export function ComplianceControlDrawer({
           </div>
         ) : null}
 
+        </div>
+      ) : null}
+
+      {tab === "evidence" ? (
+        <div>
         {control.affected_packages.length > 0 ? (
           <div className="mb-4">
             <div className="mb-2 flex items-center gap-1.5 text-xs text-[color:var(--text-tertiary)]">
@@ -167,7 +156,16 @@ export function ComplianceControlDrawer({
           </div>
         ) : null}
 
-        <div className="mt-6 flex flex-wrap gap-2 border-t border-[color:var(--border-subtle)] pt-4">
+        {control.affected_packages.length === 0 && control.affected_agents.length === 0 ? (
+          <p className="text-sm text-[color:var(--text-secondary)]">
+            No affected package or agent identities were reported for this control.
+          </p>
+        ) : null}
+        </div>
+      ) : null}
+
+      {tab === "actions" ? (
+        <div className="flex flex-wrap gap-2">
           <Link
             href={findingsHref({ q: control.code })}
             className="rounded-lg border border-emerald-700/50 bg-emerald-500/10 dark:bg-emerald-950/30 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-200 transition hover:border-emerald-600"
@@ -190,7 +188,7 @@ export function ComplianceControlDrawer({
             Remediation
           </Link>
         </div>
-      </aside>
-    </div>
+      ) : null}
+    </Drawer>
   );
 }

--- a/ui/components/detail-tabs.tsx
+++ b/ui/components/detail-tabs.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+export interface DetailTab<T extends string> {
+  key: T;
+  label: string;
+  badge?: string | undefined;
+}
+
+export function DetailTabs<T extends string>({
+  tabs,
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  tabs: readonly DetailTab<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  ariaLabel: string;
+}) {
+  return (
+    <div
+      className="mb-4 flex flex-wrap gap-1 border-b border-[color:var(--border-subtle)]"
+      role="tablist"
+      aria-label={ariaLabel}
+    >
+      {tabs.map((entry) => {
+        const active = value === entry.key;
+        return (
+          <button
+            key={entry.key}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            tabIndex={active ? 0 : -1}
+            onClick={() => onChange(entry.key)}
+            className={`-mb-px border-b-2 px-3 py-2 text-sm font-medium transition-colors ${
+              active
+                ? "border-emerald-500 text-[color:var(--foreground)]"
+                : "border-transparent text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]"
+            }`}
+          >
+            {entry.label}
+            {entry.badge ? (
+              <span className="ml-1.5 rounded-full bg-[color:var(--surface-muted)] px-1.5 py-0.5 text-[10px] text-[color:var(--text-secondary)]">
+                {entry.badge}
+              </span>
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/components/finding-drawer.tsx
+++ b/ui/components/finding-drawer.tsx
@@ -9,6 +9,7 @@ import { useAuthState } from "@/components/auth-provider";
 import { buildFindingInvestigationHref } from "@/lib/finding-investigation-href";
 import { buildWhyItMatters } from "@/lib/finding-why-matters";
 import { Drawer } from "@/components/drawer";
+import { DetailTabs } from "@/components/detail-tabs";
 import {
   findingsDrawerEyebrow,
   findingsDrawerSubtitle,
@@ -75,32 +76,15 @@ export function FindingDrawer({
         </span>
       }
     >
-      <div className="mb-4 flex flex-wrap gap-1 border-b border-[color:var(--border-subtle)]" role="tablist">
-        {TABS.map((entry) => {
-          const active = tab === entry.key;
-          return (
-            <button
-              key={entry.key}
-              type="button"
-              role="tab"
-              aria-selected={active}
-              onClick={() => setTab(entry.key)}
-              className={`-mb-px border-b-2 px-3 py-2 text-sm font-medium transition-colors ${
-                active
-                  ? "border-emerald-500 text-[color:var(--foreground)]"
-                  : "border-transparent text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]"
-              }`}
-            >
-              {entry.label}
-              {entry.key === "triage" && triage ? (
-                <span className="ml-1.5 rounded-full bg-[color:var(--surface-muted)] px-1.5 py-0.5 text-[10px] text-[color:var(--text-secondary)]">
-                  {triage.queue_state}
-                </span>
-              ) : null}
-            </button>
-          );
-        })}
-      </div>
+      <DetailTabs
+        tabs={TABS.map((entry) => ({
+          ...entry,
+          ...(entry.key === "triage" && triage ? { badge: triage.queue_state } : {}),
+        }))}
+        value={tab}
+        onChange={setTab}
+        ariaLabel="Finding detail views"
+      />
 
       {tab === "overview" ? <OverviewTab vuln={vuln} triage={triage} /> : null}
       {tab === "evidence" ? <EvidenceTab vuln={vuln} /> : null}

--- a/ui/components/findings-queue.tsx
+++ b/ui/components/findings-queue.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronDown, ChevronRight, ChevronUp, ExternalLink } from "lucide-react";
-import { useLayoutEffect, useState } from "react";
+import { Fragment, useLayoutEffect, useState } from "react";
 
 import { useAuthState } from "@/components/auth-provider";
 import { severityColor, severityDot, type FindingTriageItem } from "@/lib/api";
@@ -135,6 +135,15 @@ export function FindingsQueueTable({
   const { hasCapability } = useAuthState();
   const canManageExceptions = hasCapability("exceptions.manage");
   const compactLayout = useCompactFindingsLayout();
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  const toggleOccurrences = (rowKey: string) => {
+    setExpandedGroups((current) => {
+      const next = new Set(current);
+      if (next.has(rowKey)) next.delete(rowKey);
+      else next.add(rowKey);
+      return next;
+    });
+  };
   const emptyLabel =
     lens === "trust"
       ? "No findings match the selected compliance query."
@@ -157,6 +166,8 @@ export function FindingsQueueTable({
               onSelect={() => onSelect(rowKey)}
               onMarkFP={() => onMarkFP(vuln.id, vuln.packages[0] ?? "")}
               canMarkFalsePositive={canManageExceptions}
+              occurrencesExpanded={expandedGroups.has(rowKey)}
+              onToggleOccurrences={() => toggleOccurrences(rowKey)}
             />
           );
         })}
@@ -198,33 +209,48 @@ export function FindingsQueueTable({
             const rowKey = vulnRowKey(v);
             const isSelected = selectedId === rowKey || selectedId === v.id;
             const triage = triageForFinding(v, triageByKey);
+            const occurrencesExpanded = expandedGroups.has(rowKey);
             return (
-              <tr
-                key={rowKey}
-                className={`cursor-pointer transition-colors ${isSelected ? "bg-[var(--surface)]/90 ring-1 ring-inset ring-emerald-900/60" : "hover:bg-[var(--surface)]"}`}
-                onClick={() => onSelect(rowKey)}
-              >
-                <FindingIdentity vuln={v} rowKey={rowKey} onSelect={onSelect} />
-                {lens === "trust" ? (
-                  <ComplianceCells vuln={v} triage={triage} onSelect={() => onSelect(rowKey)} />
-                ) : (
-                  <>
-                    <td className="px-4 py-3">
-                    <span className={`text-xs font-medium px-2 py-0.5 rounded border ${severityColor(v.severity)}`}>
-                      {v.severity}
-                    </span>
+              <Fragment key={rowKey}>
+                <tr
+                  className={`cursor-pointer transition-colors ${isSelected ? "bg-[var(--surface)]/90 ring-1 ring-inset ring-emerald-900/60" : "hover:bg-[var(--surface)]"}`}
+                  onClick={() => onSelect(rowKey)}
+                >
+                  <FindingIdentity
+                    vuln={v}
+                    rowKey={rowKey}
+                    onSelect={onSelect}
+                    occurrencesExpanded={occurrencesExpanded}
+                    onToggleOccurrences={() => toggleOccurrences(rowKey)}
+                  />
+                  {lens === "trust" ? (
+                    <ComplianceCells vuln={v} triage={triage} onSelect={() => onSelect(rowKey)} />
+                  ) : (
+                    <>
+                      <td className="px-4 py-3">
+                      <span className={`text-xs font-medium px-2 py-0.5 rounded border ${severityColor(v.severity)}`}>
+                        {v.severity}
+                      </span>
+                      </td>
+                      <EngineeringCells
+                        vuln={v}
+                        triage={triage}
+                        suppressed={suppressed.has(v.id)}
+                        onSelect={() => onSelect(rowKey)}
+                        onMarkFP={() => onMarkFP(v.id, v.packages[0] ?? "")}
+                        canMarkFalsePositive={canManageExceptions}
+                      />
+                    </>
+                  )}
+                </tr>
+                {occurrencesExpanded ? (
+                  <tr className="bg-[var(--surface)]/45">
+                    <td colSpan={lens === "trust" ? 6 : 8} className="px-10 py-3">
+                      <OccurrenceList vuln={v} />
                     </td>
-                    <EngineeringCells
-                      vuln={v}
-                      triage={triage}
-                      suppressed={suppressed.has(v.id)}
-                      onSelect={() => onSelect(rowKey)}
-                      onMarkFP={() => onMarkFP(v.id, v.packages[0] ?? "")}
-                      canMarkFalsePositive={canManageExceptions}
-                    />
-                  </>
-                )}
-              </tr>
+                  </tr>
+                ) : null}
+              </Fragment>
             );
           })}
         </tbody>
@@ -265,6 +291,8 @@ function MobileFindingCard({
   onSelect,
   onMarkFP,
   canMarkFalsePositive,
+  occurrencesExpanded,
+  onToggleOccurrences,
 }: {
   vuln: EnrichedVuln;
   lens: FindingsLens;
@@ -274,6 +302,8 @@ function MobileFindingCard({
   onSelect: () => void;
   onMarkFP: () => void;
   canMarkFalsePositive: boolean;
+  occurrencesExpanded: boolean;
+  onToggleOccurrences: () => void;
 }) {
   const controls = controlLabels(vuln);
   const evidenceSources = vuln.sources.filter((source) => source !== "finding");
@@ -313,6 +343,12 @@ function MobileFindingCard({
           {vuln.severity}
         </span>
       </button>
+
+      <OccurrenceDisclosure
+        vuln={vuln}
+        expanded={occurrencesExpanded}
+        onToggle={onToggleOccurrences}
+      />
 
       {lens === "trust" ? (
         <dl className="mt-3 grid min-w-0 grid-cols-2 gap-x-3 gap-y-2 text-xs">
@@ -406,10 +442,14 @@ function FindingIdentity({
   vuln,
   rowKey,
   onSelect,
+  occurrencesExpanded,
+  onToggleOccurrences,
 }: {
   vuln: EnrichedVuln;
   rowKey: string;
   onSelect: (vulnId: string | null) => void;
+  occurrencesExpanded: boolean;
+  onToggleOccurrences: () => void;
 }) {
   const secondary = findingSecondaryText(vuln);
   return (
@@ -457,9 +497,84 @@ function FindingIdentity({
               {secondary}
             </p>
           ) : null}
+          <OccurrenceDisclosure
+            vuln={vuln}
+            expanded={occurrencesExpanded}
+            onToggle={onToggleOccurrences}
+            showDetails={false}
+          />
         </div>
       </div>
     </td>
+  );
+}
+
+function OccurrenceDisclosure({
+  vuln,
+  expanded,
+  onToggle,
+  showDetails = true,
+}: {
+  vuln: EnrichedVuln;
+  expanded: boolean;
+  onToggle: () => void;
+  showDetails?: boolean;
+}) {
+  const count = vuln.occurrence_count ?? 1;
+  if (count <= 1) return null;
+  const label = `${expanded ? "Hide" : "Show"} ${count} affected asset occurrences`;
+  return (
+    <div className="mt-2">
+      <button
+        type="button"
+        aria-label={label}
+        aria-expanded={expanded}
+        onClick={(event) => {
+          event.stopPropagation();
+          onToggle();
+        }}
+        className="inline-flex items-center gap-1 rounded border border-[var(--border-subtle)] px-2 py-1 text-[11px] font-medium text-[var(--text-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
+      >
+        {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        {count} occurrences
+      </button>
+      {expanded && showDetails ? <OccurrenceList vuln={vuln} /> : null}
+    </div>
+  );
+}
+
+function OccurrenceList({ vuln }: { vuln: EnrichedVuln }) {
+  const visible = (vuln.occurrences ?? []).slice(0, 8);
+  const remaining = Math.max(0, (vuln.occurrence_count ?? visible.length) - visible.length);
+  return (
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--background)] p-3">
+      <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
+        Asset-scoped occurrences
+      </p>
+      <ul className="grid gap-2 text-[11px] text-[var(--text-secondary)] sm:grid-cols-2 xl:grid-cols-4">
+        {visible.map((occurrence, index) => {
+          const asset = occurrence.asset;
+          const key = occurrence.finding_id ?? occurrence.occurrence_id ?? asset?.stable_id ?? String(index);
+          return (
+            <li key={key} className="min-w-0 rounded border border-[var(--border-subtle)] bg-[var(--surface)] px-2.5 py-2">
+              <span className="block truncate font-mono text-[var(--foreground)]" title={asset?.name || asset?.stable_id || undefined}>
+                {asset?.name || asset?.stable_id || "Asset unavailable"}
+              </span>
+              <span className="mt-0.5 block truncate text-[var(--text-tertiary)]">
+                {[asset?.asset_type, occurrence.package_version, occurrence.owner]
+                  .filter((value): value is string => Boolean(value))
+                  .join(" · ") || "Evidence retained"}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+      {remaining > 0 || vuln.occurrences_truncated ? (
+        <p className="mt-2 text-[11px] text-[var(--text-tertiary)]">
+          {remaining > 0 ? `${remaining} more occurrences retained.` : "Additional occurrences are retained."} Narrow the query to inspect a specific asset.
+        </p>
+      ) : null}
+    </div>
   );
 }
 

--- a/ui/components/overview-cockpit.tsx
+++ b/ui/components/overview-cockpit.tsx
@@ -176,6 +176,12 @@ export interface OverviewCockpitProps {
   /** Called when the user picks a display format; parent persists it (#3940). */
   onScoreFormatChange?: ((format: PostureScoreFormat) => void) | undefined;
   postureSummary?: string | undefined;
+  postureTrend?: {
+    direction: "improved" | "worsened" | "unchanged";
+    delta: number;
+    previousScore: number;
+    points: number;
+  } | null | undefined;
   critical: number;
   high: number;
   kev: number | null;
@@ -215,6 +221,7 @@ export function OverviewCockpit({
   scoreBreakdown = null,
   onScoreFormatChange,
   postureSummary,
+  postureTrend = null,
   critical,
   high,
   kev,
@@ -275,6 +282,7 @@ export function OverviewCockpit({
               scoreFormat={scoreFormat}
               onScoreFormatChange={onScoreFormatChange}
               summary={postureSummary}
+              trend={postureTrend}
               critical={critical}
               high={high}
               cves={cves}
@@ -1144,6 +1152,7 @@ function PostureHero({
   scoreFormat = "percent",
   onScoreFormatChange,
   summary,
+  trend,
   critical,
   high,
   cves,
@@ -1154,6 +1163,7 @@ function PostureHero({
   scoreFormat?: PostureScoreFormat | undefined;
   onScoreFormatChange?: ((format: PostureScoreFormat) => void) | undefined;
   summary?: string | undefined;
+  trend?: OverviewCockpitProps["postureTrend"];
   critical: number;
   high: number;
   cves: number | null;
@@ -1217,9 +1227,21 @@ function PostureHero({
           )}
         </p>
         {graded ? (
-          <p className="mt-1 text-[10px] text-[color:var(--text-tertiary)]">
-            Current evidence snapshot · ranked exposure paths below show what to fix first
-          </p>
+          trend && trend.points >= 2 ? (
+            <p
+              className="mt-1 text-[10px] text-[color:var(--text-tertiary)]"
+              data-testid="overview-posture-trend"
+              title={`Previous posture score: ${Math.round(trend.previousScore)}%`}
+            >
+              {trend.direction === "unchanged"
+                ? "Unchanged since the previous scan"
+                : `${trend.direction === "improved" ? "Improved" : "Worsened"} ${Math.abs(Math.round(trend.delta))} points since the previous scan`}
+            </p>
+          ) : (
+            <p className="mt-1 text-[10px] text-[color:var(--text-tertiary)]">
+              Current evidence snapshot · ranked exposure paths below show what to fix first
+            </p>
+          )
         ) : null}
         <p className="mt-0.5 line-clamp-2 text-xs text-[color:var(--text-secondary)]">{blurb}</p>
       </div>

--- a/ui/e2e/overview-findings-reconciliation.spec.ts
+++ b/ui/e2e/overview-findings-reconciliation.spec.ts
@@ -4,11 +4,11 @@ import { expect, test, type Page, type TestInfo } from "@playwright/test";
 
 const COUNTS = {
   critical: 7,
-  high: 26,
+  high: 28,
   medium: 13,
   low: 17,
   unrated: 19,
-  total: 82,
+  total: 84,
   kev: 5,
   compound_issues: 3,
   deployment_mode: "fleet",
@@ -35,29 +35,29 @@ const OVERVIEW = {
     summary: "Current estate needs prioritized remediation.",
     breakdown: [
       { driver: "critical", label: "Critical findings", count: 7, weight: 12, contribution: 84 },
-      { driver: "high", label: "High findings", count: 26, weight: 6, contribution: 156 },
+      { driver: "high", label: "High findings", count: 28, weight: 6, contribution: 168 },
     ],
   },
   headline: {
     critical: 7,
-    high: 26,
-    critical_high: 33,
+    high: 28,
+    critical_high: 35,
     kev: 5,
     credential_exposed: 4,
     scans: 14,
     latest_scan_at: "2026-07-17T16:30:00Z",
-    hub_findings: 82,
+    hub_findings: 84,
   },
   coverage: [
     { domain: "cspm", label: "CSPM", href: "/findings?scope=all&domain=cspm", count: 22, severity: { critical: 2, high: 9, medium: 7, low: 3, unrated: 1 } },
-    { domain: "vuln", label: "Vuln mgmt", href: "/findings?scope=all&domain=vuln", count: 33, severity: { critical: 5, high: 15, medium: 7, low: 4, unrated: 2 } },
+    { domain: "vuln", label: "Vuln mgmt", href: "/findings?scope=all&domain=vuln", count: 35, severity: { critical: 5, high: 17, medium: 7, low: 4, unrated: 2 } },
     { domain: "aspm", label: "ASPM", href: "/findings?scope=all&domain=aspm", count: 12, severity: { critical: 0, high: 2, medium: 5, low: 3, unrated: 2 } },
     { domain: "dspm", label: "DSPM", href: "/findings?scope=all&domain=dspm", count: 9, severity: { critical: 1, high: 2, medium: 2, low: 1, unrated: 3 } },
     { domain: "aispm", label: "AISPM", href: "/findings?scope=all&domain=aispm", count: 6, severity: { critical: 0, high: 1, medium: 2, low: 1, unrated: 2 } },
   ],
   domains: {
     cloud: domain("Cloud posture", 4, "accounts connected", "/connections"),
-    vuln: domain("Vuln / SCA", 33, "open CVEs", "/findings?scope=all&issue=vulnerability"),
+    vuln: domain("Vuln / SCA", 35, "open CVEs", "/findings?scope=all&issue=vulnerability"),
     code: domain("Code / repo", 12, "repo scans", "/scan"),
     runtime: domain("Runtime", 3, "active surfaces", "/runtime"),
     cost: domain("LLM Cost", 1824, "USD tracked", "/cost"),
@@ -94,6 +94,7 @@ function staleScan(index: number) {
 }
 
 function finding(index: number) {
+  const occurrenceCount = index === 0 ? 3 : 1;
   return {
     id: `finding-${index}`,
     cve_id: `CVE-2026-${String(8000 + index)}`,
@@ -104,6 +105,16 @@ function finding(index: number) {
     package: { name: `runtime-lib-${index}`, version: "1.0.0" },
     effective_reach_score: 8.2,
     last_seen: "2026-07-17T16:00:00Z",
+    occurrence_count: occurrenceCount,
+    occurrences: Array.from({ length: occurrenceCount }, (_, occurrenceIndex) => ({
+      finding_id: `finding-${index}-occurrence-${occurrenceIndex}`,
+      asset: {
+        name: `prod-workload-${index}-${occurrenceIndex}`,
+        stable_id: `workload:prod-workload-${index}-${occurrenceIndex}`,
+        asset_type: "workload",
+      },
+      package_version: "1.0.0",
+    })),
   };
 }
 
@@ -189,7 +200,7 @@ for (const theme of ["light", "dark"] as const) {
     await page.goto("/");
     await expect(page.getByText("Current findings · configured window")).toBeVisible();
     const critical = page.getByRole("link", { name: /^Critical 7/i });
-    const high = page.getByRole("link", { name: /^High 26/i });
+    const high = page.getByRole("link", { name: /^High 28/i });
     await expect(critical).toHaveAttribute("href", "/findings?scope=all&severity=critical");
     await expect(high).toHaveAttribute("href", "/findings?scope=all&severity=high");
     await expect(page.getByRole("link", { name: /^Critical 10/i })).toHaveCount(0);
@@ -200,8 +211,12 @@ for (const theme of ["light", "dark"] as const) {
     await expect.poll(() => new URL(page.url()).searchParams.get("scope")).toBe("all");
     await expect.poll(() => new URL(page.url()).searchParams.get("severity")).toBe("high");
     await expect(page.getByText("Current state · Last 90 days")).toBeVisible();
-    await expect(page.getByText(/26 findings/).first()).toBeVisible();
-    await expect(page.getByText("Page 1 of 2 (26 findings)")).toBeVisible();
+    await expect(page.getByText(/26 issues/).first()).toBeVisible();
+    await expect(page.getByText("Page 1 of 2 (26 issues)")).toBeVisible();
+    const occurrences = page.getByRole("button", { name: "Show 3 affected asset occurrences" });
+    await expect(occurrences).toBeVisible();
+    await occurrences.click();
+    await expect(page.getByText("Asset-scoped occurrences")).toBeVisible();
     await page.getByRole("button", { name: /Next/i }).click();
     await expect(page.getByText("Page 2 · total unavailable")).toBeVisible();
     await expect(page.getByRole("button", { name: /Next/i })).toBeDisabled();
@@ -219,7 +234,7 @@ test("overview and current-state findings remain readable without mobile overflo
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true);
   await capture(page, testInfo, "overview-reconciled-mobile.png");
 
-  await page.getByRole("link", { name: /^High 26/i }).click();
+  await page.getByRole("link", { name: /^High 28/i }).click();
   await expect(page.getByText("Current state · Last 90 days")).toBeVisible();
   const overflow = await page.evaluate(() => {
     const viewportWidth = document.documentElement.clientWidth;

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1042,8 +1042,33 @@ export interface Vulnerability {
   match_confidence_tier?: string | undefined;
 }
 
+export interface FindingOccurrenceSummary {
+  finding_id?: string | undefined;
+  occurrence_id?: string | undefined;
+  canonical_id?: string | undefined;
+  asset?: {
+    name?: string | undefined;
+    asset_type?: string | undefined;
+    stable_id?: string | undefined;
+  } | undefined;
+  severity?: string | undefined;
+  package_version?: string | null | undefined;
+  scan_id?: string | undefined;
+  status?: string | undefined;
+  owner?: string | null | undefined;
+  sla_due_at?: string | null | undefined;
+  last_seen?: string | null | undefined;
+  last_observed?: string | null | undefined;
+  graph_reachable?: boolean | null | undefined;
+  graph_min_hop_distance?: number | null | undefined;
+}
+
 export interface UnifiedFinding {
   id: string;
+  finding_id?: string | undefined;
+  occurrence_id?: string | undefined;
+  finding_group_id?: string | undefined;
+  finding_group_key?: string | undefined;
   finding_class: "vulnerability" | "misconfiguration" | "secret" | "identity" | "unclassified";
   canonical_id?: string | undefined;
   finding_type?: string | undefined;
@@ -1120,6 +1145,8 @@ export interface UnifiedFinding {
   scan_count?: number | undefined;
   last_observed?: string | null | undefined;
   occurrence_count?: number | null | undefined;
+  occurrences?: FindingOccurrenceSummary[] | undefined;
+  occurrences_truncated?: boolean | undefined;
   remediation_versions?: string[] | null | undefined;
   provenance?: Record<string, unknown> | string | null | undefined;
   owner?: string | null | undefined;
@@ -1150,6 +1177,13 @@ export interface FindingListEnvelope<T> {
   next_cursor: string;
   has_more: boolean;
   warnings: string[];
+  grouping?: {
+    status: "complete" | "partial";
+    scanned_occurrences: number;
+    scan_budget: number;
+    occurrence_total: number | null;
+    occurrence_sample_limit: number;
+  } | undefined;
   count_metadata: {
     definition: string;
     source: string;
@@ -2790,6 +2824,23 @@ export interface PostureResponse {
     string,
     { score: number; label: string; details?: string }
   >;
+}
+
+export interface TrendPointResponse {
+  scan_id?: string | null;
+  timestamp: string;
+  total_vulns: number;
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  posture_score: number;
+  posture_grade: string;
+}
+
+export interface TrendsResponse {
+  data_points: TrendPointResponse[];
+  count: number;
 }
 
 // ─── Cross-domain overview (landing page) ────────────────────────────────────

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -37,6 +37,7 @@ import type {
   GraphExportFormat,
   AgentBomManifestResponse,
   PostureCountsResponse,
+  TrendsResponse,
   OverviewResponse,
   AccountSummaryResponse,
   ScoreConfigRuntime,
@@ -345,6 +346,7 @@ export type {
   FirewallDecisionRecord,
   EvaluateResult,
   PostureResponse,
+  TrendsResponse,
   EnrichmentSourcePosture,
   EnrichmentPostureResponse,
   GovernanceFinding,
@@ -1289,6 +1291,9 @@ export const api = {
   /** Full posture grade + dimensions */
   getPosture: () => get<PostureResponse>("/v1/posture"),
 
+  /** Idempotent scan-backed posture history, newest point first. */
+  getTrends: (limit = 30) => get<TrendsResponse>(`/v1/trends?limit=${encodeURIComponent(String(limit))}`),
+
   /** Cross-domain posture snapshot for the unified overview landing page */
   getOverview: () => get<OverviewResponse>("/v1/overview"),
 
@@ -1544,6 +1549,7 @@ export const api = {
     offset?: number;
     cursor?: string;
     approximateTotal?: boolean;
+    groupOccurrences?: boolean;
     // First-class scope + taxonomy filters (issue #3946). All optional +
     // backward compatible; the server canonicalizes and never rejects them.
     provider?: string;
@@ -1575,6 +1581,7 @@ export const api = {
     if (filters?.offset != null) params.set("offset", String(filters.offset));
     if (filters?.cursor) params.set("cursor", filters.cursor);
     if (filters?.approximateTotal) params.set("approximate_total", "true");
+    if (filters?.groupOccurrences) params.set("group_occurrences", "true");
     if (filters?.provider) params.set("provider", filters.provider);
     if (filters?.account) params.set("account", filters.account);
     if (filters?.environment) params.set("environment", filters.environment);

--- a/ui/lib/findings-view.ts
+++ b/ui/lib/findings-view.ts
@@ -1,5 +1,5 @@
 import type { Vulnerability } from "@/lib/api";
-import type { WorkloadRuntimeEvidence } from "@/lib/api-types";
+import type { FindingOccurrenceSummary, WorkloadRuntimeEvidence } from "@/lib/api-types";
 
 export interface EnrichedVuln extends Vulnerability {
   /**
@@ -10,6 +10,8 @@ export interface EnrichedVuln extends Vulnerability {
    * merge one row per CVE.
    */
   finding_id?: string | undefined;
+  finding_group_id?: string | undefined;
+  finding_group_key?: string | undefined;
   /** Estate UnifiedNode id (graph FK) when the API stamped the finding. */
   node_id?: string | undefined;
   finding_node_id?: string | undefined;
@@ -53,6 +55,8 @@ export interface EnrichedVuln extends Vulnerability {
   /** Canonical timestamp of the most recent observation, when available. */
   last_observed?: string | undefined;
   occurrence_count?: number | undefined;
+  occurrences?: FindingOccurrenceSummary[] | undefined;
+  occurrences_truncated?: boolean | undefined;
   remediation_versions?: string[] | undefined;
   provenance?: Record<string, unknown> | string | undefined;
   owner?: string | undefined;

--- a/ui/tests/compliance-page.test.tsx
+++ b/ui/tests/compliance-page.test.tsx
@@ -221,10 +221,26 @@ describe("CompliancePage (dense restyle)", () => {
     const injection = await screen.findByText("Prompt Injection");
     fireEvent.click(injection);
 
-    await waitFor(() =>
-      expect(
-        screen.getByRole("dialog", { name: /Control details for LLM01/i }),
-      ).toBeInTheDocument(),
+    const drawer = await screen.findByRole("dialog", {
+      name: /Control details for LLM01/i,
+    });
+    const tabs = within(drawer).getByRole("tablist", {
+      name: "Control detail views",
+    });
+    expect(within(tabs).getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "Overview",
+      "Evidence",
+      "Actions",
+    ]);
+    expect(within(tabs).getByRole("tab", { name: "Overview" })).toHaveAttribute(
+      "aria-selected",
+      "true",
     );
+
+    fireEvent.click(within(tabs).getByRole("tab", { name: "Evidence" }));
+    expect(within(drawer).getByText(/no affected package or agent identities/i)).toBeInTheDocument();
+
+    fireEvent.click(within(tabs).getByRole("tab", { name: "Actions" }));
+    expect(within(drawer).getByRole("link", { name: "View findings" })).toBeInTheDocument();
   });
 });

--- a/ui/tests/findings-page.test.tsx
+++ b/ui/tests/findings-page.test.tsx
@@ -126,6 +126,51 @@ describe("FindingsPage", () => {
     expect(await screen.findByText("CVE-2026-1234")).toBeInTheDocument();
   });
 
+  it("uses the server-backed issue view and expands preserved asset occurrences", async () => {
+    apiMock.listFindings.mockResolvedValue({
+      schema_version: "v1",
+      findings: [
+        {
+          ...canonicalFinding,
+          finding_group_id: "group-1",
+          occurrence_count: 2,
+          occurrences_truncated: false,
+          occurrences: [
+            {
+              finding_id: "finding-api",
+              asset: { name: "api-image", asset_type: "package", stable_id: "asset-api" },
+              severity: "critical",
+            },
+            {
+              finding_id: "finding-worker",
+              asset: { name: "worker-image", asset_type: "package", stable_id: "asset-worker" },
+              severity: "high",
+            },
+          ],
+        },
+      ],
+      total: 1,
+      has_more: false,
+      next_cursor: "",
+    });
+
+    render(<FindingsPage />);
+
+    await waitFor(() =>
+      expect(apiMock.listFindings).toHaveBeenCalledWith(
+        expect.objectContaining({ groupOccurrences: true }),
+      ),
+    );
+    expect(await screen.findByText(/1 issues · current state/)).toBeInTheDocument();
+    const expander = await screen.findByRole("button", { name: "Show 2 affected asset occurrences" });
+    expect(screen.queryByText("api-image")).not.toBeInTheDocument();
+
+    fireEvent.click(expander);
+
+    expect(await screen.findByText("api-image")).toBeInTheDocument();
+    expect(screen.getByText("worker-image")).toBeInTheDocument();
+  });
+
   it("keeps findings as a compact queue and opens evidence in a drawer", async () => {
     render(<FindingsPage />);
 

--- a/ui/tests/overview-cockpit.test.tsx
+++ b/ui/tests/overview-cockpit.test.tsx
@@ -75,6 +75,19 @@ describe("OverviewCockpit", () => {
     expect(screen.getByText(/Why #1:/i)).toHaveTextContent(/critical path reaches an agent/i);
   });
 
+  it("renders a scan-backed posture change when trend history exists", () => {
+    render(
+      <OverviewCockpit
+        {...baseProps}
+        postureTrend={{ direction: "improved", delta: 8, previousScore: 29, points: 2 }}
+      />,
+    );
+
+    expect(screen.getByTestId("overview-posture-trend")).toHaveTextContent(
+      "Improved 8 points since the previous scan",
+    );
+  });
+
   it("consolidates security coverage and estate operations into one compact section", async () => {
     const user = userEvent.setup();
     render(<OverviewCockpit {...baseProps} domains={sampleDomains} />);

--- a/ui/tests/overview-page-reconciliation.test.tsx
+++ b/ui/tests/overview-page-reconciliation.test.tsx
@@ -7,6 +7,7 @@ const { apiMock, deploymentCounts } = vi.hoisted(() => ({
   apiMock: {
     getPosture: vi.fn(),
     getOverview: vi.fn(),
+    getTrends: vi.fn(),
     getCompliance: vi.fn(),
     listJobs: vi.fn(),
     listAgents: vi.fn(),
@@ -104,6 +105,7 @@ describe("Overview canonical finding counts", () => {
     vi.clearAllMocks();
     apiMock.getPosture.mockResolvedValue({ grade: "D", score: 49 });
     apiMock.getOverview.mockResolvedValue(overviewFixture());
+    apiMock.getTrends.mockResolvedValue({ tenant_id: "tenant-ui", count: 0, points: [] });
     apiMock.getCompliance.mockRejectedValue(new Error("not configured"));
     apiMock.listAgents.mockResolvedValue({ count: 4, agents: [] });
     apiMock.updateScoreConfig.mockResolvedValue({});


### PR DESCRIPTION
## Summary

- preserve asset-scoped finding IDs while exposing a server-backed, expandable issue queue with issue-level facets and reusable evidence tabs
- record idempotent posture trend points across memory, SQLite, Postgres, and Supabase paths, then surface the previous-scan delta in the overview
- connect only explicit credential-to-managed-identity bindings and require adaptive AWS retries plus matching CloudWatch alarms for CIS monitoring evidence

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q <affected API, graph, persistence, and AWS CIS suites>` (717 passed)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check <changed Python files>`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy <11 changed source files>`
- `PATH=<bundled-node-24> npm run verify:toolchain && npm test -- --run && npm run lint && npm run typecheck && npm run build` (194 files, 1,209 tests, 52 routes)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight`
- changed-file pre-commit hooks and `git diff --check`
- loopback demo API + dashboard browser QA in light and dark themes; 3,469 occurrences grouped into 1,933 issues with reconciled severity facets and expandable asset evidence

## Notes

- raw `GET /v1/findings` remains the authoritative occurrence/workflow surface; grouping is opt-in and bounded to 50,000 occurrence rows with explicit partial metadata
- credential-to-identity graph edges are emitted only from declared bindings; no name- or environment-based identity inference was added
- trend persistence is best effort and sanitized so observability storage cannot fail a completed scan
