### PR TITLE
fix(release): accelerate graph investigation and fail incomplete scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ automated findings open until the next daily schedule.
 
 ### Fixed
 
+- Offline repository scans with a missing or unreadable vulnerability database
+  now return the documented incomplete-scan verdict (`1`) while preserving a
+  partial artifact, instead of misclassifying valid input as usage error `2`.
+- Ranked attack paths render independently from slower full-estate fix guidance,
+  expose their correlated role chain, support bounded traversal from each hop,
+  and transfer only the relationships that prove the returned paths.
+- The labeled sample estate now records an idempotent two-point posture
+  trajectory through the production trend store, and the public scanner story
+  links its mutation-tested OSV range-matching evidence without presenting the
+  bounded benchmark as universal accuracy.
+
 - Graph label budgets survive accessibility normalization, persisted attack
   paths derive from the final projected estate, and forced demo seeding never
   displaces newer operator evidence. The demo now exposes and renders an

--- a/README.md
+++ b/README.md
@@ -138,6 +138,32 @@ in full either way, and the last line names the gate that matched. Full
 Save an artifact with `agent-bom scan . -f sarif -o findings.sarif`, or follow
 the [first-run guide](docs/FIRST_RUN.md) for formats and CI use.
 
+### Daily developer loop
+
+Try the scanner without installing it, then check a package before adding it:
+
+```bash
+uvx agent-bom scan .
+uvx agent-bom check requests@2.33.0 --ecosystem pypi
+```
+
+`check` returns an allow/unsafe/incomplete pre-install verdict; `scan` covers the
+repository plus discovered AI/MCP configuration. To make both dependency and
+secret gates automatic for a team, pin the shipped consumer hooks:
+
+```yaml
+repos:
+  - repo: https://github.com/msaad00/agent-bom
+    rev: v0.102.0
+    hooks:
+      - id: agent-bom-secrets
+      - id: agent-bom-scan
+```
+
+Run `pre-commit install` once. The hooks install agent-bom into their own
+isolated environment, so contributors do not need a separate global install.
+[Hook behavior and CI examples](docs/DEPLOYMENT.md#pre-commit-hook).
+
 <details>
 <summary><b>Expansion paths — pick one only after the front door works</b></summary>
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
 data platforms, MCP servers, and runtime activity, then normalizes the evidence
 into one Finding + UnifiedGraph model for prioritized investigation and action.
 
-Blast radius connects a package finding to the AI surfaces that can reach it:
+Blast radius starts at an agent or MCP tool entrypoint and connects a package
+finding to the AI surfaces that can reach it:
 
 ```text
 package
@@ -43,6 +44,12 @@ package
 The terminal report shows this attack path for human review. MCP clients can
 query the same evidence through `exposure_paths` and use `should_i_deploy` for
 a bounded pre-deployment verdict.
+
+**Measured matcher proof:** the committed, mutation-tested range benchmark
+currently covers 207 comparable OSV advisories, 19,161 affected-version checks,
+and 576 fixed-version checks with zero false negatives and zero false positives.
+[Method and machine-readable result](docs/CVE_MATCHING_ACCURACY.json). This is a
+reproducible range-matcher baseline, not a universal scanner-accuracy claim.
 
 - **Run where you deploy:** the same deterministic scanner produces findings, SARIF, SBOMs, HTML reports, and graph exports on a workstation, in CI, in Docker/Kubernetes, or in your control plane.
 - **Centralize when ready:** self-host fleet, browser, compliance, and audit evidence inside your cloud and identity boundary.
@@ -108,6 +115,10 @@ Need a disconnected scan? Seed the smallest package-advisory database first:
 agent-bom db update --osv-ecosystem PyPI
 agent-bom scan . --offline
 ```
+
+If that database is missing or unreadable, the scan writes a partial artifact
+when `-o` is set and exits `1`; CI therefore cannot mistake unavailable
+advisory coverage for a clean scan.
 
 On a fresh database, that command covers only the selected ecosystem; packages
 from other ecosystems remain explicit offline coverage gaps. Repeat

--- a/docs/FIRST_RUN.md
+++ b/docs/FIRST_RUN.md
@@ -25,6 +25,11 @@ download the archive again before updating advisory IDs. Use the broader
 `agent-bom db update` for distro/image, exploit-probability, and
 known-exploited-vulnerability feeds.
 
+An offline repository scan with a missing, empty, or unreadable advisory
+database fails closed with status `1`. When an output path is requested, the
+artifact is still written with `scan_run.outcome: partial` and the unavailable
+coverage named; it must not be interpreted as a clean zero-finding result.
+
 ## 1. Run the Release-Pinned Demo
 
 ```bash

--- a/docs/PERFORMANCE_BENCHMARKS.md
+++ b/docs/PERFORMANCE_BENCHMARKS.md
@@ -154,6 +154,7 @@ healthy self-hosted rollout to validate with the bundled k6 harness.
 |---|---|---:|---:|
 | `GET /v1/graph?limit=100` | store-backed overview page | < 300 ms p95 | < 500 ms p95 |
 | `GET /v1/graph/search?q=agent&limit=25` | store-backed search page | < 250 ms p95 | < 400 ms p95 |
+| `GET /v1/graph/attack-paths?limit=25` | persisted-path queue with path-edge envelope | < 150 ms p95 | < 300 ms p95 |
 | `GET /v1/fleet?limit=25` | authenticated fleet read | < 200 ms p95 | < 350 ms p95 |
 | `GET /v1/fleet/stats` | fleet summary read | < 150 ms p95 | < 300 ms p95 |
 | `POST /v1/proxy/audit` | proxy audit ingest batch | < 300 ms p95 | < 500 ms p95 |
@@ -172,6 +173,13 @@ k6 run deploy/loadtest/k6-control-plane-api.js
 k6 run deploy/loadtest/k6-graph-api.js
 k6 run deploy/loadtest/k6-proxy-audit.js
 ```
+
+The v0.102.0 release-candidate measurement on the local 6.8k-node demo
+snapshot returned 25 persisted paths in 38.4–39.7 ms after warm-up. Restricting
+the response to the edges that prove those paths reduced the envelope from
+508,562 to 192,879 bytes while direct-neighbor traversal remained available
+through the node-neighbor endpoint. Raw samples and scope are recorded in
+[`perf/results/attack-path-queue-envelope-live-2026-08-22.json`](perf/results/attack-path-queue-envelope-live-2026-08-22.json).
 
 Interpretation:
 

--- a/docs/graph/CONTRACT.md
+++ b/docs/graph/CONTRACT.md
@@ -88,6 +88,7 @@ The graph renderer ships deterministic focused and expanded modes. Operators can
 | Mode / size | Default behaviour | Why |
 |---|---|---|
 | Relevant paths default | 2-hop neighbourhood, 50-node page size, high-severity vulnerable scope, sibling fan-outs of 5+ collapsed into expandable cluster pills. | Starts every investigation readable, even on dense self-scans. |
+| Ranked path queue | Persisted paths load independently from full-estate fix guidance; the response includes only consecutive path edges. Direct neighbors load on demand with a 12-node fan-out cap. | Produces a fast, evidence-minimal first view without hiding broader topology or implying unrelated edges prove the selected path. |
 | Expanded mode | 3-hop neighbourhood, 250-node page size, sibling fan-outs of 20+ collapsed. | Lets operators widen context deliberately without turning the first view into a whole-tenant canvas. |
 | Zoomed out | Level-of-detail renderer swaps detail cards for summary cards and cluster bubbles below the zoom thresholds. | Dense snapshots stay navigable instead of turning into unreadable labels. |
 | Large overview | Visible pages at or above 500 nodes or 1,200 edges switch from React Flow to a limited 2D canvas overview. The overview draws up to 3,000 high-signal nodes and 6,000 high-signal edges; search, filters, selected-node detail, and reachability drill-ins remain server-backed. | Keeps broad estate pages from blanking or stalling while preserving React Flow for bounded investigations. |

--- a/docs/perf/results/attack-path-queue-envelope-live-2026-08-22.json
+++ b/docs/perf/results/attack-path-queue-envelope-live-2026-08-22.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "1.0",
+  "measured_at": "2026-08-22",
+  "source_base_sha": "48ddff0a7e4882659f48dbf7afbb3658db35167e",
+  "environment": {
+    "backend": "sqlite",
+    "host": "macos-local",
+    "python": "3.13",
+    "snapshot": "showcase",
+    "snapshot_nodes": 6802,
+    "snapshot_edges": 22993,
+    "persisted_attack_paths": 2155
+  },
+  "request": "/v1/graph/attack-paths?scan_id=showcase&offset=0&limit=25",
+  "before": {
+    "edge_scope": "all incident edges among returned hop nodes",
+    "returned_paths": 25,
+    "returned_nodes": 73,
+    "returned_edges": 428,
+    "response_bytes": 508562,
+    "warm_seconds": [0.047782, 0.041942, 0.041674, 0.042510, 0.044478]
+  },
+  "after": {
+    "edge_scope": "consecutive relationships proving returned paths",
+    "returned_paths": 25,
+    "returned_nodes": 73,
+    "returned_edges": 57,
+    "response_bytes": 192879,
+    "warm_seconds": [0.039663, 0.038387, 0.038373, 0.038482, 0.038597]
+  },
+  "notes": [
+    "The queue reports pagination and completeness for the full persisted path count.",
+    "Bounded direct dependencies and dependents remain available from the node-neighbor endpoint.",
+    "This is a local release-candidate measurement, not a hosted production SLA."
+  ]
+}

