### PR TITLE
fix(graph): preserve reachability truth across paths

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260823_01_attack_path_reachability.py
+++ b/deploy/supabase/postgres/alembic/versions/20260823_01_attack_path_reachability.py
@@ -1,0 +1,25 @@
+"""Persist attack-path reachability verdicts and their evidence basis.
+
+Revision ID: 20260823_01
+Revises: 20260819_01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260823_01"
+down_revision = "20260819_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE IF EXISTS attack_paths ADD COLUMN IF NOT EXISTS reachability TEXT DEFAULT 'unknown'")
+    op.execute("ALTER TABLE IF EXISTS attack_paths ADD COLUMN IF NOT EXISTS reachability_basis TEXT DEFAULT '[]'")
+
+
+def downgrade() -> None:
+    # Additive compatibility columns are retained so a rolling downgrade does
+    # not make a newer writer fail against an older application instance.
+    return

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -540,6 +540,8 @@ CREATE TABLE IF NOT EXISTS attack_paths (
     credential_exposure JSONB DEFAULT '[]'::jsonb,
     tool_exposure       TEXT DEFAULT '[]',
     vuln_ids            JSONB DEFAULT '[]'::jsonb,
+    reachability        TEXT DEFAULT 'unknown',
+    reachability_basis  TEXT DEFAULT '[]',
     technique_mappings  TEXT DEFAULT '[]',
     scan_id             TEXT NOT NULL,
     tenant_id           TEXT NOT NULL DEFAULT 'default',

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-22",
+  "generated_on": "2026-08-23",
   "version": "0.102.0",
   "metrics": [
     {
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 866,
+      "value": 867,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-22`
+- Generated on: `2026-08-23`
 - Version: `0.102.0`
 
 | Metric | Value | Source | Notes |
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 48 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 866 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 867 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -22890,6 +22890,21 @@
                                 "minimum": 1,
                                 "type": "integer"
                               },
+                              "reachability": {
+                                "enum": [
+                                  "confirmed",
+                                  "likely",
+                                  "unlikely",
+                                  "unknown"
+                                ],
+                                "type": "string"
+                              },
+                              "reachabilityBasis": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
                               "reachableTools": {
                                 "items": {
                                   "type": "string"
@@ -22936,6 +22951,23 @@
                           },
                           "mitre_technique_ids": {
                             "description": "Deduped technique IDs mapped across the path's hops (convenience projection).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "reachability": {
+                            "description": "Evidence strength for whether the path is executable; structural topology alone is unknown.",
+                            "enum": [
+                              "confirmed",
+                              "likely",
+                              "unlikely",
+                              "unknown"
+                            ],
+                            "type": "string"
+                          },
+                          "reachability_basis": {
+                            "description": "Machine-readable evidence that produced the reachability verdict.",
                             "items": {
                               "type": "string"
                             },
@@ -25065,6 +25097,21 @@
                               "rank": {
                                 "minimum": 1,
                                 "type": "integer"
+                              },
+                              "reachability": {
+                                "enum": [
+                                  "confirmed",
+                                  "likely",
+                                  "unlikely",
+                                  "unknown"
+                                ],
+                                "type": "string"
+                              },
+                              "reachabilityBasis": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "reachableTools": {
                                 "items": {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -15206,6 +15206,17 @@ paths:
                             rank:
                               minimum: 1
                               type: integer
+                            reachability:
+                              enum:
+                              - confirmed
+                              - likely
+                              - unlikely
+                              - unknown
+                              type: string
+                            reachabilityBasis:
+                              items:
+                                type: string
+                              type: array
                             reachableTools:
                               items:
                                 type: string
@@ -15241,6 +15252,21 @@ paths:
                         mitre_technique_ids:
                           description: Deduped technique IDs mapped across the path's
                             hops (convenience projection).
+                          items:
+                            type: string
+                          type: array
+                        reachability:
+                          description: Evidence strength for whether the path is executable;
+                            structural topology alone is unknown.
+                          enum:
+                          - confirmed
+                          - likely
+                          - unlikely
+                          - unknown
+                          type: string
+                        reachability_basis:
+                          description: Machine-readable evidence that produced the
+                            reachability verdict.
                           items:
                             type: string
                           type: array
@@ -16739,6 +16765,17 @@ paths:
                             rank:
                               minimum: 1
                               type: integer
+                            reachability:
+                              enum:
+                              - confirmed
+                              - likely
+                              - unlikely
+                              - unknown
+                              type: string
+                            reachabilityBasis:
+                              items:
+                                type: string
+                              type: array
                             reachableTools:
                               items:
                                 type: string

--- a/site-docs/architecture/security-graph-model.md
+++ b/site-docs/architecture/security-graph-model.md
@@ -11,13 +11,28 @@ snapshot gets large?"
   misconfigurations
 - **edges** are typed relationships such as `uses`, `depends_on`,
   `exposes_cred`, `affects`, `invoked`, and `lateral_path`
-- **attack paths** are precomputed fix-first exploit chains derived from the
-  persisted graph
+- **attack paths** are precomputed fix-first paths derived from the persisted
+  graph, with an explicit reachability verdict and evidence basis
 - **interaction risks** are runtime-oriented overlays that highlight where
   agent behavior or shared control surfaces can expand blast radius
 
 This is not a best-effort browser-only canvas. It is a persisted graph snapshot
 loaded from the control plane.
+
+## Reachability truth
+
+Every path distinguishes executable evidence from investigation context:
+
+- `confirmed` — a persisted graph path or function-level symbol proof exists
+- `likely` — package/dependency or observed graph evidence supports the path
+- `unknown` — structural topology connects the entities, but executable reach
+  has not been proven; these candidates stay below evidence-backed paths
+- `unlikely` — graph or symbol evidence disproves reachability; the finding is
+  retained as evidence but is not emitted as an exploit chain
+
+Credential and tool exposure increase impact, not reachability. MITRE ATT&CK
+and ATLAS enrich evidence-backed hops; their technique mappings never create a
+hop or promote a structural candidate into an executable path.
 
 ## What a snapshot means
 

--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -1236,7 +1236,8 @@ class SQLiteGraphStore:
             rows = conn.execute(
                 f"""
                 SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
-                       summary, credential_exposure, tool_exposure, vuln_ids, technique_mappings
+                       summary, credential_exposure, tool_exposure, vuln_ids,
+                       reachability, reachability_basis, technique_mappings
                 FROM attack_paths
                 WHERE tenant_id = ? AND scan_id = ? AND source_node IN ({placeholders})
                 """,  # nosec B608 - placeholders are generated internally
@@ -1253,6 +1254,8 @@ class SQLiteGraphStore:
                     credential_exposure=json.loads(row["credential_exposure"]),
                     tool_exposure=json.loads(row["tool_exposure"]),
                     vuln_ids=json.loads(row["vuln_ids"]),
+                    reachability=row["reachability"] or "unknown",
+                    reachability_basis=json.loads(row["reachability_basis"] or "[]"),
                     technique_mappings=technique_mappings_from_json(row["technique_mappings"]),
                 )
                 for row in rows
@@ -1283,7 +1286,8 @@ class SQLiteGraphStore:
             rows = conn.execute(
                 """
                 SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
-                       summary, credential_exposure, tool_exposure, vuln_ids, technique_mappings
+                       summary, credential_exposure, tool_exposure, vuln_ids,
+                       reachability, reachability_basis, technique_mappings
                 FROM attack_paths
                 WHERE tenant_id = ? AND scan_id = ?
                 ORDER BY composite_risk DESC, source_node ASC, target_node ASC
@@ -1305,6 +1309,8 @@ class SQLiteGraphStore:
                         credential_exposure=json.loads(row["credential_exposure"]),
                         tool_exposure=json.loads(row["tool_exposure"]),
                         vuln_ids=json.loads(row["vuln_ids"]),
+                        reachability=row["reachability"] or "unknown",
+                        reachability_basis=json.loads(row["reachability_basis"] or "[]"),
                         technique_mappings=technique_mappings_from_json(row["technique_mappings"]),
                     )
                     for row in rows

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -370,6 +370,8 @@ class PostgresGraphStore:
                     credential_exposure TEXT DEFAULT '[]',
                     tool_exposure TEXT DEFAULT '[]',
                     vuln_ids TEXT DEFAULT '[]',
+                    reachability TEXT DEFAULT 'unknown',
+                    reachability_basis TEXT DEFAULT '[]',
                     technique_mappings TEXT DEFAULT '[]',
                     scan_id TEXT NOT NULL,
                     tenant_id TEXT NOT NULL DEFAULT 'default',
@@ -391,6 +393,8 @@ class PostgresGraphStore:
             conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS summary TEXT DEFAULT ''")
             conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS tool_exposure TEXT DEFAULT '[]'")
             conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS technique_mappings TEXT DEFAULT '[]'")
