### PR TITLE
fix(graph): unify investigation lenses

### DIFF
--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -4,8 +4,8 @@ import { Suspense, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Loader2 } from "lucide-react";
 
-// The Context lens now lives on the unified `/graph` surface, selected with
-// `?lens=context` (graph-unification epic, workstream 4). This route stays only
+// The Context lens lives on the canonical `/security-graph` investigation
+// surface, selected with `?lens=context`. This route stays only
 // as a client-side redirect so old `/context` deep links keep resolving instead
 // of 404-ing — required because static export (`output: export`) has no server
 // to run next.config `redirects()`. Any incoming query params (scan, agent, …)
@@ -16,7 +16,7 @@ function ContextRedirect() {
   useEffect(() => {
     const params = new URLSearchParams(searchParams?.toString() ?? "");
     params.set("lens", "context");
-    router.replace(`/graph?${params.toString()}`);
+    router.replace(`/security-graph?${params.toString()}`);
   }, [router, searchParams]);
   return (
     <div className="flex min-h-[40vh] items-center justify-center">

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -859,6 +859,11 @@ function GraphPageInner() {
     const preference = parseGraphRollupUrlPreference(searchParams);
     rollupPreferenceRef.current = preference;
     setRollupDismissed(rollupDismissedForPreference(preference));
+    const requestedScanId =
+      searchParams.get("scan") || searchParams.get("scan_id") || "";
+    if (requestedScanId) {
+      requestedScanIdRef.current = requestedScanId;
+    }
   }, [searchParams]);
   const firstScanSelectionRef = useRef(true);
   // Last URL the filter→URL sync effect wrote, used to break an infinite
@@ -1353,7 +1358,24 @@ function GraphPageInner() {
     // no-op guard below so we never re-sync an unchanged URL.
     const currentSearch = new URLSearchParams(window.location.search);
     const nextParams = encodeFiltersToParams(filters);
-    if (selectedScanId) nextParams.set("scan", selectedScanId);
+    // Client-side lens navigation can mount this surface before the snapshot
+    // request resolves. Preserve the destination scan until the canonical
+    // selection is available, otherwise the first URL sync silently widens a
+    // pinned investigation to the newest snapshot.
+    const requestedScanId =
+      currentSearch.get("scan") ||
+      currentSearch.get("scan_id") ||
+      searchParams.get("scan") ||
+      searchParams.get("scan_id") ||
+      requestedScanIdRef.current;
+    const shareableScanId =
+      selectedScanId || (loadingSnapshots ? requestedScanId : "");
+    if (shareableScanId) nextParams.set("scan", shareableScanId);
+    // `lens` is composition state rather than a graph filter, so the filter
+    // encoder intentionally does not own it. Keep it while syncing the rest
+    // of the shareable view state.
+    const lens = currentSearch.get("lens") || searchParams.get("lens");
+    if (lens) nextParams.set("lens", lens);
     if (captureMode) {
       nextParams.set("capture", "1");
     }
@@ -1414,11 +1436,13 @@ function GraphPageInner() {
     captureMode,
     filters,
     investigationMode,
+    loadingSnapshots,
     pathname,
     rollupDismissed,
     rollupNavigationActive,
     rollupStack,
     router,
+    searchParams,
     selectedScanId,
   ]);
 

--- a/ui/app/graph/graph-surface.tsx
+++ b/ui/app/graph/graph-surface.tsx
@@ -6,8 +6,8 @@ import { useSearchParams } from "next/navigation";
 import { GraphPanelSkeleton } from "@/components/graph-state-panels";
 import GraphPageClient from "./graph-page-client";
 
-// One graph surface, three lenses selected by the `?lens=` param (graph
-// unification epic, workstream 4). Lineage (default) and Asset Drift
+// One graph surface, several lenses selected by URL params. Lineage (default)
+// and Asset Drift
 // (`?scope=asset-drift`) render the full unified-graph client; the Agent Mesh
 // and Context lenses render their own bespoke pipelines — each a distinct data
 // source (raw scan mesh / context-graph API) with distinct panels — so they are
@@ -15,9 +15,9 @@ import GraphPageClient from "./graph-page-client";
 //
 // The lens views are lazily loaded (ssr:false) so the default lineage bundle
 // never pays for the mesh/context pipelines and they never run during static
-// prerender. Switching lenses on `/graph` swaps which component mounts, giving
-// each lens a fresh mount (its URL-seeded state re-initialises) exactly as a
-// route change used to.
+// prerender. The canonical `/security-graph` investigation route composes this
+// surface for non-attack-path lenses; `/graph` remains a compatible direct
+// entry point for existing deep links.
 const MeshLensView = dynamic(
   () => import("@/components/mesh-lens-view").then((mod) => mod.MeshLensView),
   {

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -4,8 +4,8 @@ import { Suspense, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Loader2 } from "lucide-react";
 
-// The Agent Mesh lens now lives on the unified `/graph` surface, selected with
-// `?lens=mesh` (graph-unification epic, workstream 4). This route stays only as
+// The Agent Mesh lens lives on the canonical `/security-graph` investigation
+// surface, selected with `?lens=mesh`. This route stays only as
 // a client-side redirect so old `/mesh` deep links keep resolving instead of
 // 404-ing — required because static export (`output: export`) has no server to
 // run next.config `redirects()`. Any incoming query params (scan, agent, cve,
@@ -16,7 +16,7 @@ function MeshRedirect() {
   useEffect(() => {
     const params = new URLSearchParams(searchParams?.toString() ?? "");
     params.set("lens", "mesh");
-    router.replace(`/graph?${params.toString()}`);
+    router.replace(`/security-graph?${params.toString()}`);
   }, [router, searchParams]);
   return (
     <div className="flex min-h-[40vh] items-center justify-center">

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -72,6 +72,7 @@ import {
   toExposurePathFromAttackPath,
 } from "@/lib/attack-paths";
 import { SecurityGraphInvestigation } from "@/components/security-graph-investigation";
+import { GraphSurface } from "@/app/graph/graph-surface";
 import type { UnifiedGraphData } from "@/lib/graph-schema";
 import { tonedChipClass } from "@/lib/toned-chip";
 import { investigationEstateMode } from "@/lib/investigation-estate-mode";
@@ -94,7 +95,7 @@ const ATTACK_PATH_QUEUE_PAGE_SIZE = 12;
 const FIX_FIRST_CARD_LIMIT = 12;
 const DEFAULT_SNAPSHOT_CHIP_COUNT = 3;
 
-function SecurityGraphPageContent() {
+function AttackPathInvestigationContent() {
   const captureMode = useCaptureMode();
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -478,7 +479,8 @@ function SecurityGraphPageContent() {
     if (selectedScanId) params.set("scan", selectedScanId);
     if (focus.agentName) params.set("agent", focus.agentName);
     const query = params.toString();
-    return query ? `/graph?${query}` : "/graph";
+    if (query) params.set("lens", "lineage");
+    return params.size > 0 ? `/security-graph?${params.toString()}` : "/security-graph?lens=lineage";
   }, [focus.agentName, investigationRoot, selectedScanId]);
   const resetFocusHref = useMemo(
     () => buildSecurityGraphHref({ scanId: selectedScanId || undefined }),
@@ -1044,6 +1046,12 @@ function SecurityGraphPageContent() {
       </Collapsible>
     </div>
   );
+}
+
+function SecurityGraphPageContent() {
+  const lens = useSearchParams()?.get("lens");
+  if (lens && lens !== "attack-path") return <GraphSurface />;
+  return <AttackPathInvestigationContent />;
 }
 
 export default function SecurityGraphPage() {

--- a/ui/components/graph-lens-switcher.tsx
+++ b/ui/components/graph-lens-switcher.tsx
@@ -6,11 +6,9 @@ import { GraphLegendDock } from "@/components/graph-chrome";
 import { ASSET_DRIFT_GRAPH_SCOPE_PARAM } from "@/components/lineage-filter";
 import type { LegendItem } from "@/lib/graph-utils";
 
-// One security-graph surface, several lenses. Attack Paths keeps its own
-// `/security-graph` route; Lineage, Asset Drift, Agent Mesh, and Context are all
-// hosted on the single `/graph` surface and switched via URL params (`?scope=`
-// for drift, `?lens=` for mesh/context) — no separate route per lens. The nav
-// exposes one "Security Graph" entry and users switch lenses from this bar.
+// One security-graph route, several lenses. URL params switch the composed
+// surface without tearing down shared investigation context. `/graph` remains
+// a compatible direct entry point for existing links.
 interface GraphLens {
   id: string;
   label: string;
@@ -19,7 +17,8 @@ interface GraphLens {
   match: (path: string, scope: string | null, lens: string | null) => boolean;
 }
 
-const isGraphPath = (p: string) => p === "/graph" || p.startsWith("/graph/");
+const isLegacyGraphPath = (p: string) => p === "/graph" || p.startsWith("/graph/");
+const isSecurityGraphPath = (p: string) => p.startsWith("/security-graph");
 
 const GRAPH_LENSES: GraphLens[] = [
   {
@@ -27,37 +26,42 @@ const GRAPH_LENSES: GraphLens[] = [
     label: "Attack Paths",
     icon: "🎯",
     href: "/security-graph",
-    match: (p) => p.startsWith("/security-graph"),
+    match: (p, _scope, lens) => isSecurityGraphPath(p) && (!lens || lens === "attack-path"),
   },
   {
     id: "lineage",
     label: "Lineage",
     icon: "🌿",
-    href: "/graph",
+    href: "/security-graph?lens=lineage",
     match: (p, scope, lens) =>
-      isGraphPath(p) && scope !== ASSET_DRIFT_GRAPH_SCOPE_PARAM && !lens,
+      scope !== ASSET_DRIFT_GRAPH_SCOPE_PARAM &&
+      ((isSecurityGraphPath(p) && lens === "lineage") || (isLegacyGraphPath(p) && !lens)),
   },
   {
     id: "asset-drift",
     label: "Asset Drift",
     icon: "📐",
-    href: `/graph?scope=${ASSET_DRIFT_GRAPH_SCOPE_PARAM}`,
-    match: (p, scope) =>
-      isGraphPath(p) && scope === ASSET_DRIFT_GRAPH_SCOPE_PARAM,
+    href: `/security-graph?lens=asset-drift&scope=${ASSET_DRIFT_GRAPH_SCOPE_PARAM}`,
+    match: (p, scope, lens) =>
+      (isSecurityGraphPath(p) || isLegacyGraphPath(p)) &&
+      scope === ASSET_DRIFT_GRAPH_SCOPE_PARAM &&
+      (lens === "asset-drift" || !lens),
   },
   {
     id: "mesh",
     label: "Agent Mesh",
     icon: "🕸️",
-    href: "/graph?lens=mesh",
-    match: (p, _scope, lens) => isGraphPath(p) && lens === "mesh",
+    href: "/security-graph?lens=mesh",
+    match: (p, _scope, lens) =>
+      (isSecurityGraphPath(p) || isLegacyGraphPath(p)) && lens === "mesh",
   },
   {
     id: "context",
     label: "Context",
     icon: "🗺️",
-    href: "/graph?lens=context",
-    match: (p, _scope, lens) => isGraphPath(p) && lens === "context",
+    href: "/security-graph?lens=context",
+    match: (p, _scope, lens) =>
+      (isSecurityGraphPath(p) || isLegacyGraphPath(p)) && lens === "context",
   },
 ];
 

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -127,9 +127,9 @@ const NAV_GROUPS: NavGroup[] = [
       { href: "/remediation", label: "Remediation", icon: Wrench },
     ],
     secondary: [
-      { href: "/graph", label: "Lineage", icon: GitBranch },
-      { href: "/graph?lens=mesh", label: "Agent Mesh", icon: Waypoints },
-      { href: "/graph?lens=context", label: "Context", icon: Layers },
+      { href: "/security-graph?lens=lineage", label: "Lineage", icon: GitBranch },
+      { href: "/security-graph?lens=mesh", label: "Agent Mesh", icon: Waypoints },
+      { href: "/security-graph?lens=context", label: "Context", icon: Layers },
     ],
   },
   {

--- a/ui/components/security-graph-investigation.tsx
+++ b/ui/components/security-graph-investigation.tsx
@@ -19,6 +19,7 @@ import { GraphEntityDrawer } from "@/components/graph-entity-drawer";
 import { FullscreenButton, GraphInteractionToolbar, GraphLegend } from "@/components/graph-chrome";
 import { useAuthState } from "@/components/auth-provider";
 import { lineageNodeTypes, type LineageNodeData } from "@/components/lineage-nodes";
+import { SigmaGraphOverview } from "@/components/sigma-graph-overview";
 import { api } from "@/lib/api";
 import type { AttackPath, UnifiedGraphData } from "@/lib/graph-schema";
 import {
@@ -34,12 +35,14 @@ import {
   readableGraphEdges,
 } from "@/lib/graph-utils";
 import { graphFitViewOptions, shouldShowGraphMiniMap } from "@/lib/graph-viewport";
+import { decideGraphRenderer } from "@/lib/graph-renderer-switch";
 import { mergeGraphNodeDetail } from "@/lib/graph-entity-detail";
 import { buildFocusedGraphData } from "@/lib/security-graph-focus";
 import { buildUnifiedFlowGraph } from "@/lib/unified-graph-flow";
 import { useGraphLayout } from "@/lib/use-graph-layout";
 import { useGraphPresentation } from "@/hooks/use-graph-presentation";
 import { graphTopologyKey, type GraphPresentationScope } from "@/lib/graph-presentation";
+import { useCaptureMode } from "@/lib/use-capture-mode";
 
 const INVESTIGATION_LAYERS = {
   provider: false,
@@ -241,6 +244,7 @@ export function SecurityGraphInvestigation({
   /** Notify parent when expand/impact actions advance the investigation step. */
   onStepHint?: ((step: "expand" | "impact" | "fix") => void) | undefined;
 }) {
+  const captureMode = useCaptureMode();
   const { session, loading: authLoading } = useAuthState();
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [drawerData, setDrawerData] = useState<LineageNodeData | null>(null);
@@ -290,6 +294,16 @@ export function SecurityGraphInvestigation({
       mode: (focusMode ? "context" : "lineage") as "context" | "lineage",
     }),
     [displayEdges.length, focusMode, layout.nodes.length, selectedNodeId],
+  );
+  const rendererDecision = useMemo(
+    () =>
+      decideGraphRenderer({
+        nodeCount: layout.nodes.length,
+        edgeCount: displayEdges.length,
+        captureMode,
+        selectedAttackPath: focusMode,
+      }),
+    [captureMode, displayEdges.length, focusMode, layout.nodes.length],
   );
   const presentationScope = useMemo(
     () => ({
@@ -444,6 +458,14 @@ export function SecurityGraphInvestigation({
           <div className="flex h-full min-h-[40rem] items-center justify-center px-6 text-center text-sm text-[color:var(--text-secondary)]">
             No graph nodes matched this path. Run a fresh scan or clear focus to inspect the full snapshot.
           </div>
+        ) : rendererDecision.kind === "webgl" ? (
+          <SigmaGraphOverview
+            nodes={layout.nodes as Node<LineageNodeData>[]}
+            edges={displayEdges}
+            legendItems={legendItems}
+            embedded
+            onNodeSelect={setSelectedNodeId}
+          />
         ) : (
           <ReactFlowProvider>
             <InvestigationFlow
@@ -460,9 +482,11 @@ export function SecurityGraphInvestigation({
           </ReactFlowProvider>
         )}
 
-        <div className="pointer-events-auto absolute left-3 top-3 max-w-[min(24rem,calc(100vw-2rem))]">
-          <GraphLegend items={legendItems} />
-        </div>
+        {rendererDecision.kind === "react-flow" ? (
+          <div className="pointer-events-auto absolute left-3 top-3 max-w-[min(24rem,calc(100vw-2rem))]">
+            <GraphLegend items={legendItems} />
+          </div>
+        ) : null}
       </div>
 
       {drawerData && (

--- a/ui/components/sigma-graph-overview.tsx
+++ b/ui/components/sigma-graph-overview.tsx
@@ -28,6 +28,7 @@ import {
 
 type SigmaGraphOverviewProps = {
   legendItems: LegendItem[];
+  embedded?: boolean;
   onNodeSelect?: (nodeId: string) => void;
 } & (
   {
@@ -96,6 +97,7 @@ export function SigmaGraphOverview({
   nodes,
   edges,
   legendItems,
+  embedded = false,
   onNodeSelect,
 }: SigmaGraphOverviewProps) {
   const captureMode = useCaptureMode();
@@ -218,7 +220,11 @@ export function SigmaGraphOverview({
 
   return (
     <div
-      className="flex h-full min-h-[72vh] flex-col overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] shadow-2xl shadow-black/30"
+      className={`flex h-full flex-col overflow-hidden bg-[var(--background)] ${
+        embedded
+          ? "min-h-0"
+          : "min-h-[72vh] rounded-xl border border-[var(--border-subtle)] shadow-2xl shadow-black/30"
+      }`}
       data-testid="sigma-graph-overview"
     >
       <div className="border-b border-[var(--border-subtle)] bg-[var(--background)]/95 p-3">
@@ -261,7 +267,7 @@ export function SigmaGraphOverview({
       <div className="relative min-h-0 flex-1 bg-[var(--background)]">
         <div
           ref={containerRef}
-          className="h-full min-h-[58vh] w-full"
+          className={`h-full w-full ${embedded ? "min-h-[28rem]" : "min-h-[58vh]"}`}
           role="img"
           aria-label="WebGL security graph overview"
           aria-describedby="sigma-graph-overview-text"

--- a/ui/e2e/security-graph-cockpit.spec.ts
+++ b/ui/e2e/security-graph-cockpit.spec.ts
@@ -465,11 +465,11 @@ test(`large estates lead with non-overlapping clusters in ${theme}`, async ({ pa
   ).toBeVisible();
   await expect(page.getByRole("link", { name: "Explore clusters" })).toHaveAttribute(
     "href",
-    "/graph?scan=scan-cockpit-fixture&rollup=1",
+    "/security-graph?scan=scan-cockpit-fixture&lens=lineage&rollup=1",
   );
   await expect(page.getByRole("link", { name: "Open raw topology" })).toHaveAttribute(
     "href",
-    "/graph?scan=scan-cockpit-fixture&rollup=0",
+    "/security-graph?scan=scan-cockpit-fixture&lens=lineage&rollup=0",
   );
   await page.screenshot({ path: testInfo.outputPath(`investigation-large-estate-${theme}.png`), fullPage: true });
 

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -380,7 +380,8 @@ export function buildGraphInvestigationHref(
   if (request.rootLabel && request.rootLabel !== request.rootId) {
     params.set("q", request.rootLabel);
   }
-  return `/graph?${params.toString()}`;
+  params.set("lens", "lineage");
+  return `/security-graph?${params.toString()}`;
 }
 
 export function decodeGraphInvestigationParams(
@@ -509,13 +510,13 @@ export function recommendedAttackPathActions(
     actions.push({
       title: "Contain credential exposure",
       detail: "Rotate or scope exposed secrets before you widen blast radius by exploring deeper topology.",
-      href: "/mesh",
+      href: "/security-graph?lens=mesh",
     });
   } else if (path.tool_exposure.length > 0) {
     actions.push({
       title: "Review reachable tools",
       detail: "Check whether the reachable tools increase impact before choosing a fix sequence.",
-      href: "/mesh",
+      href: "/security-graph?lens=mesh",
     });
   }
 
@@ -523,7 +524,7 @@ export function recommendedAttackPathActions(
     actions.push({
       title: "Open full graph for neighbor context",
       detail: "Use the full graph when you need broader topology, additional paths, or related assets outside this shortlist.",
-      href: "/graph",
+      href: "/security-graph?lens=lineage",
     });
   }
 

--- a/ui/lib/graph-renderer-switch.ts
+++ b/ui/lib/graph-renderer-switch.ts
@@ -99,8 +99,7 @@ export function decideGraphRenderer({
       kind: "webgl",
       reason: "large-graph-webgl-overview",
       interactive: true,
-      supportsInvestigation: false,
-      investigationHandoff: "react-flow-focus",
+      supportsInvestigation: true,
     };
   }
 

--- a/ui/lib/investigation-estate-mode.ts
+++ b/ui/lib/investigation-estate-mode.ts
@@ -10,14 +10,15 @@ export interface InvestigationEstateMode {
 export function investigationEstateMode(nodeCount: number, scanId?: string): InvestigationEstateMode {
   const params = new URLSearchParams();
   if (scanId) params.set("scan", scanId);
+  params.set("lens", "lineage");
   params.set("rollup", "1");
-  const clusteredHref = `/graph?${params.toString()}`;
+  const clusteredHref = `/security-graph?${params.toString()}`;
   params.set("rollup", "0");
 
   return {
     large: nodeCount >= LARGE_ESTATE_NODE_THRESHOLD,
     summary: `${nodeCount.toLocaleString("en-US")} nodes`,
     clusteredHref,
-    rawHref: `/graph?${params.toString()}`,
+    rawHref: `/security-graph?${params.toString()}`,
   };
 }

--- a/ui/tests/attack-paths.test.ts
+++ b/ui/tests/attack-paths.test.ts
@@ -317,7 +317,7 @@ describe("attack path helpers", () => {
         rootId: "pkg-1",
         rootLabel: "flask",
       }),
-    ).toBe("/graph?scan=scan-123&agent=Claude+Desktop&investigate=1&root=pkg-1&q=flask");
+    ).toBe("/security-graph?scan=scan-123&agent=Claude+Desktop&investigate=1&root=pkg-1&q=flask&lens=lineage");
   });
 
   it("decodes graph investigation roots from URL params", () => {
@@ -739,7 +739,7 @@ describe("attack path helpers", () => {
       {
         title: "Contain credential exposure",
         detail: "Rotate or scope exposed secrets before you widen blast radius by exploring deeper topology.",
-        href: "/mesh",
+        href: "/security-graph?lens=mesh",
       },
     ]);
   });
@@ -764,6 +764,26 @@ describe("attack path helpers", () => {
       total: 2,
       uniqueAgents: 2,
       highestRisk: 8.8,
+    });
+  });
+
+  it("keeps the full-topology follow-up inside the investigation workspace", () => {
+    const path: AttackPath = {
+      source: "source-1",
+      target: "target-1",
+      hops: ["source-1", "target-1"],
+      edges: [],
+      composite_risk: 5,
+      summary: "unclassified path",
+      credential_exposure: [],
+      tool_exposure: [],
+      vuln_ids: [],
+    };
+
+    expect(recommendedAttackPathActions(path, new Map())).toContainEqual({
+      title: "Open full graph for neighbor context",
+      detail: "Use the full graph when you need broader topology, additional paths, or related assets outside this shortlist.",
+      href: "/security-graph?lens=lineage",
     });
   });
 

--- a/ui/tests/graph-lens-redirects.test.tsx
+++ b/ui/tests/graph-lens-redirects.test.tsx
@@ -12,27 +12,27 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => params,
 }));
 
-describe("retired lens routes redirect to the unified /graph surface", () => {
+describe("retired lens routes redirect to the canonical investigation surface", () => {
   beforeEach(() => {
     replace.mockClear();
     params = new URLSearchParams();
   });
 
-  it("redirects /mesh to /graph?lens=mesh (no 404)", () => {
+  it("redirects /mesh to /security-graph?lens=mesh (no 404)", () => {
     render(<MeshRedirectPage />);
-    expect(replace).toHaveBeenCalledWith("/graph?lens=mesh");
+    expect(replace).toHaveBeenCalledWith("/security-graph?lens=mesh");
   });
 
-  it("redirects /context to /graph?lens=context (no 404)", () => {
+  it("redirects /context to /security-graph?lens=context (no 404)", () => {
     render(<ContextRedirectPage />);
-    expect(replace).toHaveBeenCalledWith("/graph?lens=context");
+    expect(replace).toHaveBeenCalledWith("/security-graph?lens=context");
   });
 
   it("preserves deep-link query params through the /mesh redirect", () => {
     params = new URLSearchParams({ scan: "scan-9", agent: "payments" });
     render(<MeshRedirectPage />);
     expect(replace).toHaveBeenCalledWith(
-      "/graph?scan=scan-9&agent=payments&lens=mesh",
+      "/security-graph?scan=scan-9&agent=payments&lens=mesh",
     );
   });
 
@@ -40,13 +40,13 @@ describe("retired lens routes redirect to the unified /graph surface", () => {
     params = new URLSearchParams({ scan: "scan-9", agent: "payments" });
     render(<ContextRedirectPage />);
     expect(replace).toHaveBeenCalledWith(
-      "/graph?scan=scan-9&agent=payments&lens=context",
+      "/security-graph?scan=scan-9&agent=payments&lens=context",
     );
   });
 
   it("overrides a stale lens param on the retired route", () => {
     params = new URLSearchParams({ lens: "context" });
     render(<MeshRedirectPage />);
-    expect(replace).toHaveBeenCalledWith("/graph?lens=mesh");
+    expect(replace).toHaveBeenCalledWith("/security-graph?lens=mesh");
   });
 });

--- a/ui/tests/graph-lens-switcher.test.tsx
+++ b/ui/tests/graph-lens-switcher.test.tsx
@@ -44,20 +44,20 @@ describe("GraphLensSwitcher", () => {
     expect(screen.getByText("Context")).toBeInTheDocument();
   });
 
-  it("switches to the mesh lens on the unified graph surface via a param", () => {
+  it("switches to the mesh lens without leaving the investigation surface", () => {
     render(<GraphLensSwitcher variant="floating" />);
 
     fireEvent.click(screen.getByRole("button", { name: /agent mesh/i }));
 
-    expect(push).toHaveBeenCalledWith("/graph?lens=mesh");
+    expect(push).toHaveBeenCalledWith("/security-graph?lens=mesh");
   });
 
-  it("switches to the context lens on the unified graph surface via a param", () => {
+  it("switches to the context lens without leaving the investigation surface", () => {
     render(<GraphLensSwitcher variant="floating" />);
 
     fireEvent.click(screen.getByRole("button", { name: /context/i }));
 
-    expect(push).toHaveBeenCalledWith("/graph?lens=context");
+    expect(push).toHaveBeenCalledWith("/security-graph?lens=context");
   });
 
   it("preserves investigation focus when switching to a param-backed lens", () => {
@@ -79,7 +79,7 @@ describe("GraphLensSwitcher", () => {
     fireEvent.click(screen.getByRole("button", { name: /agent mesh/i }));
 
     expect(push).toHaveBeenCalledWith(
-      "/graph?scan=scan-123&agent=payments-agent&cve=CVE-2026-0042&package=werkzeug&root=agent%3Apayments&root_label=Payments+agent&investigate=1&q=Payments+agent&rollup=1&lens=mesh",
+      "/security-graph?scan=scan-123&agent=payments-agent&cve=CVE-2026-0042&package=werkzeug&root=agent%3Apayments&root_label=Payments+agent&investigate=1&q=Payments+agent&rollup=1&lens=mesh",
     );
   });
 
@@ -89,7 +89,7 @@ describe("GraphLensSwitcher", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /asset drift/i }));
 
-    expect(push).toHaveBeenCalledWith("/graph?scan=scan-123&scope=asset-drift");
+    expect(push).toHaveBeenCalledWith("/security-graph?scan=scan-123&lens=asset-drift&scope=asset-drift");
   });
 
   it("routes to the asset drift lens on the lineage graph", () => {
@@ -97,7 +97,7 @@ describe("GraphLensSwitcher", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /asset drift/i }));
 
-    expect(push).toHaveBeenCalledWith("/graph?scope=asset-drift");
+    expect(push).toHaveBeenCalledWith("/security-graph?lens=asset-drift&scope=asset-drift");
   });
 
   it("does not reroute when the active param lens is selected", () => {

--- a/ui/tests/graph-reactflow-surface-contract.test.ts
+++ b/ui/tests/graph-reactflow-surface-contract.test.ts
@@ -38,6 +38,19 @@ describe("interactive React Flow surface contract", () => {
     );
   });
 
+  it("uses the shared renderer decision for broad full-snapshot investigations", () => {
+    const content = source("components/security-graph-investigation.tsx");
+    expect(content).toContain("decideGraphRenderer");
+    expect(content).toContain("<SigmaGraphOverview");
+    expect(content).toContain("selectedAttackPath: focusMode");
+  });
+
+  it("hosts every graph lens on the canonical investigation route", () => {
+    const content = source("app/security-graph/page.tsx");
+    expect(content).toContain("<GraphSurface />");
+    expect(content).toContain('lens !== "attack-path"');
+  });
+
   it.each([
     "components/agent-topology.tsx",
     "components/scan-pipeline.tsx",

--- a/ui/tests/graph-renderer-switch.test.ts
+++ b/ui/tests/graph-renderer-switch.test.ts
@@ -57,8 +57,7 @@ describe("graph renderer switch", () => {
     ).toMatchObject({
       kind: "webgl",
       reason: "large-graph-webgl-overview",
-      supportsInvestigation: false,
-      investigationHandoff: "react-flow-focus",
+      supportsInvestigation: true,
     });
 
     expect(
@@ -69,8 +68,7 @@ describe("graph renderer switch", () => {
     ).toMatchObject({
       kind: "webgl",
       reason: "large-graph-webgl-overview",
-      supportsInvestigation: false,
-      investigationHandoff: "react-flow-focus",
+      supportsInvestigation: true,
     });
   });
 
@@ -83,7 +81,7 @@ describe("graph renderer switch", () => {
     expect(decideGraphRenderer(broad)).toMatchObject({
       kind: "webgl",
       reason: "large-graph-webgl-overview",
-      supportsInvestigation: false,
+      supportsInvestigation: true,
     });
 
     // The legacy ?webgl / renderer=webgl opt-in is gone; passing it changes

--- a/ui/tests/investigation-estate-mode.test.ts
+++ b/ui/tests/investigation-estate-mode.test.ts
@@ -7,8 +7,8 @@ describe("investigationEstateMode", () => {
     expect(investigationEstateMode(1_241, "scan-large")).toEqual({
       large: true,
       summary: "1,241 nodes",
-      clusteredHref: "/graph?scan=scan-large&rollup=1",
-      rawHref: "/graph?scan=scan-large&rollup=0",
+      clusteredHref: "/security-graph?scan=scan-large&lens=lineage&rollup=1",
+      rawHref: "/security-graph?scan=scan-large&lens=lineage&rollup=0",
     });
   });
 

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -366,7 +366,11 @@ describe('Nav', () => {
     fireEvent.keyDown(window, { key: 'k', metaKey: true })
     const palette = screen.getByRole('dialog', { name: /command palette/i })
     const paletteHrefs = within(palette).getAllByRole('link').map((l) => l.getAttribute('href'))
-    expect(paletteHrefs).toEqual(expect.arrayContaining(['/graph', '/graph?lens=mesh', '/graph?lens=context']))
+    expect(paletteHrefs).toEqual(expect.arrayContaining([
+      '/security-graph?lens=lineage',
+      '/security-graph?lens=mesh',
+      '/security-graph?lens=context',
+    ]))
   })
 
   it('keeps Investigation selected while a deep graph lens route is open', () => {
@@ -449,9 +453,9 @@ describe('Nav', () => {
     expect(palette).toBeInTheDocument()
     expect(within(palette).getByRole('button', { name: /refresh current view/i })).toBeInTheDocument()
     expect(within(palette).getByRole('link', { name: /overview/i })).toHaveAttribute('href', '/')
-    expect(within(palette).getByRole('link', { name: /lineage/i })).toHaveAttribute('href', '/graph')
-    expect(within(palette).getByRole('link', { name: /agent mesh/i })).toHaveAttribute('href', '/graph?lens=mesh')
-    expect(within(palette).getByRole('link', { name: /context/i })).toHaveAttribute('href', '/graph?lens=context')
+    expect(within(palette).getByRole('link', { name: /lineage/i })).toHaveAttribute('href', '/security-graph?lens=lineage')
+    expect(within(palette).getByRole('link', { name: /agent mesh/i })).toHaveAttribute('href', '/security-graph?lens=mesh')
+    expect(within(palette).getByRole('link', { name: /context/i })).toHaveAttribute('href', '/security-graph?lens=context')
   })
 
   it('renders the canonical agent-bom mark in the top bar', () => {


### PR DESCRIPTION
## Summary

- host every graph lens in the canonical Investigation route while preserving legacy `/graph` deep links
- choose WebGL for broad estate topology and ReactFlow for focused paths, with shared evidence selection
- preserve scan, lens, and rollup state through cluster and drill-down navigation

## Verification

- `npm test -- --run ui/tests/attack-paths.test.ts ui/tests/graph-lens-redirects.test.tsx ui/tests/graph-lens-switcher.test.tsx ui/tests/graph-reactflow-surface-contract.test.ts ui/tests/graph-renderer-switch.test.ts ui/tests/investigation-estate-mode.test.ts ui/tests/nav.test.tsx` (116 passed)
- `npm test -- --run` (1,212 passed)
- `npm run verify:toolchain`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run check:bundle`
- `npx playwright test ui/e2e/security-graph-cockpit.spec.ts` (15 passed)
- dark- and light-theme browser screenshot review
- `git diff --check`

## Notes

- Broad WebGL graphs remain interactive and open the shared evidence drawer.
- The compatibility route remains available for existing links.