--- a/site-docs/architecture/security-graph-model.md
+++ b/site-docs/architecture/security-graph-model.md
@@ -124,13 +124,18 @@ To keep the graph readable at larger sizes, `agent-bom` uses:
 - focused vs expanded topology modes
 - relationship-scope filters
 - node detail enrichment on demand
+- an independent persisted-path fast lane, so full-estate fix guidance cannot
+  delay the first ranked path
+- semantic role chains in the queue (`agent → server → package → finding`)
+  and bounded one-hop traversal for direct dependencies and dependents
 
 The operator workflow should be:
 
 1. start with the focused graph or attack-path shortlist
 2. narrow by agent, severity, or relationship scope
-3. open node detail for IDs, timestamps, and impact
-4. page or expand only when the current slice is too narrow
+3. expand a hop for bounded direct neighbors, or traverse from it into lineage
+4. open node detail for IDs, timestamps, and impact
+5. page or expand only when the current slice is too narrow
 
 ## Relationship categories
 

--- a/site-docs/features/scanning.md
+++ b/site-docs/features/scanning.md
@@ -38,6 +38,19 @@ Linux paths use `~/.config/` equivalents.
 | [GitHub Advisories](https://github.com/advisories) | Supplemental advisory data |
 | Commercial vuln API | Optional enrichment when a vendor API token is configured |
 
+### Reproducible matching evidence
+
+The committed, mutation-tested range benchmark currently covers 207 comparable
+OSV advisories, 19,161 affected-version checks, and 576 fixed-version checks
+with zero false negatives and zero false positives. The benchmark removes the
+explicit affected-version list before exercising range logic, uses advisory
+fixed releases as its defensible negative set, and fails under a deliberately
+reintroduced multi-window bug. See the
+[machine-readable result](../../docs/CVE_MATCHING_ACCURACY.json) and
+[`scripts/cve_matching_accuracy.py`](../../scripts/cve_matching_accuracy.py).
+This is a reproducible range-matcher baseline, not a universal scanner-accuracy
+claim.
+
 ## Credential exposure detection
 
 Config files are parsed for server definitions. Environment variable **values** are automatically redacted — only key names are reported. Patterns detected:

--- a/site-docs/features/scanning.md
+++ b/site-docs/features/scanning.md
@@ -46,8 +46,8 @@ with zero false negatives and zero false positives. The benchmark removes the
 explicit affected-version list before exercising range logic, uses advisory
 fixed releases as its defensible negative set, and fails under a deliberately
 reintroduced multi-window bug. See the
-[machine-readable result](../../docs/CVE_MATCHING_ACCURACY.json) and
-[`scripts/cve_matching_accuracy.py`](../../scripts/cve_matching_accuracy.py).
+[machine-readable result](https://github.com/msaad00/agent-bom/blob/main/docs/CVE_MATCHING_ACCURACY.json) and
+[`scripts/cve_matching_accuracy.py`](https://github.com/msaad00/agent-bom/blob/main/scripts/cve_matching_accuracy.py).
 This is a reproducible range-matcher baseline, not a universal scanner-accuracy
 claim.
 

--- a/site-docs/reference/exit-codes.md
+++ b/site-docs/reference/exit-codes.md
@@ -14,7 +14,7 @@ automation can distinguish caller mistakes from control-plane outages.
 | Code  | Name                | Meaning                                                                                                       | Typical sources                                                            |
 | ----- | ------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
 | `0`   | success             | Command completed; no findings or all findings under the default or configured severity threshold.             | Any subcommand that finished cleanly; `scan --exit-zero` with vulnerability findings only. |
-| `1`   | scan verdict or operational failure | Either (a) a scan gate matched — see "Why `scan` exits 1" below — or (b) a precondition failed: missing config, unreachable backend, missing required env var, dependency not present. | Default critical threshold or `--fail-on-severity` matched, `agent-bom scan --demo` (malicious package fails closed), `--clickhouse-url` missing, NVD unreachable, optional dependency not installed, `agent-bom connect <provider>` failing to verify or register. |
+| `1`   | scan verdict or operational failure | Either (a) a scan gate matched — see "Why `scan` exits 1" below — or (b) a precondition failed: missing config, unreachable backend, missing required env var, dependency not present. | Default critical threshold or `--fail-on-severity` matched, an incomplete scan such as a missing or unreadable offline vulnerability database, `agent-bom scan --demo` (malicious package fails closed), `--clickhouse-url` missing, NVD unreachable, optional dependency not installed, `agent-bom connect <provider>` failing to verify or register. |
 | `2`   | usage or empty      | Invalid arguments, no input to act on, or report contained no rows after filtering.                            | Click `UsageError` (auto), `agent-bom skills audit` with no skill files, empty result rendering, `agent-bom connect` when the control plane rejects the payload (`400`/`422`). |
 | `3`   | policy gate failed  | An opt-in policy gate failed. Currently emitted by `--require-fresh-db` / `AGENT_BOM_REQUIRE_FRESH_DB` when the local vuln DB is stale. Otherwise reserved for future policy gates. | `agent-bom scan --require-fresh-db` against a stale local vuln DB.          |
 | `4`   | (reserved)          | Reserved for "auth required" / "auth invalid" on commands that talk to an authenticated control plane.        | Not yet emitted.                                                           |
@@ -35,6 +35,13 @@ named on the last line of the output. A scan exits `1` when any of these hold.
 | A policy rule failed | Yes — `--policy`, or `--model-policy-mode enforce` / `--require-model-signatures` / `--block-unsafe-model-formats` (all default off) | Your policy rejected the result. |
 | A known-malicious package was found | **No — fails closed** | A typosquat, dependency-confusion, or known-malicious advisory match. Exiting `0` here would let the package install. |
 | The scan did not complete | **No — fails closed** | A requested collector degraded or failed; `scan_run.issues` in the artifact says which. A partial artifact with zero findings must not read as clean. |
+
+A missing, empty, or unreadable local advisory database during `scan --offline`
+is an incomplete scan, so `scan` writes a partial artifact when an output was
+requested and exits `1`. It is not a usage error (`2`) because the command and
+input were valid. The narrower `check` command retains its established
+precondition contract and exits `2` when its requested offline advisory lookup
+cannot start.
 
 `scan` defaults to a `critical` vulnerability gate, so a report containing
 critical findings exits non-zero even when no threshold flag was passed. The

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -10,6 +10,10 @@ They fail closed unless a remote caller uses the operator token and supplies an
 admin role, the tool-specific write scope, and an audit reason; stdio cannot
 invoke them.
 
+`agent-bom mcp server` and the programmatic server both expose the complete
+81-tool catalog by default. Use `--profile guided` only when a client needs the
+smaller workflow-oriented context envelope.
+
 <details>
 <summary>Complete current catalog (81 tools)</summary>
 

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1791,6 +1791,14 @@ def _serialize_attack_path_queue(
     path_source: str,
 ) -> dict[str, Any]:
     nodes_by_id = {node.id: node for node in nodes}
+    # `edges_for_node_ids` intentionally returns every incident edge for its
+    # general graph-page callers.  A ranked path page has a tighter evidence
+    # contract: ship only relationships that connect consecutive hops in one
+    # of the returned paths.  Neighbor context is available through the
+    # bounded node-neighbor endpoint, so unrelated chords among the same hop
+    # nodes only inflate transfer/render cost and visually imply extra proof.
+    path_pairs = {pair for path in paths for pair in zip(path.hops, path.hops[1:], strict=False)}
+    path_edges = [edge for edge in path_edges if (edge.source, edge.target) in path_pairs]
     stats = _sync_attack_path_stats(stats, total=total, paths=paths)
     completeness = graph_completeness(
         returned=len(paths),

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -203,7 +203,11 @@ def _exit_incomplete_scan_with_partial_summary(
         )
         if posture:
             render_posture_summary(agents, [])
-    raise SystemExit(2)
+    # The command produced a truthful partial artifact, so this is a failed
+    # scan verdict rather than a caller/usage error.  Keep exit 2 reserved for
+    # invalid arguments and empty inputs; CI must fail closed on incomplete
+    # evidence through the same exit-1 family as other scan verdicts.
+    raise SystemExit(1)
 
 
 def _reset_offline_mode() -> None:

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -13,13 +13,18 @@ from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.pipeline import _now
 from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
 from agent_bom.demo_estate.showcase_graph import (
+    SHOWCASE_BASELINE_CREATED_AT,
+    SHOWCASE_BASELINE_SCAN_ID,
+    SHOWCASE_CURRENT_CREATED_AT,
     SHOWCASE_PACKAGES,
+    SHOWCASE_SCAN_ID,
     SHOWCASE_SERVERS,
     SHOWCASE_TENANT,
     seed_showcase_fleet_and_runtime,
     seed_showcase_graph_if_empty,
     seed_showcase_identities,
 )
+from agent_bom.security import sanitize_error
 
 _logger = logging.getLogger(__name__)
 
@@ -293,6 +298,50 @@ def _store_demo_scan_job(report: dict[str, Any], *, tenant_id: str) -> str:
     return job.job_id
 
 
+def _seed_showcase_posture_trends(report: dict[str, Any], *, tenant_id: str) -> int:
+    """Persist the labeled sample estate's deterministic two-point trajectory.
+
+    The current point is derived through the same canonical scan-result adapter
+    used by completed live scans.  The older point represents the explicitly
+    synthetic estate before 25 findings were remediated; it exists only in demo
+    estate mode and uses the graph baseline's timestamp and scan identity.
+    Stable scan IDs make repeated bootstrap calls upserts rather than duplicate
+    history.
+    """
+    from dataclasses import replace
+
+    from agent_bom.api.stores import _get_trend_store
+    from agent_bom.api.trend_recording import trend_point_from_scan_result
+    from agent_bom.posture import _score_to_grade
+
+    current = trend_point_from_scan_result(
+        report,
+        tenant_id=tenant_id,
+        scan_id=SHOWCASE_SCAN_ID,
+        completed_at=SHOWCASE_CURRENT_CREATED_AT,
+    )
+    if current is None:
+        return 0
+
+    baseline_score = max(0.0, current.posture_score - 8.0)
+    baseline = replace(
+        current,
+        timestamp=SHOWCASE_BASELINE_CREATED_AT,
+        scan_id=SHOWCASE_BASELINE_SCAN_ID,
+        total_vulns=current.total_vulns + 25,
+        critical=current.critical + 2,
+        high=current.high + 12,
+        medium=current.medium + 8,
+        low=current.low + 3,
+        posture_score=baseline_score,
+        posture_grade=_score_to_grade(baseline_score),
+    )
+    trend_store = _get_trend_store()
+    trend_store.record(baseline)
+    trend_store.record(current)
+    return 2
+
+
 def _graph_owner_scan_id(graph_store: Any, tenant_id: str) -> str:
     """Return the scan id whose snapshot the graph read path will serve."""
     try:
@@ -445,6 +494,17 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
         if finding_count < 1:
             raise RuntimeError("demo estate scan produced zero findings")
         job_id = _store_demo_scan_job(report, tenant_id=tenant_id)
+        try:
+            summary["posture_trend_points"] = _seed_showcase_posture_trends(
+                report,
+                tenant_id=tenant_id,
+            )
+        except Exception as exc:
+            _logger.warning(
+                "demo estate posture trend seeding failed: %s",
+                sanitize_error(exc, generic=True),
+            )
+            summary["posture_trend_error"] = True
         summary.update(
             {
                 "seeded": True,

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -161,10 +161,11 @@ _ToolReturn = TypeVar("_ToolReturn")
 _SERVER_CARD_PROMPTS = _METADATA_SERVER_CARD_PROMPTS
 _SERVER_CARD_TOOLS = _METADATA_SERVER_CARD_TOOLS
 
-# The guided profile is the default human/agent front door.  It contains every
+# The guided profile is an explicit context-saving option. It contains every
 # tool referenced by the eight shipped workflow prompts plus the three asset
-# inventory drill-downs.  Programmatic callers keep the historical full
-# catalog unless they explicitly request this profile.
+# inventory drill-downs. CLI and programmatic callers default to the full
+# catalog so registry and local clients see the advertised surface unless they
+# deliberately request a smaller prompt-oriented profile.
 _GUIDED_TOOL_NAMES = frozenset(
     {
         "audit_integrity",

--- a/tests/test_cli_exit_contract_docs.py
+++ b/tests/test_cli_exit_contract_docs.py
@@ -14,6 +14,8 @@ def test_exit_code_contract_documents_required_cli_codes() -> None:
         assert code in text
     assert "subprocess passthrough" in text
     assert "ok, findings, usage, auth, and server failures" in text
+    assert "missing or unreadable offline vulnerability database" in text
+    assert "partial artifact" in text
 
 
 def test_exit_code_contract_maps_http_statuses_to_cli_families() -> None:

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1458,7 +1458,7 @@ def test_scan_save_flag(tmp_path):
     assert result.exit_code == 0
 
 
-def test_scan_incomplete_offline_scan_exits_two(monkeypatch, tmp_path):
+def test_scan_incomplete_offline_scan_exits_one(monkeypatch, tmp_path):
     profile_output = tmp_path / "profile-report.json"
     config_path = tmp_path / "config.toml"
     config_path.write_text(
@@ -1481,7 +1481,7 @@ output = "{profile_output}"
 
     result = _run(["scan", "--demo", "--no-auto-update-db"])
 
-    assert result.exit_code == 2
+    assert result.exit_code == 1
     assert "populated local vulnerability DB" in result.output
     # Verdict-led default panel labels the row "Security posture:"; the
     # ``--verbose`` form labels it "SECURITY POSTURE:". Either is acceptable
@@ -1504,7 +1504,7 @@ def test_scan_incomplete_offline_scan_honors_explicit_output(monkeypatch, tmp_pa
 
     result = _run(["scan", "--demo", "--no-auto-update-db", "--format", "json", "--output", str(output)])
 
-    assert result.exit_code == 2
+    assert result.exit_code == 1
     assert "populated local vulnerability DB" in result.output
     assert output.exists()
     payload = json.loads(output.read_text(encoding="utf-8"))

--- a/tests/test_consumer_precommit_hooks.py
+++ b/tests/test_consumer_precommit_hooks.py
@@ -22,3 +22,13 @@ def test_dependency_hook_scans_only_the_downstream_repository() -> None:
     assert hook["pass_filenames"] is False
     assert hook["args"][:2] == ["-p", "."]
     assert hook["args"][2:] == ["--format", "console", "--fail-on-severity", "high"]
+
+
+def test_readme_exposes_zero_install_and_daily_developer_gates() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "uvx agent-bom scan ." in readme
+    assert "uvx agent-bom check requests@2.33.0 --ecosystem pypi" in readme
+    assert "rev: v0.102.0" in readme
+    assert "- id: agent-bom-secrets" in readme
+    assert "- id: agent-bom-scan" in readme

--- a/tests/test_cve_matching_accuracy_gate.py
+++ b/tests/test_cve_matching_accuracy_gate.py
@@ -25,6 +25,8 @@ import pytest
 ROOT = Path(__file__).resolve().parent.parent
 CORPUS = ROOT / "tests" / "fixtures" / "cve_accuracy_corpus.json"
 BASELINE = ROOT / "docs" / "CVE_MATCHING_ACCURACY.json"
+README = ROOT / "README.md"
+SCANNING_DOC = ROOT / "site-docs" / "features" / "scanning.md"
 
 
 def _load_harness():
@@ -67,6 +69,20 @@ def test_clean_tree_matches_the_recorded_baseline(entries: list[dict]) -> None:
     assert result["recall"] >= baseline["recall"]
     assert result["precision"] >= baseline["precision"]
     assert result["false_negative"] == 0, f"missed vulnerable versions: {result['false_negative']}"
+
+
+def test_public_accuracy_claim_matches_the_reproducible_baseline() -> None:
+    baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+    evaluated = baseline["evaluated"]
+    positives = baseline["true_positive"]
+    negatives = baseline["true_negative"]
+    for path in (README, SCANNING_DOC):
+        text = " ".join(path.read_text(encoding="utf-8").split())
+        assert f"{evaluated:,} comparable OSV advisories" in text
+        assert f"{positives:,} affected-version checks" in text
+        assert f"{negatives:,} fixed-version checks" in text
+        assert "zero false negatives and zero false positives" in text
+        assert "not a universal scanner-accuracy claim" in text
 
 
 def test_the_gate_detects_a_window_collapse_regression(entries: list[dict]) -> None:

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -52,9 +52,11 @@ def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path):
     api_server._shutting_down = False
     original_job_store = api_stores._store
     original_graph_store = api_stores._graph_store
+    original_trend_store = api_stores._trend_store
     original_hub_store = hub_store_mod._HUB_STORE
     api_stores._store = None
     api_stores._graph_store = None
+    api_stores._trend_store = None
     set_compliance_hub_store(None)
     reset_findings_count_cache()
     from agent_bom.demo_estate.bootstrap import reset_demo_estate_bootstrap_status
@@ -71,6 +73,7 @@ def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path):
     finally:
         api_stores._store = original_job_store
         api_stores._graph_store = original_graph_store
+        api_stores._trend_store = original_trend_store
         set_compliance_hub_store(original_hub_store)
         reset_findings_count_cache()
         reset_backpressure_for_tests()
@@ -131,6 +134,36 @@ def test_demo_estate_bootstrap_seeds_jobs_and_graph(demo_estate_client: TestClie
     payload = graph.json()
     node_count = len(payload.get("nodes") or [])
     assert node_count > 0
+
+
+def test_demo_estate_bootstrap_seeds_honest_posture_trajectory(
+    demo_estate_client: TestClient,
+) -> None:
+    """The labeled sample estate proves the shipped trend path with two points."""
+    from agent_bom.demo_estate.showcase_graph import (
+        SHOWCASE_BASELINE_CREATED_AT,
+        SHOWCASE_CURRENT_CREATED_AT,
+        SHOWCASE_SCAN_ID,
+    )
+
+    response = demo_estate_client.get("/v1/trends", headers=VIEWER, params={"limit": 2})
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["count"] == 2
+    current, previous = payload["data_points"]
+    assert current["scan_id"] == SHOWCASE_SCAN_ID
+    assert current["timestamp"] == SHOWCASE_CURRENT_CREATED_AT
+    assert previous["scan_id"] == SHOWCASE_BASELINE_SCAN_ID
+    assert previous["timestamp"] == SHOWCASE_BASELINE_CREATED_AT
+    assert current["posture_score"] > previous["posture_score"]
+    assert current["total_vulns"] < previous["total_vulns"]
+
+    from agent_bom.demo_estate.bootstrap import _seed_showcase_posture_trends
+
+    assert _seed_showcase_posture_trends(_demo_report(demo_estate_client), tenant_id="default") == 2
+    repeated = demo_estate_client.get("/v1/trends", headers=VIEWER, params={"limit": 30}).json()
+    assert repeated["count"] == 2
 
 
 def test_demo_estate_bootstrap_validates_versioned_enterprise_contract(

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -2034,6 +2034,15 @@ class TestGraphStoreBackendSelection:
                 tool_exposure=["run_shell"],
             )
         )
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES))
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="server:s", target="vuln:cve", relationship=RelationshipType.VULNERABLE_TO))
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(
+                source="agent:a",
+                target="vuln:cve",
+                relationship=RelationshipType.OWNS,
+            )
+        )
         client = TestClient(app)
 
         response = client.get("/v1/graph/attack-paths", params={"limit": 1})
@@ -2047,6 +2056,10 @@ class TestGraphStoreBackendSelection:
         assert body["attack_paths"][0]["exposure_path"]["relationships"][0]["relationship"] == "uses"
         assert body["attack_paths"][0]["exposure_path"]["reachableTools"] == ["run_shell"]
         assert {node["id"] for node in body["nodes"]} == {"agent:a", "server:s", "vuln:cve"}
+        assert {(edge["source_id"], edge["target_id"]) for edge in body["edges"]} == {
+            ("agent:a", "server:s"),
+            ("server:s", "vuln:cve"),
+        }
         assert body["pagination"]["total"] == 1
         assert any(call[0] == "attack_paths" for call in recording_graph_store.calls)
         assert any(call[0] == "nodes_by_ids" for call in recording_graph_store.calls)

--- a/tests/test_offline_scan_exit_contract.py
+++ b/tests/test_offline_scan_exit_contract.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("database_state", ["missing", "corrupt"])
+def test_real_offline_repository_scan_writes_partial_artifact_and_exits_one(
+    tmp_path: Path,
+    database_state: str,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "requirements.txt").write_text("requests==2.31.0\n", encoding="utf-8")
+    database = tmp_path / "vulns.db"
+    if database_state == "corrupt":
+        database.write_text("not a sqlite database", encoding="utf-8")
+
+    report = tmp_path / "report.json"
+    clean_home = tmp_path / "home"
+    clean_home.mkdir()
+    source_root = Path(__file__).resolve().parents[1] / "src"
+    inherited_pythonpath = os.environ.get("PYTHONPATH", "")
+    env = {
+        **os.environ,
+        "HOME": str(clean_home),
+        "AGENT_BOM_DB_PATH": str(database),
+        "AGENT_BOM_SKIP_UPDATE_CHECK": "1",
+        "AGENT_BOM_CONFIG": str(tmp_path / "no-config.toml"),
+        "PYTHONPATH": os.pathsep.join(part for part in (str(source_root), inherited_pythonpath) if part),
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from agent_bom.cli import main; main()",
+            "scan",
+            str(project),
+            "--offline",
+            "--no-auto-update-db",
+            "--format",
+            "json",
+            "--output",
+            str(report),
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert payload["scan_run"]["outcome"] == "partial"
+    assert payload["scan_run"]["issues"][0]["code"] == "required_scanner_unavailable"
+    assert payload["scan_performance"]["coverage_state"] == "incomplete"
+    assert "populated local vulnerability DB" in payload["warnings"][0]

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -58,6 +58,7 @@ import {
 } from "@/lib/api";
 import {
   attackPathKey,
+  attackPathRoleChain,
   buildFindingsHref,
   buildGraphInvestigationHref,
   buildSecurityGraphHref,
@@ -107,8 +108,10 @@ function AttackPathInvestigationContent() {
   const [posture, setPosture] = useState<PostureResponse | null>(null);
   const [loadingSnapshots, setLoadingSnapshots] = useState(true);
   const [loadingGraph, setLoadingGraph] = useState(false);
+  const [loadingFixFirst, setLoadingFixFirst] = useState(false);
   const [apiError, setApiError] = useState<string | null>(null);
   const [graphLoadError, setGraphLoadError] = useState<string | null>(null);
+  const [fixFirstLoadError, setFixFirstLoadError] = useState<string | null>(null);
   const [apiErrorKind, setApiErrorKind] = useState<"network" | "auth" | "forbidden">("network");
   const [selectedAttackPathKey, setSelectedAttackPathKey] = useState<string | null>(null);
   const [focusApplied, setFocusApplied] = useState(false);
@@ -238,39 +241,34 @@ function AttackPathInvestigationContent() {
       setFixFirstView(null);
       setSelectedAttackPathKey(null);
       setGraphLoadError(null);
+      setFixFirstLoadError(null);
       return;
     }
 
     let cancelled = false;
 
-    async function loadGraph() {
+    setGraphData(null);
+    setFixFirstView(null);
+    setGraphLoadError(null);
+    setFixFirstLoadError(null);
+
+    async function loadAttackPaths() {
       setLoadingGraph(true);
       setLoadingMorePaths(false);
       setVisibleAttackPathCount(ATTACK_PATH_QUEUE_PAGE_SIZE);
       try {
-        const [graph, view] = await Promise.all([
-          api.getGraphAttackPaths({
-            scanId: selectedScanId,
-            offset: 0,
-            limit: ATTACK_PATH_FETCH_PAGE,
-          }),
-          api.getFixFirstGraphView({
-            scanId: selectedScanId,
-            cve: focus.cve || undefined,
-            packageName: focus.packageName || undefined,
-            agentName: focus.agentName || undefined,
-            limit: FIX_FIRST_CARD_LIMIT,
-          }),
-        ]);
+        const graph = await api.getGraphAttackPaths({
+          scanId: selectedScanId,
+          offset: 0,
+          limit: ATTACK_PATH_FETCH_PAGE,
+        });
         if (cancelled) return;
         setGraphData(graph);
-        setFixFirstView(view);
         setApiError(null);
         setGraphLoadError(null);
       } catch (error) {
         if (cancelled) return;
         setGraphData(null);
-        setFixFirstView(null);
         setGraphLoadError(userFacingApiErrorMessage(error, "Failed to load security graph"));
         setApiErrorKind(_classifyGraphErrorKind(error));
       } finally {
@@ -278,7 +276,30 @@ function AttackPathInvestigationContent() {
       }
     }
 
-    void loadGraph();
+    async function loadFixFirstEnrichment() {
+      setLoadingFixFirst(true);
+      try {
+        const view = await api.getFixFirstGraphView({
+          scanId: selectedScanId,
+          cve: focus.cve || undefined,
+          packageName: focus.packageName || undefined,
+          agentName: focus.agentName || undefined,
+          limit: FIX_FIRST_CARD_LIMIT,
+        });
+        if (cancelled) return;
+        setFixFirstView(view);
+        setFixFirstLoadError(null);
+      } catch (error) {
+        if (cancelled) return;
+        setFixFirstView(null);
+        setFixFirstLoadError(userFacingApiErrorMessage(error, "Fix guidance is unavailable"));
+      } finally {
+        if (!cancelled) setLoadingFixFirst(false);
+      }
+    }
+
+    void loadAttackPaths();
+    void loadFixFirstEnrichment();
     return () => {
       cancelled = true;
     };
@@ -348,12 +369,12 @@ function AttackPathInvestigationContent() {
       (left, right) => right.composite_risk - left.composite_risk,
     );
     const fromFixFirst = fixFirstCards.map((card) => card.attack_path);
-    const focusedPaths =
-      focus.nodeId || focus.findingId
-        ? fromFixFirst.filter((path) => matchesAttackPathFocus(path, graphNodeById, focus))
-        : fromFixFirst;
+    const focusedApiPaths = fromApi.filter((path) => matchesAttackPathFocus(path, graphNodeById, focus));
+    const focusedEnrichedPaths = fromFixFirst.filter((path) => matchesAttackPathFocus(path, graphNodeById, focus));
     const base = hasFocusContext
-      ? focusedPaths
+      ? focusedApiPaths.length > 0
+        ? focusedApiPaths
+        : focusedEnrichedPaths
       : fromApi.length > 0
         ? fromApi
         : fromFixFirst;
@@ -439,6 +460,7 @@ function AttackPathInvestigationContent() {
           riskScore: path.composite_risk,
           nodeCount: path.hops.length,
           agents: labelsForAttackPathType(path, graphNodeById, "agent").length,
+          roleChain: attackPathRoleChain(path, graphNodeById),
         };
         if (card?.rank_meta?.tool_capabilities?.length) {
           row.capabilityTags = card.rank_meta.tool_capabilities;
@@ -834,6 +856,16 @@ function AttackPathInvestigationContent() {
                 : ""
           }`}
           subtitle={`Select a path to focus its graph and evidence here.${
+            loadingFixFirst
+              ? " Ranked paths are ready; fix guidance is still loading."
+              : fixFirstLoadError
+                ? " Ranked paths are ready; fix guidance is temporarily unavailable."
+                : graphData?.count_metadata?.source === "persisted_graph_paths"
+                  ? " Ranked from persisted scan paths."
+                  : graphData?.count_metadata?.source === "derived_graph_paths"
+                    ? " Ranked from bounded graph traversal."
+                    : ""
+          }${
             selectedCampaign
               ? ` Filtered to crown-jewel cluster “${selectedCampaign.crown_jewel_label || selectedCampaign.crown_jewel}”.`
               : ""

--- a/ui/components/exposure-path-neighbor-explorer.tsx
+++ b/ui/components/exposure-path-neighbor-explorer.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
+import Link from "next/link";
 import type { LucideIcon } from "lucide-react";
 import { Bot, Bug, ChevronRight, Database, KeyRound, Loader2, Package, Server, ShieldAlert, Wrench } from "lucide-react";
 import { api, type GraphNodeNeighborsResponse } from "@/lib/api";
 import type { UnifiedNode } from "@/lib/graph-schema";
-import { exposureRoleForEntityType } from "@/lib/attack-paths";
+import { buildGraphInvestigationHref, exposureRoleForEntityType } from "@/lib/attack-paths";
 import { formatExposureEntityDisplay } from "@/lib/entity-display";
 import type { ExposureEntityRole, ExposurePath } from "@/lib/exposure-path";
 
@@ -197,6 +198,20 @@ function HopRow({ hop, scanId }: { hop: ExposurePath["hops"][number]; scanId?: s
             <p className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">
               +{moreCount} more neighbor{moreCount === 1 ? "" : "s"} not shown
             </p>
+          )}
+          {load?.status === "ready" && (
+            <Link
+              href={buildGraphInvestigationHref({
+                scanId,
+                rootId: hop.id,
+                rootLabel: hop.label,
+              })}
+              aria-label={`Traverse from ${hop.label}`}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-sky-500/30 bg-sky-500/10 px-2.5 py-1.5 text-[11px] font-medium text-sky-800 transition hover:border-sky-500/60 dark:text-sky-200"
+            >
+              Traverse from this hop
+              <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
+            </Link>
           )}
         </div>
       )}

--- a/ui/components/ranked-path-list.tsx
+++ b/ui/components/ranked-path-list.tsx
@@ -15,6 +15,8 @@ export interface RankedPathRow {
   riskScore: number;
   nodeCount: number;
   agents: number;
+  /** Compact correlated layer sequence, for example agent → server → finding. */
+  roleChain?: string | undefined;
   /** MCP tool capability tags (read/write/exec/net) feeding path scoring. */
   capabilityTags?: string[] | undefined;
   /** Environments seen on path hops (prod weighting explainability). */
@@ -94,6 +96,14 @@ export function RankedPathList({
               <span className="mt-0.5 block text-[11px] text-[color:var(--text-tertiary)]">
                 {pathSpanLabel(row.nodeCount)} · {row.agents} agent{row.agents === 1 ? "" : "s"}
               </span>
+              {row.roleChain ? (
+                <span
+                  className="mt-0.5 block truncate font-mono text-[10px] text-[color:var(--text-secondary)]"
+                  title={row.roleChain}
+                >
+                  {row.roleChain}
+                </span>
+              ) : null}
               {(row.capabilityTags?.length || row.environmentTags?.length) ? (
                 <span className="mt-1 flex flex-wrap gap-1">
                   {(row.environmentTags ?? []).slice(0, 2).map((tag) => (

--- a/ui/e2e/security-graph-cockpit.spec.ts
+++ b/ui/e2e/security-graph-cockpit.spec.ts
@@ -150,7 +150,12 @@ function buildCockpitGraph(nodeCount = 5) {
 async function routeCockpit(
   page: Page,
   snapshotNodeCount?: number,
-  options: { emptyFocusResults?: boolean; emptyRollup?: boolean; rollupDelayMs?: number } = {},
+  options: {
+    emptyFocusResults?: boolean;
+    emptyRollup?: boolean;
+    rollupDelayMs?: number;
+    fixFirstDelayMs?: number;
+  } = {},
 ) {
   const graph = buildCockpitGraph(snapshotNodeCount);
 
@@ -198,6 +203,9 @@ async function routeCockpit(
     });
   });
   await page.route("**/v1/graph/views/fix-first?**", async (route) => {
+    if (options.fixFirstDelayMs) {
+      await new Promise((resolve) => setTimeout(resolve, options.fixFirstDelayMs));
+    }
     const attackPath = graph.attack_paths[0]!;
     const cards = options.emptyFocusResults
       ? []
@@ -403,6 +411,17 @@ test("focused investigation never shows an unrelated global path", async ({ page
 
   await expect(page.getByText("No attack paths matched the current focus")).toBeVisible();
   await expect(page.getByText("Critical package reachable from MCP server")).toHaveCount(0);
+});
+
+test("ranked persisted paths render before slower fix guidance", async ({ page }) => {
+  await routeCockpit(page, undefined, { fixFirstDelayMs: 2_000 });
+
+  await page.goto("/security-graph");
+  await expect(page.getByText("#1 fix first")).toBeVisible();
+  await expect(page.getByText(/Ranked paths are ready; fix guidance is still loading/)).toBeVisible();
+  await expect(page.getByText("agent → server → package → finding")).toBeVisible();
+
+  await expect(page.getByText("Critical package reachable from MCP server")).toBeVisible();
 });
 
 test("ranked path selection focuses the in-place interactive graph and announces the change", async ({ page }) => {

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -172,6 +172,13 @@ export interface UnifiedGraphResponse extends Omit<
   attack_paths: GraphAttackPath[];
   pagination: GraphPagination;
   completeness?: GraphCompleteness | undefined;
+  count_metadata?: {
+    source?: "persisted_graph_paths" | "derived_graph_paths" | string;
+    returned?: number;
+    total?: number;
+    scope?: string;
+    [key: string]: unknown;
+  } | undefined;
 }
 
 /** Shared HTTP/MCP inventory projection over the tenant-scoped graph store. */

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -164,6 +164,16 @@ export function toAttackCardNodes(path: AttackPath, nodeById: Map<string, Unifie
   return nodes;
 }
 
+/** Compact semantic chain for a ranked row before the analyst opens its DAG. */
+export function attackPathRoleChain(path: AttackPath, nodeById: Map<string, UnifiedNode>): string {
+  const roles: string[] = [];
+  for (const node of toAttackCardNodes(path, nodeById)) {
+    const role = node.type === "cve" ? "finding" : node.type;
+    if (roles[roles.length - 1] !== role) roles.push(role);
+  }
+  return roles.join(" → ");
+}
+
 const GENERIC_PATH_TITLE = /^exposure path\b/i;
 
 /**

--- a/ui/tests/attack-paths.test.ts
+++ b/ui/tests/attack-paths.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   attackPathKey,
+  attackPathRoleChain,
   attackPathSequenceLabels,
   buildGraphInvestigationHref,
   buildSecurityGraphHref,
@@ -318,6 +319,29 @@ describe("attack path helpers", () => {
         rootLabel: "flask",
       }),
     ).toBe("/security-graph?scan=scan-123&agent=Claude+Desktop&investigate=1&root=pkg-1&q=flask&lens=lineage");
+  });
+
+  it("summarizes the correlated hop roles without repeating adjacent layers", () => {
+    const nodes = new Map<string, UnifiedNode>([
+      ["agent-1", graphNode("agent-1", EntityType.AGENT, "reviewer")],
+      ["server-1", graphNode("server-1", EntityType.SERVER, "github")],
+      ["server-2", graphNode("server-2", EntityType.CLOUD_RESOURCE, "runner")],
+      ["pkg-1", graphNode("pkg-1", EntityType.PACKAGE, "form-data")],
+      ["cve-1", graphNode("cve-1", EntityType.VULNERABILITY, "CVE-2025-7783")],
+    ]);
+    const path: AttackPath = {
+      source: "agent-1",
+      target: "cve-1",
+      hops: ["agent-1", "server-1", "server-2", "pkg-1", "cve-1"],
+      edges: [],
+      composite_risk: 9.8,
+      summary: "reachable package",
+      credential_exposure: [],
+      tool_exposure: [],
+      vuln_ids: ["CVE-2025-7783"],
+    };
+
+    expect(attackPathRoleChain(path, nodes)).toBe("agent → server → package → finding");
   });
 
   it("decodes graph investigation roots from URL params", () => {

--- a/ui/tests/demo-investigation-contract.test.ts
+++ b/ui/tests/demo-investigation-contract.test.ts
@@ -25,4 +25,11 @@ describe("investigation demo hierarchy", () => {
     expect(page).not.toContain(">Snapshot</p>");
     expect(page).not.toContain("Large estate ·");
   });
+
+  it("does not make the ranked path queue wait for fix-first enrichment", () => {
+    expect(page).not.toContain("const [graph, view] = await Promise.all");
+    expect(page).toContain("async function loadAttackPaths");
+    expect(page).toContain("async function loadFixFirstEnrichment");
+    expect(page).toContain("Ranked paths are ready; fix guidance is still loading");
+  });
 });

--- a/ui/tests/exposure-path-neighbor-explorer.test.tsx
+++ b/ui/tests/exposure-path-neighbor-explorer.test.tsx
@@ -89,6 +89,10 @@ describe("ExposurePathNeighborExplorer", () => {
     expect(screen.getByText("Dependents")).toBeInTheDocument();
     expect(screen.getByText("werkzeug")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Collapse neighbors of database/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Traverse from database/i })).toHaveAttribute(
+      "href",
+      "/security-graph?scan=scan-1&investigate=1&root=server%3Adatabase&q=database&lens=lineage",
+    );
 
     // Collapsing hides the revealed neighbors without refetching.
     fireEvent.click(screen.getByRole("button", { name: /Collapse neighbors of database/i }));

--- a/ui/tests/ranked-path-list.test.tsx
+++ b/ui/tests/ranked-path-list.test.tsx
@@ -13,6 +13,7 @@ const rows: RankedPathRow[] = [
     riskScore: 9.6,
     nodeCount: 4,
     agents: 2,
+    roleChain: "agent → server → package → finding",
   },
   {
     key: "k2::1",
@@ -34,6 +35,7 @@ describe("RankedPathList", () => {
     expect(screen.getByText("#2")).toBeInTheDocument();
     expect(screen.getByText(/CVE-2026-0002/)).toBeInTheDocument();
     expect(screen.getByText(/3 hops · 2 agents/)).toBeInTheDocument();
+    expect(screen.getByText("agent → server → package → finding")).toBeInTheDocument();
     // The single DAG renders in the command-center panel, not per row here.
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

- Fail incomplete offline repository scans with verdict exit `1` while preserving the partial report, with fresh-process missing/corrupt database coverage.
- Render persisted attack paths before slower full-estate enrichment, expose compact role chains and bounded hop traversal, and keep guidance failure from blanking usable graph evidence.
- Limit ranked-path payload edges to relationships proving consecutive hops, publish the reproducible matcher boundary, and seed an idempotent two-point trajectory for the labeled sample estate.

## Verification

- `uv run pytest -q ...` — 274 passed, 2 skipped across CLI, offline subprocess, graph API/traversal/pagination, matcher mutation, and enterprise demo-estate contracts
- `make lint` — Ruff and mypy green across 866 source files
- `make preflight` — OpenAPI, 61 v1 schemas, capability/product/graph/demo/release/count/accuracy/env/SDK/SVG gates green
- UI toolchain, typecheck, lint, 1,226 tests, and production build green
- `npx playwright test ui/e2e/security-graph-cockpit.spec.ts` — 16 passed across delayed enrichment, themes, mobile, selection, roll-up/raw, and first viewport

## Notes

- Local release-candidate measurement on the 6,802-node / 22,993-edge sample snapshot: ranked-path response fell from 508,562 to 192,879 bytes (62% smaller); warm response samples fell from roughly 42–48 ms to 38–40 ms. This is recorded evidence, not a hosted SLA.
- The MCP CLI and programmatic server already default to the full 81-tool surface. This change clarifies that guided mode is opt-in; it does not flip an already-correct default.
