### PR TITLE
fix(findings): align queue filters and VEX scope

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -18145,6 +18145,49 @@
           },
           {
             "in": "query",
+            "name": "reachability",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "reachable",
+                    "unreachable",
+                    "unassessed"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reachability"
+            }
+          },
+          {
+            "in": "query",
+            "name": "triage",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "not_affected",
+                    "affected",
+                    "under_investigation",
+                    "untriaged"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Triage"
+            }
+          },
+          {
+            "in": "query",
             "name": "include_facets",
             "required": false,
             "schema": {
@@ -18944,6 +18987,49 @@
                 }
               ],
               "title": "Sla"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reachability",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "reachable",
+                    "unreachable",
+                    "unassessed"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reachability"
+            }
+          },
+          {
+            "in": "query",
+            "name": "triage",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "not_affected",
+                    "affected",
+                    "under_investigation",
+                    "untriaged"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Triage"
             }
           }
         ],

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -12224,6 +12224,31 @@ paths:
           - type: 'null'
           title: Sla
       - in: query
+        name: reachability
+        required: false
+        schema:
+          anyOf:
+          - enum:
+            - reachable
+            - unreachable
+            - unassessed
+            type: string
+          - type: 'null'
+          title: Reachability
+      - in: query
+        name: triage
+        required: false
+        schema:
+          anyOf:
+          - enum:
+            - not_affected
+            - affected
+            - under_investigation
+            - untriaged
+            type: string
+          - type: 'null'
+          title: Triage
+      - in: query
         name: include_facets
         required: false
         schema:
@@ -12712,6 +12737,31 @@ paths:
             type: string
           - type: 'null'
           title: Sla
+      - in: query
+        name: reachability
+        required: false
+        schema:
+          anyOf:
+          - enum:
+            - reachable
+            - unreachable
+            - unassessed
+            type: string
+          - type: 'null'
+          title: Reachability
+      - in: query
+        name: triage
+        required: false
+        schema:
+          anyOf:
+          - enum:
+            - not_affected
+            - affected
+            - under_investigation
+            - untriaged
+            type: string
+          - type: 'null'
+          title: Triage
       responses:
         '200':
           content:

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -313,6 +313,41 @@ def _triage_response(exc: Any) -> dict[str, Any]:
 
 TriageOwnerKey = tuple[str, str, str]
 TriageOwnerIndex = dict[TriageOwnerKey, tuple[int, str]]
+TriageStateIndex = dict[TriageOwnerKey, tuple[int, dict[str, Any]]]
+
+
+def build_tenant_triage_state_index(tenant_id: str) -> TriageStateIndex:
+    """Return the tenant's newest active triage state per match key."""
+    index: TriageStateIndex = {}
+    for sequence, exc in enumerate(_get_exception_store().list_all(tenant_id=tenant_id)):
+        if _parse_triage_reason(str(exc.reason)) is None:
+            continue
+        if exc.status.value not in {"approved", "active"} or exc.is_expired():
+            continue
+        key = (str(exc.vuln_id), str(exc.package_name), str(exc.server_name))
+        index.setdefault(key, (sequence, _triage_response(exc)))
+    return index
+
+
+def triage_state_for(
+    index: TriageStateIndex,
+    *,
+    vuln_id: str,
+    package: str,
+    server_name: str = "",
+) -> dict[str, Any] | None:
+    """Return the newest active triage state matching one finding."""
+    candidates: list[tuple[int, dict[str, Any]]] = []
+    server_keys = tuple(dict.fromkeys((server_name, "*", "")))
+    for candidate_vuln in (vuln_id, "*"):
+        for candidate_package in (package, "*"):
+            for candidate_server in server_keys:
+                candidate = index.get((candidate_vuln, candidate_package, candidate_server))
+                if candidate is not None:
+                    candidates.append(candidate)
+    if not candidates:
+        return None
+    return dict(min(candidates, key=lambda item: item[0])[1])
 
 
 def build_tenant_triage_owner_index(tenant_id: str) -> TriageOwnerIndex:
@@ -2679,6 +2714,8 @@ async def export_finding_triage_vex(
     control: Annotated[str | None, Query(max_length=64)] = None,
     owner: Annotated[str | None, Query(max_length=256)] = None,
     sla: Literal["overdue", "due", "unassigned"] | None = None,
+    reachability: Literal["reachable", "unreachable", "unassessed"] | None = None,
+    triage: Literal["not_affected", "affected", "under_investigation", "untriaged"] | None = None,
 ) -> dict:
     """Export signed OpenVEX for eligible tenant-scoped not_affected triage decisions."""
     from agent_bom.api.compliance_signing import describe_signer_disclosure, sign_compliance_bundle