+            conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS reachability TEXT DEFAULT 'unknown'")
+            conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS reachability_basis TEXT DEFAULT '[]'")
             conn.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS analysis_status TEXT NOT NULL DEFAULT '{}'")
             conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS valid_from TEXT DEFAULT ''")
             conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS valid_to TEXT DEFAULT NULL")
@@ -816,6 +820,8 @@ class PostgresGraphStore:
                         json.dumps(ap.credential_exposure),
                         json.dumps(ap.tool_exposure),
                         json.dumps(ap.vuln_ids),
+                        ap.reachability,
+                        json.dumps(ap.reachability_basis),
                         json.dumps([m.to_dict() for m in ap.technique_mappings]),
                         scan,
                         tenant,
@@ -936,9 +942,9 @@ class PostgresGraphStore:
                 INSERT INTO attack_paths (
                     source_node, target_node, hop_count, composite_risk,
                     summary, path_nodes, path_edges, credential_exposure,
-                    tool_exposure, vuln_ids, technique_mappings, scan_id,
-                    tenant_id, computed_at
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    tool_exposure, vuln_ids, reachability, reachability_basis,
+                    technique_mappings, scan_id, tenant_id, computed_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (source_node, target_node, scan_id, tenant_id) DO UPDATE SET
                     hop_count = EXCLUDED.hop_count,
                     composite_risk = EXCLUDED.composite_risk,
@@ -948,6 +954,8 @@ class PostgresGraphStore:
                     credential_exposure = EXCLUDED.credential_exposure,
                     tool_exposure = EXCLUDED.tool_exposure,
                     vuln_ids = EXCLUDED.vuln_ids,
+                    reachability = EXCLUDED.reachability,
+                    reachability_basis = EXCLUDED.reachability_basis,
                     technique_mappings = EXCLUDED.technique_mappings,
                     computed_at = EXCLUDED.computed_at
                 """,
@@ -1221,7 +1229,8 @@ class PostgresGraphStore:
                 for row in conn.execute(
                     """
                     SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
-                           summary, credential_exposure, tool_exposure, vuln_ids, technique_mappings
+                           summary, credential_exposure, tool_exposure, vuln_ids,
+                           reachability, reachability_basis, technique_mappings
                     FROM attack_paths
                     WHERE tenant_id = %s AND scan_id = %s
                     ORDER BY source_node, target_node, composite_risk DESC, path_nodes
@@ -1239,7 +1248,9 @@ class PostgresGraphStore:
                             credential_exposure=_decode_json_array(row[6], field="attack path credential exposure"),
                             tool_exposure=_decode_json_array(row[7], field="attack path tool exposure"),
                             vuln_ids=_decode_json_array(row[8], field="attack path vulnerability IDs"),
-                            technique_mappings=technique_mappings_from_json(row[9]),
+                            reachability=row[9] or "unknown",
+                            reachability_basis=_decode_json_array(row[10], field="attack path reachability basis"),
+                            technique_mappings=technique_mappings_from_json(row[11]),
                         )
                     )
 
@@ -1753,7 +1764,8 @@ class PostgresGraphStore:
             rows = conn.execute(
                 f"""
                 SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
-                       summary, credential_exposure, tool_exposure, vuln_ids, technique_mappings
+                       summary, credential_exposure, tool_exposure, vuln_ids,
+                       reachability, reachability_basis, technique_mappings
                 FROM attack_paths
                 WHERE tenant_id = %s AND scan_id = %s AND source_node IN ({placeholders})
                 ORDER BY composite_risk DESC, source_node ASC, target_node ASC
@@ -1774,7 +1786,9 @@ class PostgresGraphStore:
                 credential_exposure=_decode_json_array(row[6], field="attack path credential exposure"),
                 tool_exposure=_decode_json_array(row[7], field="attack path tool exposure"),
                 vuln_ids=_decode_json_array(row[8], field="attack path vulnerability IDs"),
-                technique_mappings=technique_mappings_from_json(row[9]),
+                reachability=row[9] or "unknown",
+                reachability_basis=_decode_json_array(row[10], field="attack path reachability basis"),
+                technique_mappings=technique_mappings_from_json(row[11]),
             )
             for row in rows
         ]
@@ -1804,7 +1818,8 @@ class PostgresGraphStore:
             rows = conn.execute(
                 """
                 SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
-                       summary, credential_exposure, tool_exposure, vuln_ids, technique_mappings
+                       summary, credential_exposure, tool_exposure, vuln_ids,
+                       reachability, reachability_basis, technique_mappings
                 FROM attack_paths
                 WHERE tenant_id = %s AND scan_id = %s
                 ORDER BY composite_risk DESC, source_node ASC, target_node ASC
@@ -1829,7 +1844,9 @@ class PostgresGraphStore:
                     credential_exposure=_decode_json_array(row[6], field="attack path credential exposure"),
                     tool_exposure=_decode_json_array(row[7], field="attack path tool exposure"),
                     vuln_ids=_decode_json_array(row[8], field="attack path vulnerability IDs"),
-                    technique_mappings=technique_mappings_from_json(row[9]),
+                    reachability=row[9] or "unknown",
+                    reachability_basis=_decode_json_array(row[10], field="attack path reachability basis"),
+                    technique_mappings=technique_mappings_from_json(row[11]),
                 )
                 for row in rows
             ],

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -57,6 +57,7 @@ from agent_bom.graph import (
     UnifiedNode,
 )
 from agent_bom.graph.completeness import bounded_walk_reason, graph_completeness
+from agent_bom.graph.reachability_truth import node_reachability
 from agent_bom.graph.rollup import ROLLUP_CONTAINMENT_RELATIONSHIPS, ROLLUP_RELATIONSHIPS
 from agent_bom.graph.scope import GraphScopeKind, select_observed_scope
 from agent_bom.graph.semantic_clusters import SEMANTIC_CLUSTER_KINDS, build_semantic_clusters, semantic_cluster_stats
@@ -163,6 +164,16 @@ _ATTACK_PATH_ITEM_OPENAPI_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
         "exposure_path": None,  # filled after _EXPOSURE_PATH_OPENAPI_SCHEMA is defined
+        "reachability": {
+            "type": "string",
+            "enum": ["confirmed", "likely", "unlikely", "unknown"],
+            "description": "Evidence strength for whether the path is executable; structural topology alone is unknown.",
+        },
+        "reachability_basis": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Machine-readable evidence that produced the reachability verdict.",
+        },
         "technique_mappings": {"type": "array", "items": _TECHNIQUE_MAPPING_OPENAPI_SCHEMA},
         "mitre_technique_ids": {
             "type": "array",
@@ -198,6 +209,8 @@ _EXPOSURE_PATH_OPENAPI_SCHEMA: dict[str, Any] = {
         "dependencyContext": {"type": "object", "additionalProperties": True},
         "evidence": {"type": "object", "additionalProperties": True},
         "provenance": {"type": "object", "additionalProperties": True},
+        "reachability": {"type": "string", "enum": ["confirmed", "likely", "unlikely", "unknown"]},
+        "reachabilityBasis": {"type": "array", "items": {"type": "string"}},
     },
 }
 
@@ -1008,6 +1021,8 @@ def _exposure_path_for_attack_path(
         "affectedServers": [hop["label"] for hop in servers],
         "reachableTools": list(path.tool_exposure),
         "exposedCredentials": list(path.credential_exposure),
+        "reachability": path.reachability,
+        "reachabilityBasis": list(path.reachability_basis),
         "provenance": {"source": "graph_attack_path", "scanId": scan_id} if scan_id else {"source": "graph_attack_path"},
     }
     if rank is not None:
@@ -1279,7 +1294,11 @@ def _derived_toxic_combination_paths(graph: UnifiedGraph) -> list[AttackPath]:
     for edge in graph.edges:
         rel = _rel_value(edge)
         if rel == RelationshipType.VULNERABLE_TO.value:
-            vulnerable.add(edge.source)
+            vulnerability_node = graph.nodes.get(edge.target)
+            if vulnerability_node is not None and node_reachability(
+                getattr(vulnerability_node, "attributes", None)
+            ).permits_exploit_chain:
+                vulnerable.add(edge.source)
         elif rel == RelationshipType.HAS_PERMISSION.value:
             principal = graph.nodes.get(edge.source)
             # A resource is admin-privilege-reachable when a principal that can
