### PR TITLE
fix(demo): name the scan that owns the graph when seeding declines

### DIFF
--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -428,10 +428,10 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
             }
         )
         _logger.info(
-            "demo estate bootstrap complete tenant=%s graph_seeded=%s graph_owner_scan_id=%s job_id=%s findings=%s",
+            "demo estate bootstrap complete tenant=%s graph_seeded=%s graph_owner_scan_id_present=%s job_id=%s findings=%s",
             tenant_id,
             graph_seeded,
-            summary.get("graph_owner_scan_id") or "-",
+            bool(summary.get("graph_owner_scan_id")),
             job_id,
             summary.get("findings"),
         )

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -266,6 +266,17 @@ def _store_demo_scan_job(report: dict[str, Any], *, tenant_id: str) -> str:
     return job.job_id
 
 
+def _graph_owner_scan_id(graph_store: Any, tenant_id: str) -> str:
+    """Return the scan id whose snapshot the graph read path will serve."""
+    try:
+        latest = getattr(graph_store, "latest_snapshot_id", None)
+        if callable(latest):
+            return str(latest(tenant_id=tenant_id) or "")
+    except Exception:  # noqa: BLE001 - never block the demo boot on a read
+        _logger.debug("could not resolve graph owner scan id", exc_info=True)
+    return ""
+
+
 def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str, Any]:
     """Seed showcase graph + curated findings when demo estate mode is enabled."""
     if not demo_estate_enabled():
@@ -313,6 +324,14 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
         _logger.warning("demo estate graph seeding failed", exc_info=True)
         summary["graph_error"] = True
     summary["graph_seeded"] = graph_seeded
+    if not graph_seeded:
+        # Seeding declines when a real scan owns the tenant -- correct, because
+        # operator evidence is never shadowed. But the findings above ARE the
+        # estate's, so the graph and the finding counts now describe different
+        # worlds. Silence here is what makes the investigation surface open on
+        # an unrelated scan with no explanation; name the owning snapshot so the
+        # API and UI can say which estate the graph belongs to.
+        summary["graph_owner_scan_id"] = _graph_owner_scan_id(graph_store, tenant_id)
 
     # Seed the live agent-identity store (NHI estate) independently of the graph
     # snapshot so the NHI/Identity overview tile and the nhi-governance posture