@@ -2712,6 +2749,8 @@ async def export_finding_triage_vex(
         "control": control,
         "owner": owner,
         "sla": sla,
+        "reachability": reachability,
+        "triage": triage,
     }
     finding_filters: dict[str, Any] = {}
     for key, value in finding_filter_values.items():

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -2609,6 +2609,8 @@ async def list_findings(
     ] = None,
     owner: Annotated[str | None, Query(max_length=256)] = None,
     sla: Literal["overdue", "due", "unassigned"] | None = None,
+    reachability: Literal["reachable", "unreachable", "unassessed"] | None = None,
+    triage: Literal["not_affected", "affected", "under_investigation", "untriaged"] | None = None,
     include_facets: bool = False,
 ) -> dict:
     """List unified findings aggregated from completed scan results.
@@ -2635,7 +2637,7 @@ async def list_findings(
     """
     try:
         async with adaptive_backpressure("findings"):
-            implementation = _list_finding_groups_impl if group_occurrences else _list_findings_impl
+            implementation = _list_finding_groups_impl if group_occurrences else _list_findings_view_impl
             return await anyio.to_thread.run_sync(
                 implementation,
                 request,
@@ -2660,6 +2662,8 @@ async def list_findings(
                 control,
                 owner,
                 sla,
+                reachability,
+                triage,
             )
     except BackpressureRejectedError as exc:
         raise HTTPException(
@@ -3154,6 +3158,199 @@ def _list_findings_impl(
     return envelope
 
 
+_FINDINGS_VIEW_FILTER_MAX_ROWS = 50_000
+
+
+def _finding_triage_state(
+    row: dict[str, Any],
+    triage_index: Any,
+) -> dict[str, Any] | None:
+    """Project the newest active triage state onto one occurrence row."""
+    from agent_bom.api.routes.enterprise import triage_state_for
+
+    raw_servers = row.get("affected_servers")
+    servers = [str(row.get("server_name") or "")]
+    if isinstance(raw_servers, list):
+        servers.extend(str(value) for value in raw_servers if str(value).strip())
+    for server_name in dict.fromkeys(servers):
+        state = triage_state_for(
+            triage_index,
+            vuln_id=_row_vuln_id(row),
+            package=_package_base_name(row),
+            server_name=server_name,
+        )
+        if state is not None:
+            return state
+    return None
+
+
+def _list_findings_view_impl(
+    request: Request,
+    q: str | None,
+    severity: str | None,
+    scan_id: str | None,
+    sort: str,
+    limit: int,
+    offset: int,
+    cursor: str | None,
+    approximate_total: bool,
+    provider: str | None = None,
+    account: str | None = None,
+    environment: str | None = None,
+    domain: str | None = None,
+    window_days: int | None = None,
+    status: str = _DEFAULT_FINDING_STATUS,
+    finding_class: str | None = None,
+    kev: bool | None = None,
+    include_facets: bool = False,
+    framework: str | None = None,
+    control: str | None = None,
+    owner: str | None = None,
+    sla: str | None = None,
+    reachability: str | None = None,
+    triage: str | None = None,
+) -> dict[str, Any]:
+    """Apply evidence-backed view filters before pagination.
+
+    Reachability is graph-derived and triage lives in the exception store, so
+    neither can be pushed into the canonical finding store query. Walk the
+    canonical keyset stream instead; this preserves occurrence IDs and avoids
+    the dishonest client-side filtering of an already-selected page.
+    """
+    if reachability is None and triage is None:
+        return _list_findings_impl(
+            request,
+            q=q,
+            severity=severity,
+            scan_id=scan_id,
+            sort=sort,
+            limit=limit,
+            offset=offset,
+            cursor=cursor,
+            approximate_total=approximate_total,
+            provider=provider,
+            account=account,
+            environment=environment,
+            domain=domain,
+            window_days=window_days,
+            status=status,
+            finding_class=finding_class,
+            kev=kev,
+            include_facets=include_facets,
+            framework=framework,
+            control=control,
+            owner=owner,
+            sla=sla,
+        )
+
+    from agent_bom.api.routes.enterprise import build_tenant_triage_state_index
+
+    target = limit if cursor else offset + limit
+    source_cursor = cursor
+    rows_seen = 0
+    matches: list[dict[str, Any]] = []
+    first_page: dict[str, Any] | None = None
+    warnings: list[str] = []
+    triage_index = build_tenant_triage_state_index(_tenant_id(request)) if triage is not None else None
+    exhausted = False
+
+    while rows_seen < _FINDINGS_VIEW_FILTER_MAX_ROWS and len(matches) < target:
+        page_limit = min(
+            1000,
+            _FINDINGS_VIEW_FILTER_MAX_ROWS - rows_seen,
+            max(1, target - len(matches)),
+        )
+        page = _list_findings_impl(
+            request,
+            q=q,
+            severity=severity,
+            scan_id=scan_id,
+            sort=sort,
+            limit=page_limit,
+            offset=0,
+            cursor=source_cursor,
+            approximate_total=True,
+            provider=provider,
+            account=account,
+            environment=environment,
+            domain=domain,
+            window_days=window_days,
+            status=status,
+            finding_class=finding_class,
+            kev=kev,
+            include_facets=False,
+            framework=framework,
+            control=control,
+            owner=owner,
+            sla=sla,
+        )
+        if first_page is None:
+            first_page = page
+        warnings.extend(str(item) for item in page.get("warnings", []) if str(item))
+        raw_rows = page.get("findings")
+        page_rows = [row for row in raw_rows if isinstance(row, dict)] if isinstance(raw_rows, list) else []
+        rows_seen += len(page_rows)
+
+        for source_row in page_rows:
+            row = dict(source_row)
+            triage_state = _finding_triage_state(row, triage_index) if triage_index is not None else None
+            if triage_index is not None:
+                row["triage_id"] = triage_state.get("id") if triage_state else None
+                row["triage_decision"] = triage_state.get("decision") if triage_state else None
+                row["triage_queue_state"] = triage_state.get("queue_state") if triage_state else None
+
+            reachable = row.get("graph_reachable")
+            reachability_matches = (
+                reachability is None
+                or (reachability == "reachable" and reachable is True)
+                or (reachability == "unreachable" and reachable is False)
+                or (reachability == "unassessed" and reachable is None)
+            )
+            decision = triage_state.get("decision") if triage_state else None
+            triage_matches = triage is None or decision == triage or (triage == "untriaged" and decision is None)
+            if reachability_matches and triage_matches:
+                matches.append(row)
+
+        source_cursor = str(page.get("next_cursor") or "") or None
+        if not source_cursor:
+            exhausted = True
+            break
+
+    truncated = not exhausted and rows_seen >= _FINDINGS_VIEW_FILTER_MAX_ROWS
+    if truncated:
+        warnings.append(f"Finding view filters inspected {_FINDINGS_VIEW_FILTER_MAX_ROWS} rows; additional occurrences remain.")
+    selected = matches[:limit] if cursor else matches[offset : offset + limit]
+    total = len(matches) if exhausted and cursor is None else None
+    total_approximate = total is None
+    filters = dict(first_page.get("filters") or {}) if first_page else {}
+    if reachability is not None:
+        filters["reachability"] = reachability
+    if triage is not None:
+        filters["triage"] = triage
+    envelope = finding_list_envelope(
+        findings=selected,
+        total=total,
+        limit=limit,
+        offset=0 if cursor else offset,
+        sort=sort,
+        scan_id=scan_id,
+        cursor=cursor or "",
+        next_cursor=source_cursor or "",
+        filters=filters,
+        warnings=list(dict.fromkeys(warnings)),
+        total_approximate=total_approximate,
+        source="scan_and_current_ingest_findings",
+        scope="tenant current-state findings with graph and triage view filters",
+    )
+    if first_page:
+        if "window" in first_page:
+            envelope["window"] = first_page["window"]
+            envelope["count_metadata"]["window"] = first_page["window"]
+        if "scope_completeness" in first_page:
+            envelope["scope_completeness"] = first_page["scope_completeness"]
+    return envelope
+
+
 _FINDING_GROUP_MAX_OCCURRENCES = 50_000
 _FINDING_GROUP_OCCURRENCE_SAMPLE = 25
 
@@ -3220,6 +3417,8 @@ def _list_finding_groups_impl(
     control: str | None = None,
     owner: str | None = None,
     sla: str | None = None,
+    reachability: str | None = None,
+    triage: str | None = None,
 ) -> dict[str, Any]:
     """Build a bounded server-side issue queue over canonical occurrence rows.
 
@@ -3247,7 +3446,7 @@ def _list_finding_groups_impl(
     first_page: dict[str, Any] | None = None
     warnings: list[str] = []
     while len(rows) < _FINDING_GROUP_MAX_OCCURRENCES:
-        page = _list_findings_impl(
+        page = _list_findings_view_impl(
             request,
             q,
             # Severity is applied after grouping so the issue histogram remains
@@ -3273,6 +3472,8 @@ def _list_finding_groups_impl(
             control,
             owner,
             sla,
+            reachability,
+            triage,
         )
         if first_page is None:
             first_page = page
@@ -3381,6 +3582,8 @@ def current_findings_snapshot(
     control: str | None = None,
     owner: str | None = None,
     sla: str | None = None,
+    reachability: str | None = None,
+    triage: str | None = None,
 ) -> dict[str, Any]:
     """Collect the canonical current finding queue for an internal consumer.
 
@@ -3395,7 +3598,7 @@ def current_findings_snapshot(
     first_metadata: dict[str, Any] | None = None
     warnings: list[str] = []
     while len(rows) < max_findings:
-        page = _list_findings_impl(
+        page = _list_findings_view_impl(
             request,
             q=q,
             severity=severity,
@@ -3417,6 +3620,8 @@ def current_findings_snapshot(
             control=control,
             owner=owner,
             sla=sla,
+            reachability=reachability,
+            triage=triage,
         )
         if first_metadata is None:
             first_metadata = page.get("count_metadata") if isinstance(page.get("count_metadata"), dict) else {}

--- a/tests/api/test_api_enterprise_tenant.py
+++ b/tests/api/test_api_enterprise_tenant.py
@@ -635,18 +635,24 @@ async def test_finding_triage_openvex_current_scope_matches_canonical_finding_fi
         severity="critical",
         environment="production",
         window_days=30,
+        reachability="reachable",
+        triage="not_affected",
     )
 
     assert captured == {
         "severity": "critical",
         "environment": "production",
         "window_days": 30,
+        "reachability": "reachable",
+        "triage": "not_affected",
     }
     assert exported["filters"] == {
         "scope": "current",
         "severity": "critical",
         "environment": "production",
         "window_days": "30",
+        "reachability": "reachable",
+        "triage": "not_affected",
     }
     assert exported["finding_scope"] == {
         "count": 1,
@@ -674,7 +680,7 @@ def test_current_findings_snapshot_forwards_the_canonical_scope(monkeypatch):
             "next_cursor": None,
         }
 
-    monkeypatch.setattr(scan_routes, "_list_findings_impl", _list_findings)
+    monkeypatch.setattr(scan_routes, "_list_findings_view_impl", _list_findings)
     monkeypatch.setattr(scan_routes, "_completed_jobs_for_tenant", lambda _tenant_id: [])
 
     snapshot = scan_routes.current_findings_snapshot(
@@ -684,6 +690,8 @@ def test_current_findings_snapshot_forwards_the_canonical_scope(monkeypatch):
         environment="production",
         owner="secops",
         sla="overdue",
+        reachability="reachable",
+        triage="under_investigation",
         window_days=30,
     )
 
@@ -694,6 +702,8 @@ def test_current_findings_snapshot_forwards_the_canonical_scope(monkeypatch):
     assert captured["owner"] == "secops"
     assert captured["sla"] == "overdue"
     assert captured["window_days"] == 30
+    assert captured["reachability"] == "reachable"
+    assert captured["triage"] == "under_investigation"
 
 
 def _openvex_doc(statements: list[dict]) -> dict:

--- a/tests/api/test_api_findings_view_filters.py
+++ b/tests/api/test_api_findings_view_filters.py
@@ -1,0 +1,137 @@
+"""Canonical findings-view filters must run before pagination and exports."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent_bom.api.routes import enterprise
+from agent_bom.api.routes import scan as scan_routes
+
+
+def _request() -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace(tenant_id="tenant-alpha"))
+
+
+def _page(findings: list[dict], *, next_cursor: str = "") -> dict:
+    return {
+        "findings": findings,
+        "total": len(findings),
+        "total_approximate": False,
+        "warnings": [],
+        "count_metadata": {},
+        "filters": {},
+        "next_cursor": next_cursor,
+        "window": {"days": 90, "label": "Last 90 days"},
+    }
+
+
+def test_reachability_filter_walks_source_pages_before_returning(monkeypatch) -> None:
+    calls: list[str | None] = []
+
+    def _raw_page(_request_obj, **kwargs):
+        cursor = kwargs["cursor"]
+        calls.append(cursor)
+        if cursor is None:
+            return _page(
+                [{"finding_id": "unreachable", "cve_id": "CVE-1", "graph_reachable": False}],
+                next_cursor="page-2",
+            )
+        return _page([{"finding_id": "reachable", "cve_id": "CVE-2", "graph_reachable": True}])
+
+    monkeypatch.setattr(scan_routes, "_list_findings_impl", _raw_page)
+
+    result = scan_routes._list_findings_view_impl(
+        _request(),
+        q=None,
+        severity=None,
+        scan_id=None,
+        sort="effective_reach",
+        limit=1,
+        offset=0,
+        cursor=None,
+        approximate_total=False,
+        reachability="reachable",
+    )
+
+    assert calls == [None, "page-2"]
+    assert [row["finding_id"] for row in result["findings"]] == ["reachable"]
+    assert result["total"] == 1
+    assert result.get("total_approximate", False) is False
+    assert result["filters"]["reachability"] == "reachable"
+
+
+def test_triage_filter_preserves_occurrence_identity_and_projects_decision(monkeypatch) -> None:
+    monkeypatch.setattr(
+        scan_routes,
+        "_list_findings_impl",
+        lambda _request_obj, **_kwargs: _page(
+            [
+                {"finding_id": "occurrence-a", "cve_id": "CVE-1", "package": "pkg-a"},
+                {"finding_id": "occurrence-b", "cve_id": "CVE-2", "package": "pkg-b"},
+            ]
+        ),
+    )
+    monkeypatch.setattr(enterprise, "build_tenant_triage_state_index", lambda _tenant_id: {"index": True})
+    monkeypatch.setattr(
+        enterprise,
+        "triage_state_for",
+        lambda _index, *, vuln_id, package, server_name="": (
+            {"id": "triage-a", "decision": "not_affected", "queue_state": "decided"} if vuln_id == "CVE-1" and package == "pkg-a" else None
+        ),
+    )
+
+    result = scan_routes._list_findings_view_impl(
+        _request(),
+        q=None,
+        severity=None,
+        scan_id=None,
+        sort="effective_reach",
+        limit=25,
+        offset=0,
+        cursor=None,
+        approximate_total=False,
+        triage="not_affected",
+    )
+
+    assert [row["finding_id"] for row in result["findings"]] == ["occurrence-a"]
+    assert result["findings"][0]["triage_id"] == "triage-a"
+    assert result["findings"][0]["triage_decision"] == "not_affected"
+    assert result["findings"][0]["triage_queue_state"] == "decided"
+    assert result["filters"]["triage"] == "not_affected"
+
+
+def test_untriaged_filter_excludes_rows_with_any_active_decision(monkeypatch) -> None:
+    monkeypatch.setattr(
+        scan_routes,
+        "_list_findings_impl",
+        lambda _request_obj, **_kwargs: _page(
+            [
+                {"finding_id": "decided", "cve_id": "CVE-1", "package": "pkg-a"},
+                {"finding_id": "untriaged", "cve_id": "CVE-2", "package": "pkg-b"},
+            ]
+        ),
+    )
+    monkeypatch.setattr(enterprise, "build_tenant_triage_state_index", lambda _tenant_id: {"index": True})
+    monkeypatch.setattr(
+        enterprise,
+        "triage_state_for",
+        lambda _index, *, vuln_id, package, server_name="": (
+            {"id": "triage-a", "decision": "affected", "queue_state": "decided"} if vuln_id == "CVE-1" else None
+        ),
+    )
+
+    result = scan_routes._list_findings_view_impl(
+        _request(),
+        q=None,
+        severity=None,
+        scan_id=None,
+        sort="effective_reach",
+        limit=25,
+        offset=0,
+        cursor=None,
+        approximate_total=False,
+        triage="untriaged",
+    )
+
+    assert [row["finding_id"] for row in result["findings"]] == ["untriaged"]
+    assert result["findings"][0]["triage_decision"] is None

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -47,6 +47,12 @@ import {
   findingTriageKey,
 } from "@/lib/findings-workspace";
 
+type ReachabilityFilter = "" | "reachable" | "unreachable" | "unassessed";
+type TriageFilter = "" | FindingTriageDecision | "untriaged";
+
+const REACHABILITY_FILTERS: ReachabilityFilter[] = ["", "reachable", "unreachable", "unassessed"];
+const TRIAGE_FILTERS: TriageFilter[] = ["", "not_affected", "affected", "under_investigation", "untriaged"];
+
 function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
   if (err instanceof ApiAuthError) return "auth";
   if (err instanceof ApiForbiddenError) return "forbidden";
@@ -272,6 +278,8 @@ function FindingsPage() {
   const paramEnvironment = searchParams.get("environment");
   const paramOwner = searchParams.get("owner");
   const paramSla = searchParams.get("sla");
+  const paramReachability = searchParams.get("reachability");
+  const paramTriage = searchParams.get("triage");
   // Compliance drill-through (epic #4790): a framework section id + optional
   // control code linked from the Compliance view's per-control finding count.
   const paramFramework = searchParams.get("framework");
@@ -305,6 +313,14 @@ function FindingsPage() {
   const [ownerFilter, setOwnerFilter] = useState<string>(paramOwner ?? "");
   const [slaFilter, setSlaFilter] = useState<"" | "overdue" | "due" | "unassigned">(
     paramSla === "overdue" || paramSla === "due" || paramSla === "unassigned" ? paramSla : "",
+  );
+  const [reachabilityFilter, setReachabilityFilter] = useState<ReachabilityFilter>(
+    REACHABILITY_FILTERS.includes(paramReachability as ReachabilityFilter)
+      ? (paramReachability as ReachabilityFilter)
+      : "",
+  );
+  const [triageFilter, setTriageFilter] = useState<TriageFilter>(
+    TRIAGE_FILTERS.includes(paramTriage as TriageFilter) ? (paramTriage as TriageFilter) : "",
   );
   const [frameworkFilter, setFrameworkFilter] = useState<string>(paramFramework ?? "");
   // A control code is only meaningful alongside a framework; it is cleared with it.
@@ -419,6 +435,17 @@ function FindingsPage() {
   }, [paramOwner, paramSla]);
 
   useEffect(() => {
+    setReachabilityFilter(
+      REACHABILITY_FILTERS.includes(paramReachability as ReachabilityFilter)
+        ? (paramReachability as ReachabilityFilter)
+        : "",
+    );
+    setTriageFilter(
+      TRIAGE_FILTERS.includes(paramTriage as TriageFilter) ? (paramTriage as TriageFilter) : "",
+    );
+  }, [paramReachability, paramTriage]);
+
+  useEffect(() => {
     setFrameworkFilter(paramFramework ?? "");
     setControlFilter(paramFramework ? (paramControl ?? "") : "");
   }, [paramFramework, paramControl]);
@@ -449,6 +476,8 @@ function FindingsPage() {
     if (environmentFilter.trim()) params.set("environment", environmentFilter.trim());
     if (ownerFilter.trim()) params.set("owner", ownerFilter.trim());
     if (slaFilter) params.set("sla", slaFilter);
+    if (reachabilityFilter) params.set("reachability", reachabilityFilter);
+    if (triageFilter) params.set("triage", triageFilter);
     if (frameworkFilter.trim()) params.set("framework", frameworkFilter.trim());
     // A control code without a framework is meaningless — only sync it alongside.
     if (frameworkFilter.trim() && controlFilter.trim()) params.set("control", controlFilter.trim());
@@ -468,6 +497,8 @@ function FindingsPage() {
     environmentFilter,
     ownerFilter,
     slaFilter,
+    reachabilityFilter,
+    triageFilter,
     frameworkFilter,
     controlFilter,
     windowDays,
@@ -568,6 +599,8 @@ function FindingsPage() {
         ...(environmentFilter.trim() ? { environment: environmentFilter.trim() } : {}),
         ...(ownerFilter.trim() ? { owner: ownerFilter.trim() } : {}),
         ...(slaFilter ? { sla: slaFilter } : {}),
+        ...(reachabilityFilter ? { reachability: reachabilityFilter } : {}),
+        ...(triageFilter ? { triage: triageFilter } : {}),
         ...(frameworkFilter.trim() ? { framework: frameworkFilter.trim() } : {}),
         ...(frameworkFilter.trim() && controlFilter.trim() ? { control: controlFilter.trim() } : {}),
         ...(issueTypeFilter !== "all" ? { findingClass: issueTypeFilter } : {}),
@@ -596,6 +629,8 @@ function FindingsPage() {
     providerFilter,
     search,
     slaFilter,
+    reachabilityFilter,
+    triageFilter,
     windowDays,
   ]);
 
@@ -620,6 +655,8 @@ function FindingsPage() {
           ...(environmentFilter.trim() ? { environment: environmentFilter.trim() } : {}),
           ...(ownerFilter.trim() ? { owner: ownerFilter.trim() } : {}),
           ...(slaFilter ? { sla: slaFilter } : {}),
+          ...(reachabilityFilter ? { reachability: reachabilityFilter } : {}),
+          ...(triageFilter ? { triage: triageFilter } : {}),
           ...(frameworkFilter.trim() ? { framework: frameworkFilter.trim() } : {}),
           ...(frameworkFilter.trim() && controlFilter.trim() ? { control: controlFilter.trim() } : {}),
           ...(issueTypeFilter !== "all" ? { findingClass: issueTypeFilter } : {}),
@@ -663,6 +700,8 @@ function FindingsPage() {
     environmentFilter,
     ownerFilter,
     slaFilter,
+    reachabilityFilter,
+    triageFilter,
     frameworkFilter,
     controlFilter,
     issueTypeFilter,
@@ -704,6 +743,12 @@ function FindingsPage() {
     providerFilter,
     accountFilter,
     environmentFilter,
+    ownerFilter,
+    slaFilter,
+    reachabilityFilter,
+    triageFilter,
+    frameworkFilter,
+    controlFilter,
     windowDays,
   ]);
 
@@ -759,6 +804,12 @@ function FindingsPage() {
     slaFilter
       ? { key: "sla", label: `SLA: ${slaFilter}`, onClear: () => setSlaFilter("") }
       : null,
+    reachabilityFilter
+      ? { key: "reachability", label: `Reach: ${reachabilityFilter}`, onClear: () => setReachabilityFilter("") }
+      : null,
+    triageFilter
+      ? { key: "triage", label: `Triage: ${triageFilter.replaceAll("_", " ")}`, onClear: () => setTriageFilter("") }
+      : null,
     // Compliance drill-through chips. Clearing the framework also clears the
     // control, since a control code without its framework is meaningless.
     frameworkFilter.trim()
@@ -783,6 +834,8 @@ function FindingsPage() {
     setEnvironmentFilter("");
     setOwnerFilter("");
     setSlaFilter("");
+    setReachabilityFilter("");
+    setTriageFilter("");
     setFrameworkFilter("");
     setControlFilter("");
   };
@@ -1121,6 +1174,33 @@ function FindingsPage() {
                           <option value="overdue">Overdue</option>
                           <option value="due">Due later</option>
                           <option value="unassigned">No SLA</option>
+                        </select>
+                      </div>
+                      <div className="flex flex-col gap-1">
+                        <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Reachability</span>
+                        <select
+                          value={reachabilityFilter}
+                          onChange={(e) => setReachabilityFilter(e.target.value as ReachabilityFilter)}
+                          className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-1.5 text-sm text-[color:var(--foreground)] focus:border-[color:var(--border-strong)] focus:outline-none"
+                        >
+                          <option value="">Any reachability</option>
+                          <option value="reachable">Reachable</option>
+                          <option value="unreachable">Unreachable</option>
+                          <option value="unassessed">Unassessed</option>
+                        </select>
+                      </div>
+                      <div className="flex flex-col gap-1">
+                        <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Triage</span>
+                        <select
+                          value={triageFilter}
+                          onChange={(e) => setTriageFilter(e.target.value as TriageFilter)}
+                          className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-1.5 text-sm text-[color:var(--foreground)] focus:border-[color:var(--border-strong)] focus:outline-none"
+                        >
+                          <option value="">Any triage state</option>
+                          <option value="not_affected">Not affected</option>
+                          <option value="affected">Affected</option>
+                          <option value="under_investigation">Under investigation</option>
+                          <option value="untriaged">Untriaged</option>
                         </select>
                       </div>
                       <div className="flex items-center justify-between gap-2 border-t border-[color:var(--border-subtle)] pt-2">

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1157,6 +1157,9 @@ export interface UnifiedFinding {
   provenance?: Record<string, unknown> | string | null | undefined;
   owner?: string | null | undefined;
   sla_due_at?: string | null | undefined;
+  triage_id?: string | null | undefined;
+  triage_decision?: "not_affected" | "affected" | "under_investigation" | null | undefined;
+  triage_queue_state?: string | null | undefined;
   /** CWPP runtime/EDR workload evidence (additive; never a clean-workload claim). */
   workload_runtime_evidence?: WorkloadRuntimeEvidence | undefined;
 }

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -1562,6 +1562,8 @@ export const api = {
     control?: string;
     owner?: string;
     sla?: "overdue" | "due" | "unassigned";
+    reachability?: "reachable" | "unreachable" | "unassessed";
+    triage?: "not_affected" | "affected" | "under_investigation" | "untriaged";
     findingClass?: "vulnerability" | "misconfiguration" | "secret" | "identity" | "unclassified";
     status?: "open" | "resolved" | "all";
     // Known-exploited only, or explicitly everything else. Omit for no filter —
@@ -1590,6 +1592,8 @@ export const api = {
     if (filters?.control) params.set("control", filters.control);
     if (filters?.owner) params.set("owner", filters.owner);
     if (filters?.sla) params.set("sla", filters.sla);
+    if (filters?.reachability) params.set("reachability", filters.reachability);
+    if (filters?.triage) params.set("triage", filters.triage);
     if (filters?.findingClass) params.set("finding_class", filters.findingClass);
     if (filters?.kev != null) params.set("kev", String(filters.kev));
     if (filters?.status) params.set("status", filters.status);
@@ -1737,6 +1741,8 @@ export const api = {
     control?: string;
     owner?: string;
     sla?: string;
+    reachability?: "reachable" | "unreachable" | "unassessed";
+    triage?: "not_affected" | "affected" | "under_investigation" | "untriaged";
   }) => {
     const params = new URLSearchParams();
     if (filters?.assignee) params.set("assignee", filters.assignee);
@@ -1759,6 +1765,8 @@ export const api = {
     if (filters?.control) params.set("control", filters.control);
     if (filters?.owner) params.set("owner", filters.owner);
     if (filters?.sla) params.set("sla", filters.sla);
+    if (filters?.reachability) params.set("reachability", filters.reachability);
+    if (filters?.triage) params.set("triage", filters.triage);
     const qs = params.toString();
     return get<FindingTriageVexResponse>(`/v1/findings/triage/vex${qs ? `?${qs}` : ""}`);
   },

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -278,6 +278,18 @@ describe('api.listFindings', () => {
       expect.objectContaining({ credentials: 'include' }),
     )
   })
+
+  it('serializes reachability and triage workflow filters', async () => {
+    const fetchMock = mockFetch({ findings: [], total: null, total_approximate: true })
+    global.fetch = fetchMock
+
+    await api.listFindings({ reachability: 'reachable', triage: 'under_investigation', limit: 25 })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/v1/findings?limit=25&reachability=reachable&triage=under_investigation',
+      expect.objectContaining({ credentials: 'include' }),
+    )
+  })
 })
 
 describe('api.getCompliance', () => {
@@ -1147,11 +1159,13 @@ describe('api finding triage helpers', () => {
       severity: 'critical',
       environment: 'production',
       windowDays: 30,
+      reachability: 'reachable',
+      triage: 'not_affected',
     })
 
     const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
     expect(url).toBe(
-      '/v1/findings/triage/vex?assignee=payments-security&package=payments-lib&scope=current&severity=critical&environment=production&window_days=30',
+      '/v1/findings/triage/vex?assignee=payments-security&package=payments-lib&scope=current&severity=critical&environment=production&window_days=30&reachability=reachable&triage=not_affected',
     )
   })
 })

--- a/ui/tests/findings-page.test.tsx
+++ b/ui/tests/findings-page.test.tsx
@@ -501,6 +501,20 @@ describe("FindingsPage", () => {
     expect(screen.getByTestId("findings-chip-sla")).toHaveTextContent("SLA: overdue");
   });
 
+  it("owns reachability and triage filters in the URL and canonical API", async () => {
+    navigationState.query = "reachability=reachable&triage=under_investigation";
+    render(<FindingsPage />);
+    expect(await screen.findByText("Findings queue")).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(apiMock.listFindings).toHaveBeenLastCalledWith(
+        expect.objectContaining({ reachability: "reachable", triage: "under_investigation" }),
+      ),
+    );
+    expect(screen.getByTestId("findings-chip-reachability")).toHaveTextContent("Reach: reachable");
+    expect(screen.getByTestId("findings-chip-triage")).toHaveTextContent("Triage: under investigation");
+  });
+
   it("sends the selected issue class to the paginated findings API", async () => {
     render(<FindingsPage />);
     expect(await screen.findByText("Findings queue")).toBeInTheDocument();
@@ -747,7 +761,7 @@ describe("FindingsPage", () => {
 
   it("exports OpenVEX from the same server-backed scope as the visible queue", async () => {
     navigationState.query =
-      "severity=critical&issue=vulnerability&domain=vuln&provider=aws&account=prod-1&environment=production&owner=secops&sla=overdue&framework=soc2&control=CC6.1&window=30&q=requests";
+      "severity=critical&issue=vulnerability&domain=vuln&provider=aws&account=prod-1&environment=production&owner=secops&sla=overdue&reachability=reachable&triage=not_affected&framework=soc2&control=CC6.1&window=30&q=requests";
     apiMock.listFindingTriage.mockResolvedValue({
       triage: [
         {
@@ -786,6 +800,8 @@ describe("FindingsPage", () => {
         environment: "production",
         owner: "secops",
         sla: "overdue",
+        reachability: "reachable",
+        triage: "not_affected",
         framework: "soc2",
         control: "CC6.1",
         windowDays: 30,


### PR DESCRIPTION
## Summary

- add bounded server-side reachability and triage filtering over canonical finding occurrences while preserving each asset-scoped `finding_id`
- expose URL-owned findings controls and project the newest active triage decision onto matching rows
- apply the identical findings-view scope to signed OpenVEX exports and regenerate the checked-in OpenAPI contract

## Verification

- red regressions: `tests/api/test_api_findings_view_filters.py` and the updated UI API/page contracts failed before implementation
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/api/test_graph_scope_contract.py tests/api/test_api_scan_findings_wiring.py tests/api/test_findings_owner_sla.py tests/api/test_api_finding_groups.py tests/api/test_persist_graph_workspace_consumer.py tests/api/test_api_findings_view_filters.py tests/api/test_findings_contract_envelope.py tests/api/test_api_pipeline_findings_surface.py tests/api/test_api_enterprise_tenant.py` (78 passed)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff format --check src/agent_bom/api/routes/enterprise.py src/agent_bom/api/routes/scan.py tests/api/test_api_enterprise_tenant.py tests/api/test_api_findings_view_filters.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check src/agent_bom/api/routes/enterprise.py src/agent_bom/api/routes/scan.py tests/api/test_api_enterprise_tenant.py tests/api/test_api_findings_view_filters.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/api/routes/enterprise.py src/agent_bom/api/routes/scan.py`
- `make preflight`
- supported Node 24.19.0: `node node_modules/vitest/vitest.mjs --run` (194 files, 1,215 tests)
- supported Node 24.19.0: changed-file ESLint and `npm run typecheck`
- supported Node 24.19.0: `node node_modules/next/dist/bin/next build --webpack` (52 routes)
- changed-file pre-commit passed all applicable hooks; the repository-wide mypy hook has pre-existing unrelated errors while targeted mypy is clean
- `git diff --check`
- visually verified the Findings filters and active chips in light and dark themes against a local fixture API

## Notes

- filtered traversal is bounded at 50,000 source rows; totals remain approximate when completeness cannot be proven
- this does not collapse legitimate per-asset occurrences or replace occurrence IDs with advisory grouping IDs
- Turbopack could not bind its local helper port in the sandbox; the production Webpack build completed successfully