@@ -1378,10 +1397,37 @@ def _derived_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
     both branches so they surface even when materialised vuln paths exist.
     """
     governance_paths = _derived_governance_attack_paths(graph) + _derived_toxic_combination_paths(graph)
+    for path in governance_paths:
+        if path.reachability == "unknown":
+            path.reachability = "likely"
+            path.reachability_basis = ["observed_graph_edges"]
     if graph.attack_paths:
+        materialized: list[AttackPath] = []
+        for path in graph.attack_paths:
+            vulnerability_nodes = [
+                graph.nodes[hop]
+                for hop in path.hops
+                if hop in graph.nodes and _node_type_value(graph.nodes[hop]) == EntityType.VULNERABILITY.value
+            ]
+            assessments = [node_reachability(getattr(node, "attributes", None)) for node in vulnerability_nodes]
+            if any(item.verdict == "unlikely" for item in assessments):
+                continue
+            if path.reachability == "unknown":
+                strongest = next((item for item in assessments if item.verdict == "confirmed"), None)
+                if strongest is None:
+                    strongest = next((item for item in assessments if item.verdict == "likely"), None)
+                if strongest is not None:
+                    path.reachability = strongest.verdict
+                    path.reachability_basis = list(strongest.basis)
+                elif vulnerability_nodes:
+                    path.composite_risk = min(path.composite_risk, 39.0)
+                    path.reachability_basis = ["structural_topology_only"]
+                    if "unverified" not in path.summary.lower():
+                        path.summary = f"Unverified structural candidate. {path.summary}".strip()
+            materialized.append(path)
         return _with_technique_mappings(
             sorted(
-                list(graph.attack_paths) + governance_paths,
+                materialized + governance_paths,
                 key=lambda path: (path.composite_risk, len(path.hops), len(path.credential_exposure), len(path.tool_exposure)),
                 reverse=True,
             ),
@@ -1400,6 +1446,9 @@ def _derived_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
 
     for finding in graph.nodes.values():
         if _node_type_value(finding) not in finding_types:
+            continue
+        reach = node_reachability(getattr(finding, "attributes", None))
+        if reach.verdict == "unlikely":
             continue
         for finding_edge in incoming.get(finding.id, []):
             if _rel_value(finding_edge) != RelationshipType.VULNERABLE_TO.value:
@@ -1461,6 +1510,19 @@ def _derived_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
                     from agent_bom.graph.asset_entity import finding_id_from_node_attributes
 
                     stamped_finding_id = finding_id_from_node_attributes(getattr(finding, "attributes", None))
+                    if reach.verdict == "unknown":
+                        # Preserve relative investigation priority while keeping
+                        # unverified topology below evidence-backed paths.
+                        risk = min(39.0, risk * 0.35)
+                        summary = (
+                            "Unverified structural candidate: graph topology connects the agent and vulnerable "
+                            "package/server, but no executable graph or symbol path has been proven."
+                        )
+                    else:
+                        summary = (
+                            "Evidence-backed graph path: vulnerable package/server is reachable from an agent "
+                            "and inherits the server's credential/tool exposure."
+                        )
                     paths.append(
                         AttackPath(
                             source=agent_id,
@@ -1468,14 +1530,13 @@ def _derived_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
                             hops=hop_ids,
                             edges=path_edges,
                             composite_risk=round(min(100.0, risk), 2),
-                            summary=(
-                                "Derived from graph topology: vulnerable package/server is reachable from an agent "
-                                "and inherits the server's credential/tool exposure."
-                            ),
+                            summary=summary,
                             credential_exposure=sorted(set(credentials)),
                             tool_exposure=sorted(set(tools)),
                             vuln_ids=[finding.label or finding.id],
                             finding_ids=[stamped_finding_id] if stamped_finding_id else [],
+                            reachability=reach.verdict,
+                            reachability_basis=list(reach.basis),
                         )
                     )
 

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1295,9 +1295,7 @@ def _derived_toxic_combination_paths(graph: UnifiedGraph) -> list[AttackPath]:
         rel = _rel_value(edge)
         if rel == RelationshipType.VULNERABLE_TO.value:
             vulnerability_node = graph.nodes.get(edge.target)
-            if vulnerability_node is not None and node_reachability(
-                getattr(vulnerability_node, "attributes", None)
-            ).permits_exploit_chain:
+            if vulnerability_node is not None and node_reachability(getattr(vulnerability_node, "attributes", None)).permits_exploit_chain:
                 vulnerable.add(edge.source)
         elif rel == RelationshipType.HAS_PERMISSION.value:
             principal = graph.nodes.get(edge.source)

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -220,6 +220,8 @@ CREATE TABLE IF NOT EXISTS attack_paths (
     credential_exposure TEXT DEFAULT '[]',
     tool_exposure   TEXT DEFAULT '[]',
     vuln_ids        TEXT DEFAULT '[]',
+    reachability    TEXT DEFAULT 'unknown',
+    reachability_basis TEXT DEFAULT '[]',
     technique_mappings TEXT DEFAULT '[]',
     scan_id         TEXT NOT NULL,
     tenant_id       TEXT NOT NULL DEFAULT 'default',
@@ -358,6 +360,10 @@ def _init_db(conn: sqlite3.Connection, *, backfill_legacy_tenants: bool = True) 
         conn.execute("ALTER TABLE attack_paths ADD COLUMN tool_exposure TEXT DEFAULT '[]'")
     if "technique_mappings" not in existing_columns:
         conn.execute("ALTER TABLE attack_paths ADD COLUMN technique_mappings TEXT DEFAULT '[]'")
+    if "reachability" not in existing_columns:
+        conn.execute("ALTER TABLE attack_paths ADD COLUMN reachability TEXT DEFAULT 'unknown'")
+    if "reachability_basis" not in existing_columns:
+        conn.execute("ALTER TABLE attack_paths ADD COLUMN reachability_basis TEXT DEFAULT '[]'")
     edge_columns = {row["name"] for row in conn.execute("PRAGMA table_info(graph_edges)").fetchall()}
     # v3 adds replay metadata. Empty valid_from is interpreted as first_seen for
     # stores created before this migration, so old snapshots remain queryable.
@@ -987,9 +993,9 @@ def save_graph_streaming(
             INSERT OR REPLACE INTO attack_paths (
                 source_node, target_node, hop_count, composite_risk,
                 summary, path_nodes, path_edges, credential_exposure,
-                tool_exposure, vuln_ids, technique_mappings, scan_id,
-                tenant_id, computed_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                tool_exposure, vuln_ids, reachability, reachability_basis,
+                technique_mappings, scan_id, tenant_id, computed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 ap.source,
@@ -1002,6 +1008,8 @@ def save_graph_streaming(
                 json.dumps(ap.credential_exposure),
                 json.dumps(ap.tool_exposure),
                 json.dumps(ap.vuln_ids),
+                ap.reachability,
+                json.dumps(ap.reachability_basis),
                 json.dumps([m.to_dict() for m in ap.technique_mappings]),
                 scan,
                 tenant,
@@ -1214,6 +1222,8 @@ def load_graph(
                     credential_exposure=json.loads(row["credential_exposure"]),
                     tool_exposure=json.loads(row["tool_exposure"]),
                     vuln_ids=json.loads(row["vuln_ids"]),
+                    reachability=row["reachability"] or "unknown",
+                    reachability_basis=json.loads(row["reachability_basis"] or "[]"),
                     technique_mappings=technique_mappings_from_json(row["technique_mappings"]),
                 )
             )

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -456,7 +456,17 @@ def build_showcase_graph(
         node(pid, EntityType.PACKAGE, purl)
         edge(f"server:{sid}", pid, RelationshipType.DEPENDS_ON)
         vid = f"vuln:{cve}"
-        node(vid, EntityType.VULNERABILITY, cve, severity=sev, risk_score=score, is_kev=cve in kev_cves)
+        node(
+            vid,
+            EntityType.VULNERABILITY,
+            cve,
+            severity=sev,
+            risk_score=score,
+            is_kev=cve in kev_cves,
+            reachability="confirmed",
+            reachability_basis=["graph_path"],
+            graph_reachable=True,
+        )
         edge(pid, vid, RelationshipType.VULNERABLE_TO)
 
     # Malicious/typosquat package — appears only in the current snapshot for drift.

--- a/src/agent_bom/graph/attack_path_fusion.py
+++ b/src/agent_bom/graph/attack_path_fusion.py
@@ -324,6 +324,8 @@ def _walk_from_entry(
                 credential_exposure=sorted(set(cred_exposure)),
                 vuln_ids=sorted(set(vuln_ids)),
                 finding_ids=sorted(set(finding_ids)),
+                reachability="likely",
+                reachability_basis=["observed_graph_edges"],
             )
             key = (hops[0], node_id)
             existing = best_by_pair.get(key)

--- a/src/agent_bom/graph/attack_path_mitre.py
+++ b/src/agent_bom/graph/attack_path_mitre.py
@@ -151,6 +151,10 @@ def derive_attack_path_techniques(path: AttackPath, graph: UnifiedGraph) -> list
             rel = RelationshipType(rel_value)
         except ValueError:
             continue
+        if path.reachability in {"unknown", "unlikely"} and rel in _VULN_RELS:
+            # ATT&CK/ATLAS annotate evidence-backed paths.  They must never
+            # manufacture exploitability from structural topology.
+            continue
         source = graph.nodes.get(hops[i])
         target = graph.nodes.get(hops[i + 1])
         edge = _resolve_hop(graph, hops[i], hops[i + 1], rel)

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -478,6 +478,10 @@ def build_unified_graph_from_report(
                     "fixed_version": br_dict.get("fixed_version"),
                     "impact_category": br_dict.get("impact_category", ""),
                     "reachability": br_dict.get("reachability", ""),
+                    "reachability_basis": list(br_dict.get("reachability_basis") or []),
+                    "graph_reachable": br_dict.get("graph_reachable"),
+                    "symbol_reachability": br_dict.get("symbol_reachability"),
+                    "dependency_reachable": br_dict.get("dependency_reachable"),
                 },
                 compliance_tags=_collect_compliance_tags(br_dict),
                 data_sources=[data_source_tag],
@@ -1018,6 +1022,10 @@ def build_unified_graph_from_report(
             vuln_node.attributes["exposed_credential_count"] = len(br_dict.get("exposed_credentials", []))
             vuln_node.attributes["exposed_tool_count"] = len(br_dict.get("exposed_tools", []))
             vuln_node.attributes["reachability"] = br_dict.get("reachability", "")
+            vuln_node.attributes["reachability_basis"] = list(br_dict.get("reachability_basis") or [])
+            vuln_node.attributes["graph_reachable"] = br_dict.get("graph_reachable")
+            vuln_node.attributes["symbol_reachability"] = br_dict.get("symbol_reachability")
+            vuln_node.attributes["dependency_reachable"] = br_dict.get("dependency_reachable")
             vuln_node.attributes["actionable"] = br_dict.get("actionable", False)
 
     # ── General cloud-asset inventory (estate-wide, opt-in) ──────────

--- a/src/agent_bom/graph/cnapp_overlay.py
+++ b/src/agent_bom/graph/cnapp_overlay.py
@@ -21,6 +21,7 @@ from dataclasses import replace
 from agent_bom.graph.container import InteractionRisk, UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.reachability_truth import node_reachability
 from agent_bom.graph.types import EntityType, NodeStatus, RelationshipType
 
 _OVERLAY_SOURCE = "cnapp-overlay"
@@ -260,7 +261,9 @@ def apply_cnapp_overlay(graph: UnifiedGraph) -> dict[str, int]:
     vulnerable_resources: set[str] = set()
     for edge in graph.edges:
         if edge.relationship == RelationshipType.VULNERABLE_TO:
-            vulnerable_resources.add(edge.source)
+            vulnerability = graph.nodes.get(edge.target)
+            if vulnerability is not None and node_reachability(vulnerability.attributes).permits_exploit_chain:
+                vulnerable_resources.add(edge.source)
 
     # Resources fronted by a WAF / API gateway (a PROTECTS edge). A protected
     # resource's internet exposure is mitigated — its exposure verdict is

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -99,6 +99,10 @@ class AttackPath:
     # in vuln_ids). Additive — empty on legacy rows; API may recompute from
     # vulnerability node attributes.finding_id.
     finding_ids: list[str] = field(default_factory=list)
+    # Whether the path is executable evidence (confirmed/likely), explicitly
+    # disproven (unlikely), or structural investigation context (unknown).
+    reachability: str = "unknown"
+    reachability_basis: list[str] = field(default_factory=list)
     # Typed MITRE ATT&CK / ATLAS techniques mapped from this path's observed
     # evidence, ordered by hop. Potential/mapped techniques for the kill-chain
     # sequence — never a claim of observed attacker activity.
@@ -120,6 +124,8 @@ class AttackPath:
             "tool_exposure": self.tool_exposure,
             "vuln_ids": self.vuln_ids,
             "finding_ids": self.finding_ids,
+            "reachability": self.reachability,
+            "reachability_basis": self.reachability_basis,
             "technique_mappings": [m.to_dict() for m in self.technique_mappings],
             "mitre_technique_ids": self.mitre_technique_ids(),
         }
@@ -137,6 +143,8 @@ class AttackPath:
             tool_exposure=data.get("tool_exposure", []),
             vuln_ids=data.get("vuln_ids", []),
             finding_ids=list(data.get("finding_ids") or []),
+            reachability=str(data.get("reachability") or "unknown"),
+            reachability_basis=[str(item) for item in data.get("reachability_basis") or []],
             technique_mappings=[TechniqueMapping.from_dict(m) for m in data.get("technique_mappings", [])],
         )
 

--- a/src/agent_bom/graph/reachability_truth.py
+++ b/src/agent_bom/graph/reachability_truth.py
@@ -1,0 +1,103 @@
+"""Canonical reachability truth used across findings and attack paths.
+
+Structural graph closure is useful investigation evidence, but it is not proof
+that a vulnerable symbol can execute.  This module keeps that distinction in
+one place so scoring, labels, correlations, and technique enrichment cannot
+silently disagree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ReachabilityAssessment:
+    """A normalized verdict plus the evidence that produced it."""
+
+    verdict: str
+    basis: tuple[str, ...]
+
+    @property
+    def permits_exploit_chain(self) -> bool:
+        """Whether evidence is strong enough to assert an exploit chain."""
+
+        return self.verdict in {"confirmed", "likely"}
+
+
+def assess_reachability(
+    *,
+    graph_reachable: bool | None = None,
+    symbol_reachability: str | None = None,
+    dependency_reachable: bool | None = None,
+    direct_dependency: bool = False,
+    affected_agents: bool = False,
+    exposed_credentials: bool = False,
+    exposed_tools: bool = False,
+    declaration_only: bool = False,
+) -> ReachabilityAssessment:
+    """Return one conservative verdict from all available evidence.
+
+    Definitive negative graph or symbol evidence wins over exposure heuristics.
+    Credentials and tools describe impact if exploitation occurs; they do not
+    prove that the vulnerable code is executable.
+    """
+
+    symbol = (symbol_reachability or "").strip().lower()
+    negative: list[str] = []
+    if graph_reachable is False:
+        negative.append("graph_unreachable")
+    if symbol == "unreachable":
+        negative.append("symbol_unreachable")
+    if negative:
+        return ReachabilityAssessment("unlikely", tuple(negative))
+
+    positive: list[str] = []
+    if graph_reachable is True:
+        positive.append("graph_path")
+    if symbol == "function_reachable":
+        positive.append("function_reachable")
+    if positive:
+        return ReachabilityAssessment("confirmed", tuple(positive))
+
+    likely: list[str] = []
+    if symbol == "package_reachable":
+        likely.append("package_reachable")
+    if dependency_reachable is True:
+        likely.append("dependency_path")
+    if direct_dependency and affected_agents and not declaration_only:
+        likely.append("direct_agent_dependency")
+    if likely:
+        return ReachabilityAssessment("likely", tuple(likely))
+
+    if dependency_reachable is False:
+        return ReachabilityAssessment("unlikely", ("dependency_unreachable",))
+
+    context: list[str] = []
+    if declaration_only:
+        context.append("declaration_only")
+    if exposed_credentials:
+        context.append("credential_exposure")
+    if exposed_tools:
+        context.append("tool_exposure")
+    if direct_dependency:
+        context.append("direct_dependency")
+    return ReachabilityAssessment("unknown", tuple(context or ["insufficient_evidence"]))
+
+
+def node_reachability(attributes: dict[str, object] | None) -> ReachabilityAssessment:
+    """Normalize persisted vulnerability-node reachability attributes."""
+
+    attrs = attributes or {}
+    explicit = str(attrs.get("reachability") or "").strip().lower()
+    if explicit in {"confirmed", "likely", "unlikely"}:
+        basis = attrs.get("reachability_basis")
+        normalized_basis = tuple(str(item) for item in basis) if isinstance(basis, list) else ("persisted_verdict",)
+        return ReachabilityAssessment(explicit, normalized_basis)
+    graph_value = attrs.get("graph_reachable")
+    dependency_value = attrs.get("dependency_reachable")
+    return assess_reachability(
+        graph_reachable=graph_value if isinstance(graph_value, bool) else None,
+        symbol_reachability=str(attrs.get("symbol_reachability") or "") or None,
+        dependency_reachable=dependency_value if isinstance(dependency_value, bool) else None,
+    )

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -1023,6 +1023,12 @@ class BlastRadius:
             Severity.LOW: RISK_BASE_LOW,
         }
         base = severity_scores.get(self.vulnerability.severity, 0.0)
