### PR TITLE
fix(graph): wrap node labels instead of clipping estate names

### DIFF
--- a/ui/components/lineage-nodes.tsx
+++ b/ui/components/lineage-nodes.tsx
@@ -168,9 +168,9 @@ function NodeCard({
         position={Position.Right}
         className={`!w-2 !h-2 !bg-current ${source ? "" : "!opacity-0"}`}
       />
-      <div className="mb-1 flex min-w-0 items-center gap-2">
+      <div className="mb-1 flex min-w-0 items-start gap-2">
         <Icon className={`w-[18px] h-[18px] shrink-0 ${iconClass}`} />
-        <span className="min-w-0 flex-1 truncate text-[15px] font-semibold leading-5 text-[var(--foreground)]">
+        <span className="min-w-0 flex-1 break-words line-clamp-2 text-[15px] font-semibold leading-5 text-[var(--foreground)]">
           {data.label}
         </span>
         <span className="ml-auto shrink-0 rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-1.5 py-0.5 text-[10px] uppercase tracking-[0.1em] text-[var(--text-secondary)]">
@@ -778,7 +778,9 @@ function SummaryNode({ data }: { data: LineageNodeData }) {
         className="!w-1.5 !h-1.5"
       />
       <div className="flex items-center gap-1">
-        <span className="min-w-0 flex-1 truncate text-[11px] font-semibold">{data.label}</span>
+        <span className="min-w-0 flex-1 break-words line-clamp-2 text-[11px] font-semibold leading-tight">
+          {data.label}
+        </span>
         {vulnCount > 0 && (
           <span className="ml-auto rounded bg-white/70 px-1 text-[9px] font-mono dark:bg-black/40">
             {vulnCount}

--- a/ui/tests/lineage-node-legibility.test.tsx
+++ b/ui/tests/lineage-node-legibility.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const source = readFileSync(
+  resolve(__dirname, "../components/lineage-nodes.tsx"),
+  "utf8",
+);
+
+describe("lineage node labels", () => {
+  it("wraps long asset names instead of clipping them to one line", () => {
+    // Estate names are long by nature -- GCS_SERVICE_ACCOUNT_JSON,
+    // data: customer-pii-prod. Clipped to a single 180px line they render as
+    // "GCS_SERVICE_ACC..." and the node stops identifying anything. The grid
+    // has vertical slack and no horizontal slack, so the label takes a second
+    // line rather than a wider node.
+    // Neither the detailed node nor the rolled-up summary node may clip.
+    expect(source).not.toMatch(/flex-1 truncate/);
+    expect(source.match(/line-clamp-2/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Summary
- wrap lineage node labels to a second line and clamp, instead of clipping them to one
- align the type badge to the top so it stays put when a name wraps
- assert both node variants against clipping so the regression cannot return quietly

## Why
Clipped to one line, the estate's own names stopped identifying anything:

| before | after |
|---|---|
| `Security group sg-pr...` | `Security group sg-prod allows 0.0.0.0/0 on po...` |
| `data: customer-pii-prod...` | `data: customer-pii-prod (S3)` |
| `GCS_SERVICE_ACC...` | `GCS_SERVICE_ACCOUNT_KEY` |

The first row is the point: a misconfiguration node that never said what the misconfiguration was.

Height is the cheap axis here — the layout grid has vertical slack and none horizontally, so widening the node would have collided with its neighbour.

## Verification
- `npx vitest run tests/lineage-node-legibility.test.tsx` — red before the change, green after
- `npx tsc --noEmit` clean
- `NEXT_EXPORT=1 npm run build` then rendered against a seeded 6,807-node snapshot at 1512x811: labels read in full, no row overlap

## Not changed
The minimap overlays the canvas bottom-right, which reads as covering nodes. Leaving it: `shouldShowGraphMiniMap` already hides it below 18 nodes / 36 edges, and an overlaid minimap on a large graph is the standard behaviour for this class of tool. Changing it would be motion without a defect.