### PR TITLE
fix(scan): align trust verdicts across surfaces

### DIFF
--- a/.github/workflows/azure-ingestion.yml
+++ b/.github/workflows/azure-ingestion.yml
@@ -140,7 +140,7 @@ jobs:
           RUN_CIS: ${{ inputs.run_cis }}
         run: |
           set -euo pipefail
-          args=(agent-bom scan --azure --azure-subscription "$AZURE_SUBSCRIPTION_ID" --format json --quiet)
+          args=(agent-bom scan --azure --azure-subscription "$AZURE_SUBSCRIPTION_ID" --preset ci --format json --quiet)
           if [ "${RUN_CIS:-true}" = "true" ]; then
             args+=(--azure-cis-benchmark)
           fi

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -46,6 +46,7 @@ jobs:
       release_ref: ${{ steps.release.outputs.release_ref }}
       release_sha: ${{ steps.release.outputs.release_sha }}
       tool_count: ${{ steps.release.outputs.tool_count }}
+      smithery_oauth_ready: ${{ steps.release.outputs.smithery_oauth_ready }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -122,11 +123,18 @@ jobs:
             echo "::error::Published release metrics do not declare a positive MCP tool count"
             exit 1
           fi
+          if git show "${RELEASE_SHA}:src/agent_bom/mcp_server_metadata.py" \
+            | grep -Fq '"schemes": ["oauth2"] if auth_required else []'; then
+            SMITHERY_OAUTH_READY=true
+          else
+            SMITHERY_OAUTH_READY=false
+          fi
           {
             echo "version=$VERSION"
             echo "release_ref=refs/tags/${RELEASE_TAG}"
             echo "release_sha=$RELEASE_SHA"
             echo "tool_count=$TOOL_COUNT"
+            echo "smithery_oauth_ready=$SMITHERY_OAUTH_READY"
           } >> "$GITHUB_OUTPUT"
 
   smithery:
@@ -148,7 +156,13 @@ jobs:
         env:
           SMITHERY_API_TOKEN: ${{ secrets.SMITHERY_API_TOKEN }}
           SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
+          SMITHERY_OAUTH_READY: ${{ needs.release.outputs.smithery_oauth_ready }}
         run: |
+          if [ "$SMITHERY_OAUTH_READY" != "true" ]; then
+            echo "::notice::Latest published release predates the OAuth-capable MCP server contract — skipping Smithery until the next forward release"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ -z "${SMITHERY_MCP_URL:-}" ]; then
             echo "::notice::SMITHERY_MCP_URL not configured — skipping Smithery publish"
             echo "enabled=false" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/logo-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/logo-light.svg" alt="agent-bom" width="320" />