+        if self.vulnerability.severity in (Severity.NONE, Severity.UNKNOWN) and (
+            self.vulnerability.is_kev or (self.vulnerability.epss_score or 0) >= EPSS_CRITICAL_THRESHOLD
+        ):
+            # An unrated advisory with active-exploitation evidence must not
+            # rank below an otherwise-equivalent LOW advisory.
+            base = RISK_BASE_LOW
 
         # Reach factors — each dimension is weight × count, capped
         agent_factor = min(len(self.affected_agents) * RISK_AGENT_WEIGHT, RISK_AGENT_CAP)
@@ -1056,18 +1062,23 @@ class BlastRadius:
             RISK_REACHABLE_BOOST,
             RISK_UNREACHABLE_PENALTY,
         )
+        from agent_bom.graph.reachability_truth import assess_reachability
 
+        reach = assess_reachability(
+            graph_reachable=self.graph_reachable,
+            symbol_reachability=self.symbol_reachability,
+            dependency_reachable=self.dependency_reachable,
+            direct_dependency=self.package.is_direct,
+            affected_agents=bool(self.affected_agents),
+            exposed_credentials=bool(self.exposed_credentials),
+            exposed_tools=bool(self.exposed_tools),
+            declaration_only=self.package.reachability_evidence == "declaration_only",
+        )
         reach_adjustment = 0.0
