### PR TITLE
fix(gateway): derive shadow-AI KPI from sanctioned profile enforcement

### DIFF
--- a/src/agent_bom/api/routes/gateway_feed.py
+++ b/src/agent_bom/api/routes/gateway_feed.py
@@ -55,6 +55,7 @@ from agent_bom.runtime.gateway_events import (
     GATEWAY_BLOCKED_EVENT_TYPES,
     GATEWAY_DATA_FILTER_EVENT_TYPES,
 )
+from agent_bom.runtime.profile_resolution import ProfileResolutionCode as _ProfileCode
 
 router = APIRouter(dependencies=[Depends(demo_daily_evidence_dependency)])
 
@@ -176,6 +177,46 @@ _EVENT_TYPES = GATEWAY_ALLOWED_EVENT_TYPES | GATEWAY_BLOCKED_EVENT_TYPES | GATEW
 # rather than an ordinary policy block. ``undeclared`` is emitted by the proxy
 # block-undeclared enforcement (``proxy.undeclared_tool_block_reason``); the
 # others cover unknown-agent / shadow-server gateway blocks.
+# Canonical sanctioned-client enforcement. The gateway resolves every caller
+# against its ``McpClientConfigAssignment`` and emits the outcome as a stable
+# ``reason_code`` (``gateway_server`` -> ``profile_failure_code``). Deriving the
+# shadow-AI KPI from these codes rather than from free-text markers is the
+# difference between "we inferred this looked like shadow AI" and "the gateway
+# refused to attribute this caller to a sanctioned profile".
+#
+# Codes are imported, never re-spelled here: one judgement, one implementation.
+_UNSANCTIONED_CLIENT_CODES = frozenset(
+    {
+        _ProfileCode.IDENTITY_INACTIVE.value,
+        _ProfileCode.TENANT_MISMATCH.value,
+        _ProfileCode.PROFILE_NOT_FOUND.value,
+        _ProfileCode.PROFILE_REVOKED.value,
+        _ProfileCode.PROFILE_DISABLED.value,
+        _ProfileCode.PROFILE_EXPIRED.value,
+        _ProfileCode.PROFILE_INCOMPLETE.value,
+        _ProfileCode.ISSUER_MISMATCH.value,
+        _ProfileCode.ENVIRONMENT_MISMATCH.value,
+        # Emitted by the gateway itself when no managed identity resolved at all.
+        "managed_identity_required",
+    }
+)
+
+# A block that is NOT a shadow-client verdict. Scope/constraint/blueprint denials
+# mean a *sanctioned* client exceeded its grant, and the ``*_unavailable`` codes
+# are operator-side outages — counting either as shadow AI would attribute our
+# own degradation, or an authorized caller, to an attacker.
+_SANCTIONED_OR_DEGRADED_CODES = frozenset(
+    {
+        _ProfileCode.RESOLVED.value,
+        _ProfileCode.INSUFFICIENT_SCOPE.value,
+        _ProfileCode.TOOL_CONSTRAINT_CONFLICT.value,
+        _ProfileCode.BLUEPRINT_UNKNOWN.value,
+        _ProfileCode.BLUEPRINT_MISMATCH.value,
+        "identity_store_unavailable",
+        "profile_store_unavailable",
+    }
+)
+
 _SHADOW_BLOCK_MARKERS = (
     "undeclared",
     "shadow",
@@ -346,6 +387,15 @@ def _is_shadow_block(alert: dict[str, Any]) -> bool:
     ``outcome``) that survive ``redact_for_persistence``. Used both to label
     feed events and to roll up the ``shadow_ai_blocked`` KPI.
     """
+    # Canonical profile enforcement wins outright when the gateway recorded it.
+    # Only fall through to marker inference when no recognized code is present
+    # (direct in-process alerts from a standalone proxy, and older records).
+    code = str(alert.get("reason_code") or "").strip().lower()
+    if code in _UNSANCTIONED_CLIENT_CODES:
+        return True
+    if code in _SANCTIONED_OR_DEGRADED_CODES:
+        return False
+
     details = alert.get("details")
     detail_reason = ""
     if isinstance(details, dict):

--- a/tests/api/test_api_gateway_feed.py
+++ b/tests/api/test_api_gateway_feed.py
@@ -540,3 +540,54 @@ def test_feed_http_is_tenant_scoped() -> None:
 
         proxy_routes._proxy_alerts.clear()
         configure_api(api_key=None)
+
+
+def _profile_block(reason_code: str, *, ts: float = 500.0) -> dict:
+    """A blocked call carrying only the redaction-safe canonical profile code.
+
+    Mirrors what survives tier-A redaction: free text is gone, and the gateway's
+    canonical ``reason_code`` from runtime profile resolution is the only signal.
+    """
+    return {
+        "ts": ts,
+        "agent_name": "caller",
+        "event_type": "gateway.policy_blocked",
+        "decision": "deny",
+        "reason_code": reason_code,
+        "details": {},
+    }
+
+
+def test_unsanctioned_client_profile_codes_count_as_shadow() -> None:
+    """A revoked/unknown client profile IS the canonical shadow-AI signal.
+
+    These codes carry none of the legacy free-text markers, so before canonical
+    profile enforcement was wired in they were silently absent from the KPI —
+    the gateway blocked an unsanctioned client and the dashboard reported zero.
+    """
+    alerts = [
+        _profile_block("profile_revoked", ts=501.0),
+        _profile_block("profile_not_found", ts=502.0),
+        _profile_block("profile_disabled", ts=503.0),
+        _profile_block("profile_expired", ts=504.0),
+        _profile_block("profile_incomplete", ts=505.0),
+        _profile_block("managed_identity_required", ts=506.0),
+    ]
+    kpis = build_gateway_feed_kpis(tenant_id="t1", alerts=alerts, llm_records=[], uptime_seconds=None)
+    assert kpis["blocked_today"] == 6
+    assert kpis["shadow_ai_blocked"] == 6
+
+
+def test_profile_infrastructure_failures_are_not_shadow() -> None:
+    """A store outage is degraded evidence, not a sanctioned-client violation.
+
+    Counting it as shadow AI would attribute an operator-side outage to an
+    attacker, which is exactly the over-claim the feed must not make.
+    """
+    alerts = [
+        _profile_block("profile_store_unavailable", ts=601.0),
+        _profile_block("identity_store_unavailable", ts=602.0),
+    ]
+    kpis = build_gateway_feed_kpis(tenant_id="t1", alerts=alerts, llm_records=[], uptime_seconds=None)
+    assert kpis["blocked_today"] == 2
+    assert kpis["shadow_ai_blocked"] == 0


### PR DESCRIPTION
## Summary
- count `shadow_ai_blocked` from the gateway's canonical client-profile resolution code instead of substring-matching free-text markers, so a caller blocked because its profile was revoked/expired/disabled/not-found/incomplete — or because no managed identity resolved at all — is finally counted
- classify store-outage and scope/constraint codes explicitly as **not** shadow, so operator-side degradation and sanctioned-but-over-scope callers are never attributed to an attacker
- keep the existing marker inference as a fallback for alerts carrying no recognized code, so standalone-proxy in-process alerts and older persisted records are unchanged

## Why
`gateway_server` resolves every caller against its `McpClientConfigAssignment` and records the outcome as a stable `reason_code`, but the feed never read it. None of the canonical codes (`profile_revoked`, `profile_not_found`, …) contain the legacy markers (`shadow`, `undeclared`, `unknown_agent`, `unregistered`), so **every canonical unsanctioned-client block was silently absent from the KPI** — the gateway refused the caller and the dashboard reported zero.

This is the "not canonical sanctioned-client profile enforcement" defect named in #4152.

Codes are imported from `ProfileResolutionCode` rather than re-spelled in the route, so the feed and the resolver cannot drift into two answers for one question.

## Verification
- `uv run pytest -q tests/api/test_api_gateway_feed.py tests/api/test_gateway_feed_durable.py tests/test_gateway_feed_event_loop.py tests/test_gateway.py` — **49 passed**
- two new red-first regressions: `test_unsanctioned_client_profile_codes_count_as_shadow` (failed `assert 0 == 6` before the change) and `test_profile_infrastructure_failures_are_not_shadow`
- `ruff check` + `ruff format --check` clean; `mypy src/agent_bom/api/routes/gateway_feed.py` clean

## Scope note
`calls_today`/`blocked_today` were also listed in #4152 as an in-process window rather than a calendar day. That is already fixed on main — the route applies a UTC-midnight-to-request-time window (`gateway_feed.py:981`) — so no change was needed there.