-  </picture>
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/social-preview.svg" alt="agent-bom — Discover. Scan. Correlate. Graph. Security evidence across code, AI agents, MCP, cloud, and containers." width="960" />
 </p>
 
 <p align="center">

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-20",
+  "generated_on": "2026-08-22",
   "version": "0.101.0",
   "metrics": [
     {
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 865,
+      "value": 866,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-20`
+- Generated on: `2026-08-22`
 - Version: `0.101.0`
 
 | Metric | Value | Source | Notes |
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 48 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 865 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 866 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -5577,6 +5577,11 @@
             "title": "Ecosystem",
             "type": "string"
           },
+          "offline": {
+            "default": false,
+            "title": "Offline",
+            "type": "boolean"
+          },
           "package": {
             "maxLength": 512,
             "minLength": 1,

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -3987,6 +3987,10 @@ components:
           minLength: 1
           title: Ecosystem
           type: string
+        offline:
+          default: false
+          title: Offline
+          type: boolean
         package:
           maxLength: 512
           minLength: 1

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -460,6 +460,7 @@ class PackageCheckRequest(BaseModel):
     package: str = Field(min_length=1, max_length=512)
     ecosystem: str = Field(default="npm", min_length=1, max_length=32)
     version: str | None = Field(default=None, max_length=256)
+    offline: bool = False
 
     @field_validator("package")
     @classmethod
@@ -1504,6 +1505,7 @@ async def check_package(body: PackageCheckRequest) -> dict[str, Any]:
             package=body.package,
             ecosystem=body.ecosystem,
             version=body.version,
+            offline=body.offline,
             _validate_ecosystem=lambda value: validate_ecosystem(value, SUPPORTED_PACKAGE_ECOSYSTEM_SET),
             _truncate_response=lambda value: value,
         )

--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sys
 from contextlib import nullcontext
+from functools import partial
 from hashlib import sha256
 from pathlib import Path
 from typing import Any, Optional
@@ -352,55 +353,31 @@ def _check_result_payload(
     exit_zero: bool = False,
     fail_on_severity: str | None = None,
     fail_on_severity_count: int | None = None,
+    lookup_mode: str = "online",
+    malicious_reason: str | None = None,
 ) -> dict:
     """Build machine-readable check output."""
-    serialized_vulns = []
-    for vuln in vulnerabilities or []:
-        serialized_vulns.append(
-            {
-                "id": vuln.id,
-                "summary": vuln.summary,
-                "severity": vuln.severity.value,
-                "fixed_version": vuln.fixed_version,
-                "is_kev": vuln.is_kev,
-                "kev_date_added": vuln.kev_date_added,
-                "kev_due_date": vuln.kev_due_date,
-                "cvss_score": vuln.cvss_score,
-                "cvss_vector": vuln.cvss_vector,
-                "attack_vector": vuln.attack_vector,
-                "attack_complexity": vuln.attack_complexity,
-                "privileges_required": vuln.privileges_required,
-                "user_interaction": vuln.user_interaction,
-                "network_exploitable": vuln.network_exploitable,
-                "epss_score": vuln.epss_score,
-                "epss_percentile": vuln.epss_percentile,
-                "nvd_status": vuln.nvd_status,
-                "published_at": vuln.published_at,
-                "modified_at": vuln.modified_at,
-                "cwe_ids": list(vuln.cwe_ids),
-                "aliases": list(vuln.aliases),
-                "references": list(vuln.references),
-                "advisory_sources": list(vuln.advisory_sources),
-            }
-        )
+    from agent_bom.scanners.package_check_result import PackageCheckResult, serialize_vulnerability
 
-    return {
-        "schema_version": "1.0",
-        "document_type": "PACKAGE-CHECK",
-        "spec_version": "1.0",
-        "package": name,
-        "version": version,
-        "ecosystems": ecosystems,
-        "verdict": verdict,
-        "message": message,
-        "exit_code": exit_code,
-        "exit_zero": exit_zero,
-        "fail_on_severity": fail_on_severity,
-        "fail_on_severity_count": fail_on_severity_count,
-        "vulnerability_count": len(serialized_vulns),
-        "scan_warnings": warnings or [],
-        "vulnerabilities": serialized_vulns,
-    }
+    result = PackageCheckResult(
+        package=name,
+        version=version,
+        ecosystems=tuple(ecosystems),
+        verdict=verdict,
+        message=message,
+        lookup_mode=lookup_mode,
+        vulnerabilities=tuple(serialize_vulnerability(vuln) for vuln in vulnerabilities or []),
+        warnings=tuple(warnings or []),
+        is_malicious=verdict == "malicious",
+        malicious_reason=malicious_reason,
+        exit_code=exit_code,
+    )
+    return result.cli_payload(
+        legacy_verdict=verdict,
+        exit_zero=exit_zero,
+        fail_on_severity=fail_on_severity,
+        fail_on_severity_count=fail_on_severity_count,
+    )
 
 
 def _format_vulnerability_count(count: int) -> str:
@@ -654,6 +631,7 @@ def check(
     console = Console(no_color=no_color, stderr=structured_output or output_path is not None)
     runtime_console = Console(stderr=True, quiet=quiet or structured_output or output_path is not None, no_color=no_color)
     _sync_runtime_consoles(runtime_console)
+    result_payload = partial(_check_result_payload, lookup_mode="offline" if offline else "online")
 
     name, version, detected_eco = _parse_package_spec(package_spec, ecosystem)
 
@@ -661,7 +639,7 @@ def check(
     if package_error:
         if structured_output:
             _write_check_output(
-                _check_result_payload(
+                result_payload(
                     name=name,
                     version=version,
                     ecosystems=[detected_eco],
@@ -689,7 +667,7 @@ def check(
         message = f"No version specified for {name}; skipping OSV lookup."
         if structured_output:
             _write_check_output(
-                _check_result_payload(
+                result_payload(
                     name=name,
                     version=version,
                     ecosystems=[detected_eco],
@@ -749,7 +727,7 @@ def check(
             message = f"Could not resolve latest version for {name} ({eco_str})."
             if structured_output:
                 _write_check_output(
-                    _check_result_payload(
+                    result_payload(
                         name=name,
                         version=version,
                         ecosystems=ecosystems,
@@ -801,7 +779,7 @@ def check(
         except IncompleteScanError as exc:
             if structured_output:
                 _write_check_output(
-                    _check_result_payload(
+                    result_payload(
                         name=name,
                         version=version,
                         ecosystems=ecosystems,
@@ -846,7 +824,7 @@ def check(
         message = f"MALICIOUS package {malicious_pkg.name}@{malicious_pkg.version} — {reason}. Do not install."
         if structured_output:
             _write_check_output(
-                _check_result_payload(
+                result_payload(
                     name=name,
                     version=version,
                     ecosystems=ecosystems,
@@ -855,6 +833,7 @@ def check(
                     exit_code=1,
                     vulnerabilities=vulns,
                     warnings=scan_warnings,
+                    malicious_reason=reason,
                 ),
                 output_path,
                 agent_mode=agent_mode,
@@ -909,7 +888,7 @@ def check(
             )
         if structured_output:
             _write_check_output(
-                _check_result_payload(
+                result_payload(
                     name=name,
                     version=version,
                     ecosystems=ecosystems,
@@ -938,7 +917,7 @@ def check(
         )
         if structured_output:
             _write_check_output(
-                _check_result_payload(
+                result_payload(
                     name=name,
                     version=version,
                     ecosystems=ecosystems,
@@ -966,7 +945,7 @@ def check(
     if not vulns:
         if structured_output:
             _write_check_output(
-                _check_result_payload(
+                result_payload(
                     name=name,
                     version=version,
                     ecosystems=ecosystems,
@@ -1046,7 +1025,7 @@ def check(
     if exit_zero:
         if structured_output:
             _write_check_output(
-                _check_result_payload(
+                result_payload(
                     name=name,
                     version=version,
                     ecosystems=ecosystems,
@@ -1078,7 +1057,7 @@ def check(
         message = f"{_format_vulnerability_count(len(vulns))} in {name}@{version}; none at or above {fail_threshold}."
         if structured_output:
             _write_check_output(
-                _check_result_payload(
+                result_payload(
                     name=name,
                     version=version,
                     ecosystems=ecosystems,
@@ -1104,7 +1083,7 @@ def check(
 
     if structured_output:
         _write_check_output(
-            _check_result_payload(
+            result_payload(
                 name=name,
                 version=version,
                 ecosystems=ecosystems,

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -821,6 +821,15 @@ def create_mcp_server(
                 ),
             ),
         ] = None,
+        offline: Annotated[
+            bool,
+            Field(
+                description=(
+                    "Use only the local advisory database. An explicit version is required; "
+                    "registry resolution and publication checks are disabled."
+                )
+            ),
+        ] = False,
     ) -> str:
         """Check a specific package for known CVEs before installing.
 
@@ -846,6 +855,7 @@ def create_mcp_server(
             package=package,
             ecosystem=ecosystem,
             version=version,
+            offline=offline,
             _validate_ecosystem=_validate_ecosystem,
             _truncate_response=_truncate_response,
         )

--- a/src/agent_bom/mcp_tools/scanning.py
+++ b/src/agent_bom/mcp_tools/scanning.py
@@ -524,10 +524,7 @@ async def check_impl(
             return service_result("incomplete", sanitize_error(exc))
         result_warnings.extend(consume_scan_warnings())
         coverage_warnings = consume_coverage_warnings()
-        result_warnings.extend(
-            str(warning.get("detail") or "Package advisory coverage is incomplete")
-            for warning in coverage_warnings
-        )
+        result_warnings.extend(str(warning.get("detail") or "Package advisory coverage is incomplete") for warning in coverage_warnings)
 
         if pkg.is_malicious:
             reason = pkg.malicious_reason or "flagged as malicious by package intelligence"
@@ -536,10 +533,7 @@ async def check_impl(
                 f"MALICIOUS package {name}@{version} — {reason}. Do not install.",
             )
 
-        coverage_gap = any(
-            warning.get("kind") in {"offline_ecosystem_gap", "remote_lookup_gap"}
-            for warning in coverage_warnings
-        )
+        coverage_gap = any(warning.get("kind") in {"offline_ecosystem_gap", "remote_lookup_gap"} for warning in coverage_warnings)
         if not pkg.vulnerabilities and coverage_gap:
             return service_result(
                 "incomplete",

--- a/src/agent_bom/mcp_tools/scanning.py
+++ b/src/agent_bom/mcp_tools/scanning.py
@@ -420,6 +420,7 @@ async def check_impl(
     package: str,
     ecosystem: str = "npm",
     version: str | None = None,
+    offline: bool = False,
     _validate_ecosystem,
     _truncate_response,
 ) -> str:
@@ -427,7 +428,15 @@ async def check_impl(
     try:
         from agent_bom.models import Package as Pkg
         from agent_bom.parsers.os_parsers import enrich_os_package_context
-        from agent_bom.scanners import ScanOptions, scan_packages
+        from agent_bom.scanners import (
+            IncompleteScanError,
+            ScanOptions,
+            consume_coverage_warnings,
+            consume_scan_warnings,
+            reset_scan_warnings,
+            scan_packages,
+        )
+        from agent_bom.scanners.package_check_result import PackageCheckResult, serialize_vulnerability
 
         try:
             name, parsed_version = normalize_check_package_spec(package, version)
@@ -440,6 +449,32 @@ async def check_impl(
         except ValueError as exc:
             raise ToolError(sanitize_error(exc)) from exc
         pkg = Pkg(name=name, version=version, ecosystem=eco)
+        result_warnings: list[str] = []
+
+        def service_result(
+            verdict: str,
+            message: str,
+            *,
+            source_context: dict | None = None,
+        ) -> str:
+            details = tuple(serialize_vulnerability(vulnerability) for vulnerability in pkg.vulnerabilities)
+            result = PackageCheckResult(
+                package=name,
+                version=version or pkg.version,
+                ecosystems=(eco,),
+                verdict=verdict,
+                message=message,
+                lookup_mode="offline" if offline else "online",
+                vulnerabilities=details,
+                warnings=tuple(result_warnings),
+                purl=pkg.purl,
+                is_malicious=bool(pkg.is_malicious),
+                malicious_reason=pkg.malicious_reason,
+                exit_code=0 if verdict == "clean" else 1 if verdict in {"vulnerable", "malicious"} else 2,
+                source_context=source_context or {},
+            )
+            return _truncate_response(json.dumps(result.service_payload(), indent=2, default=str))
+
         os_context_complete = True
         if eco in {"deb", "apk", "rpm"}:
             os_context_complete = enrich_os_package_context(pkg)
@@ -456,6 +491,11 @@ async def check_impl(
 
         # Resolve "latest" via registry
         if version in ("latest", ""):
+            if offline:
+                return service_result(
+                    "incomplete",
+                    f"Offline package checks require an explicit version for {name}",
+                )
             from agent_bom.http_client import create_client
             from agent_bom.resolver import resolve_package_version
 
@@ -477,85 +517,70 @@ async def check_impl(
                     }
                 )
 
-        await scan_packages([pkg], options=ScanOptions(offline=False))
+        reset_scan_warnings()
+        try:
+            await scan_packages([pkg], options=ScanOptions(offline=offline))
+        except IncompleteScanError as exc:
+            return service_result("incomplete", sanitize_error(exc))
+        result_warnings.extend(consume_scan_warnings())
+        coverage_warnings = consume_coverage_warnings()
+        result_warnings.extend(
+            str(warning.get("detail") or "Package advisory coverage is incomplete")
+            for warning in coverage_warnings
+        )
+
+        if pkg.is_malicious:
+            reason = pkg.malicious_reason or "flagged as malicious by package intelligence"
+            return service_result(
+                "malicious",
+                f"MALICIOUS package {name}@{version} — {reason}. Do not install.",
+            )
+
+        coverage_gap = any(
+            warning.get("kind") in {"offline_ecosystem_gap", "remote_lookup_gap"}
+            for warning in coverage_warnings
+        )
+        if not pkg.vulnerabilities and coverage_gap:
+            return service_result(
+                "incomplete",
+                f"Advisory coverage was incomplete for {name}@{version}; a clean verdict cannot be trusted",
+            )
 
         if not pkg.vulnerabilities and eco in {"deb", "apk", "rpm"} and not os_context_complete:
-            return json.dumps(
-                {
-                    "package": name,
-                    "version": version,
-                    "ecosystem": eco,
-                    "vulnerabilities": 0,
-                    "status": "incomplete",
-                    "message": "OS package context was insufficient for a trustworthy clean verdict",
+            return service_result(
+                "incomplete",
+                "OS package context was insufficient for a trustworthy clean verdict",
+                source_context={
                     "source_package": pkg.source_package,
                     "distro_name": pkg.distro_name,
                     "distro_version": pkg.distro_version,
-                }
+                },
             )
 
         # An explicit pinned version that found no vulns might simply not exist
         # (a typo'd or hallucinated pin). Confirm it is published before calling
         # it clean, so a fake pin can't read as safe.
-        if not pkg.vulnerabilities and version not in ("latest", "") and eco in ("npm", "pypi"):
+        if not offline and not pkg.vulnerabilities and version not in ("latest", "") and eco in ("npm", "pypi"):
             from agent_bom.http_client import create_client
 
             async with create_client(timeout=15.0) as client:
                 published = await _version_published(name, version, eco, client)
             if not published:
-                return json.dumps(
-                    {
-                        "package": name,
-                        "version": version,
-                        "ecosystem": eco,
-                        "status": "unknown",
-                        "message": (
-                            f"Version {version} of {name} was not found in the {eco} registry — "
-                            f"cannot confirm it is free of vulnerabilities (typo or unpublished "
-                            f"version?). agent-bom only verifies published versions."
-                        ),
-                    }
+                return service_result(
+                    "unknown",
+                    (
+                        f"Version {version} of {name} was not found in the {eco} registry — "
+                        f"cannot confirm it is free of vulnerabilities (typo or unpublished "
+                        f"version?). agent-bom only verifies published versions."
+                    ),
                 )
 
         if not pkg.vulnerabilities:
-            return json.dumps(
-                {
-                    "package": name,
-                    "version": version,
-                    "ecosystem": eco,
-                    "vulnerabilities": 0,
-                    "status": "clean",
-                    "message": f"No known vulnerabilities in {name}@{version}",
-                }
-            )
+            return service_result("clean", f"No known vulnerabilities in {name}@{version}")
 
-        vulns = pkg.vulnerabilities
-        return _truncate_response(
-            json.dumps(
-                {
-                    "package": name,
-                    "version": version,
-                    "ecosystem": eco,
-                    "vulnerabilities": len(vulns),
-                    "status": "vulnerable",
-                    "details": [
-                        {
-                            "id": v.id,
-                            "severity": v.severity.value,
-                            "cvss_score": v.cvss_score,
-                            "cvss_vector": v.cvss_vector,
-                            "epss_score": v.epss_score,
-                            "is_kev": v.is_kev,
-                            "fixed_version": v.fixed_version,
-                            "summary": (v.summary or "")[:200],
-                            "compliance_tags": v.compliance_tags,
-                        }
-                        for v in vulns
-                    ],
-                },
-                indent=2,
-                default=str,
-            )
+        return service_result(
+            "vulnerable",
+            f"{len(pkg.vulnerabilities)} known vulnerabilities in {name}@{version}",
         )
     except ToolError:
         raise

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -690,6 +690,10 @@ def _cve_sarif_result(
         kev_due_date=evidence(finding, "kev_due_date"),
     )
     result_properties: dict[str, Any] = {
+        "advisory_id": rule_id,
+        "asset_canonical_id": finding.asset.stable_id,
+        "occurrence_id": finding.id,
+        "canonical_id": finding.id,
         "owner": finding_owner(finding.owner),
         "sla_due_at": finding_sla_due_at,
         "blast_score": finding.risk_score,
@@ -929,6 +933,10 @@ def to_sarif(
             },
             **fingerprint_fields,
             "properties": {
+                "advisory_id": rule_id,
+                "asset_canonical_id": finding.asset.stable_id,
+                "occurrence_id": finding.id,
+                "canonical_id": finding.id,
                 "risk_score": finding.risk_score,
                 "asset_type": finding.asset.asset_type,
                 "asset_name": sanitize_advisory_text("title", finding.asset.name, fallback=finding.asset.asset_type),

--- a/src/agent_bom/parsers/ruby_parsers.py
+++ b/src/agent_bom/parsers/ruby_parsers.py
@@ -78,6 +78,8 @@ def parse_gemfile_lock(directory: str | Path) -> list[Package]:
     # Parse the GEM specs section
     in_gem_section = False
     in_specs = False
+    saw_gem_section = False
+    saw_specs = False
     # Pattern: 4 spaces + gem_name (version)
     gem_pattern = re.compile(r"^    (\S+)\s+\(([^)]+)\)$")
     malformed_specs = False
@@ -89,9 +91,11 @@ def parse_gemfile_lock(directory: str | Path) -> list[Package]:
         if stripped == "GEM":
             in_gem_section = True
             in_specs = False
+            saw_gem_section = True
             continue
         if in_gem_section and stripped.strip() == "specs:":
             in_specs = True
+            saw_specs = True
             continue
         # End of GEM section (new section starts at column 0)
         if in_gem_section and stripped and not stripped.startswith(" "):
@@ -130,7 +134,7 @@ def parse_gemfile_lock(directory: str | Path) -> list[Package]:
 
     if packages:
         logger.info("Parsed %d gems from %s", len(packages), lockfile)
-    if malformed_specs:
+    if malformed_specs or (saw_gem_section and not saw_specs):
         record_manifest_parse_warning(
             ecosystem="rubygems",
             path=str(lockfile),
@@ -155,9 +159,9 @@ def parse_ruby_packages(directory: str | Path) -> list[Package]:
     list[Package]
         All discovered Ruby gems.
     """
-    packages = parse_gemfile_lock(directory)
-    if packages:
-        return packages
+    lockfile = Path(directory) / "Gemfile.lock"
+    if lockfile.is_file():
+        return parse_gemfile_lock(directory)
 
     # Fallback: parse Gemfile for declared (not resolved) dependencies
     gemfile = Path(directory) / "Gemfile"

--- a/src/agent_bom/scanners/package_check_result.py
+++ b/src/agent_bom/scanners/package_check_result.py
@@ -1,0 +1,126 @@
+"""Canonical package-check verdict shared by CLI, MCP, and REST projectors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from agent_bom.canonical_ids import canonical_package_id
+
+_CANONICAL_VERDICTS = {
+    "unsafe": "vulnerable",
+    "vulnerable": "vulnerable",
+    "skipped": "incomplete",
+}
+
+
+@dataclass(frozen=True)
+class PackageCheckResult:
+    """Surface-neutral package verdict and its evidence."""
+
+    package: str
+    version: str
+    ecosystems: tuple[str, ...]
+    verdict: str
+    message: str
+    lookup_mode: str
+    vulnerabilities: tuple[dict[str, Any], ...] = ()
+    warnings: tuple[str, ...] = ()
+    purl: str | None = None
+    is_malicious: bool = False
+    malicious_reason: str | None = None
+    exit_code: int = 0
+    source_context: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def canonical_verdict(self) -> str:
+        return _CANONICAL_VERDICTS.get(self.verdict, self.verdict)
+
+    @property
+    def package_canonical_id(self) -> str:
+        ecosystem = self.ecosystems[0] if self.ecosystems else "unknown"
+        return canonical_package_id(self.package, self.version, ecosystem, self.purl)
+
+    def contract(self) -> dict[str, Any]:
+        """Return fields whose meaning is identical on every public surface."""
+        ecosystem = self.ecosystems[0] if len(self.ecosystems) == 1 else None
+        return {
+            "package": self.package,
+            "version": self.version,
+            "ecosystem": ecosystem,
+            "ecosystems": list(self.ecosystems),
+            "package_canonical_id": self.package_canonical_id,
+            "purl": self.purl,
+            "canonical_verdict": self.canonical_verdict,
+            "message": self.message,
+            "lookup_mode": self.lookup_mode,
+            "is_malicious": self.is_malicious,
+            "malicious_reason": self.malicious_reason,
+            "vulnerability_count": len(self.vulnerabilities),
+            "vulnerability_details": list(self.vulnerabilities),
+            "scan_warnings": list(self.warnings),
+            **self.source_context,
+        }
+
+    def cli_payload(
+        self,
+        *,
+        legacy_verdict: str,
+        exit_zero: bool = False,
+        fail_on_severity: str | None = None,
+        fail_on_severity_count: int | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "schema_version": "1.0",
+            "document_type": "PACKAGE-CHECK",
+            "spec_version": "1.0",
+            **self.contract(),
+            "verdict": legacy_verdict,
+            "exit_code": self.exit_code,
+            "exit_zero": exit_zero,
+            "fail_on_severity": fail_on_severity,
+            "fail_on_severity_count": fail_on_severity_count,
+            # Backward-compatible list alias used by existing CLI consumers.
+            "vulnerabilities": list(self.vulnerabilities),
+        }
+
+    def service_payload(self, *, legacy_status: str | None = None) -> dict[str, Any]:
+        return {
+            **self.contract(),
+            "status": legacy_status or self.canonical_verdict,
+            # Backward-compatible MCP/REST aliases.
+            "vulnerabilities": len(self.vulnerabilities),
+            "details": list(self.vulnerabilities),
+        }
+
+
+def serialize_vulnerability(vulnerability: Any) -> dict[str, Any]:
+    """Serialize the common vulnerability evidence without surface drift."""
+    severity = getattr(vulnerability, "severity", None)
+    severity_value = getattr(severity, "value", severity)
+    return {
+        "id": getattr(vulnerability, "id", None),
+        "summary": getattr(vulnerability, "summary", None),
+        "severity": severity_value,
+        "fixed_version": getattr(vulnerability, "fixed_version", None),
+        "is_kev": bool(getattr(vulnerability, "is_kev", False)),
+        "kev_date_added": getattr(vulnerability, "kev_date_added", None),
+        "kev_due_date": getattr(vulnerability, "kev_due_date", None),
+        "cvss_score": getattr(vulnerability, "cvss_score", None),
+        "cvss_vector": getattr(vulnerability, "cvss_vector", None),
+        "attack_vector": getattr(vulnerability, "attack_vector", None),
+        "attack_complexity": getattr(vulnerability, "attack_complexity", None),
+        "privileges_required": getattr(vulnerability, "privileges_required", None),
+        "user_interaction": getattr(vulnerability, "user_interaction", None),
+        "network_exploitable": bool(getattr(vulnerability, "network_exploitable", False)),
+        "epss_score": getattr(vulnerability, "epss_score", None),
+        "epss_percentile": getattr(vulnerability, "epss_percentile", None),
+        "nvd_status": getattr(vulnerability, "nvd_status", None),
+        "published_at": getattr(vulnerability, "published_at", None),
+        "modified_at": getattr(vulnerability, "modified_at", None),
+        "cwe_ids": list(getattr(vulnerability, "cwe_ids", []) or []),
+        "aliases": list(getattr(vulnerability, "aliases", []) or []),
+        "references": list(getattr(vulnerability, "references", []) or []),
+        "advisory_sources": list(getattr(vulnerability, "advisory_sources", []) or []),
+        "compliance_tags": dict(getattr(vulnerability, "compliance_tags", {}) or {}),
+    }

--- a/src/agent_bom/secret_scanner.py
+++ b/src/agent_bom/secret_scanner.py
@@ -496,10 +496,15 @@ def scan_secrets(project_path: str | Path, *, detect_entropy: bool = False) -> S
     result = SecretScanResult()
     file_count = 0
 
-    for f in sorted(iter_discovery_files(project, extra_skip_dirs=_SKIP_DIRS)):
+    def traversal_error(_exc: OSError) -> None:
+        warning = "Directory traversal incomplete; one or more paths could not be read"
+        if warning not in result.warnings:
+            result.warnings.append(warning)
+
+    for f in sorted(iter_discovery_files(project, extra_skip_dirs=_SKIP_DIRS, on_error=traversal_error)):
         if not f.is_file():
             continue
-        if not _should_scan(f):
+        if not _should_scan(f.relative_to(project)):
             continue
         if file_count >= _MAX_FILES:
             result.warnings.append(f"Stopped at {_MAX_FILES} files")

--- a/src/agent_bom/traversal.py
+++ b/src/agent_bom/traversal.py
@@ -21,7 +21,7 @@ never entered) and enforces a file-count budget as a safety valve.
 from __future__ import annotations
 
 import os
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path, PurePosixPath
 
 # Directory names never worth descending for source/manifest discovery: VCS
@@ -98,6 +98,7 @@ def iter_discovery_files(
     *,
     extra_skip_dirs: frozenset[str] = frozenset(),
     max_files: int | None = DEFAULT_MAX_FILES,
+    on_error: Callable[[OSError], None] | None = None,
 ) -> Iterator[Path]:
     """Yield files under *root*, pruning vendored/worktree subtrees while walking.
 
@@ -114,7 +115,7 @@ def iter_discovery_files(
         return
     skip = VENDOR_SKIP_DIRS | extra_skip_dirs
     yielded = 0
-    for dirpath_str, dirnames, filenames in os.walk(root, followlinks=False):
+    for dirpath_str, dirnames, filenames in os.walk(root, followlinks=False, onerror=on_error):
         dirpath = Path(dirpath_str)
         _prune_dirnames(dirpath, dirnames, skip)
         for name in filenames:

--- a/tests/test_audit_sarif_malicious_heredoc.py
+++ b/tests/test_audit_sarif_malicious_heredoc.py
@@ -87,3 +87,34 @@ def test_sarif_cve_path_carries_is_malicious():
     assert props.get("malicious_reason"), props
     # And it survives serialization (what GitHub Security ingests).
     assert "is_malicious" in json.dumps(doc)
+
+
+def test_sarif_keeps_advisory_asset_and_occurrence_identities_distinct():
+    from agent_bom.models import AIBOMReport, BlastRadius, Package, Severity, Vulnerability
+    from agent_bom.output.sarif import to_sarif
+
+    radii = []
+    for name in ("alpha", "beta"):
+        vuln = Vulnerability(id="CVE-2026-SHARED", summary="shared advisory", severity=Severity.HIGH)
+        package = Package(name=name, version="1.0.0", ecosystem="pypi", vulnerabilities=[vuln])
+        radii.append(
+            BlastRadius(
+                vulnerability=vuln,
+                package=package,
+                affected_servers=[],
+                affected_agents=[],
+                exposed_credentials=[],
+                exposed_tools=[],
+            )
+        )
+
+    results = [
+        result
+        for result in to_sarif(AIBOMReport(), blast_radii=radii)["runs"][0]["results"]
+        if result["ruleId"] == "CVE-2026-SHARED"
+    ]
+    assert len(results) == 2
+    properties = [result["properties"] for result in results]
+    assert {item["advisory_id"] for item in properties} == {"CVE-2026-SHARED"}
+    assert len({item["asset_canonical_id"] for item in properties}) == 2
+    assert len({item["occurrence_id"] for item in properties}) == 2

--- a/tests/test_audit_sarif_malicious_heredoc.py
+++ b/tests/test_audit_sarif_malicious_heredoc.py
@@ -109,9 +109,7 @@ def test_sarif_keeps_advisory_asset_and_occurrence_identities_distinct():
         )
 
     results = [
-        result
-        for result in to_sarif(AIBOMReport(), blast_radii=radii)["runs"][0]["results"]
-        if result["ruleId"] == "CVE-2026-SHARED"
+        result for result in to_sarif(AIBOMReport(), blast_radii=radii)["runs"][0]["results"] if result["ruleId"] == "CVE-2026-SHARED"
     ]
     assert len(results) == 2
     properties = [result["properties"] for result in results]

--- a/tests/test_ci_scan_gate_contract.py
+++ b/tests/test_ci_scan_gate_contract.py
@@ -1,0 +1,26 @@
+"""Headless scan workflows must choose a failure policy explicitly."""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_azure_ingestion_scan_uses_ci_preset() -> None:
+    workflow = yaml.safe_load((ROOT / ".github" / "workflows" / "azure-ingestion.yml").read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["ingest"]["steps"]
+    run = next(step["run"] for step in steps if step.get("name") == "Run Azure scan and push results")
+
+    assert "--preset ci" in run
+
+
+def test_interactive_scan_default_remains_threshold_free() -> None:
+    from click.testing import CliRunner
+
+    from agent_bom.cli import main
+
+    result = CliRunner().invoke(main, ["scan", "--help"])
+
+    assert result.exit_code == 0
+    assert "--preset" in result.output

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -681,6 +681,12 @@ def test_check_malicious_package_json_verdict(monkeypatch):
     assert payload["verdict"] == "malicious"
     assert payload["exit_code"] == 1
     assert "Dependency confusion risk" in payload["message"]
+    assert payload["canonical_verdict"] == "malicious"
+    assert payload["is_malicious"] is True
+    assert payload["malicious_reason"] == "Dependency confusion risk"
+    assert payload["lookup_mode"] == "online"
+    assert payload["package_canonical_id"]
+    assert payload["vulnerability_details"] == payload["vulnerabilities"]
 
 
 def test_check_malicious_beats_exit_zero(monkeypatch):

--- a/tests/test_manifest_parser_coverage.py
+++ b/tests/test_manifest_parser_coverage.py
@@ -223,3 +223,18 @@ def test_malformed_line_oriented_warning_reaches_partial_scan_artifact(tmp_path:
     parse_errors = [warning for warning in payload["coverage_warnings"] if warning["reason"] == "manifest_parse_error"]
     assert any(warning["ecosystem"] == "pypi" for warning in parse_errors), parse_errors
     assert payload["scan_run"]["outcome"] == "partial"
+
+
+def test_gemfile_lock_truncated_before_specs_is_partial_without_gemfile_fallback(tmp_path: Path) -> None:
+    (tmp_path / "Gemfile.lock").write_text(
+        "GEM\n  remote: https://rubygems.org/\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "Gemfile").write_text('gem "rails", "7.1.3"\n', encoding="utf-8")
+
+    assert parse_ruby_packages(tmp_path) == []
+    warnings = scanner_state.consume_coverage_warnings()
+    assert len(warnings) == 1, warnings
+    assert warnings[0]["ecosystem"] == "rubygems"
+    assert warnings[0]["reason"] == "manifest_parse_error"
+    assert "partial" in warnings[0]["detail"].lower()

--- a/tests/test_mcp_check_impl.py
+++ b/tests/test_mcp_check_impl.py
@@ -73,3 +73,78 @@ async def test_check_impl_marks_os_packages_incomplete_when_context_missing():
     payload = json.loads(result)
     assert payload["status"] == "incomplete"
     assert payload["vulnerabilities"] == 0
+
+
+@pytest.mark.asyncio
+async def test_check_impl_blocks_malicious_package_without_cve_rows():
+    async def fake_scan(packages: list[Package], **_kwargs):
+        packages[0].is_malicious = True
+        packages[0].malicious_reason = "Possible typosquat of requests"
+
+    with patch("agent_bom.scanners.scan_packages", side_effect=fake_scan):
+        result = await check_impl(
+            package="reqeusts@1.0.0",
+            ecosystem="pypi",
+            offline=True,
+            _validate_ecosystem=lambda eco: eco,
+            _truncate_response=lambda response: response,
+        )
+
+    payload = json.loads(result)
+    assert payload["canonical_verdict"] == "malicious"
+    assert payload["status"] == "malicious"
+    assert payload["is_malicious"] is True
+    assert payload["malicious_reason"] == "Possible typosquat of requests"
+    assert payload["vulnerability_count"] == 0
+    assert payload["lookup_mode"] == "offline"
+    assert payload["package_canonical_id"]
+
+
+@pytest.mark.asyncio
+async def test_check_impl_offline_explicit_version_never_queries_registry():
+    scan = AsyncMock()
+    with (
+        patch("agent_bom.scanners.scan_packages", new=scan),
+        patch("agent_bom.mcp_tools.scanning._version_published", new=AsyncMock()) as published,
+    ):
+        result = await check_impl(
+            package="six==1.16.0",
+            ecosystem="pypi",
+            offline=True,
+            _validate_ecosystem=lambda eco: eco,
+            _truncate_response=lambda response: response,
+        )
+
+    payload = json.loads(result)
+    assert payload["canonical_verdict"] == "clean"
+    assert payload["lookup_mode"] == "offline"
+    assert scan.await_args.kwargs["options"].offline is True
+    published.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_check_impl_offline_coverage_gap_is_incomplete_not_clean():
+    async def fake_scan(_packages: list[Package], **_kwargs):
+        from agent_bom.scanners import record_coverage_warning
+
+        record_coverage_warning(
+            {
+                "kind": "offline_ecosystem_gap",
+                "release": "offline:pypi",
+                "detail": "Local advisory coverage is unavailable for pypi",
+            }
+        )
+
+    with patch("agent_bom.scanners.scan_packages", side_effect=fake_scan):
+        result = await check_impl(
+            package="six==1.16.0",
+            ecosystem="pypi",
+            offline=True,
+            _validate_ecosystem=lambda eco: eco,
+            _truncate_response=lambda response: response,
+        )
+
+    payload = json.loads(result)
+    assert payload["canonical_verdict"] == "incomplete"
+    assert payload["status"] == "incomplete"
+    assert payload["scan_warnings"] == ["Local advisory coverage is unavailable for pypi"]

--- a/tests/test_package_check_surface_parity.py
+++ b/tests/test_package_check_surface_parity.py
@@ -1,0 +1,82 @@
+"""CLI, MCP, and REST expose one canonical package-check contract."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+from agent_bom.models import Package
+
+
+def _malicious_scan(packages: list[Package], **_kwargs):
+    for package in packages:
+        package.is_malicious = True
+        package.malicious_reason = "Dependency confusion risk"
+
+
+def test_cli_and_mcp_share_canonical_malicious_evidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def malicious_scan(packages: list[Package], **kwargs):
+        _malicious_scan(packages, **kwargs)
+
+    monkeypatch.setattr("agent_bom.scanners.scan_packages", malicious_scan)
+    cli = CliRunner().invoke(
+        main,
+        ["check", "internal-lib@1.0.0", "--ecosystem", "pypi", "--offline", "--format", "json"],
+    )
+    assert cli.exit_code == 1, cli.output
+    cli_payload = json.loads(cli.output)
+
+    from agent_bom.mcp_tools.scanning import check_impl
+
+    mcp_payload = json.loads(
+        asyncio.run(
+            check_impl(
+                package="internal-lib@1.0.0",
+                ecosystem="pypi",
+                offline=True,
+                _validate_ecosystem=lambda ecosystem: ecosystem,
+                _truncate_response=lambda response: response,
+            )
+        )
+    )
+
+    for field in (
+        "canonical_verdict",
+        "package_canonical_id",
+        "lookup_mode",
+        "is_malicious",
+        "malicious_reason",
+        "vulnerability_count",
+        "vulnerability_details",
+    ):
+        assert cli_payload[field] == mcp_payload[field]
+
+
+@pytest.mark.asyncio
+async def test_rest_threads_offline_mode_into_shared_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.api.routes.scan import PackageCheckRequest, check_package
+    from agent_bom.mcp_tools import scanning
+
+    expected = {
+        "canonical_verdict": "clean",
+        "package_canonical_id": "package-id",
+        "lookup_mode": "offline",
+        "is_malicious": False,
+        "vulnerability_count": 0,
+        "vulnerability_details": [],
+        "status": "clean",
+    }
+    implementation = AsyncMock(return_value=json.dumps(expected))
+    monkeypatch.setattr(scanning, "check_impl", implementation)
+
+    payload = await check_package(
+        PackageCheckRequest(package="six", version="1.16.0", ecosystem="pypi", offline=True)
+    )
+
+    assert payload == expected
+    assert implementation.await_args.kwargs["offline"] is True

--- a/tests/test_package_check_surface_parity.py
+++ b/tests/test_package_check_surface_parity.py
@@ -74,9 +74,7 @@ async def test_rest_threads_offline_mode_into_shared_check(monkeypatch: pytest.M
     implementation = AsyncMock(return_value=json.dumps(expected))
     monkeypatch.setattr(scanning, "check_impl", implementation)
 
-    payload = await check_package(
-        PackageCheckRequest(package="six", version="1.16.0", ecosystem="pypi", offline=True)
-    )
+    payload = await check_package(PackageCheckRequest(package="six", version="1.16.0", ecosystem="pypi", offline=True))
 
     assert payload == expected
     assert implementation.await_args.kwargs["offline"] is True

--- a/tests/test_public_frontdoor_contract.py
+++ b/tests/test_public_frontdoor_contract.py
@@ -85,6 +85,16 @@ def test_readme_keeps_one_readable_product_proof_and_links_the_gallery() -> None
         assert diagram not in readme
 
 
+def test_readme_leads_with_discover_scan_correlate_graph_brand_header() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    header = readme.split("<!-- mcp-name:", 1)[0]
+
+    assert "docs/images/social-preview.svg" in header
+    assert "Discover. Scan. Correlate. Graph." in header
+    assert "logo-dark.svg" not in header
+    assert header.index("social-preview.svg") < header.index("img.shields.io")
+
+
 def test_gallery_retains_full_size_product_screens() -> None:
     gallery = (ROOT / "docs" / "GALLERY.md").read_text(encoding="utf-8")
 

--- a/tests/test_publish_registries_release_auth_gate.py
+++ b/tests/test_publish_registries_release_auth_gate.py
@@ -1,0 +1,16 @@
+"""Registry repair must evaluate Smithery auth from the published release."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_smithery_publish_waits_for_oauth_capable_forward_release() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "publish-registries.yml").read_text(encoding="utf-8")
+
+    assert "smithery_oauth_ready: ${{ steps.release.outputs.smithery_oauth_ready }}" in workflow
+    assert 'git show "${RELEASE_SHA}:src/agent_bom/mcp_server_metadata.py"' in workflow
+    assert "SMITHERY_OAUTH_READY: ${{ needs.release.outputs.smithery_oauth_ready }}" in workflow
+    assert 'if [ "$SMITHERY_OAUTH_READY" != "true" ]; then' in workflow
+    assert "skipping Smithery until the next forward release" in workflow
+    assert '(.authentication.schemes | index("oauth2") != null)' in workflow

--- a/tests/test_secret_scanner.py
+++ b/tests/test_secret_scanner.py
@@ -36,6 +36,40 @@ def test_scan_secrets_detects_real_findings_and_skips_test_fixtures(tmp_path: Pa
     }
 
 
+def test_scan_secrets_uses_paths_relative_to_requested_root(tmp_path: Path):
+    project = tmp_path / "env" / "customer-project"
+    project.mkdir(parents=True)
+    (project / ".env").write_text("DB_PASSWORD=correct-horse-battery-staple\n", encoding="utf-8")
+    internal_env = project / "env"
+    internal_env.mkdir()
+    (internal_env / ".env").write_text("DB_PASSWORD=must-remain-skipped\n", encoding="utf-8")
+
+    result = scan_secrets(project)
+
+    assert result.files_scanned == 1
+    assert any(finding.file_path == ".env" for finding in result.findings)
+    assert all(not finding.file_path.startswith("env/") for finding in result.findings)
+
+
+def test_scan_secrets_marks_directory_traversal_errors_incomplete(tmp_path: Path, monkeypatch):
+    target = tmp_path / ".env"
+    target.write_text("DB_PASSWORD=correct-horse-battery-staple\n", encoding="utf-8")
+
+    def fake_walk(root, *, followlinks, onerror):
+        assert followlinks is False
+        onerror(PermissionError("private path must not leak"))
+        yield str(root), [], [target.name]
+
+    monkeypatch.setattr("agent_bom.traversal.os.walk", fake_walk)
+
+    result = scan_secrets(tmp_path)
+
+    assert result.files_scanned == 1
+    assert result.to_dict()["complete"] is False
+    assert result.warnings == ["Directory traversal incomplete; one or more paths could not be read"]
+    assert "private path" not in " ".join(result.warnings)
+
+
 def test_scan_secrets_suppresses_doc_pii_but_keeps_doc_credentials(tmp_path: Path):
     doc_key = "sk-" + "proj-" + "abc123def456" + "ghi789jkl012" + "mno345pqr678stu"
     (tmp_path / "README.md").write_text(


### PR DESCRIPTION
## Summary

- project package checks through one canonical CLI/MCP/REST evidence contract, preserve malicious verdicts without CVEs, and make offline incompleteness explicit instead of contacting registries or reporting false-clean results
- make secret traversal relative to the scan root and incomplete on unreadable paths; keep truncated Ruby locks authoritative and incomplete rather than inventing fallback versions
- give SARIF advisory occurrences distinct asset/finding identities, apply the CI severity preset to Azure ingestion, and lock each behavior with regression contracts
- restore the logo-rich `Discover. Scan. Correlate. Graph.` README hero above the live badges
- make registry repair evaluate Smithery OAuth compatibility from the published release, so the current pre-OAuth release is skipped honestly and the next forward release retains the fail-closed live card validation

## Verification

- `make preflight`
- `make lint`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_cli_check.py tests/test_mcp_check_impl.py tests/test_package_check_surface_parity.py tests/test_secret_scanner.py tests/test_manifest_parser_coverage.py tests/test_audit_sarif_malicious_heredoc.py tests/test_public_frontdoor_contract.py tests/test_ci_scan_gate_contract.py tests/test_publish_registries_release_auth_gate.py tests/api/test_api_gateway_feed.py` — 134 passed
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/api/test_runtime_evidence_ingest_route.py tests/api/test_side_scan_execution_route.py tests/cloud/test_cloud_side_scan_targets.py tests/cloud/test_side_scan_lifecycle_contract.py tests/cloud/test_side_scan_provider_adapters.py tests/test_cli_runtime_evidence_ingest.py tests/test_cli_side_scan.py tests/test_finding_runtime_evidence.py tests/test_mcp_cloud_side_scan.py tests/test_runtime_evidence_pack.py tests/test_side_scan.py tests/test_side_scan_capability_docs.py tests/test_side_scan_cross_cloud_terraform.py tests/test_side_scan_scheduler.py tests/test_workload_runtime_evidence_exports.py -rs` — 141 passed
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run agent-bom scan --demo --offline` — produced a complete report and the expected nonzero finding exit (23 packages, 15 vulnerabilities)
- full-suite diagnostic reached 7,006 passed / 42 skipped before interruption; its one order-sensitive AWS retry assertion passed immediately in isolation and neither involved file differs from `origin/main`

## Notes

- 25 cohesive files are included; generated OpenAPI and product metrics were refreshed with `make preflight-fix` and revalidated after rebasing onto `efb4c170b`.
- Repairs the `Publish to Registries` main regression tracked by #4897. The automated issue should close only after a successful post-merge workflow run.
- #4722 remains automation-owned: Smithery publication must occur from the next forward release containing the OAuth server contract, after which the fresh 81-tool catalog can close the drift issue. It is not closed manually.
- No registry authentication policy was weakened. No Azure/GCP credentials or cloud mutations were used.