-        if self.graph_reachable is True:
+        if reach.verdict == "confirmed":
             reach_adjustment = RISK_REACHABLE_BOOST
-        elif self.graph_reachable is False:
+        elif reach.verdict == "unlikely":
             reach_adjustment = -RISK_UNREACHABLE_PENALTY
-
-        sym = getattr(self, "symbol_reachability", None)
-        if sym == "function_reachable":
-            reach_adjustment = max(reach_adjustment, RISK_REACHABLE_BOOST)
-        elif sym == "unreachable":
-            reach_adjustment = min(reach_adjustment, -RISK_UNREACHABLE_PENALTY)
 
         self.risk_score = max(
             0.0,
@@ -1083,27 +1094,23 @@ class BlastRadius:
         """Classify how reachable this vulnerability is through the blast radius.
 
         Returns:
-            "confirmed"  — credentials OR tools exposed + direct dependency
-            "likely"     — credentials OR tools exposed OR direct dep with agents
-            "unlikely"   — transitive dep, no creds, no tools, LOW severity
-            "unknown"    — insufficient data to determine
+            "confirmed"  — graph-path or function-level evidence proves reach
+            "likely"     — package/dependency evidence supports reach
+            "unlikely"   — graph/symbol/dependency evidence disproves reach
+            "unknown"    — structural or exposure context without path proof
         """
-        has_creds = bool(self.exposed_credentials)
-        has_tools = bool(self.exposed_tools)
-        is_direct = self.package.is_direct
-        is_high = self.vulnerability.severity in (Severity.CRITICAL, Severity.HIGH)
-        has_agents = bool(self.affected_agents)
-        declaration_only = self.package.reachability_evidence == "declaration_only"
+        from agent_bom.graph.reachability_truth import assess_reachability
 
-        if (has_creds or has_tools) and is_direct:
-            return "confirmed"
-        if declaration_only and not has_creds and not has_tools:
-            return "unknown"
-        if has_creds or has_tools or (is_direct and has_agents) or is_high:
-            return "likely"
-        if not is_direct and not has_creds and not has_tools:
-            return "unlikely"
-        return "unknown"
+        return assess_reachability(
+            graph_reachable=self.graph_reachable,
+            symbol_reachability=self.symbol_reachability,
+            dependency_reachable=self.dependency_reachable,
+            direct_dependency=self.package.is_direct,
+            affected_agents=bool(self.affected_agents),
+            exposed_credentials=bool(self.exposed_credentials),
+            exposed_tools=bool(self.exposed_tools),
+            declaration_only=self.package.reachability_evidence == "declaration_only",
+        ).verdict
 
     @property
     def is_actionable(self) -> bool:

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -886,7 +886,19 @@ def _blast_radius_json_entry(
     exposure_path: dict[str, Any],
 ) -> dict[str, Any]:
     """Build one blast_radius JSON row from a unified Finding plus legacy BlastRadius fields."""
+    from agent_bom.graph.reachability_truth import assess_reachability
+
     asset = finding.asset
+    reach = assess_reachability(
+        graph_reachable=getattr(br, "graph_reachable", None),
+        symbol_reachability=getattr(br, "symbol_reachability", None),
+        dependency_reachable=getattr(br, "dependency_reachable", None),
+        direct_dependency=br.package.is_direct,
+        affected_agents=bool(br.affected_agents),
+        exposed_credentials=bool(br.exposed_credentials),
+        exposed_tools=bool(br.exposed_tools),
+        declaration_only=br.package.reachability_evidence == "declaration_only",
+    )
     return {
         "schema_version": BLAST_RADIUS_SCHEMA_VERSION,
         # The blast-radius block is a compatibility projection of this exact
@@ -911,7 +923,8 @@ def _blast_radius_json_entry(
         "package_canonical_id": br.package.canonical_id,
         **effective_blast_radius_tags(br),
         "risk_score": br.risk_score,
-        "reachability": br.reachability,
+        "reachability": reach.verdict,
+        "reachability_basis": list(reach.basis),
         "actionable": br.is_actionable,
         "vulnerability_id": finding.cve_id or br.vulnerability.id,
         "severity": br.vulnerability.severity.value,

--- a/src/agent_bom/toxic_combos.py
+++ b/src/agent_bom/toxic_combos.py
@@ -65,15 +65,18 @@ def detect_toxic_combinations(
     combos: list[ToxicCombination] = []
 
     if report.blast_radii:
-        combos.extend(_detect_cred_blast(report.blast_radii))
-        combos.extend(_detect_kev_with_creds(report.blast_radii))
-        combos.extend(_detect_execute_exploit(report.blast_radii))
-        combos.extend(_detect_multi_agent_cve(report.blast_radii))
-        combos.extend(_detect_transitive_critical(report.blast_radii))
+        # Exposure describes impact, not exploitability.  Definitively
+        # unreachable findings cannot form executable toxic chains.
+        chainable = [br for br in report.blast_radii if br.reachability != "unlikely"]
+        combos.extend(_detect_cred_blast(chainable))
+        combos.extend(_detect_kev_with_creds(chainable))
+        combos.extend(_detect_execute_exploit(chainable))
+        combos.extend(_detect_multi_agent_cve(chainable))
+        combos.extend(_detect_transitive_critical(chainable))
         # Cache poison can be detected from tool names alone — no context required
-        combos.extend(_detect_cache_poison(report.blast_radii, context_graph_data or {}))
+        combos.extend(_detect_cache_poison(chainable, context_graph_data or {}))
         if context_graph_data:
-            combos.extend(_detect_lateral_chain(report.blast_radii, context_graph_data))
+            combos.extend(_detect_lateral_chain(chainable, context_graph_data))
 
     # Context-graph-based detectors run even without blast_radii (structural risk)
     if context_graph_data:

--- a/tests/api/test_api_oidc.py
+++ b/tests/api/test_api_oidc.py
@@ -324,7 +324,8 @@ def test_verify_raises_oidc_error_on_discovery_failure():
                 verify_oidc_token("tok", "https://down.example.com")
 
 
-def test_verify_oidc_token_requires_pinned_or_allowlisted_jwks_uri():
+@patch("agent_bom.security.validate_url")
+def test_verify_oidc_token_requires_pinned_or_allowlisted_jwks_uri(_mock_validate_url):
     from agent_bom.api.oidc import verify_oidc_token
 
     with patch("agent_bom.api.oidc.discover_oidc", return_value={"jwks_uri": "https://example.com/jwks.json"}):
@@ -332,7 +333,8 @@ def test_verify_oidc_token_requires_pinned_or_allowlisted_jwks_uri():
             verify_oidc_token("tok", "https://example.com", audience="agent-bom")
 
 
-def test_verify_oidc_token_accepts_allowlisted_discovered_jwks_uri():
+@patch("agent_bom.security.validate_url")
+def test_verify_oidc_token_accepts_allowlisted_discovered_jwks_uri(_mock_validate_url):
     from agent_bom.api.oidc import verify_oidc_token
 
     mock_jwks_client = MagicMock()
@@ -350,7 +352,8 @@ def test_verify_oidc_token_accepts_allowlisted_discovered_jwks_uri():
                 )
 
 
-def test_verify_raises_oidc_error_on_bad_jwt():
+@patch("agent_bom.security.validate_url")
+def test_verify_raises_oidc_error_on_bad_jwt(_mock_validate_url):
     """Invalid JWT signature raises OIDCError."""
     from agent_bom.api.oidc import verify_oidc_token
 
@@ -368,7 +371,8 @@ def test_verify_raises_oidc_error_on_bad_jwt():
                     verify_oidc_token("not.a.real.jwt", "https://example.com", jwks_uri="https://example.com/.well-known/jwks.json")
 
 
-def test_verify_oidc_token_allows_modern_asymmetric_algorithms():
+@patch("agent_bom.security.validate_url")
+def test_verify_oidc_token_allows_modern_asymmetric_algorithms(_mock_validate_url):
     from agent_bom.api.oidc import OIDC_ALLOWED_ALGORITHMS, verify_oidc_token
 
     mock_jwks_client = MagicMock()

--- a/tests/cloud/test_cloud_network_edge.py
+++ b/tests/cloud/test_cloud_network_edge.py
@@ -427,7 +427,15 @@ def _exposed_vuln_graph(*, protected: bool) -> UnifiedGraph:
             attributes={"internet_exposed": True, "resource_type": "instance"},
         )
     )
-    g.add_node(UnifiedNode(id="vuln", entity_type=EntityType.VULNERABILITY, label="CVE-x", severity="high"))
+    g.add_node(
+        UnifiedNode(
+            id="vuln",
+            entity_type=EntityType.VULNERABILITY,
+            label="CVE-x",
+            severity="high",
+            attributes={"reachability": "likely", "reachability_basis": ["dependency_path"]},
+        )
+    )
     g.add_edge(UnifiedEdge(source="res", target="vuln", relationship=RelationshipType.VULNERABLE_TO))
     if protected:
         g.add_node(UnifiedNode(id="gw", entity_type=EntityType.API_GATEWAY, label="gateway"))

--- a/tests/graph/test_store_backed_build_wiring.py
+++ b/tests/graph/test_store_backed_build_wiring.py
@@ -143,6 +143,7 @@ def _make_cnapp_estate(g: UnifiedGraph, *, resources: int, fillers: int) -> None
                 entity_type=EntityType.VULNERABILITY,
                 label=vid,
                 severity="critical",
+                attributes={"reachability": "likely", "reachability_basis": ["dependency_path"]},
                 first_seen=_FIXED_CREATED_AT,
                 last_seen=_FIXED_CREATED_AT,
             )