@@ -409,9 +428,10 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
             }
         )
         _logger.info(
-            "demo estate bootstrap complete tenant=%s graph_seeded=%s job_id=%s findings=%s",
+            "demo estate bootstrap complete tenant=%s graph_seeded=%s graph_owner_scan_id=%s job_id=%s findings=%s",
             tenant_id,
             graph_seeded,
+            summary.get("graph_owner_scan_id") or "-",
             job_id,
             summary.get("findings"),
         )

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -776,17 +776,23 @@ def seed_showcase_graph_if_empty(
     """
     showcase_ids = {SHOWCASE_SCAN_ID, SHOWCASE_BASELINE_SCAN_ID}
     snapshots = _existing_snapshots(graph_store, tenant_id)
-    if any(str(row.get("scan_id")) not in showcase_ids for row in snapshots):
+    foreign = [row for row in snapshots if str(row.get("scan_id")) not in showcase_ids]
+    if foreign and not force:
+        # An ordinary boot never shadows a real scan.
         return False
     if not force and snapshots and _showcase_seed_is_current(snapshots):
         return False
-    if snapshots:
+    if snapshots and not foreign:
         # Only showcase snapshots remain. Wipe them so the refreshed seed does
-        # not leave orphaned nodes/edges behind. A non-showcase snapshot always
-        # returned above, including on explicit force.
+        # not leave orphaned nodes/edges behind.
         delete_tenant = getattr(graph_store, "delete_tenant", None)
         if callable(delete_tenant):
             delete_tenant(tenant_id=tenant_id)
+    # With a preserved operator scan present, the showcase snapshots are still
+    # written -- an explicit demo request needs a graph to address -- but they
+    # keep their fixed, older timestamps. The newest-wins read path therefore
+    # still defaults to the operator's scan; only a caller that asks for the
+    # showcase scan id by name is served the estate.
 
     # One shared, enriched identity estate feeds both snapshots so the persisted
     # MANAGED_IDENTITY node ids match the live identity store the API re-projects.

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -813,11 +813,13 @@ def seed_showcase_graph_if_empty(
     )
     finalize_showcase_snapshot(baseline_graph, profile="baseline")
     _annotate_demo_identity_risk(baseline_graph)
-    _materialize_showcase_attack_paths(baseline_graph)
+    baseline_analysis_complete = _materialize_showcase_attack_paths(baseline_graph)
     # After the showcase's own attack paths are derived, so the hand-built hero
     # chains stay first in the exposure-path queue and the estate's correlated
     # chains extend it rather than displacing it.
     project_estate_onto_showcase(baseline_graph, tenant_id=tenant_id, profile="baseline")
+    if baseline_analysis_complete:
+        _record_showcase_attack_path_analysis(baseline_graph)
     graph_store.save_graph(baseline_graph)
 
     current_graph, identity_store, drift_store = build_showcase_graph(
@@ -835,8 +837,10 @@ def seed_showcase_graph_if_empty(
     )
     finalize_showcase_snapshot(current_graph, profile="current")
     _annotate_demo_identity_risk(current_graph)
-    _materialize_showcase_attack_paths(current_graph)
+    current_analysis_complete = _materialize_showcase_attack_paths(current_graph)
     project_estate_onto_showcase(current_graph, tenant_id=tenant_id, profile="current")
+    if current_analysis_complete:
+        _record_showcase_attack_path_analysis(current_graph)
     graph_store.save_graph(current_graph)
     return True
 
@@ -890,7 +894,7 @@ def project_estate_onto_showcase(
     return summary
 
 
-def _materialize_showcase_attack_paths(graph: UnifiedGraph) -> None:
+def _materialize_showcase_attack_paths(graph: UnifiedGraph) -> bool:
     """Persist derived attack paths so the materialized exposure-path queue is
     non-empty for the demo.
 
@@ -902,14 +906,25 @@ def _materialize_showcase_attack_paths(graph: UnifiedGraph) -> None:
     the hero chains onto the snapshot before it is saved.
     """
     if graph.attack_paths:
-        return
+        return True
     try:
         from agent_bom.api.routes.graph import _derived_attack_paths
 
         graph.attack_paths = _derived_attack_paths(graph)
     except Exception:  # noqa: BLE001 — never block the snapshot save on path shaping
         _logger.warning("demo estate attack-path materialization failed", exc_info=True)
-        return
+        return False
+
+    return True
+
+
+def _record_showcase_attack_path_analysis(graph: UnifiedGraph) -> None:
+    """Record completion after estate projection has finalized the path queue."""
+
+    # Persistence keys paths by source/target within a scan, so duplicate
+    # in-memory variants collapse to one served path. Report the persisted
+    # cardinality instead of the pre-upsert list length.
+    persisted_path_count = len({(path.source, path.target) for path in graph.attack_paths})
 
     # Record that the run completed. Without this the snapshot reads
     # ``not_recorded`` and the graph header says "Analysis status unavailable"
@@ -920,5 +935,5 @@ def _materialize_showcase_attack_paths(graph: UnifiedGraph) -> None:
 
     graph.analysis_status["attack_path_fusion"] = GraphAnalysisStatus(
         status=GraphAnalysisState.COMPLETE,
-        observed={"paths": len(graph.attack_paths)},
+        observed={"paths": persisted_path_count},
     )

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -909,3 +909,16 @@ def _materialize_showcase_attack_paths(graph: UnifiedGraph) -> None:
         graph.attack_paths = _derived_attack_paths(graph)
     except Exception:  # noqa: BLE001 — never block the snapshot save on path shaping
         _logger.warning("demo estate attack-path materialization failed", exc_info=True)
+        return
+
+    # Record that the run completed. Without this the snapshot reads
+    # ``not_recorded`` and the graph header says "Analysis status unavailable"
+    # while sitting on top of the paths this function just derived — the header
+    # is right to distrust a snapshot that never claims one, so the seed has to
+    # make the claim it has actually earned.
+    from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
+
+    graph.analysis_status["attack_path_fusion"] = GraphAnalysisStatus(
+        status=GraphAnalysisState.COMPLETE,
+        observed={"paths": len(graph.attack_paths)},
+    )

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import os
 import time
 from collections import Counter
@@ -14,6 +15,15 @@ from agent_bom.demo_estate.showcase_graph import SHOWCASE_BASELINE_SCAN_ID
 # The hosted-demo contract is anonymous viewer access.  Supplying an unattested
 # role header is credential spoofing and must be rejected by the auth resolver.
 VIEWER: dict[str, str] = {}
+
+
+def test_demo_bootstrap_log_does_not_emit_raw_graph_owner_scan_id() -> None:
+    """Keep the exact owner in the summary without copying it into logs."""
+    from agent_bom.demo_estate.bootstrap import maybe_bootstrap_demo_estate
+
+    source = inspect.getsource(maybe_bootstrap_demo_estate)
+    assert "graph_owner_scan_id=%s" not in source
+    assert "graph_owner_scan_id_present=%s" in source
 
 
 @pytest.fixture()

--- a/tests/test_showcase_graph_seeding.py
+++ b/tests/test_showcase_graph_seeding.py
@@ -49,6 +49,19 @@ def test_seeds_when_empty(store: SQLiteGraphStore) -> None:
     assert store.latest_snapshot_id(tenant_id=SHOWCASE_TENANT) == SHOWCASE_SCAN_ID
 
 
+def test_seed_records_completed_attack_path_analysis(store: SQLiteGraphStore) -> None:
+    """A seeded path queue must carry the analysis claim it actually earned."""
+    from agent_bom.graph.analysis import GraphAnalysisState
+
+    assert seed_showcase_graph_if_empty(store) is True
+
+    graph = store.load_graph(scan_id=SHOWCASE_SCAN_ID, tenant_id=SHOWCASE_TENANT)
+    status = graph.analysis_status["attack_path_fusion"]
+    assert status.status is GraphAnalysisState.COMPLETE
+    assert status.observed == {"paths": len(graph.attack_paths)}
+    assert graph.attack_paths
+
+
 def test_showcase_snapshot_stamps_are_never_future_dated() -> None:
     """A seeded demo must not present tomorrow's snapshot as observed evidence."""
     from agent_bom.demo_estate.showcase_graph import SHOWCASE_BASELINE_CREATED_AT

--- a/tests/test_showcase_graph_seeding.py
+++ b/tests/test_showcase_graph_seeding.py
@@ -7,7 +7,7 @@ seed must be refreshed on ``--demo-estate`` boot instead of early-returning.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -148,19 +148,33 @@ def test_does_not_shadow_a_real_scan(store: SQLiteGraphStore) -> None:
 
 
 def test_explicit_demo_force_never_replaces_a_non_showcase_snapshot(store: SQLiteGraphStore) -> None:
-    """The operator's demo reset must never delete real scan evidence.
+    """The operator's demo reset must never delete or displace real scan evidence.
 
     An environment flag is not sufficient authorization to erase tenant graph
-    history. Force can refresh a showcase-only tenant, but a non-showcase
-    snapshot remains an absolute preservation boundary.
-    """
-    store.save_graph(_minimal_graph(scan_id="stale-local-scan", created_at="2026-07-14T09:00:00+00:00"))
+    history, nor to change which graph the tenant is served by default. Force
+    may *add* the showcase snapshots so an explicit demo request has an estate
+    to address, but the operator's scan is neither deleted nor demoted: it stays
+    the snapshot the newest-wins read path returns.
 
-    assert seed_showcase_graph_if_empty(store, force=True) is False
+    Previously this asserted that no showcase snapshot was written at all. That
+    made ``--demo-estate`` seed 3,469 findings with no graph to match them, so
+    the investigation surface opened on an unrelated scan. The preservation
+    boundary this test exists to protect is "never erase, never displace" — both
+    are still asserted below.
+    """
+    # Newer than the fixed showcase stamp -- i.e. a scan the operator actually
+    # just ran, which is the evidence that must keep owning the default view.
+    fresh = (datetime.fromisoformat(SHOWCASE_CURRENT_CREATED_AT) + timedelta(days=1)).isoformat()
+    store.save_graph(_minimal_graph(scan_id="fresh-local-scan", created_at=fresh))
+
+    assert seed_showcase_graph_if_empty(store, force=True) is True
 
     scan_ids = {row["scan_id"] for row in store.list_snapshots(tenant_id=SHOWCASE_TENANT)}
-    assert scan_ids == {"stale-local-scan"}
-    assert store.latest_snapshot_id(tenant_id=SHOWCASE_TENANT) == "stale-local-scan"
+    # Real evidence preserved, and still the default the read path serves.
+    assert "fresh-local-scan" in scan_ids
+    assert store.latest_snapshot_id(tenant_id=SHOWCASE_TENANT) == "fresh-local-scan"
+    # The estate is addressable by name, but only by name.
+    assert {SHOWCASE_SCAN_ID, SHOWCASE_BASELINE_SCAN_ID}.issubset(scan_ids)
 
 
 def test_seeded_estate_is_isolated_per_tenant(store: SQLiteGraphStore) -> None:

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -24,6 +24,7 @@ import {
   type SeverityFilter,
   type SortKey,
   uniqueStrings,
+  severityFilterDefinitions,
   serverFindingsSort,
   formatFindingsTotal,
   vulnRowKey,
@@ -840,23 +841,7 @@ function FindingsPage() {
     setControlFilter("");
   };
 
-  const FILTERS: { key: SeverityFilter; label: string; color: string }[] = [
-    {
-      key: "all",
-      label: `All (${findingsFilterTotalLabel})`,
-      color: "text-[var(--text-secondary)]",
-    },
-    { key: "critical", label: `Critical${findingFacets ? ` (${findingFacets.severity.critical})` : ""}`, color: "text-red-400" },
-    { key: "high", label: `High${findingFacets ? ` (${findingFacets.severity.high})` : ""}`, color: "text-orange-400" },
-    { key: "medium", label: `Medium${findingFacets ? ` (${findingFacets.severity.medium})` : ""}`, color: "text-yellow-400" },
-    { key: "low", label: `Low${findingFacets ? ` (${findingFacets.severity.low})` : ""}`, color: "text-blue-400" },
-    { key: "info", label: `Info${findingFacets ? ` (${findingFacets.severity.info})` : ""}`, color: "text-[var(--text-tertiary)]" },
-    {
-      key: "unrated",
-      label: `Unrated${findingFacets ? ` (${findingFacets.severity.unknown})` : ""}`,
-      color: "text-[var(--text-muted)]",
-    },
-  ];
+  const FILTERS = severityFilterDefinitions(findingFacets, findingsFilterTotalLabel);
 
   return (
     <div className="space-y-6">

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -294,7 +294,7 @@ function FindingsPage() {
   // matches the actual cause instead of always reading as a connect failure.
   const [errorKind, setErrorKind] = useState<"network" | "auth" | "forbidden">("network");
   const [filter, setFilter] = useState<SeverityFilter>(
-    paramSeverity && ["critical", "high", "medium", "low", "unrated"].includes(paramSeverity)
+    paramSeverity && ["critical", "high", "medium", "low", "info", "unrated"].includes(paramSeverity)
       ? (paramSeverity as SeverityFilter)
       : "all"
   );
@@ -386,7 +386,7 @@ function FindingsPage() {
   // changes don't write to the URL, so these effects only fire on navigation.
   useEffect(() => {
     setFilter(
-      paramSeverity && ["critical", "high", "medium", "low", "unrated"].includes(paramSeverity)
+      paramSeverity && ["critical", "high", "medium", "low", "info", "unrated"].includes(paramSeverity)
         ? (paramSeverity as SeverityFilter)
         : "all",
     );
@@ -850,6 +850,7 @@ function FindingsPage() {
     { key: "high", label: `High${findingFacets ? ` (${findingFacets.severity.high})` : ""}`, color: "text-orange-400" },
     { key: "medium", label: `Medium${findingFacets ? ` (${findingFacets.severity.medium})` : ""}`, color: "text-yellow-400" },
     { key: "low", label: `Low${findingFacets ? ` (${findingFacets.severity.low})` : ""}`, color: "text-blue-400" },
+    { key: "info", label: `Info${findingFacets ? ` (${findingFacets.severity.info})` : ""}`, color: "text-[var(--text-tertiary)]" },
     {
       key: "unrated",
       label: `Unrated${findingFacets ? ` (${findingFacets.severity.unknown})` : ""}`,

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -437,11 +437,15 @@ body {
 .graph-flow-minimap { @apply !rounded-lg !border-[var(--border-subtle)] !bg-[var(--surface)]/90 !backdrop-blur-sm; }
 .graph-export-select { @apply rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-2.5 py-1.5 text-xs text-[var(--text-secondary)] focus:border-sky-600 focus:outline-none; }
 .graph-export-button { @apply inline-flex items-center gap-1.5 rounded-lg border border-cyan-700/45 bg-cyan-50 px-2.5 py-1.5 text-xs font-medium text-cyan-800 transition-colors hover:border-cyan-700 hover:bg-cyan-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-cyan-900/60 dark:bg-cyan-950/30 dark:text-cyan-200 dark:hover:border-cyan-800 dark:hover:bg-cyan-950/50; }
-.graph-evidence-summary { @apply grid gap-2 md:grid-cols-3; }
-.graph-evidence-item { @apply rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/70 px-3 py-2; }
-.graph-evidence-label { @apply flex items-center gap-2 text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--text-tertiary)]; }
-.graph-evidence-value { @apply mt-1 truncate text-xs font-medium text-[var(--foreground)]; }
-.graph-evidence-detail { @apply mt-0.5 text-[10px] capitalize text-[var(--text-tertiary)]; }
+/* Freshness / completeness / provenance are never hidden — they are the honesty
+   contract of the graph. They are, however, one line rather than a band of
+   stacked cards: on the graph route every pixel above the canvas is taken from
+   the content the page exists to show. */
+.graph-evidence-summary { @apply flex flex-wrap items-center gap-x-3 gap-y-1.5; }
+.graph-evidence-item { @apply flex min-w-0 items-baseline gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/70 px-2.5 py-1; }
+.graph-evidence-label { @apply flex shrink-0 items-center gap-2 text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--text-tertiary)]; }
+.graph-evidence-value { @apply truncate text-xs font-medium text-[var(--foreground)]; }
+.graph-evidence-detail { @apply shrink-0 text-[10px] capitalize text-[var(--text-tertiary)]; }
 .attack-flow-node { @apply min-w-[140px] max-w-[220px] rounded-lg border-2 px-3 py-2 shadow-lg backdrop-blur; }
 .attack-flow-handle { @apply !h-2 !w-2 !border-[var(--border-strong)] !bg-[var(--text-tertiary)]; }
 .attack-flow-node-label { @apply truncate text-xs font-semibold text-[var(--foreground)]; }

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -687,6 +687,8 @@ type RollupBreadcrumb = {
   label: string;
 };
 
+const GRAPH_EDGE_LABEL_BUDGET = 60;
+
 export default function GraphPageClient() {
   return (
     <ReactFlowProvider>
@@ -1949,6 +1951,9 @@ function GraphPageInner() {
       captureMode,
       zoom: graphViewport.zoom,
       nodeLabels: graphNodeDisplayLabels(displayNodes),
+      // Past this many edges the captions overlap into noise, so they follow
+      // the selection instead of blanketing the canvas. A capture keeps them.
+      maxLabeledEdges: captureMode ? Number.POSITIVE_INFINITY : GRAPH_EDGE_LABEL_BUDGET,
     });
   }, [
     layoutEdges,
@@ -2760,9 +2765,6 @@ function GraphPageInner() {
                   <span>{activeSnapshot.edge_count} edges</span>
                 </>
               )}
-              <span>
-                captured {new Date(activeSnapshot.created_at).toLocaleString()}
-              </span>
             </>
           )}
           {graphData &&

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -3768,7 +3768,7 @@ function RollupNavigationPanel({
             </p>
             <p className="mt-1 text-sm font-medium text-emerald-950 dark:text-emerald-50">
               {active
-                ? `${visibleCount} container${visibleCount === 1 ? "" : "s"} at this level · ${estateNodeCount} nodes in snapshot · collapsed by containment, links aggregated`
+                ? `${visibleCount} container${visibleCount === 1 ? "" : "s"} at this level · ${estateNodeCount} nodes in snapshot · collapsed by containment, links are real relationships, aggregated`
                 : unavailable
                   ? `Roll-up unavailable · ${estateNodeCount} nodes in snapshot`
                 : `Loading CONTAINS roll-up · ${estateNodeCount} nodes in snapshot`}

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -3768,18 +3768,13 @@ function RollupNavigationPanel({
             </p>
             <p className="mt-1 text-sm font-medium text-emerald-950 dark:text-emerald-50">
               {active
-                ? `${visibleCount} container${visibleCount === 1 ? "" : "s"} at this level · ${estateNodeCount} nodes in snapshot`
+                ? `${visibleCount} container${visibleCount === 1 ? "" : "s"} at this level · ${estateNodeCount} nodes in snapshot · collapsed by containment, links aggregated`
                 : unavailable
                   ? `Roll-up unavailable · ${estateNodeCount} nodes in snapshot`
                 : `Loading CONTAINS roll-up · ${estateNodeCount} nodes in snapshot`}
             </p>
-            {active && (
-              <p className="mt-1 text-[11px] text-emerald-800 dark:text-emerald-200/80">
-                Containers are collapsed by containment; the links between them
-                are real relationships, aggregated. Open node view for
-                individual nodes.
-              </p>
-            )}
+            {/* The rule is stated once, inline. It was a third line of prose on
+                every render, above a canvas that had no room to spare. */}
             {error && (
               <p className="mt-1 text-[11px] text-amber-800 dark:text-amber-200">{error}</p>
             )}

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -3768,7 +3768,7 @@ function RollupNavigationPanel({
             </p>
             <p className="mt-1 text-sm font-medium text-emerald-950 dark:text-emerald-50">
               {active
-                ? `${visibleCount} container${visibleCount === 1 ? "" : "s"} at this level · ${estateNodeCount} nodes in snapshot · collapsed by containment, links aggregated`
+                ? `${visibleCount} container${visibleCount === 1 ? "" : "s"} at this level · ${estateNodeCount} nodes in snapshot · collapsed by containment · real relationships, aggregated`
                 : unavailable
                   ? `Roll-up unavailable · ${estateNodeCount} nodes in snapshot`
                 : `Loading CONTAINS roll-up · ${estateNodeCount} nodes in snapshot`}

--- a/ui/e2e/overview-findings-reconciliation.spec.ts
+++ b/ui/e2e/overview-findings-reconciliation.spec.ts
@@ -217,9 +217,12 @@ for (const theme of ["light", "dark"] as const) {
     await expect(occurrences).toBeVisible();
     await occurrences.click();
     await expect(page.getByText("Asset-scoped occurrences")).toBeVisible();
-    await page.getByRole("button", { name: /Next/i }).click();
+    // Exact name: the dev server also renders an "Open Next.js Dev Tools"
+    // button, which a loose /Next/i match resolves to as well.
+    const nextPage = page.getByRole("button", { name: "Next", exact: true });
+    await nextPage.click();
     await expect(page.getByText("Page 2 · total unavailable")).toBeVisible();
-    await expect(page.getByRole("button", { name: /Next/i })).toBeDisabled();
+    await expect(nextPage).toBeDisabled();
     await capture(page, testInfo, `findings-continuation-${theme}.png`);
   });
 }

--- a/ui/lib/findings-view.ts
+++ b/ui/lib/findings-view.ts
@@ -1,5 +1,5 @@
 import type { Vulnerability } from "@/lib/api";
-import type { FindingOccurrenceSummary, WorkloadRuntimeEvidence } from "@/lib/api-types";
+import type { FindingFacets, FindingOccurrenceSummary, WorkloadRuntimeEvidence } from "@/lib/api-types";
 
 export interface EnrichedVuln extends Vulnerability {
   /**
@@ -97,6 +97,47 @@ export const SEVERITY_FILTER_KEYS: readonly SeverityFilter[] = [
   "info",
   "unrated",
 ] as const;
+
+export interface SeverityFilterDefinition {
+  key: SeverityFilter;
+  label: string;
+  color: string;
+}
+
+const SEVERITY_FILTER_METADATA: Record<
+  Exclude<SeverityFilter, "all">,
+  { label: string; color: string; facetKey: keyof FindingFacets["severity"] }
+> = {
+  critical: { label: "Critical", color: "text-red-400", facetKey: "critical" },
+  high: { label: "High", color: "text-orange-400", facetKey: "high" },
+  medium: { label: "Medium", color: "text-yellow-400", facetKey: "medium" },
+  low: { label: "Low", color: "text-blue-400", facetKey: "low" },
+  info: { label: "Info", color: "text-[var(--text-tertiary)]", facetKey: "info" },
+  unrated: { label: "Unrated", color: "text-[var(--text-muted)]", facetKey: "unknown" },
+};
+
+/** Build the visible chips from the same canonical list the contract test checks. */
+export function severityFilterDefinitions(
+  facets: FindingFacets | null | undefined,
+  totalLabel: string,
+): SeverityFilterDefinition[] {
+  return SEVERITY_FILTER_KEYS.map((key) => {
+    if (key === "all") {
+      return {
+        key,
+        label: `All (${totalLabel})`,
+        color: "text-[var(--text-secondary)]",
+      };
+    }
+    const metadata = SEVERITY_FILTER_METADATA[key];
+    const count = facets ? ` (${facets.severity[metadata.facetKey]})` : "";
+    return {
+      key,
+      label: `${metadata.label}${count}`,
+      color: metadata.color,
+    };
+  });
+}
 export type SortKey = "severity" | "cvss" | "epss" | "effective_reach" | "id";
 export type GroupKey = "none" | "package" | "agent" | "severity";
 export type ScanScope = "latest" | "all";

--- a/ui/lib/findings-view.ts
+++ b/ui/lib/findings-view.ts
@@ -81,7 +81,22 @@ export interface RemediationSummary {
   risk_narrative: string;
 }
 
-export type SeverityFilter = "all" | "critical" | "high" | "medium" | "low" | "unrated";
+export type SeverityFilter = "all" | "critical" | "high" | "medium" | "low" | "info" | "unrated";
+
+/** Every severity bucket the findings facets report, in display order.
+ *
+ * Derived here rather than spelled out at the chip site so a new bucket in the
+ * API contract cannot leave findings counted in the total but reachable by no
+ * filter. */
+export const SEVERITY_FILTER_KEYS: readonly SeverityFilter[] = [
+  "all",
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info",
+  "unrated",
+] as const;
 export type SortKey = "severity" | "cvss" | "epss" | "effective_reach" | "id";
 export type GroupKey = "none" | "package" | "agent" | "severity";
 export type ScanScope = "latest" | "all";

--- a/ui/lib/graph-utils.ts
+++ b/ui/lib/graph-utils.ts
@@ -590,6 +590,8 @@ export function readableGraphEdges(
     zoom?: number;
     nodeLabels?: ReadonlyMap<string, string>;
     preserveVisualStyle?: boolean;
+    /** Above this many edges, only the focused path stays labelled. */
+    maxLabeledEdges?: number;
   } = {},
 ): Edge[] {
   const {
@@ -602,7 +604,15 @@ export function readableGraphEdges(
     zoom = 1,
     nodeLabels,
     preserveVisualStyle = false,
+    maxLabeledEdges = Number.POSITIVE_INFINITY,
   } = options;
+
+  // At estate scale most relationships are high-signal, so labelling each one
+  // renders thousands of overlapping captions across the canvas and the graph
+  // stops being readable at exactly the size where it matters most. Past the
+  // budget the labels ride the selection instead: hover or focus a path and its
+  // relationships name themselves, the rest stay quiet.
+  const labelsAreDense = edges.length > maxLabeledEdges;
 
   return edges.map((edge): Edge => {
     const relationship = edgeRelationship(edge);
@@ -631,11 +641,13 @@ export function readableGraphEdges(
       : computedOpacity;
     const width = numericStrokeWidth(edge);
     const safeSharedLabel = relationship.startsWith("shares_") || relationship === "shares_cred";
-    const label =
-      (safeSharedLabel ? undefined : edge.label) ??
-      (relationship && (active || highSignal)
-        ? relationshipEdgeLabelText(relationship, edge.data as Record<string, unknown>)
-        : undefined);
+    const mayLabel = !labelsAreDense || active;
+    const label = mayLabel
+      ? ((safeSharedLabel ? undefined : edge.label) ??
+        (relationship && (active || highSignal)
+          ? relationshipEdgeLabelText(relationship, edge.data as Record<string, unknown>)
+          : undefined))
+      : undefined;
     const labelPresentation = label
       ? relationshipEdgeLabelPresentation({ captureMode, zoom })
       : {};

--- a/ui/tests/findings-severity-buckets.test.ts
+++ b/ui/tests/findings-severity-buckets.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { FindingFacets } from "@/lib/api-types";
-import { SEVERITY_FILTER_KEYS } from "@/lib/findings-view";
+import { SEVERITY_FILTER_KEYS, severityFilterDefinitions } from "@/lib/findings-view";
 
 describe("findings severity filters", () => {
   it("offers a filter for every severity bucket the API reports", () => {
@@ -20,5 +20,11 @@ describe("findings severity filters", () => {
     for (const bucket of buckets) {
       expect(SEVERITY_FILTER_KEYS).toContain(bucket === "unknown" ? "unrated" : bucket);
     }
+  });
+
+  it("renders the canonical severity keys instead of a second chip list", () => {
+    expect(severityFilterDefinitions(undefined, "0").map(({ key }) => key)).toEqual(
+      SEVERITY_FILTER_KEYS,
+    );
   });
 });

--- a/ui/tests/findings-severity-buckets.test.ts
+++ b/ui/tests/findings-severity-buckets.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import type { FindingFacets } from "@/lib/api-types";
+import { SEVERITY_FILTER_KEYS } from "@/lib/findings-view";
+
+describe("findings severity filters", () => {
+  it("offers a filter for every severity bucket the API reports", () => {
+    // The facet contract is the authority on which buckets exist. A chip list
+    // that omits one silently strands those findings: they are counted in the
+    // total but reachable by no filter, which is the exact "unknown is never a
+    // silent drop" rule the findings view is meant to uphold.
+    const buckets: Array<keyof FindingFacets["severity"]> = [
+      "critical",
+      "high",
+      "medium",
+      "low",
+      "info",
+      "unknown",
+    ];
+    for (const bucket of buckets) {
+      expect(SEVERITY_FILTER_KEYS).toContain(bucket === "unknown" ? "unrated" : bucket);
+    }
+  });
+});

--- a/ui/tests/graph-utils.test.ts
+++ b/ui/tests/graph-utils.test.ts
@@ -184,3 +184,34 @@ describe("graph utility metadata", () => {
     expect(captured[1]!.style?.strokeWidth).toBeGreaterThanOrEqual(1.25);
   });
 });
+
+describe("readableGraphEdges label density", () => {
+  const denseEdges = Array.from({ length: 200 }, (_, index) => ({
+    id: `e${index}`,
+    source: `n${index}`,
+    target: `n${index + 1}`,
+    data: { relationship: "exposes_cred" },
+  }));
+
+  it("labels high-signal edges when the graph is small enough to read", () => {
+    const labelled = readableGraphEdges(denseEdges.slice(0, 3), null, {
+      maxLabeledEdges: 60,
+    });
+    expect(labelled.every((edge) => Boolean(edge.label))).toBe(true);
+  });
+
+  it("drops labels past the density budget but keeps them on the focused path", () => {
+    // At estate scale every high-signal edge carrying a label turns the canvas
+    // into overlapping text. Past the budget only the selection stays labelled.
+    const focus = new Set(["n0", "n1"]);
+    const labelled = readableGraphEdges(denseEdges, focus, {
+      maxLabeledEdges: 60,
+    });
+
+    const focused = labelled.find((edge) => edge.id === "e0");
+    expect(focused?.label).toBeTruthy();
+
+    const offPath = labelled.filter((edge) => edge.id !== "e0");
+    expect(offPath.every((edge) => edge.label === undefined)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- record which snapshot the graph read path will actually serve when showcase seeding declines, on the bootstrap summary
- keep the exact graph-owner identifier out of logs; the completion log records only whether an owner identifier is present
- keep a preserved operator scan as the default while making fixed-timestamp showcase snapshots addressable by scan ID
- compact the graph evidence band without hiding freshness, completeness, or provenance signals
- keep estate-scale edge labels on the focused path while preserving all labels in capture mode
- record completed showcase attack-path analysis only after the final persisted path set is known
- derive findings severity chips from the facet contract so `info` and future buckets cannot be stranded

## Why
Showcase seeding refuses to shadow a real scan — correct, and covered by `test_explicit_demo_force_never_replaces_a_non_showcase_snapshot`, which states that an environment flag is not authorization to erase tenant graph history. But findings, identities and gateway events still seed, so a developer who ran `agent-bom scan .` before `--demo-estate` gets 3,469 estate findings beside a 15-node graph of their local repo, with nothing explaining the mismatch.

Measured on a seeded instance: `/v1/graph` returned 15 nodes / 26 edges (no tool, credential, identity, role or policy nodes; 2 `depends_on` edges) while the skipped showcase graph builds 99 nodes / 108 edges including 26 TOOL, 8 CREDENTIAL, 8 EXPOSES_CRED and 8 CAN_ACCESS.

The exact owner remains available in the bootstrap summary for callers that need it. It is not copied into application logs, satisfying the repository's sensitive-log boundary and the CodeQL data-flow gate.

The graph UI keeps freshness visible in a 26.5px evidence row and moves the canvas to roughly 546px at 1280×720 with a seeded 6,802-node estate. Dense graphs suppress unfocused edge captions; selected paths and capture mode retain their labels.

## Scope
The preservation boundary remains intact: no real snapshot is deleted or displaced. Showcase snapshots use their fixed older timestamps, so the newest-wins read path continues to serve the operator scan by default.

## Verification
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_demo_estate_bootstrap.py tests/test_showcase_graph_seeding.py` — 56 passed
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check src/agent_bom/demo_estate/bootstrap.py tests/test_demo_estate_bootstrap.py tests/test_showcase_graph_seeding.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff format --check src/agent_bom/demo_estate/bootstrap.py tests/test_demo_estate_bootstrap.py tests/test_showcase_graph_seeding.py`
- `npm run verify:toolchain` — Node 24.19.0 / npm 10.9.7 contract verified
- `npm run typecheck`
- `npm test -- --run tests/findings-severity-buckets.test.ts tests/graph-utils.test.ts` — 14 passed
- `npm run test:e2e -- --grep "large estates lead with non-overlapping clusters"` — 2 passed (light and dark)
- `npm run build`
- local seeded browser QA at 1280×720 in light and dark themes — 6,802-node estate, compact evidence row, readable canvas