--- a/tests/test_attack_path_mitre.py
+++ b/tests/test_attack_path_mitre.py
@@ -107,11 +107,31 @@ def test_multihop_evidence_maps_to_catalog_techniques_ordered():
 def test_vulnerable_edge_from_internet_entry_maps_to_exploit_public_facing():
     g = _kill_chain_graph()
     # Direct exploit hop off the internet-exposed entry.
-    path = AttackPath(source="res:web", target="vuln:CVE-1", hops=["res:web", "vuln:CVE-1"], edges=["vulnerable_to"])
+    path = AttackPath(
+        source="res:web",
+        target="vuln:CVE-1",
+        hops=["res:web", "vuln:CVE-1"],
+        edges=["vulnerable_to"],
+        reachability="confirmed",
+        reachability_basis=["graph_path"],
+    )
     mappings = derive_attack_path_techniques(path, g)
     assert len(mappings) == 1
     assert mappings[0].technique_id == "T1190"  # Exploit Public-Facing Application
     assert "initial-access" in mappings[0].tactics
+
+
+def test_unverified_candidate_path_never_gets_exploit_technique_mapping():
+    g = _kill_chain_graph()
+    path = AttackPath(
+        source="res:web",
+        target="vuln:CVE-1",
+        hops=["res:web", "vuln:CVE-1"],
+        edges=["vulnerable_to"],
+        reachability="unknown",
+    )
+
+    assert derive_attack_path_techniques(path, g) == []
 
 
 def test_tool_reach_maps_to_atlas_and_resolves():
@@ -170,6 +190,19 @@ def test_to_dict_from_dict_roundtrip_preserves_typed_fields():
     assert restored.technique_mappings == path.technique_mappings
 
 
+def test_to_dict_from_dict_roundtrip_preserves_reachability_evidence():
+    path = AttackPath(
+        source="agent:a",
+        target="vuln:CVE-1",
+        reachability="confirmed",
+        reachability_basis=["graph_path"],
+    )
+
+    restored = AttackPath.from_dict(path.to_dict())
+    assert restored.reachability == "confirmed"
+    assert restored.reachability_basis == ["graph_path"]
+
+
 def test_sqlite_roundtrip_preserves_technique_mappings(tmp_path):
     g = _kill_chain_graph(tenant_id="acme", scan_id="s1")
     apply_attack_path_fusion(g)
@@ -185,6 +218,29 @@ def test_sqlite_roundtrip_preserves_technique_mappings(tmp_path):
 
     assert len(loaded.attack_paths) == 1
     assert loaded.attack_paths[0].technique_mappings == expected
+
+
+def test_sqlite_roundtrip_preserves_path_reachability(tmp_path):
+    g = _kill_chain_graph(tenant_id="acme", scan_id="reachability")
+    g.attack_paths.append(
+        AttackPath(
+            source="res:web",
+            target="vuln:CVE-1",
+            hops=["res:web", "vuln:CVE-1"],
+            edges=["vulnerable_to"],
+            reachability="confirmed",
+            reachability_basis=["graph_path", "function_reachable"],
+        )
+    )
+
+    db = tmp_path / "graph.db"
+    with gs.open_graph_db(db) as conn:
+        gs.save_graph(conn, g)
+    with gs.open_graph_db(db) as conn:
+        loaded = gs.load_graph(conn, tenant_id="acme", scan_id="reachability")
+
+    assert loaded.attack_paths[0].reachability == "confirmed"
+    assert loaded.attack_paths[0].reachability_basis == ["graph_path", "function_reachable"]
 
 
 def test_tenant_isolation_technique_mappings_do_not_leak(tmp_path):

--- a/tests/test_cwe_blast_radius.py
+++ b/tests/test_cwe_blast_radius.py
@@ -227,8 +227,14 @@ def test_dos_summary_says_no_credentials():
 # ── Reachability and actionability ───────────────────────────────────────────
 
 
-def test_rce_is_confirmed_reachability():
+def test_rce_exposure_alone_is_not_confirmed_reachability():
     br = _make_blast_radius(["CWE-94"])
+    assert br.reachability == "likely"
+
+
+def test_rce_with_graph_path_is_confirmed_reachability():
+    br = _make_blast_radius(["CWE-94"])
+    br.graph_reachable = True
     assert br.reachability == "confirmed"
 
 

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -1103,6 +1103,8 @@ def test_graph_diff_route_tags_change_kind(tmp_path) -> None:
                 credential_exposure=["AWS_SECRET_ACCESS_KEY"],
                 tool_exposure=["run_shell"],
                 vuln_ids=["CVE-2026-1"],
+                reachability="confirmed",
+                reachability_basis=["graph_path"],
             )
         )
 
@@ -1784,6 +1786,8 @@ class TestGraphStoreBackendSelection:
                 credential_exposure=["AWS_SECRET_ACCESS_KEY"],
                 tool_exposure=["run_shell"],
                 vuln_ids=["CVE-2026-1"],
+                reachability="confirmed",
+                reachability_basis=["graph_path"],
             )
         )
         client = TestClient(app)
@@ -1811,6 +1815,8 @@ class TestGraphStoreBackendSelection:
         assert body["cards"][0]["exposure_path"]["findings"] == ["CVE-2026-1"]
         assert body["cards"][0]["exposure_path"]["exposedCredentials"] == ["AWS_SECRET_ACCESS_KEY"]
         assert body["cards"][0]["exposure_path"]["reachableTools"] == ["run_shell"]
+        assert body["cards"][0]["exposure_path"]["reachability"] == "confirmed"
+        assert body["cards"][0]["exposure_path"]["reachabilityBasis"] == ["graph_path"]
         assert {reason["kind"] for reason in body["cards"][0]["risk_reasons"]} >= {
             "critical_reach",
             "credential_exposure",

--- a/tests/test_graph_attack_path_e2e.py
+++ b/tests/test_graph_attack_path_e2e.py
@@ -34,7 +34,15 @@ def _scenario() -> UnifiedGraph:
     add("agent:a", EntityType.AGENT, "billing-agent")
     add("server:fs", EntityType.SERVER, "mcp-fs")
     add("pkg:express", EntityType.PACKAGE, "express")
-    add("vuln:CVE-1", EntityType.VULNERABILITY, "CVE-2024-1", severity="critical", risk_score=9.0)
+    add(
+        "vuln:CVE-1",
+        EntityType.VULNERABILITY,
+        "CVE-2024-1",
+        severity="critical",
+        risk_score=9.0,
+        reachability="likely",
+        reachability_basis=["dependency_path"],
+    )
     add("tool:run_shell", EntityType.TOOL, "run_shell")
     add("cred:aws", EntityType.CREDENTIAL, "AWS_SECRET_ACCESS_KEY")
     g.add_edge(UnifiedEdge(source="agent:a", target="server:fs", relationship=RelationshipType.USES))
@@ -49,7 +57,14 @@ def _scenario() -> UnifiedGraph:
     # public PII bucket that is also vulnerable, reached by a misconfiguration
     add("cloud:bucket", EntityType.CLOUD_RESOURCE, "customer-pii prod S3 bucket", resource_type="s3")
     add("mc:public", EntityType.MISCONFIGURATION, "S3 bucket is publicly accessible")
-    add("vuln:CVE-2", EntityType.VULNERABILITY, "CVE-2024-2", severity="high")
+    add(
+        "vuln:CVE-2",
+        EntityType.VULNERABILITY,
+        "CVE-2024-2",
+        severity="high",
+        reachability="likely",
+        reachability_basis=["dependency_path"],
+    )
     g.add_edge(UnifiedEdge(source="mc:public", target="cloud:bucket", relationship=RelationshipType.AFFECTS))
     g.add_edge(UnifiedEdge(source="cloud:bucket", target="vuln:CVE-2", relationship=RelationshipType.VULNERABLE_TO))
 

--- a/tests/test_graph_attack_path_fusion.py
+++ b/tests/test_graph_attack_path_fusion.py
@@ -47,6 +47,24 @@ def test_no_signals_yields_no_boost():
     assert _fusion_signals_for_path(g, path.hops) == []
 
 
+def test_proven_unreachable_vulnerability_does_not_become_attack_path():
+    g = _chain_graph(expose=True, drift=True)
+    g.nodes["vuln:CVE-1"].attributes["reachability"] = "unlikely"
+
+    assert _derived_attack_paths(g) == []
+
+
+def test_unknown_structural_chain_is_bounded_and_clearly_unverified():
+    paths = _derived_attack_paths(_chain_graph(expose=True, drift=True))
+
+    assert paths
+    path = paths[0]
+    assert path.reachability == "unknown"
+    assert path.composite_risk < 40
+    assert "unverified" in path.summary.lower()
+    assert path.technique_mappings == []
+
+
 def test_runtime_observed_activity_boosts_path():
     from agent_bom.api.routes.graph import _fusion_signals_for_path
     from agent_bom.graph.types import EntityType, RelationshipType

--- a/tests/test_graph_cnapp_overlay.py
+++ b/tests/test_graph_cnapp_overlay.py
@@ -30,7 +30,15 @@ def test_overlay_marks_exposure_classifies_data_store_and_flags_toxic():
             label="S3 bucket is publicly accessible",
         )
     )
-    graph.add_node(UnifiedNode(id="vuln:CVE-1", entity_type=EntityType.VULNERABILITY, label="CVE-1", severity="critical"))
+    graph.add_node(
+        UnifiedNode(
+            id="vuln:CVE-1",
+            entity_type=EntityType.VULNERABILITY,
+            label="CVE-1",
+            severity="critical",
+            attributes={"reachability": "likely", "reachability_basis": ["dependency_path"]},
+        )
+    )
     # misconfig AFFECTS the bucket; bucket VULNERABLE_TO a CVE.
     graph.add_edge(UnifiedEdge(source="mc:public", target="cloud:s3-prod", relationship=RelationshipType.AFFECTS))
     graph.add_edge(UnifiedEdge(source="cloud:s3-prod", target="vuln:CVE-1", relationship=RelationshipType.VULNERABLE_TO))
@@ -54,6 +62,25 @@ def test_overlay_marks_exposure_classifies_data_store_and_flags_toxic():
     assert stats["data_stores_added"] == 1
     assert stats["toxic_combinations"] == 1
     assert any(r.pattern == "internet_exposed_vulnerable" for r in graph.interaction_risks)
+
+
+def test_overlay_does_not_call_structural_only_vulnerability_exploitable():
+    graph = UnifiedGraph(scan_id="s", tenant_id="t")
+    graph.add_node(
+        UnifiedNode(
+            id="cloud:vm",
+            entity_type=EntityType.CLOUD_RESOURCE,
+            label="public VM",
+            attributes={"internet_exposed": True},
+        )
+    )
+    graph.add_node(UnifiedNode(id="vuln:unknown", entity_type=EntityType.VULNERABILITY, label="CVE-UNKNOWN"))
+    graph.add_edge(UnifiedEdge(source="cloud:vm", target="vuln:unknown", relationship=RelationshipType.VULNERABLE_TO))
+
+    stats = apply_cnapp_overlay(graph)
+
+    assert stats["toxic_combinations"] == 0
+    assert graph.nodes["cloud:vm"].attributes.get("toxic_exposed_vulnerable") is None
 
 
 def test_overlay_no_exposure_is_noop_for_private_resources():

--- a/tests/test_graph_crown_jewel_paths.py
+++ b/tests/test_graph_crown_jewel_paths.py
@@ -26,7 +26,15 @@ def _crown_jewel_graph() -> UnifiedGraph:
             attributes={"internet_exposed": True, "toxic_exposed_vulnerable": True},
         )
     )
-    g.add_node(UnifiedNode(id="vuln:rce", entity_type=EntityType.VULNERABILITY, label="CVE-RCE", severity="critical"))
+    g.add_node(
+        UnifiedNode(
+            id="vuln:rce",
+            entity_type=EntityType.VULNERABILITY,
+            label="CVE-RCE",
+            severity="critical",
+            attributes={"reachability": "likely", "reachability_basis": ["dependency_path"]},
+        )
+    )
     g.add_node(
         UnifiedNode(
             id="ds:pay",
@@ -84,7 +92,15 @@ def test_two_factor_is_a_toxic_combination_not_crown_jewel():
             attributes={"internet_exposed": True},
         )
     )
-    g.add_node(UnifiedNode(id="vuln:x", entity_type=EntityType.VULNERABILITY, label="CVE-X", severity="high"))
+    g.add_node(
+        UnifiedNode(
+            id="vuln:x",
+            entity_type=EntityType.VULNERABILITY,
+            label="CVE-X",
+            severity="high",
+            attributes={"reachability": "likely", "reachability_basis": ["dependency_path"]},
+        )
+    )
     g.add_edge(UnifiedEdge(source="cloud:vm", target="vuln:x", relationship=RelationshipType.VULNERABLE_TO))
     paths = _derived_toxic_combination_paths(g)
     assert len(paths) == 1

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -362,8 +362,13 @@ def test_check_vulnerable_package(mock_osv, mock_ghsa):
 
     mock_osv.side_effect = _fake_osv
     mock_ghsa.return_value = 0
-    server = create_mcp_server()
-    result = _call_tool(server, "check", {"package": "bad-pkg@1.0.0", "ecosystem": "npm"})
+    # The test owns its advisory universe. An ambient user DB may already
+    # advertise complete npm coverage and correctly suppress the OSV fallback;
+    # isolate both local-DB signals so this contract always exercises the mock.
+    with patch("agent_bom.scanners._scan_packages_local_db", return_value=(0, set())):
+        with patch("agent_bom.scanners._db_covered_ecosystems", return_value=set()):
+            server = create_mcp_server()
+            result = _call_tool(server, "check", {"package": "bad-pkg@1.0.0", "ecosystem": "npm"})
     assert result["status"] == "vulnerable"
     assert result["vulnerabilities"] >= 1
     assert result["details"][0]["id"] == "CVE-2025-9999"

--- a/tests/test_postgres_graph_streaming.py
+++ b/tests/test_postgres_graph_streaming.py
@@ -509,6 +509,8 @@ def test_edge_and_attack_path_reads_accept_native_jsonb_and_preserve_tenant(monk
         ["API_KEY"],
         ["run_shell"],
         ["CVE-2026-0001"],
+        "confirmed",
+        ["graph_path"],
         [],
     )
 
@@ -546,6 +548,8 @@ def test_edge_and_attack_path_reads_accept_native_jsonb_and_preserve_tenant(monk
     assert paths[0].hops == ["agent:native", "tool:native"]
     assert paths[0].credential_exposure == ["API_KEY"]
     assert paths[0].tool_exposure == ["run_shell"]
+    assert paths[0].reachability == "confirmed"
+    assert paths[0].reachability_basis == ["graph_path"]
     assert ("paths", ("tenant-alpha", "scan-jsonb", "agent:native")) in conn.read_params
     edge_params = next(params for kind, params in conn.read_params if kind == "edges")
     assert edge_params[:2] == ("tenant-alpha", "scan-jsonb")

--- a/tests/test_postgres_migrated_graph_parity.py
+++ b/tests/test_postgres_migrated_graph_parity.py
@@ -4,7 +4,7 @@ Opt-in live tier: proves the graph store works on a database whose schema was
 created ONLY by Alembic (``alembic upgrade head``) — the store's dev-mode
 bootstrap DDL never runs because ``AGENT_BOM_POSTGRES_URL`` is set. Regression
 for the P1 where ``attack_paths.summary`` / ``tool_exposure`` /
-``technique_mappings`` existed only in the bootstrap DDL, so every
+``technique_mappings`` / reachability evidence existed only in the bootstrap DDL, so every
 migration-owned deployment 500'd on the first ``/v1/graph`` read.
 
 Requires two opt-in env vars (skipped otherwise):
@@ -95,6 +95,8 @@ def test_attack_paths_round_trip_on_migration_owned_schema(migrated_fresh_databa
         credential_exposure=["prod-db-password"],
         tool_exposure=["shell-tool"],
         vuln_ids=["CVE-2026-0001"],
+        reachability="confirmed",
+        reachability_basis=["graph_path", "runtime_observed"],
         technique_mappings=[TechniqueMapping(hop_index=0, technique_id="T1078", technique_name="Valid Accounts", confidence=0.6)],
     )
     token = set_current_tenant("default")
@@ -116,6 +118,8 @@ def test_attack_paths_round_trip_on_migration_owned_schema(migrated_fresh_databa
     assert got.tool_exposure == ["shell-tool"]
     assert got.credential_exposure == ["prod-db-password"]
     assert got.vuln_ids == ["CVE-2026-0001"]
+    assert got.reachability == "confirmed"
+    assert got.reachability_basis == ["graph_path", "runtime_observed"]
     assert [m.technique_id for m in got.technique_mappings] == ["T1078"]
 
 

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -48,7 +48,7 @@ _FORK_GUARD_INDEX_CANON = "createuniqueindexifnotexistsaudit_log_team_prevsig_un
 
 # The newest migration. One place to update when a revision lands, so the
 # single-head property and the head's identity do not drift apart.
-ALEMBIC_HEAD = "20260819_01"
+ALEMBIC_HEAD = "20260823_01"
 
 
 def _canonical_sql(text: str) -> str:

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -294,10 +294,10 @@ class MockConnection:
                     scan_id = params[1] if len(params) > 1 else ""
                     requested_sources = set(params[2:])
                     rows = [
-                        r for r in rows if r[12] == tenant_id and r[11] == scan_id and (not requested_sources or r[0] in requested_sources)
+                        r for r in rows if r[14] == tenant_id and r[13] == scan_id and (not requested_sources or r[0] in requested_sources)
                     ]
                 rows.sort(key=lambda r: (-float(r[3]), str(r[0]), str(r[1])))
-                cursor.rows = [(r[0], r[1], r[5], r[6], r[3], r[4], r[7], r[8], r[9], r[10]) for r in rows]
+                cursor.rows = [(r[0], r[1], r[5], r[6], r[3], r[4], r[7], r[8], r[9], r[10], r[11], r[12]) for r in rows]
             elif params:
                 for table_data in self._store.values():
                     for pk, row in table_data.items():
@@ -1900,6 +1900,8 @@ def test_graph_store_attack_paths_for_sources_uses_materialized_table(mock_pool,
             edges=["edge:1"],
             composite_risk=9.4,
             summary="agent-a reaches CVE-2026-0001",
+            reachability="confirmed",
+            reachability_basis=["graph_path", "function_reachable"],
             credential_exposure=["API_KEY"],
             tool_exposure=["run_shell"],
             vuln_ids=["CVE-2026-0001"],
@@ -1939,6 +1941,8 @@ def test_graph_store_attack_paths_preserve_technique_mappings(mock_pool, mock_ma
             edges=["vulnerable_to"],
             composite_risk=9.4,
             summary="agent-a reaches CVE-2026-0001",
+            reachability="confirmed",
+            reachability_basis=["graph_path", "function_reachable"],
             technique_mappings=[
                 TechniqueMapping(
                     hop_index=0,
@@ -1962,10 +1966,14 @@ def test_graph_store_attack_paths_preserve_technique_mappings(mock_pool, mock_ma
     assert mappings[0].hop_index == 0
     assert mappings[0].tactics == ["initial-access"]
     assert mappings[0].catalog == "attack"
+    assert paths[0].reachability == "confirmed"
+    assert paths[0].reachability_basis == ["graph_path", "function_reachable"]
 
-    # The INSERT must include the technique_mappings column (generated SQL check).
+    # The INSERT must include all path-truth columns (generated SQL check).
     insert_sql = "\n".join(sql for sql, _p in mock_pool._conn.executed if "INSERT INTO attack_paths" in sql)
     assert "technique_mappings" in insert_sql
+    assert "reachability" in insert_sql
+    assert "reachability_basis" in insert_sql
 
 
 def test_scan_cache_put_get(mock_pool):

--- a/tests/test_reachability_truth.py
+++ b/tests/test_reachability_truth.py
@@ -44,4 +44,3 @@ def test_unrated_active_exploitation_never_ranks_below_equivalent_low() -> None:
 
     assert unknown.calculate_risk_score() >= low.calculate_risk_score()
     assert none.calculate_risk_score() >= low.calculate_risk_score()
-

--- a/tests/test_reachability_truth.py
+++ b/tests/test_reachability_truth.py
@@ -1,0 +1,47 @@
+"""One reachability verdict drives labels, ranking, paths, and correlations."""
+
+from __future__ import annotations
+
+from agent_bom.models import BlastRadius, MCPTool, Package, Severity, Vulnerability
+
+
+def _blast(*, severity: Severity, graph: bool | None = None, symbol: str | None = None) -> BlastRadius:
+    return BlastRadius(
+        vulnerability=Vulnerability(
+            id="CVE-2026-9001",
+            summary="unrated actively exploited advisory",
+            severity=severity,
+            is_kev=True,
+            epss_score=0.95,
+        ),
+        package=Package(name="edge-case", version="1.0.0", ecosystem="pypi", is_direct=True),
+        affected_servers=[],
+        affected_agents=[],
+        exposed_credentials=["PROD_TOKEN"],
+        exposed_tools=[MCPTool(name="run_shell", description="execute a shell command")],
+        graph_reachable=graph,
+        symbol_reachability=symbol,
+    )
+
+
+def test_proven_unreachable_overrides_exposure_heuristics_everywhere() -> None:
+    blast = _blast(severity=Severity.HIGH, graph=False, symbol="unreachable")
+
+    assert blast.reachability == "unlikely"
+    blast.calculate_risk_score()
+    assert blast.risk_score < _blast(severity=Severity.HIGH, graph=True, symbol="function_reachable").calculate_risk_score()
+
+
+def test_confirmed_path_and_symbol_evidence_produce_confirmed_label() -> None:
+    assert _blast(severity=Severity.HIGH, graph=True).reachability == "confirmed"
+    assert _blast(severity=Severity.HIGH, symbol="function_reachable").reachability == "confirmed"
+
+
+def test_unrated_active_exploitation_never_ranks_below_equivalent_low() -> None:
+    unknown = _blast(severity=Severity.UNKNOWN)
+    none = _blast(severity=Severity.NONE)
+    low = _blast(severity=Severity.LOW)
+
+    assert unknown.calculate_risk_score() >= low.calculate_risk_score()
+    assert none.calculate_risk_score() >= low.calculate_risk_score()
+

--- a/tests/test_toxic_combos.py
+++ b/tests/test_toxic_combos.py
@@ -81,6 +81,21 @@ def _report(blast_radii: list[BlastRadius]) -> AIBOMReport:
     return AIBOMReport(blast_radii=blast_radii)
 
 
+def test_proven_unreachable_findings_never_form_exploit_chains():
+    br = _br(
+        vuln=_vuln("CVE-2026-9002", Severity.CRITICAL, is_kev=True),
+        creds=["PROD_TOKEN"],
+        tools=[_tool("run_shell", "execute shell commands")],
+        agents=[_agent("prod-agent")],
+        servers=[_server("prod-server")],
+        risk_score=9.8,
+    )
+    br.graph_reachable = False
+    br.symbol_reachability = "unreachable"
+
+    assert detect_toxic_combinations(_report([br])) == []
+
+
 # ---------------------------------------------------------------------------
 # TestCredentialBlast
 # ---------------------------------------------------------------------------

--- a/tests/test_vuln_matching_honesty.py
+++ b/tests/test_vuln_matching_honesty.py
@@ -108,10 +108,11 @@ def test_declaration_only_downgrades_reachability_to_unknown():
     assert _blast_radius(pkg).reachability == "unknown"
 
 
-def test_runtime_dependency_high_still_reads_likely():
-    # Control: without declaration-only evidence a HIGH direct dep stays "likely".
+def test_runtime_dependency_without_path_evidence_reads_unknown():
+    # Severity and direct-dependency status are priority context, not proof that
+    # the vulnerable code executes.
     pkg = Package(name="requests", version="2.28.0", ecosystem="pypi", is_direct=True)
-    assert _blast_radius(pkg).reachability == "likely"
+    assert _blast_radius(pkg).reachability == "unknown"
 
 
 # --- Defect 2: bare deps resolved against target, never the scanner host ----


### PR DESCRIPTION
## Summary

- centralize reachability precedence so graph/symbol negatives override exposure heuristics, unrated exploited findings do not rank below LOW, and unreachable findings cannot form toxic chains
- keep structural graph chains as bounded unverified candidates while suppressing exploit technique mappings; carry reachability verdicts and evidence through builders, SQLite, Postgres, API/OpenAPI, exports, and the Alembic-owned schema
- make CNAPP toxic/crown-jewel overlays require evidence-backed reachability and harden OIDC/MCP tests against ambient DNS and vulnerability-database state

## Verification

- `uv run pytest -q <34 impacted graph/reachability/store suites>` — 1,138 passed, 3 skipped
- `uv run pytest -q tests/api/test_api_oidc.py::<4 OIDC contracts> tests/test_mcp_server.py::test_check_vulnerable_package` — 5 passed
- `uv run ruff check src tests`
- `uv run mypy src/agent_bom` — 867 source files clean
- `make preflight`
- `mkdocs build --strict`
- `git diff --check`

## Notes

- MITRE ATT&CK and ATLAS remain enrichment only: technique mappings annotate evidence-backed hops and never manufacture reachability.
- The full-suite diagnostic was stopped after 1,818 passes; seven pre-existing non-hermetic failures were reproduced or isolated, and the affected OIDC/MCP contracts are included in this batch.