### PR TITLE
fix(platform): harden graph and control-plane read paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ Finding + UnifiedGraph contracts. Select any image for the full-size proof.
 
 <table>
   <tr>
-    <th>1 · Discover</th>
+    <th>1 · Discover inventory</th>
     <th>2 · Scan</th>
   </tr>
   <tr>
-    <td><a href="docs/images/mesh-live.png"><img src="docs/images/mesh-live.png" alt="Discovered agents, MCP servers, tools, packages, findings, and labeled relationships" width="440" /></a></td>
+    <td><a href="docs/images/fleet-state-live.png"><img src="docs/images/fleet-state-live.png" alt="Persisted developer endpoint and agent inventory with evidence state, lifecycle, and trust posture" width="440" /></a></td>
     <td><a href="docs/images/jobs-pipeline-live.png"><img src="docs/images/jobs-pipeline-live.png" alt="Completed read-only scan pipeline from discovery through persisted findings, graph, and report evidence" width="440" /></a></td>
   </tr>
   <tr>

--- a/deploy/supabase/postgres/runtime-schema.sql
+++ b/deploy/supabase/postgres/runtime-schema.sql
@@ -44,6 +44,8 @@ CREATE INDEX IF NOT EXISTS idx_fleet_tenant_name_lower ON fleet_agents(tenant_id
 CREATE TABLE IF NOT EXISTS fleet_endpoints (tenant_id TEXT NOT NULL,endpoint_id TEXT NOT NULL,completeness TEXT NOT NULL,updated_at TEXT NOT NULL,data JSONB NOT NULL,PRIMARY KEY(tenant_id,endpoint_id));
 CREATE INDEX IF NOT EXISTS idx_fleet_endpoints_tenant_updated ON fleet_endpoints(tenant_id,updated_at DESC,endpoint_id);
 CREATE INDEX IF NOT EXISTS idx_pg_jobs_team_created ON scan_jobs(team_id,created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_jobs_status ON scan_jobs(status);
+CREATE INDEX IF NOT EXISTS idx_jobs_team_status ON scan_jobs(team_id,status);
 CREATE INDEX IF NOT EXISTS idx_pg_jobs_batch ON scan_jobs(team_id,batch_id,created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_pg_jobs_parent ON scan_jobs(team_id,parent_job_id,created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_pg_jobs_schedule ON scan_jobs(team_id,schedule_id,created_at DESC);

--- a/src/agent_bom/api/postgres_job_store.py
+++ b/src/agent_bom/api/postgres_job_store.py
@@ -166,6 +166,8 @@ class PostgresJobStore:
                 )
             """)
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_jobs_team_created ON scan_jobs(team_id, created_at DESC)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_status ON scan_jobs(status)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_team_status ON scan_jobs(team_id, status)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_jobs_batch ON scan_jobs(team_id, batch_id, created_at DESC)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_jobs_parent ON scan_jobs(team_id, parent_job_id, created_at DESC)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_jobs_schedule ON scan_jobs(team_id, schedule_id, created_at DESC)")
@@ -408,6 +410,21 @@ class PostgresJobStore:
                 tuple(params),
             ).fetchall()
         return {str(status): int(count) for status, count in rows}
+
+    def count_active(self, tenant_id: str | None = None, *, all_tenants: bool = False) -> int:
+        """Count active jobs without selecting or deserializing report JSON."""
+        _require_tenant_scope(tenant_id, all_tenants, "PostgresJobStore.count_active()")
+        clauses = ["status IN (%s, %s)"]
+        params: list[object] = ["pending", "running"]
+        if tenant_id is not None:
+            clauses.append("team_id = %s")
+            params.append(tenant_id)
+        with self._scope_connection(all_tenants=all_tenants) as conn:
+            row = conn.execute(
+                f"SELECT COUNT(*) FROM scan_jobs WHERE {' AND '.join(clauses)}",  # nosec B608
+                tuple(params),
+            ).fetchone()
+        return int(row[0]) if row else 0
 
     def query_cis_benchmark_checks(
         self,

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -87,6 +87,8 @@ _FILTERED_GRAPH_ATTACK_PATH_LIMIT = 100
 _GOVERNANCE_EDGE_LIMIT = 5_000
 _GOVERNANCE_ATTACK_PATH_LIMIT = 100
 
+_EdgeLookup = dict[tuple[str, str], UnifiedEdge]
+
 
 class GraphScopeDescriptor(BaseModel):
     kind: GraphScopeKind
@@ -695,7 +697,13 @@ def _next_actions_for_path(graph: UnifiedGraph, path: AttackPath) -> list[dict[s
     return actions[:4]
 
 
-def _fix_first_card_for_path(graph: UnifiedGraph, path: AttackPath, rank: int) -> dict:
+def _fix_first_card_for_path(
+    graph: UnifiedGraph,
+    path: AttackPath,
+    rank: int,
+    *,
+    edge_lookup: _EdgeLookup | None = None,
+) -> dict:
     findings = _finding_ids_for_path(graph, path.hops, path.vuln_ids)
     agents = _node_labels_for_types(
         graph,
@@ -716,7 +724,14 @@ def _fix_first_card_for_path(graph: UnifiedGraph, path: AttackPath, rank: int) -
         "title": " ".join(title_parts),
         "summary": path.summary or "Review this path before opening the full topology graph.",
         "attack_path": path.to_dict(),
-        "exposure_path": _exposure_path_for_attack_path(path, nodes_by_id=graph.nodes, edges=graph.edges, rank=rank, scan_id=graph.scan_id),
+        "exposure_path": _exposure_path_for_attack_path(
+            path,
+            nodes_by_id=graph.nodes,
+            edges=graph.edges,
+            rank=rank,
+            scan_id=graph.scan_id,
+            edge_lookup=edge_lookup,
+        ),
         "nodes": [graph.nodes[hop].to_dict() for hop in path.hops if hop in graph.nodes],
         "sequence_labels": sequence,
         "risk_reasons": _risk_reasons_for_path(graph, path),
@@ -876,21 +891,31 @@ def _boundary_edge_count(edges: list[UnifiedEdge], node_ids: set[str]) -> int:
     return sum(1 for edge in edges if edge.source not in node_ids or edge.target not in node_ids)
 
 
-def _edge_relationships_for_hops(hops: list[str], edges: list[UnifiedEdge]) -> list[str]:
+def _build_edge_lookup(edges: list[UnifiedEdge] | None) -> _EdgeLookup:
+    """Index directed hop pairs once for a response serialization batch."""
+    by_pair: _EdgeLookup = {}
+    for edge in edges or []:
+        by_pair.setdefault((edge.source, edge.target), edge)
+        if edge.is_bidirectional:
+            by_pair.setdefault((edge.target, edge.source), edge)
+    return by_pair
+
+
+def _edge_relationships_for_hops(
+    hops: list[str],
+    edges: list[UnifiedEdge] | None = None,
+    *,
+    edge_lookup: _EdgeLookup | None = None,
+) -> list[str]:
     """Return relationship names for consecutive hop pairs when topology is available."""
     if len(hops) < 2:
         return []
-    by_pair: dict[tuple[str, str], str] = {}
-    for edge in edges:
-        rel = _rel_value(edge)
-        by_pair.setdefault((edge.source, edge.target), rel)
-        if edge.is_bidirectional:
-            by_pair.setdefault((edge.target, edge.source), rel)
+    by_pair = edge_lookup if edge_lookup is not None else _build_edge_lookup(edges)
     relationships: list[str] = []
     for source, target in zip(hops, hops[1:], strict=False):
-        relationship = by_pair.get((source, target))
-        if relationship:
-            relationships.append(relationship)
+        edge = by_pair.get((source, target))
+        if edge is not None:
+            relationships.append(_rel_value(edge))
     return relationships
 
 
@@ -931,17 +956,17 @@ def _exposure_ref_for_node(node_id: str, nodes_by_id: dict[str, Any]) -> dict[st
     return ref
 
 
-def _exposure_relationships_for_path(path: AttackPath, edges: list[UnifiedEdge] | None) -> list[dict[str, Any]]:
-    by_pair: dict[tuple[str, str], UnifiedEdge] = {}
-    edge: UnifiedEdge | None
-    for edge in edges or []:
-        by_pair.setdefault((edge.source, edge.target), edge)
-        if edge.is_bidirectional:
-            by_pair.setdefault((edge.target, edge.source), edge)
+def _exposure_relationships_for_path(
+    path: AttackPath,
+    edges: list[UnifiedEdge] | None,
+    *,
+    edge_lookup: _EdgeLookup | None = None,
+) -> list[dict[str, Any]]:
+    by_pair = edge_lookup if edge_lookup is not None else _build_edge_lookup(edges)
 
     relationships: list[dict[str, Any]] = []
     for index, (source, target) in enumerate(zip(path.hops, path.hops[1:], strict=False)):
-        edge = by_pair.get((source, target))
+        edge: UnifiedEdge | None = by_pair.get((source, target))
         relationship = ""
         if edge is not None:
             relationship = _rel_value(edge)
@@ -993,12 +1018,13 @@ def _exposure_path_for_attack_path(
     edges: list[UnifiedEdge] | None = None,
     rank: int | None = None,
     scan_id: str = "",
+    edge_lookup: _EdgeLookup | None = None,
 ) -> dict[str, Any]:
     hops = [_exposure_ref_for_node(hop, nodes_by_id) for hop in path.hops]
     empty_ref = {"id": "", "label": "", "role": "unknown"}
     source = _exposure_ref_for_node(path.source, nodes_by_id) if path.source else (hops[0] if hops else empty_ref)
     target = _exposure_ref_for_node(path.target, nodes_by_id) if path.target else (hops[-1] if hops else empty_ref)
-    relationships = _exposure_relationships_for_path(path, edges)
+    relationships = _exposure_relationships_for_path(path, edges, edge_lookup=edge_lookup)
     packages = [hop for hop in hops if hop["role"] == "package"]
     servers = [hop for hop in hops if hop["role"] == "server"]
     agents = [hop for hop in hops if hop["role"] == "agent"]
@@ -1061,17 +1087,48 @@ def _serialize_attack_path(
     nodes_by_id: dict[str, Any] | None = None,
     rank: int | None = None,
     scan_id: str = "",
+    edge_lookup: _EdgeLookup | None = None,
 ) -> dict:
     data = path.to_dict()
     if not data.get("edges") and edges is not None:
-        data["edges"] = _edge_relationships_for_hops(path.hops, edges)
+        data["edges"] = _edge_relationships_for_hops(path.hops, edges, edge_lookup=edge_lookup)
     if nodes_by_id is not None:
         # Prefer stamped Finding.id values over CVE labels when available.
         resolved = _finding_ids_for_nodes(nodes_by_id, path.hops, path.vuln_ids)
         if resolved:
             data["finding_ids"] = resolved
-        data["exposure_path"] = _exposure_path_for_attack_path(path, nodes_by_id=nodes_by_id, edges=edges, rank=rank, scan_id=scan_id)
+        data["exposure_path"] = _exposure_path_for_attack_path(
+            path,
+            nodes_by_id=nodes_by_id,
+            edges=edges,
+            rank=rank,
+            scan_id=scan_id,
+            edge_lookup=edge_lookup,
+        )
     return data
+
+
+def _serialize_attack_path_batch(
+    paths: list[AttackPath],
+    edges: list[UnifiedEdge] | None = None,
+    *,
+    nodes_by_id: dict[str, Any] | None = None,
+    scan_id: str = "",
+    rank_offset: int | None = None,
+) -> list[dict[str, Any]]:
+    """Serialize a page of paths with one topology index shared by every row."""
+    edge_lookup = _build_edge_lookup(edges)
+    return [
+        _serialize_attack_path(
+            path,
+            edges,
+            nodes_by_id=nodes_by_id,
+            rank=(rank_offset + index + 1) if rank_offset is not None else None,
+            scan_id=scan_id,
+            edge_lookup=edge_lookup,
+        )
+        for index, path in enumerate(paths)
+    ]
 
 
 def _node_type_value(node: UnifiedNode) -> str:
@@ -1434,6 +1491,7 @@ def _derived_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
 
     incoming: dict[str, list] = {}
     outgoing: dict[str, list] = {}
+    edge_lookup = _build_edge_lookup(graph.edges)
     for edge in graph.edges:
         incoming.setdefault(edge.target, []).append(edge)
         outgoing.setdefault(edge.source, []).append(edge)
@@ -1493,7 +1551,11 @@ def _derived_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
                     if vulnerable_source.id != server_id:
                         hop_ids.append(vulnerable_source.id)
                     hop_ids.append(finding.id)
-                    path_edges = _edge_relationships_for_hops(hop_ids, graph.edges)
+                    path_edges = _edge_relationships_for_hops(
+                        hop_ids,
+                        graph.edges,
+                        edge_lookup=edge_lookup,
+                    )
                     key = (agent_id, server_id, vulnerable_source.id, finding.id)
                     if key in seen:
                         continue
@@ -1718,7 +1780,12 @@ def _filtered_graph_response(graph: UnifiedGraph, *, offset: int, limit: int) ->
     off_page_hops = {hop for p in kept_paths for hop in p.hops} - paged_ids
     nodes_by_id = {n.id: n for n in paged_nodes}
     nodes_by_id.update({hop: graph.nodes[hop] for hop in off_page_hops if hop in graph.nodes})
-    attack_paths = [_serialize_attack_path(p, graph.edges, nodes_by_id=nodes_by_id, scan_id=graph.scan_id) for p in kept_paths]
+    attack_paths = _serialize_attack_path_batch(
+        kept_paths,
+        graph.edges,
+        nodes_by_id=nodes_by_id,
+        scan_id=graph.scan_id,
+    )
     interaction_risks = [
         r.to_dict() for r in graph.interaction_risks if r.agents and all(f"agent:{agent_name}" in paged_ids for agent_name in r.agents)
     ]
@@ -1793,8 +1860,9 @@ def _fix_first_graph_view_payload(graph: UnifiedGraph, *, cve: str, package: str
         reverse=True,
     )
     cards = []
+    edge_lookup = _build_edge_lookup(graph.edges)
     for index, path in enumerate(ranked_paths[:limit]):
-        card = _fix_first_card_for_path(graph, path, index + 1)
+        card = _fix_first_card_for_path(graph, path, index + 1, edge_lookup=edge_lookup)
         card["rank_meta"] = criticality_rank_meta(graph, path)
         cards.append(card)
     covered_findings = {finding for card in cards for finding in card["affected"]["findings"]}
@@ -1871,10 +1939,13 @@ def _serialize_attack_path_queue(
         "created_at": created_at,
         "nodes": [node.to_dict() for node in nodes],
         "edges": [edge.to_dict() for edge in path_edges],
-        "attack_paths": [
-            _serialize_attack_path(path, path_edges, nodes_by_id=nodes_by_id, rank=offset + index + 1, scan_id=scan_id)
-            for index, path in enumerate(paths)
-        ],
+        "attack_paths": _serialize_attack_path_batch(
+            paths,
+            path_edges,
+            nodes_by_id=nodes_by_id,
+            scan_id=scan_id,
+            rank_offset=offset,
+        ),
         "interaction_risks": [],
         "stats": stats,
         "pagination": _page_meta(total, offset, limit),
@@ -1919,9 +1990,12 @@ def _governance_graph_payload(
     edges = candidate_edges[:edge_limit]
 
     matching_paths = [p for p in _derived_attack_paths(graph) if p.hops and any(hop in governance_ids for hop in p.hops)]
-    attack_paths = [
-        _serialize_attack_path(p, keep_edges, nodes_by_id=graph.nodes, scan_id=graph.scan_id) for p in matching_paths[:attack_path_limit]
-    ]
+    attack_paths = _serialize_attack_path_batch(
+        matching_paths[:attack_path_limit],
+        keep_edges,
+        nodes_by_id=graph.nodes,
+        scan_id=graph.scan_id,
+    )
     counts: dict[str, int] = {}
     for node in graph.nodes.values():
         if node.entity_type in governance_types:
@@ -2386,9 +2460,12 @@ async def get_graph(
         "created_at": created_at,
         "nodes": [n.to_dict() for n in response_nodes],
         "edges": [e.to_dict() for e in response_edges],
-        "attack_paths": [
-            _serialize_attack_path(path, paged_edges, nodes_by_id=nodes_by_id, scan_id=effective_scan_id) for path in source_attack_paths
-        ],
+        "attack_paths": _serialize_attack_path_batch(
+            source_attack_paths,
+            paged_edges,
+            nodes_by_id=nodes_by_id,
+            scan_id=effective_scan_id,
+        ),
         "interaction_risks": [],
         "stats": snapshot_stats,
         "pagination": _page_meta(total, offset, limit, cursor=cursor, next_cursor=next_cursor),
@@ -2829,11 +2906,12 @@ async def get_graph_paths(
         "reachable_count": len(reachable),
         "reachable_nodes": sorted(reachable),
         "paths": [{"target": p[-1], "hops": p, "depth": len(p) - 1} for p in paged_paths],
-        "attack_paths": [
-            _serialize_attack_path(ap, path_edges, nodes_by_id=nodes_by_id, scan_id=requested_scan_id)
-            for ap in attack_paths
-            if ap.source == source_node_id
-        ],
+        "attack_paths": _serialize_attack_path_batch(
+            [ap for ap in attack_paths if ap.source == source_node_id],
+            path_edges,
+            nodes_by_id=nodes_by_id,
+            scan_id=requested_scan_id,
+        ),
         "pagination": pagination,
         "truncated": traversal_truncated,
         "depth_limited": depth_limited,
@@ -3107,9 +3185,12 @@ async def query_graph(request: Request, body: GraphQueryRequest) -> dict:
             node_ids=missing_hop_ids,
         )
         nodes_by_id = {**filtered_graph.nodes, **{node.id: node for node in backfilled_nodes}}
-        attack_paths = [
-            _serialize_attack_path(ap, filtered_graph.edges, nodes_by_id=nodes_by_id, scan_id=filtered_graph.scan_id) for ap in root_paths
-        ]
+        attack_paths = _serialize_attack_path_batch(
+            root_paths,
+            filtered_graph.edges,
+            nodes_by_id=nodes_by_id,
+            scan_id=filtered_graph.scan_id,
+        )
 
     return {
         "scan_id": filtered_graph.scan_id,

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1248,6 +1248,14 @@ def _job_for_request(request: Request, job_id: str) -> ScanJob:
     return cast(ScanJob, job)
 
 
+async def _load_job_for_request(request: Request, job_id: str) -> ScanJob:
+    """Hydrate one job off-loop because durable stores use synchronous I/O."""
+    return cast(
+        ScanJob,
+        await anyio.to_thread.run_sync(partial(_job_for_request, request, job_id)),
+    )
+
+
 def _redact_scan_result_for_response(result: dict[str, Any] | None) -> dict[str, Any] | None:
     """Drop replay-only fields from top-level scan findings before API return."""
     if not isinstance(result, dict):
@@ -1543,13 +1551,13 @@ async def get_scan(request: Request, job_id: str) -> ScanJob:
     non-json ``format``, ``result_document`` carries that rendering and
     ``result_format`` names it.
     """
-    return _job_response_payload(_job_for_request(request, job_id))
+    return _job_response_payload(await _load_job_for_request(request, job_id))
 
 
 @router.get("/scan/{job_id}/status", tags=["scan"])
 async def get_scan_status(request: Request, job_id: str) -> dict[str, Any]:
     """Poll lightweight scan status without serializing large result payloads."""
-    return _job_summary_payload(_job_for_request(request, job_id))
+    return _job_summary_payload(await _load_job_for_request(request, job_id))
 
 
 @router.get("/scan/{job_id}/attack-flow", tags=["scan"])
@@ -1572,7 +1580,7 @@ async def get_attack_flow(
       ?framework=LLM05       - filter by OWASP/ATLAS/NIST tag
       ?agent=claude-desktop  - filter to a specific agent
     """
-    job = _job_for_request(request, job_id)
+    job = await _load_job_for_request(request, job_id)
     if job.status != JobStatus.DONE or not job.result:
         raise HTTPException(status_code=409, detail="Scan not completed yet")
 
@@ -1601,7 +1609,7 @@ async def get_context_graph(request: Request, job_id: str, agent: str | None = N
     Query params:
       ?agent=claude-desktop  - only compute lateral paths from this agent
     """
-    job = _job_for_request(request, job_id)
+    job = await _load_job_for_request(request, job_id)
     if job.status != JobStatus.DONE or not job.result:
         raise HTTPException(status_code=409, detail="Scan not completed yet")
 
@@ -1636,7 +1644,7 @@ async def get_graph_export(
       ?format=cypher    Neo4j Cypher import script
       ?mermaid_limit=80 Maximum nodes rendered for Mermaid; 0 renders all
     """
-    job = _job_for_request(request, job_id)
+    job = await _load_job_for_request(request, job_id)
     if job.status != JobStatus.DONE or not job.result:
         raise HTTPException(status_code=409, detail="Scan not completed yet")
 
@@ -1662,7 +1670,7 @@ async def get_remediation_plan(request: Request, job_id: str) -> dict:
     asset — so it is returned whole, with ``total`` stated rather than left for
     the client to infer.
     """
-    job = _job_for_request(request, job_id)
+    job = await _load_job_for_request(request, job_id)
     if job.status != JobStatus.DONE or not job.result:
         raise HTTPException(status_code=409, detail="Scan not completed yet")
     plan = job.result.get("remediation_plan") or [] if isinstance(job.result, dict) else []
@@ -1676,7 +1684,7 @@ async def get_licenses(request: Request, job_id: str) -> dict:
     Returns license findings, summary, compliance status, and per-package
     license categorization (permissive, copyleft, commercial risk, unknown).
     """
-    job = _job_for_request(request, job_id)
+    job = await _load_job_for_request(request, job_id)
     if job.status != JobStatus.DONE or not job.result:
         raise HTTPException(status_code=409, detail="Scan not completed yet")
 
@@ -1723,7 +1731,7 @@ async def get_vex(request: Request, job_id: str) -> dict:
     Returns VEX statements with vulnerability status (affected, not_affected,
     fixed, under_investigation), justifications, and statistics.
     """
-    job = _job_for_request(request, job_id)
+    job = await _load_job_for_request(request, job_id)
     if job.status != JobStatus.DONE or not job.result:
         raise HTTPException(status_code=409, detail="Scan not completed yet")
 
@@ -1743,7 +1751,7 @@ async def get_skill_audit(request: Request, job_id: str) -> dict:
     typosquat detection, unverified servers, shell access, and more.
     Empty results if no skill files were scanned.
     """
-    job = _job_for_request(request, job_id)
+    job = await _load_job_for_request(request, job_id)
 
     if job.status != JobStatus.DONE or not job.result:
         raise HTTPException(status_code=409, detail="Scan not completed yet")
@@ -1771,9 +1779,9 @@ async def cancel_scan(request: Request, job_id: str) -> ScanJob:
     checkpoint. Terminal jobs are returned unchanged. Use ``DELETE`` to discard
     the job record after cancellation (or for already-finished jobs).
     """
-    job = _job_for_request(request, job_id)
-    request_scan_cancellation(job)
-    return _job_response_payload(_job_for_request(request, job_id))
+    job = await _load_job_for_request(request, job_id)
+    await anyio.to_thread.run_sync(partial(request_scan_cancellation, job))
+    return _job_response_payload(await _load_job_for_request(request, job_id))
 
 
 @router.delete("/scan/{job_id}", status_code=204, tags=["scan"])
@@ -1783,11 +1791,11 @@ async def delete_scan(request: Request, job_id: str) -> None:
     For pending/running jobs, requests cooperative cancellation first so the
     worker does not finish into a resurrected DONE state after discard.
     """
-    job = _job_for_request(request, job_id)
+    job = await _load_job_for_request(request, job_id)
     if job.status in {JobStatus.PENDING, JobStatus.RUNNING}:
-        request_scan_cancellation(job)
+        await anyio.to_thread.run_sync(partial(request_scan_cancellation, job))
     in_memory = _jobs_pop(job_id) if _visible_to_tenant(job, _tenant_id(request)) else None
-    in_store = _get_store().delete(job_id, tenant_id=_tenant_id(request))
+    in_store = await anyio.to_thread.run_sync(partial(_get_store().delete, job_id, tenant_id=_tenant_id(request)))
     if not in_memory and not in_store:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
 
@@ -1808,7 +1816,7 @@ async def stream_scan(request: Request, job_id: str) -> Response:
             detail="SSE requires sse-starlette. Install: pip install 'agent-bom[api]'",
         ) from exc
 
-    _job_for_request(request, job_id)
+    await _load_job_for_request(request, job_id)
     tenant_id = _tenant_id(request)
 
     import json as _json

--- a/src/agent_bom/api/scan_job_reconciliation.py
+++ b/src/agent_bom/api/scan_job_reconciliation.py
@@ -15,13 +15,21 @@ def is_active_scan_job(job: ScanJob) -> bool:
 
 
 def active_scan_job_count(store: Any, tenant_id: str | None = None) -> int:
-    # A missing tenant means "count active jobs across every tenant" for the
-    # global gauge — an explicit cross-tenant reconciliation, not a leak.
-    if tenant_id is None:
-        jobs = store.list_all(all_tenants=True)
-    else:
-        jobs = store.list_all(tenant_id=tenant_id)
-    return sum(1 for job in jobs if is_active_scan_job(job))
+    """Count active jobs through an indexed aggregate, never report blobs."""
+    counter = getattr(store, "count_active", None)
+    if callable(counter):
+        value = counter(tenant_id=tenant_id, all_tenants=tenant_id is None)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+
+    # Compatibility boundary for third-party stores implementing the older
+    # summary protocol. This still avoids selecting/deserializing full reports.
+    status_counter = getattr(store, "count_summary_by_status", None)
+    if callable(status_counter):
+        counts = status_counter(tenant_id=tenant_id)
+        if isinstance(counts, dict):
+            return sum(int(counts.get(status.value, 0) or 0) for status in ACTIVE_SCAN_JOB_STATUSES)
+    raise TypeError("Job store must provide count_active or count_summary_by_status")
 
 
 def reconcile_scan_jobs_active(store: Any, tenant_id: str | None = None) -> int:

--- a/src/agent_bom/api/snowflake_store.py
+++ b/src/agent_bom/api/snowflake_store.py
@@ -29,7 +29,7 @@ from .exception_store import ExceptionStatus, VulnException
 from .fleet_store import FleetAgent, FleetEndpoint, FleetLifecycleState
 from .policy_store import GatewayPolicy, PolicyAuditEntry
 from .server import ScanJob
-from .store import _literal_like_pattern
+from .store import _literal_like_pattern, _require_tenant_scope
 
 if TYPE_CHECKING:
     from .schedule_store import ScanSchedule
@@ -359,6 +359,23 @@ class SnowflakeJobStore:
             )
             rows = cur.fetchall()
         return {str(status): int(count) for status, count in rows}
+
+    def count_active(self, tenant_id: str | None = None, *, all_tenants: bool = False) -> int:
+        """Count active jobs without fetching VARIANT report payloads."""
+        _require_tenant_scope(tenant_id, all_tenants, "SnowflakeJobStore.count_active()")
+        clauses = ["status IN (%s, %s)"]
+        params: list[object] = ["pending", "running"]
+        if tenant_id is not None:
+            clauses.append("tenant_id = %s")
+            params.append(tenant_id)
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                f"SELECT COUNT(*) FROM scan_jobs WHERE {' AND '.join(clauses)}",  # nosec B608
+                tuple(params),
+            )
+            row = cur.fetchone()
+        return int(row[0]) if row else 0
 
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int:
         from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY

--- a/src/agent_bom/api/store.py
+++ b/src/agent_bom/api/store.py
@@ -124,6 +124,12 @@ class JobStore(Protocol):
         *,
         query: str | None = None,
     ) -> dict[str, int]: ...
+    def count_active(
+        self,
+        tenant_id: str | None = None,
+        *,
+        all_tenants: bool = False,
+    ) -> int: ...
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int: ...
 
 
@@ -264,6 +270,16 @@ class InMemoryJobStore:
                 key = job.status.value if isinstance(job.status, JobStatus) else str(job.status)
                 counts[key] = counts.get(key, 0) + 1
             return counts
+
+    def count_active(self, tenant_id: str | None = None, *, all_tenants: bool = False) -> int:
+        """Count pending/running jobs without materialising job payloads."""
+        _require_tenant_scope(tenant_id, all_tenants, "InMemoryJobStore.count_active()")
+        with self._lock:
+            return sum(
+                1
+                for job in self._jobs.values()
+                if (tenant_id is None or job.tenant_id == tenant_id) and job.status in {JobStatus.PENDING, JobStatus.RUNNING}
+            )
 
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int:
         with self._lock:
@@ -537,6 +553,24 @@ class SQLiteJobStore:
                 params,
             ).fetchall()
             return {str(status): int(count) for status, count in rows}
+        finally:
+            self._shrink_connection_memory()
+            self._close_thread_connection()
+
+    def count_active(self, tenant_id: str | None = None, *, all_tenants: bool = False) -> int:
+        """Count pending/running jobs with the indexed status columns only."""
+        _require_tenant_scope(tenant_id, all_tenants, "SQLiteJobStore.count_active()")
+        try:
+            clauses = ["status IN (?, ?)"]
+            params: list[object] = [JobStatus.PENDING.value, JobStatus.RUNNING.value]
+            if tenant_id is not None:
+                clauses.append("tenant_id = ?")
+                params.append(tenant_id)
+            row = self._conn.execute(
+                f"SELECT COUNT(*) FROM jobs WHERE {' AND '.join(clauses)}",  # nosec B608
+                params,
+            ).fetchone()
+            return int(row[0]) if row else 0
         finally:
             self._shrink_connection_memory()
             self._close_thread_connection()

--- a/tests/api/test_api_store.py
+++ b/tests/api/test_api_store.py
@@ -87,6 +87,18 @@ def test_in_memory_list_summary_pages_beyond_two_hundred_after_filtering():
     assert store.count_summary(query="bulk-source") == 225
 
 
+def test_in_memory_count_active_is_tenant_scoped_and_excludes_terminal_jobs():
+    store = InMemoryJobStore()
+    store.put(_make_job("a-pending", tenant_id="tenant-a", status=JobStatus.PENDING))
+    store.put(_make_job("a-running", tenant_id="tenant-a", status=JobStatus.RUNNING))
+    store.put(_make_job("a-done", tenant_id="tenant-a", status=JobStatus.DONE))
+    store.put(_make_job("b-running", tenant_id="tenant-b", status=JobStatus.RUNNING))
+
+    assert store.count_active(tenant_id="tenant-a") == 2
+    assert store.count_active(tenant_id="tenant-b") == 1
+    assert store.count_active(all_tenants=True) == 3
+
+
 def test_in_memory_cleanup():
     store = InMemoryJobStore()
     store.put(_make_job("j1", status=JobStatus.DONE, completed_at="2020-01-01T00:00:00+00:00"))
@@ -371,6 +383,23 @@ def test_sqlite_list_summary_filters_before_pagination_and_counts():
         assert store.count_summary(query="alpha", status=JobStatus.DONE) == 1
         assert store.count_summary_by_status(query="alpha") == {"done": 1, "running": 1}
         assert store.count_summary(query="%") == 0
+    finally:
+        Path(db_path).unlink(missing_ok=True)
+
+
+def test_sqlite_count_active_is_tenant_scoped_and_excludes_terminal_jobs():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        store = SQLiteJobStore(db_path=db_path)
+        store.put(_make_job("a-pending", tenant_id="tenant-a", status=JobStatus.PENDING))
+        store.put(_make_job("a-running", tenant_id="tenant-a", status=JobStatus.RUNNING))
+        store.put(_make_job("a-done", tenant_id="tenant-a", status=JobStatus.DONE))
+        store.put(_make_job("b-running", tenant_id="tenant-b", status=JobStatus.RUNNING))
+
+        assert store.count_active(tenant_id="tenant-a") == 2
+        assert store.count_active(tenant_id="tenant-b") == 1
+        assert store.count_active(all_tenants=True) == 3
     finally:
         Path(db_path).unlink(missing_ok=True)
 

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -204,6 +204,27 @@ def test_finding_distinct_packages_under_one_server_get_distinct_ids():
     assert f_torch.id != f_numpy.id
 
 
+def test_distinct_cves_on_one_non_package_asset_never_share_an_id():
+    """The vulnerability identity remains part of a non-package occurrence ID."""
+    server_asset = Asset(name="filesystem", asset_type="mcp_server")
+    first = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=server_asset,
+        severity="HIGH",
+        cve_id="CVE-2026-1001",
+    )
+    second = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=server_asset,
+        severity="HIGH",
+        cve_id="CVE-2026-1002",
+    )
+
+    assert first.id != second.id
+
+
 def test_finding_effective_severity_vendor_wins():
     finding = Finding(
         finding_type=FindingType.CVE,

--- a/tests/test_graph_attack_path_serialization_scale.py
+++ b/tests/test_graph_attack_path_serialization_scale.py
@@ -1,0 +1,56 @@
+"""Attack-path serialization must index topology once per response page."""
+
+from __future__ import annotations
+
+from agent_bom.api.routes import graph as graph_routes
+from agent_bom.graph import AttackPath, EntityType, RelationshipType, UnifiedEdge, UnifiedNode
+
+
+def test_attack_path_page_builds_one_edge_lookup(monkeypatch) -> None:
+    edges = [
+        UnifiedEdge(source=f"noise:{index}", target=f"noise:{index + 1}", relationship=RelationshipType.USES) for index in range(1_000)
+    ]
+    edges.extend(
+        [
+            UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES),
+            UnifiedEdge(source="server:s", target="vuln:v", relationship=RelationshipType.VULNERABLE_TO),
+        ]
+    )
+    paths = [
+        AttackPath(
+            source="agent:a",
+            target="vuln:v",
+            hops=["agent:a", "server:s", "vuln:v"],
+            composite_risk=90.0 - index / 100,
+        )
+        for index in range(100)
+    ]
+    nodes = {
+        "agent:a": UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="Agent A"),
+        "server:s": UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="Server S"),
+        "vuln:v": UnifiedNode(id="vuln:v", entity_type=EntityType.VULNERABILITY, label="CVE-2026-1"),
+    }
+
+    calls = 0
+    real_builder = graph_routes._build_edge_lookup
+
+    def recording_builder(topology):
+        nonlocal calls
+        calls += 1
+        return real_builder(topology)
+
+    monkeypatch.setattr(graph_routes, "_build_edge_lookup", recording_builder)
+    serialized = graph_routes._serialize_attack_path_batch(
+        paths,
+        edges,
+        nodes_by_id=nodes,
+        scan_id="scan-1",
+    )
+
+    assert calls == 1
+    assert len(serialized) == 100
+    assert serialized[0]["edges"] == ["uses", "vulnerable_to"]
+    assert [item["relationship"] for item in serialized[0]["exposure_path"]["relationships"]] == [
+        "uses",
+        "vulnerable_to",
+    ]

--- a/tests/test_jobs_route_offload.py
+++ b/tests/test_jobs_route_offload.py
@@ -23,6 +23,19 @@ _TICK_SECONDS = 0.01
 _MIN_TICKS_WHILE_OFFLOADED = 5
 
 
+def _completed_job():
+    from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+
+    return ScanJob(
+        job_id="job-offload",
+        tenant_id="default",
+        status=JobStatus.DONE,
+        created_at="2026-08-23T00:00:00+00:00",
+        request=ScanRequest(),
+        result={"findings": []},
+    )
+
+
 def _blocking_store() -> MagicMock:
     store = MagicMock()
 
@@ -93,3 +106,47 @@ async def test_list_jobs_response_contract_is_unchanged() -> None:
     assert body["offset"] == 0
     assert body["status_counts"] == {"done": 2, "failed": 1}
     assert [job["job_id"] for job in body["jobs"]] == ["j-1", "j-2"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/v1/scan/job-offload",
+        "/v1/scan/job-offload/status",
+        "/v1/scan/job-offload/remediation",
+        "/v1/scan/job-offload/skill-audit",
+        "/v1/scan/job-offload/stream",
+    ],
+)
+async def test_per_job_reads_keep_the_event_loop_responsive(path: str) -> None:
+    """Every per-job route must offload a potentially remote durable read."""
+    import httpx
+
+    from agent_bom.api.server import app
+
+    ticks = 0
+    job = _completed_job()
+
+    def slow_job_lookup(*_args: Any, **_kwargs: Any):
+        time.sleep(_BLOCKING_SECONDS)
+        return job
+
+    async def heartbeat() -> None:
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(_TICK_SECONDS)
+            ticks += 1
+
+    with patch("agent_bom.api.routes.scan._job_for_request", side_effect=slow_job_lookup):
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            beat = asyncio.create_task(heartbeat())
+            await asyncio.sleep(_TICK_SECONDS * 2)
+            before = ticks
+            response = await client.get(path)
+            observed = ticks - before
+            beat.cancel()
+
+    assert response.status_code == 200, response.text
+    assert observed >= _MIN_TICKS_WHILE_OFFLOADED, f"{path} advanced only {observed} tick(s) during a {_BLOCKING_SECONDS}s job read"

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -6,8 +6,11 @@ Uses a mock psycopg_pool to avoid needing a real PostgreSQL instance.
 import json
 import sys
 import types
+from pathlib import Path
 
 import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
 
 # ─── Mock psycopg infrastructure ─────────────────────────────────────────────
 
@@ -558,6 +561,32 @@ def test_job_store_init_migrates_triggered_by_column(mock_pool):
     PostgresJobStore(pool=mock_pool)
     migration_sql = "\n".join(sql for sql, _params in mock_pool._conn.executed if "ALTER TABLE scan_jobs" in sql)
     assert "ADD COLUMN triggered_by TEXT" in migration_sql
+
+
+def test_job_store_active_count_uses_indexed_columns_without_job_json(mock_pool, mock_maintenance_pool):
+    from agent_bom.api.postgres_store import PostgresJobStore
+
+    store = PostgresJobStore(pool=mock_pool, maintenance_pool=mock_maintenance_pool)
+    mock_pool._conn.executed.clear()
+
+    store.count_active(tenant_id="tenant-alpha")
+
+    sql, params = next((sql, params) for sql, params in mock_pool._conn.executed if "SELECT COUNT(*) FROM scan_jobs" in sql)
+    assert "status IN (%s, %s)" in sql
+    assert "team_id = %s" in sql
+    assert "data" not in sql.lower()
+    assert params == ("pending", "running", "tenant-alpha")
+
+
+def test_job_store_active_count_indexes_exist_in_runtime_store_and_schema(mock_pool):
+    from agent_bom.api.postgres_store import PostgresJobStore
+
+    PostgresJobStore(pool=mock_pool)
+    runtime_sql = (ROOT / "deploy" / "supabase" / "postgres" / "runtime-schema.sql").read_text()
+    init_sql = "\n".join(sql for sql, _params in mock_pool._conn.executed)
+    for index_name in ("idx_jobs_status", "idx_jobs_team_status"):
+        assert index_name in init_sql
+        assert index_name in runtime_sql
 
 
 # ─── PostgresFleetStore ───────────────────────────────────────────────────────

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -232,10 +232,10 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert commands == ["pip install agent-bom", "agent-bom scan --demo --offline"]
 
     assert "<summary><b>Try without a repository</b></summary>" in readme
-    for stage in ("1 · Discover", "2 · Scan", "3 · Reachable graph", "4 · Ranked path", "5 · Act and verify"):
+    for stage in ("1 · Discover inventory", "2 · Scan", "3 · Reachable graph", "4 · Ranked path", "5 · Act and verify"):
         assert stage in readme
     for image in (
-        "mesh-live.png",
+        "fleet-state-live.png",
         "jobs-pipeline-live.png",
         "lineage-graph-live.png",
         "security-graph-live.png",

--- a/tests/test_public_frontdoor_contract.py
+++ b/tests/test_public_frontdoor_contract.py
@@ -87,8 +87,8 @@ def test_readme_shows_the_end_to_end_product_journey_and_links_the_gallery() -> 
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
 
     journey = readme.split("### Product journey", 1)[1].split("## Quick start", 1)[0]
-    stages = ["Discover", "Scan", "Reachable graph", "Ranked path", "Act and verify"]
-    images = ["mesh-live.png", "jobs-pipeline-live.png", "lineage-graph-live.png", "security-graph-live.png", "remediation-live.png"]
+    stages = ["Discover inventory", "Scan", "Reachable graph", "Ranked path", "Act and verify"]
+    images = ["fleet-state-live.png", "jobs-pipeline-live.png", "lineage-graph-live.png", "security-graph-live.png", "remediation-live.png"]
     assert all(stage in journey for stage in stages)
     assert all(image in journey for image in images)
     assert [journey.index(stage) for stage in stages] == sorted(journey.index(stage) for stage in stages)

--- a/tests/test_scan_jobs_active_gauge.py
+++ b/tests/test_scan_jobs_active_gauge.py
@@ -20,6 +20,7 @@ import pytest
 from agent_bom.api import metrics
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.scan_job_reconciliation import (
+    active_scan_job_count,
     fail_orphaned_active_scan_jobs,
     fail_stale_active_scan_jobs,
     reconcile_scan_jobs_active,
@@ -97,6 +98,21 @@ def test_reconcile_sets_gauge_from_durable_active_jobs() -> None:
 
     assert reconcile_scan_jobs_active(store) == 2
     assert metrics.scan_jobs_active() == 2
+
+
+def test_active_count_never_deserializes_historical_job_payloads() -> None:
+    """Gauge reconciliation must use a bounded aggregate, not ``list_all``."""
+
+    class AggregateOnlyStore:
+        def count_active(self, tenant_id=None, *, all_tenants=False):
+            assert tenant_id is None
+            assert all_tenants is True
+            return 2
+
+        def list_all(self, *args, **kwargs):
+            raise AssertionError("active reconciliation must not load historical job blobs")
+
+    assert active_scan_job_count(AggregateOnlyStore()) == 2
 
 
 def test_fail_stale_active_jobs_then_reconcile_clears_leaked_gauge() -> None:

--- a/tests/test_snowflake_stores.py
+++ b/tests/test_snowflake_stores.py
@@ -9,6 +9,8 @@ import json
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # ─── Fixtures ─────────────────────────────────────────────────────────────────
 
 
@@ -386,6 +388,23 @@ class TestSnowflakeJobStore:
         assert len(result) == 1
         assert result[0]["job_id"] == "j1"
         assert result[0]["tenant_id"] == "tenant-alpha"
+
+    @patch("agent_bom.api.snowflake_store._sf_connect")
+    def test_count_active_is_tenant_scoped_and_avoids_variant_payload(self, mock_connect):
+        cur = _mock_cursor(fetchone_val=(2,))
+        conn = _mock_connection(cursor=cur)
+        mock_connect.return_value = conn
+        store = self._make_store()
+
+        assert store.count_active(tenant_id="tenant-alpha") == 2
+        sql, params = cur.execute.call_args_list[-1].args
+        assert "status IN (%s, %s)" in sql
+        assert "tenant_id = %s" in sql
+        assert "data" not in sql.lower()
+        assert params == ("pending", "running", "tenant-alpha")
+
+        with pytest.raises(ValueError, match="requires a tenant_id"):
+            store.count_active()
 
     @patch("agent_bom.api.snowflake_store._sf_connect")
     def test_cleanup_expired(self, mock_connect):

--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -68,7 +68,13 @@ import { Drawer } from "@/components/drawer";
 import { GraphInteractionToolbar } from "@/components/graph-chrome";
 import { useGraphPresentation } from "@/hooks/use-graph-presentation";
 import { graphTopologyKey } from "@/lib/graph-presentation";
-import { graphNodeDisplayLabels, readableGraphEdges } from "@/lib/graph-utils";
+import {
+  ATTACK_FLOW_MINIMAP_COLORS,
+  ATTACK_FLOW_NODE_CLASS_MAP,
+  ATTACK_FLOW_SEVERITY_NODE_CLASS_MAP,
+  graphNodeDisplayLabels,
+  readableGraphEdges,
+} from "@/lib/graph-utils";
 import { useAuthState } from "@/components/auth-provider";
 
 // ─── Agents List Helpers ────────────────────────────────────────────────────
@@ -1258,39 +1264,15 @@ const NODE_ICONS: Record<string, React.ElementType> = {
   tool: Wrench,
 };
 
-const NODE_COLORS: Record<string, string> = {
-  cve: "border-red-600 bg-red-950/80",
-  package: "border-[color:var(--border-strong)] bg-[color:var(--surface-muted)]/80",
-  server: "border-blue-600 bg-blue-950/80",
-  agent: "border-emerald-600 bg-emerald-950/80",
-  credential: "border-yellow-600 bg-yellow-950/80",
-  tool: "border-purple-600 bg-purple-950/80",
-};
-
-const MINIMAP_COLORS: Record<string, string> = {
-  cve: "#ef4444",
-  package: "#52525b",
-  server: "#3b82f6",
-  agent: "#10b981",
-  credential: "#eab308",
-  tool: "#a855f7",
-};
-
 // ─── Lifecycle Custom Node ──────────────────────────────────────────────────
 
 function LifecycleNode({ data }: { data: AttackFlowNodeData }) {
   const nodeType = data.nodeType;
   const Icon = NODE_ICONS[nodeType] ?? Bug;
 
-  const sevColors: Record<string, string> = {
-    critical: "border-red-500 bg-red-950",
-    high: "border-orange-500 bg-orange-950",
-    medium: "border-yellow-500 bg-yellow-950",
-    low: "border-blue-500 bg-blue-950",
-  };
   const border = nodeType === "cve" && data.severity
-    ? sevColors[data.severity.toLowerCase()] ?? NODE_COLORS[nodeType]
-    : NODE_COLORS[nodeType];
+    ? ATTACK_FLOW_SEVERITY_NODE_CLASS_MAP[data.severity.toLowerCase()] ?? ATTACK_FLOW_NODE_CLASS_MAP[nodeType]
+    : ATTACK_FLOW_NODE_CLASS_MAP[nodeType];
 
   return (
     <div className={`rounded-lg border-2 px-3 py-2 min-w-[140px] max-w-[200px] shadow-lg ${border}`}>
@@ -1529,7 +1511,7 @@ function LifecycleFlow({
         <Background color="#27272a" gap={20} />
         <Controls className="agents-flow-controls" />
         <MiniMap
-          nodeColor={(n) => MINIMAP_COLORS[(n.data as AttackFlowNodeData)?.nodeType] ?? "#52525b"}
+          nodeColor={(n) => ATTACK_FLOW_MINIMAP_COLORS[(n.data as AttackFlowNodeData)?.nodeType] ?? "#52525b"}
           className="!bg-[color:var(--surface-muted)] !border-[color:var(--border-subtle)] !rounded-lg"
           maskColor="rgba(0,0,0,0.7)"
         />

--- a/ui/components/agent-topology.tsx
+++ b/ui/components/agent-topology.tsx
@@ -131,6 +131,8 @@ function TopologyFlow({
     nodeHeight: 72,
     rankSep: 120,
     nodeSep: 28,
+    fitAspect: 2.6,
+    minSeparation: { width: 168, height: 72, gap: 24 },
   });
   const displayEdges = useMemo(
     () =>
@@ -144,7 +146,10 @@ function TopologyFlow({
 
   useEffect(() => {
     if (pending) return;
-    const timer = window.setTimeout(() => fitView({ padding: 0.2, duration: 300 }), 80);
+    const timer = window.setTimeout(
+      () => fitView({ padding: 0.14, duration: 300, minZoom: 0.48, maxZoom: 1.05 }),
+      80,
+    );
     return () => window.clearTimeout(timer);
   }, [fitView, nodes, pending]);
 
@@ -172,7 +177,8 @@ function TopologyFlow({
       nodeTypes={nodeTypes}
       onNodeClick={handleNodeClick}
       fitView
-      minZoom={0.15}
+      fitViewOptions={{ padding: 0.14, minZoom: 0.48, maxZoom: 1.05 }}
+      minZoom={0.35}
       maxZoom={1.5}
       panOnDrag
       zoomOnScroll

--- a/ui/components/attack-flow.tsx
+++ b/ui/components/attack-flow.tsx
@@ -20,7 +20,17 @@ import {
 import type { AttackFlowNodeData, AttackFlowResponse } from "@/lib/api";
 import { FrameworkTagChips } from "@/components/framework-tag-chips";
 import { SeverityBadge } from "@/components/severity-badge";
-import { CONTROLS_CLASS, MINIMAP_CLASS, BACKGROUND_COLOR, BACKGROUND_GAP, ATTACK_FLOW_MINIMAP_COLORS, graphNodeDisplayLabels, readableGraphEdges } from "@/lib/graph-utils";
+import {
+  ATTACK_FLOW_MINIMAP_COLORS,
+  ATTACK_FLOW_NODE_CLASS_MAP,
+  ATTACK_FLOW_SEVERITY_NODE_CLASS_MAP,
+  BACKGROUND_COLOR,
+  BACKGROUND_GAP,
+  CONTROLS_CLASS,
+  MINIMAP_CLASS,
+  graphNodeDisplayLabels,
+  readableGraphEdges,
+} from "@/lib/graph-utils";
 import { getOsvVulnerabilityUrl } from "@/lib/vulnerabilities";
 import { FullscreenButton, GraphInteractionToolbar } from "@/components/graph-chrome";
 import { useGraphPresentation } from "@/hooks/use-graph-presentation";
@@ -34,28 +44,16 @@ const NODE_ICONS: Record<string, React.ElementType> = {
   agent: ShieldAlert, credential: KeyRound, tool: Wrench,
 };
 
-const NODE_COLORS: Record<string, string> = {
-  cve: "border-red-600 bg-red-950/80",
-  package: "border-[var(--border-strong)] bg-[var(--surface)]/80",
-  server: "border-blue-600 bg-blue-950/80",
-  agent: "border-emerald-600 bg-emerald-950/80",
-  credential: "border-yellow-600 bg-yellow-950/80",
-  tool: "border-purple-600 bg-purple-950/80",
-};
-
 // ─── Custom Node ────────────────────────────────────────────────────────────
 
 function AttackFlowNode({ data }: { data: AttackFlowNodeData }) {
   const nodeType = data.nodeType;
   const Icon = NODE_ICONS[nodeType] ?? Bug;
 
-  let colorClass = NODE_COLORS[nodeType] ?? NODE_COLORS.cve;
+  let colorClass = ATTACK_FLOW_NODE_CLASS_MAP[nodeType] ?? ATTACK_FLOW_NODE_CLASS_MAP.cve;
   if (nodeType === "cve" && data.severity) {
     const sev = data.severity.toLowerCase();
-    if (sev === "critical") colorClass = "border-red-600 bg-red-950/80";
-    else if (sev === "high") colorClass = "border-orange-600 bg-orange-950/80";
-    else if (sev === "medium") colorClass = "border-yellow-600 bg-yellow-950/80";
-    else colorClass = "border-blue-600 bg-blue-950/80";
+    colorClass = ATTACK_FLOW_SEVERITY_NODE_CLASS_MAP[sev] ?? ATTACK_FLOW_SEVERITY_NODE_CLASS_MAP.low;
   }
 
   const showTarget = nodeType !== "cve";

--- a/ui/components/drawer.tsx
+++ b/ui/components/drawer.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 import { ChevronLeft, X } from "lucide-react";
 
 const FOCUSABLE_SELECTOR =
   'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
 
-export type DrawerSize = "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "5xl";
+export type DrawerSize = "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "5xl" | "none";
 
 const SIZE_CLASS: Record<DrawerSize, string> = {
   sm: "max-w-sm",
@@ -17,6 +23,7 @@ const SIZE_CLASS: Record<DrawerSize, string> = {
   "3xl": "max-w-3xl",
   "4xl": "max-w-4xl",
   "5xl": "max-w-5xl",
+  none: "max-w-none",
 };
 
 export interface DrawerProps {
@@ -34,6 +41,15 @@ export interface DrawerProps {
   footer?: ReactNode;
   size?: DrawerSize;
   ariaLabel?: string;
+  /** Accessible label shared by the backdrop and header close controls. */
+  closeLabel?: string;
+  /** Optional distinct label for the full-screen backdrop dismissal control. */
+  backdropLabel?: string;
+  panelStyle?: CSSProperties;
+  panelClassName?: string;
+  bodyClassName?: string;
+  /** Optional keyboard-accessible resize handle or other panel-edge control. */
+  panelLeading?: ReactNode;
   children: ReactNode;
 }
 
@@ -52,6 +68,12 @@ export function Drawer({
   footer,
   size = "xl",
   ariaLabel,
+  closeLabel = "Close",
+  backdropLabel,
+  panelStyle,
+  panelClassName,
+  bodyClassName,
+  panelLeading,
   children,
 }: DrawerProps) {
   const [entered, setEntered] = useState(false);
@@ -120,16 +142,18 @@ export function Drawer({
       <button
         type="button"
         className="absolute inset-0 cursor-default"
-        aria-label="Close"
+        aria-label={backdropLabel ?? closeLabel}
         onClick={onClose}
       />
       <aside
         ref={panelRef}
         tabIndex={-1}
+        style={panelStyle}
         className={`relative flex h-full w-full flex-col border-l border-[color:var(--border-subtle)] bg-[color:var(--surface)] elev-3 outline-none transition-transform duration-200 ease-out motion-reduce:transition-none ${
           SIZE_CLASS[size]
-        } ${entered ? "translate-x-0" : "translate-x-full"}`}
+        } ${entered ? "translate-x-0" : "translate-x-full"} ${panelClassName ?? ""}`}
       >
+        {panelLeading}
         <div className="flex items-start justify-between gap-4 border-b border-[color:var(--border-subtle)] p-5">
           <div className="flex min-w-0 items-start gap-2">
             {onBack ? (
@@ -162,14 +186,14 @@ export function Drawer({
               type="button"
               onClick={onClose}
               className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-2 text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
-              aria-label="Close"
+              aria-label={closeLabel}
             >
               <X className="h-4 w-4" />
             </button>
           </div>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto p-5">{children}</div>
+        <div className={`min-h-0 flex-1 overflow-y-auto p-5 ${bodyClassName ?? ""}`}>{children}</div>
 
         {footer ? (
           <div className="border-t border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">

--- a/ui/components/lineage-nodes.tsx
+++ b/ui/components/lineage-nodes.tsx
@@ -6,6 +6,7 @@ import { Bug, KeyRound, Package, Wrench } from "lucide-react";
 
 import { severityColor } from "@/lib/api";
 import type { ReachBreakdown } from "@/lib/effective-reach";
+import { NODE_COLOR_MAP } from "@/lib/graph-utils";
 import {
   ENTITY_ICONS,
   entityIcon,
@@ -826,47 +827,7 @@ function ClusterBubbleNode({ data }: { data: LineageNodeData }) {
   );
 }
 
-const CLUSTER_BUBBLE_COLORS: Record<LineageNodeType, string> = {
-  provider: "#71717a",
-  agent: "#10b981",
-  user: "#34d399",
-  group: "#d946ef",
-  serviceAccount: "#fbbf24",
-  environment: "#14b8a6",
-  fleet: "#22d3ee",
-  cluster: "#38bdf8",
-  server: "#3b82f6",
-  sharedServer: "#22d3ee",
-  package: "#52525b",
-  vulnerability: "#ef4444",
-  credential: "#f59e0b",
-  tool: "#a855f7",
-  model: "#8b5cf6",
-  framework: "#06b6d4",
-  dataset: "#06b6d4",
-  container: "#6366f1",
-  cloudResource: "#0ea5e9",
-  org: "#115e59",
-  account: "#0f766e",
-  misconfiguration: "#f97316",
-  role: "#ea580c",
-  policy: "#d97706",
-  servicePrincipal: "#0f766e",
-  federatedIdentity: "#0e7490",
-  managedIdentity: "#0891b2",
-  accessGrant: "#ca8a04",
-  accessPolicy: "#a16207",
-  driftIncident: "#fb923c",
-  dataStore: "#0284c7",
-  directory: "#0d9488",
-  sourceFile: "#22d3ee",
-  configFile: "#f97316",
-  codeModule: "#06b6d4",
-  ciJob: "#a855f7",
-  apiGateway: "#2563eb",
-  toolCall: "#c084fc",
-  blueprint: "#818cf8",
-};
+const CLUSTER_BUBBLE_COLORS: Record<LineageNodeType, string> = NODE_COLOR_MAP;
 
 const DETAIL_RENDERERS: Record<
   LineageNodeType,

--- a/ui/components/proxy-alert-drawer.tsx
+++ b/ui/components/proxy-alert-drawer.tsx
@@ -1,18 +1,16 @@
 "use client";
 
-import { X } from "lucide-react";
-
+import { Drawer } from "@/components/drawer";
 import { useDrawerWidth } from "@/lib/use-drawer-width";
-import { useEscToClose } from "@/hooks/use-esc-to-close";
 import type { ProxyAlert } from "@/lib/api";
 import { formatDate } from "@/lib/api";
 import { proxyAlertDetailEntries, proxyAlertSummary } from "@/lib/proxy-alerts";
 
 const SEVERITY_COLORS: Record<string, string> = {
-  critical: "bg-red-950 text-red-300 border-red-800",
-  high: "bg-orange-950 text-orange-300 border-orange-800",
-  medium: "bg-yellow-950 text-yellow-300 border-yellow-800",
-  low: "bg-blue-950 text-blue-300 border-blue-800",
+  critical: "border-red-300 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-300",
+  high: "border-orange-300 bg-orange-50 text-orange-800 dark:border-orange-800 dark:bg-orange-950 dark:text-orange-300",
+  medium: "border-yellow-300 bg-yellow-50 text-yellow-800 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-300",
+  low: "border-blue-300 bg-blue-50 text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300",
   info: "bg-[var(--surface-elevated)] text-[var(--text-secondary)] border-[var(--border-subtle)]",
 };
 
@@ -23,29 +21,34 @@ export function ProxyAlertDrawer({
   alert: ProxyAlert;
   onClose: () => void;
 }) {
-  useEscToClose(true, onClose);
   const rows = proxyAlertDetailEntries(alert);
   const { width, onHandlePointerDown, onHandleKeyDown } = useDrawerWidth();
 
   return (
-    <div
-      className="fixed inset-0 z-[80] flex justify-end bg-black/45 backdrop-blur-sm"
-      role="dialog"
-      aria-modal="true"
-      aria-label={`Proxy alert details for ${alert.tool_name}`}
-    >
-      <button
-        type="button"
-        className="absolute inset-0 cursor-default"
-        aria-label="Close proxy alert details"
-        onClick={onClose}
-      />
-      <aside
-        style={{ width }}
-        className="relative h-full w-full max-w-full overflow-y-auto border-l border-[var(--border-subtle)] bg-[var(--background)] p-5 shadow-2xl"
-      >
-        {/* A fixed 32rem drawer forces long values to wrap and short ones to
-            waste the row. Let the reader size it to what they are reading. */}
+    <Drawer
+      open
+      onClose={onClose}
+      size="none"
+      panelStyle={{ width }}
+      ariaLabel={`Proxy alert details for ${alert.tool_name}`}
+      closeLabel="Close proxy alert drawer"
+      backdropLabel="Dismiss proxy alert drawer"
+      eyebrow="Runtime alert"
+      title={alert.tool_name}
+      subtitle={proxyAlertSummary(alert)}
+      headerAside={
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className={`rounded border px-1.5 py-0.5 text-[10px] ${
+              SEVERITY_COLORS[alert.severity] ?? SEVERITY_COLORS.info
+            }`}
+          >
+            {alert.severity}
+          </span>
+          <span className="font-mono text-xs text-[var(--text-secondary)]">{alert.detector}</span>
+        </div>
+      }
+      panelLeading={
         <div
           role="separator"
           aria-label="Resize drawer"
@@ -56,53 +59,21 @@ export function ProxyAlertDrawer({
           title="Drag to resize"
           className="absolute inset-y-0 left-0 z-10 w-1.5 cursor-col-resize bg-transparent transition-colors hover:bg-[color:var(--accent-border)] focus:bg-[color:var(--accent-border)] focus:outline-none"
         />
-        <div className="mb-4 flex items-start justify-between gap-4 border-b border-[var(--border-subtle)] pb-4">
-          <div className="min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
-              Runtime alert
-            </p>
-            <div className="mt-2 flex flex-wrap items-center gap-2">
-              <span
-                className={`text-[10px] px-1.5 py-0.5 rounded border ${
-                  SEVERITY_COLORS[alert.severity] ?? SEVERITY_COLORS.info
-                }`}
-              >
-                {alert.severity}
-              </span>
-              <span className="font-mono text-sm text-[var(--foreground)]">{alert.detector}</span>
-            </div>
-            <h2 className="mt-2 break-all font-mono text-lg font-semibold text-[var(--foreground)]">
-              {alert.tool_name}
-            </h2>
-            <p className="mt-1 text-sm text-[var(--text-secondary)]">{proxyAlertSummary(alert)}</p>
-            {alert.ts ? (
-              <p className="mt-2 text-xs text-[var(--text-tertiary)]">{formatDate(alert.ts)}</p>
-            ) : null}
+      }
+    >
+      {alert.ts ? (
+        <p className="mb-4 text-xs text-[var(--text-tertiary)]">{formatDate(alert.ts)}</p>
+      ) : null}
+      <dl data-testid="proxy-alert-fields" className="grid grid-cols-2 gap-x-5 gap-y-3">
+        {rows.map((row) => (
+          <div key={`${row.label}:${row.value}`} className="min-w-0">
+            <dt className="text-[10px] uppercase tracking-[0.16em] text-[var(--text-tertiary)]">
+              {row.label}
+            </dt>
+            <dd className="mt-0.5 break-words font-mono text-xs text-[var(--foreground)]">{row.value}</dd>
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] p-2 text-[var(--text-secondary)] transition-colors hover:border-[var(--border-subtle)] hover:text-[var(--foreground)]"
-            aria-label="Close proxy alert drawer"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-
-        {/* Two columns of label/value pairs instead of one bordered card per
-            field: nine short values cost roughly five rows rather than nine,
-            and the eye scans a column instead of a mile of boxes. */}
-        <dl data-testid="proxy-alert-fields" className="grid grid-cols-2 gap-x-5 gap-y-3">
-          {rows.map((row) => (
-            <div key={`${row.label}:${row.value}`} className="min-w-0">
-              <dt className="text-[10px] uppercase tracking-[0.16em] text-[var(--text-tertiary)]">
-                {row.label}
-              </dt>
-              <dd className="mt-0.5 break-words font-mono text-xs text-[var(--foreground)]">{row.value}</dd>
-            </div>
-          ))}
-        </dl>
-      </aside>
-    </div>
+        ))}
+      </dl>
+    </Drawer>
   );
 }

--- a/ui/components/topology-detail-drawer.tsx
+++ b/ui/components/topology-detail-drawer.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { Lock, Package, Server, ShieldAlert, Users, Wrench, X } from "lucide-react";
+import { useState } from "react";
+import { Lock, Package, Server, ShieldAlert, Users, Wrench } from "lucide-react";
 
-import { useEscToClose } from "@/hooks/use-esc-to-close";
+import { Drawer } from "@/components/drawer";
 import type { Agent } from "@/lib/api";
 import {
   serverHasCredentials,
@@ -14,6 +15,13 @@ import {
 } from "@/lib/agent-topology-graph";
 
 type MCPServer = NonNullable<Agent["mcp_servers"]>[number];
+type DetailTab = "overview" | "services" | "actions";
+
+const DETAIL_TABS: { id: DetailTab; label: string }[] = [
+  { id: "overview", label: "Overview" },
+  { id: "services", label: "Services" },
+  { id: "actions", label: "Actions" },
+];
 
 export function TopologyDetailDrawer({
   agents,
@@ -27,7 +35,7 @@ export function TopologyDetailDrawer({
     | null;
   onClose: () => void;
 }) {
-  useEscToClose(selection !== null, onClose);
+  const [activeTab, setActiveTab] = useState<DetailTab>("overview");
   if (!selection) return null;
 
   const agent =
@@ -64,92 +72,146 @@ export function TopologyDetailDrawer({
   const hasCredentials = serverMatches.some((match) => serverHasCredentials(match.server));
 
   return (
-    <div
-      className="fixed inset-0 z-[80] flex justify-end bg-black/45 backdrop-blur-sm"
-      role="dialog"
-      aria-modal="true"
-      aria-label={`Topology details for ${title}`}
+    <Drawer
+      open
+      onClose={onClose}
+      size="2xl"
+      ariaLabel={`Topology details for ${title}`}
+      closeLabel="Close topology details"
+      backdropLabel="Dismiss topology details"
+      bodyClassName="!overflow-hidden !p-0"
+      eyebrow={selection.kind === "agent" ? "Agent runtime" : "Shared MCP service"}
+      title={title}
+      subtitle={subtitle}
     >
-      <button type="button" className="absolute inset-0 cursor-default" aria-label="Close topology details" onClick={onClose} />
-      <aside className="relative h-full w-full max-w-md overflow-y-auto border-l border-[var(--border-subtle)] bg-[var(--background)] p-5 shadow-2xl">
-        <div className="mb-4 flex items-start justify-between gap-4 border-b border-[var(--border-subtle)] pb-4">
-          <div className="min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
-              {selection.kind === "agent" ? "Agent runtime" : "Shared MCP service"}
-            </p>
-            <h2 className="mt-2 text-lg font-semibold text-[var(--foreground)]">{title}</h2>
-            <p className="mt-1 text-sm text-[var(--text-secondary)]">{subtitle}</p>
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="border-b border-[var(--border-subtle)] px-5 pt-4">
+          <div className="mb-4 grid grid-cols-2 gap-2 sm:grid-cols-4">
+            <Metric label="Servers" value={serverMatches.length} icon={Server} />
+            <Metric label="Packages" value={totalPackages} icon={Package} />
+            <Metric label="Tools" value={totalTools} icon={Wrench} />
+            <Metric label="CVEs" value={totalVulns} icon={ShieldAlert} tone={totalVulns > 0 ? "danger" : "neutral"} />
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] p-2 text-[var(--text-secondary)] transition hover:text-[var(--foreground)]"
-            aria-label="Close topology drawer"
-          >
-            <X className="h-4 w-4" />
-          </button>
+          <div className="flex gap-1" role="tablist" aria-label="Topology detail sections">
+            {DETAIL_TABS.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={activeTab === tab.id}
+                aria-controls={`topology-${tab.id}-panel`}
+                id={`topology-${tab.id}-tab`}
+                onClick={() => setActiveTab(tab.id)}
+                className={`border-b-2 px-3 py-2 text-xs font-semibold transition-colors ${
+                  activeTab === tab.id
+                    ? "border-emerald-500 text-[var(--foreground)]"
+                    : "border-transparent text-[var(--text-tertiary)] hover:text-[var(--foreground)]"
+                }`}
+              >
+                {tab.label}
+                {tab.id === "services" ? (
+                  <span className="ml-1.5 rounded-full bg-[var(--surface-muted)] px-1.5 py-0.5 font-mono text-[10px]">
+                    {serverMatches.length}
+                  </span>
+                ) : null}
+              </button>
+            ))}
+          </div>
         </div>
 
-        <div className="mb-4 grid grid-cols-2 gap-2">
-          <Metric label="Servers" value={serverMatches.length} icon={Server} />
-          <Metric label="Packages" value={totalPackages} icon={Package} />
-          <Metric label="Tools" value={totalTools} icon={Wrench} />
-          <Metric label="CVEs" value={totalVulns} icon={ShieldAlert} tone={totalVulns > 0 ? "danger" : "neutral"} />
-        </div>
-
-        {hasCredentials ? (
-          <div className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 dark:bg-amber-950/20 px-3 py-2 text-xs text-amber-700 dark:text-amber-200">
-            <Lock className="mr-1.5 inline h-3.5 w-3.5" />
-            Credential-backed env vars detected on this service path.
-          </div>
-        ) : null}
-
-        {selection.kind === "server" && connectedAgents.length > 1 ? (
-          <div className="mb-4">
-            <p className="mb-2 flex items-center gap-1.5 text-xs text-[var(--text-tertiary)]">
-              <Users className="h-3.5 w-3.5" />
-              Shared blast radius
-            </p>
-            <div className="flex flex-wrap gap-1.5">
-              {connectedAgents.map((entry) => (
-                <span key={entry.name} className="rounded bg-[var(--surface)] px-2 py-0.5 text-xs text-[var(--text-secondary)]">
-                  {topologyAgentDisplayName(entry)}
-                </span>
-              ))}
-            </div>
-          </div>
-        ) : null}
-
-        <div className="space-y-2">
-          {serverMatches.map(({ agent: entry, server }) => (
-            <ServerCard key={`${entry.name}:${serviceKey(server)}`} agentName={entry.name} server={server} />
-          ))}
-        </div>
-
-        <div className="mt-5 flex flex-wrap gap-2 border-t border-[var(--border-subtle)] pt-4">
-          {selection.kind === "agent" ? (
-            <Link
-              href={`/agents?name=${encodeURIComponent(selection.name)}`}
-              className="rounded-lg border border-emerald-700/50 bg-emerald-500/10 dark:bg-emerald-950/30 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-200"
-            >
-              Open agent record
-            </Link>
+        <div className="min-h-0 flex-1 overflow-y-auto p-5">
+          {activeTab === "overview" ? (
+            <section role="tabpanel" id="topology-overview-panel" aria-labelledby="topology-overview-tab" className="space-y-4">
+              {hasCredentials ? (
+                <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-800 dark:bg-amber-950/20 dark:text-amber-200">
+                  <Lock className="mr-1.5 inline h-3.5 w-3.5" />
+                  Credential-backed env vars detected on this service path.
+                </div>
+              ) : (
+                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-3 py-2 text-xs text-[var(--text-secondary)]">
+                  No credential-backed environment variables were observed on this service path.
+                </div>
+              )}
+              {selection.kind === "server" && connectedAgents.length > 1 ? (
+                <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-muted)] p-4">
+                  <p className="mb-3 flex items-center gap-1.5 text-xs font-semibold text-[var(--foreground)]">
+                    <Users className="h-3.5 w-3.5" /> Shared blast radius
+                  </p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {connectedAgents.map((entry) => (
+                      <span key={entry.name} className="rounded bg-[var(--surface)] px-2 py-1 text-xs text-[var(--text-secondary)]">
+                        {topologyAgentDisplayName(entry)}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+              <div className="grid gap-3 sm:grid-cols-2">
+                <SummaryCard label="Evidence scope" value={`${serverMatches.length} service path${serverMatches.length === 1 ? "" : "s"}`} />
+                <SummaryCard
+                  label="Priority"
+                  value={totalVulns > 0 ? `${totalVulns} vulnerability finding${totalVulns === 1 ? "" : "s"}` : "No CVE evidence in this view"}
+                  tone={totalVulns > 0 ? "danger" : "neutral"}
+                />
+              </div>
+            </section>
           ) : null}
-          <Link
-            href="/mesh"
-            className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-3 py-1.5 text-xs font-medium text-[var(--text-secondary)]"
-          >
-            Agent mesh
-          </Link>
-          <Link
-            href="/security-graph"
-            className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-3 py-1.5 text-xs font-medium text-[var(--text-secondary)]"
-          >
-            Security graph
-          </Link>
+          {activeTab === "services" ? (
+            <section role="tabpanel" id="topology-services-panel" aria-labelledby="topology-services-tab" className="grid gap-2 sm:grid-cols-2">
+              {serverMatches.map(({ agent: entry, server }) => (
+                <ServerCard key={`${entry.name}:${serviceKey(server)}`} agentName={entry.name} server={server} />
+              ))}
+            </section>
+          ) : null}
+          {activeTab === "actions" ? (
+            <section role="tabpanel" id="topology-actions-panel" aria-labelledby="topology-actions-tab" className="grid gap-3 sm:grid-cols-2">
+              {selection.kind === "agent" ? (
+                <ActionLink href={`/agents?name=${encodeURIComponent(selection.name)}`} title="Open agent record" description="Review inventory, ownership, and discovered services." />
+              ) : null}
+              <ActionLink href="/mesh" title="Open agent mesh" description="Compare agent-to-agent and shared-service relationships." />
+              <ActionLink href="/security-graph" title="Open security graph" description="Traverse correlated findings, reachability, and ranked paths." />
+            </section>
+          ) : null}
         </div>
-      </aside>
+      </div>
+    </Drawer>
+  );
+}
+
+function SummaryCard({
+  label,
+  value,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  tone?: "neutral" | "danger";
+}) {
+  return (
+    <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-muted)] p-4">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-tertiary)]">{label}</p>
+      <p
+        className={`mt-2 text-sm font-medium ${
+          tone === "danger" ? "text-red-700 dark:text-red-200" : "text-[var(--foreground)]"
+        }`}
+      >
+        {value}
+      </p>
     </div>
+  );
+}
+
+function ActionLink({ href, title, description }: { href: string; title: string; description: string }) {
+  return (
+    <Link
+      href={href}
+      className="group rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-muted)] p-4 transition-colors hover:border-emerald-500/45 hover:bg-emerald-500/5"
+    >
+      <p className="text-sm font-semibold text-[var(--foreground)] group-hover:text-emerald-700 dark:group-hover:text-emerald-200">
+        {title}
+      </p>
+      <p className="mt-1 text-xs leading-5 text-[var(--text-secondary)]">{description}</p>
+    </Link>
   );
 }
 
@@ -166,11 +228,11 @@ function Metric({
 }) {
   return (
     <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/70 px-3 py-2">
-      <div className={`flex items-center gap-1.5 text-[10px] ${tone === "danger" ? "text-red-300" : "text-[var(--text-tertiary)]"}`}>
+      <div className={`flex items-center gap-1.5 text-[10px] ${tone === "danger" ? "text-red-700 dark:text-red-300" : "text-[var(--text-tertiary)]"}`}>
         <Icon className="h-3.5 w-3.5" />
         {label}
       </div>
-      <div className={`mt-1 font-mono text-sm ${tone === "danger" ? "text-red-100" : "text-[var(--foreground)]"}`}>{value}</div>
+      <div className={`mt-1 font-mono text-sm ${tone === "danger" ? "text-red-700 dark:text-red-100" : "text-[var(--foreground)]"}`}>{value}</div>
     </div>
   );
 }
@@ -181,13 +243,13 @@ function ServerCard({ agentName, server }: { agentName: string; server: MCPServe
     <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/60 px-3 py-2.5">
       <div className="flex items-center justify-between gap-2">
         <span className="text-sm font-medium text-[var(--foreground)]">{server.name}</span>
-        {serverHasCredentials(server) ? <Lock className="h-3.5 w-3.5 text-amber-300" /> : null}
+        {serverHasCredentials(server) ? <Lock className="h-3.5 w-3.5 text-amber-700 dark:text-amber-300" /> : null}
       </div>
       <p className="mt-1 truncate font-mono text-[10px] text-[var(--text-tertiary)]">{agentName}</p>
       <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-[var(--text-tertiary)]">
         <span>{server.packages?.length ?? 0} packages</span>
         <span>{server.tools?.length ?? 0} tools</span>
-        {vulns > 0 ? <span className="text-red-300">{vulns} CVE{vulns === 1 ? "" : "s"}</span> : null}
+        {vulns > 0 ? <span className="text-red-700 dark:text-red-300">{vulns} CVE{vulns === 1 ? "" : "s"}</span> : null}
       </div>
     </div>
   );

--- a/ui/lib/graph-utils.ts
+++ b/ui/lib/graph-utils.ts
@@ -126,12 +126,30 @@ export function minimapNodeColor(n: { data: Record<string, unknown> }): string {
 // ─── Attack Flow Node Colors ─────────────────────────────────────────────────
 
 export const ATTACK_FLOW_MINIMAP_COLORS: Record<string, string> = {
-  cve: "#ef4444",
-  package: "#52525b",
-  server: "#3b82f6",
-  agent: "#10b981",
-  credential: "#eab308",
-  tool: "#a855f7",
+  cve: NODE_COLOR_MAP.vulnerability,
+  package: NODE_COLOR_MAP.package,
+  server: NODE_COLOR_MAP.server,
+  agent: NODE_COLOR_MAP.agent,
+  credential: NODE_COLOR_MAP.credential,
+  tool: NODE_COLOR_MAP.tool,
+};
+
+/** Theme-safe node cards shared by both attack-flow renderers. */
+export const ATTACK_FLOW_NODE_CLASS_MAP: Record<string, string> = {
+  cve: "border-red-600 bg-red-50/90 dark:bg-red-950/80",
+  package:
+    "border-[color:var(--border-strong)] bg-[color:var(--surface-elevated)]",
+  server: "border-blue-600 bg-blue-50/90 dark:bg-blue-950/80",
+  agent: "border-emerald-600 bg-emerald-50/90 dark:bg-emerald-950/80",
+  credential: "border-amber-600 bg-amber-50/90 dark:bg-amber-950/80",
+  tool: "border-purple-600 bg-purple-50/90 dark:bg-purple-950/80",
+};
+
+export const ATTACK_FLOW_SEVERITY_NODE_CLASS_MAP: Record<string, string> = {
+  critical: "border-red-500 bg-red-50 dark:bg-red-950",
+  high: "border-orange-500 bg-orange-50 dark:bg-orange-950",
+  medium: "border-yellow-500 bg-yellow-50 dark:bg-yellow-950",
+  low: "border-blue-500 bg-blue-50 dark:bg-blue-950",
 };
 
 // ─── Edge Styling — Turbo Flow Pattern ───────────────────────────────────────

--- a/ui/lib/unified-graph-flow.ts
+++ b/ui/lib/unified-graph-flow.ts
@@ -16,6 +16,7 @@ import {
   reachStrokeColor,
 } from "@/lib/effective-reach";
 import {
+  NODE_COLOR_MAP,
   NODE_TYPE_LEGEND_ORDER,
   relationshipLegendItem,
   type LegendItem,
@@ -171,48 +172,6 @@ const NODE_LABELS: Record<LineageNodeType, string> = {
   apiGateway: "API Gateway",
   toolCall: "Tool Call",
   blueprint: "Blueprint",
-};
-
-const NODE_COLORS: Record<LineageNodeType, string> = {
-  provider: "#71717a",
-  agent: "#10b981",
-  org: "#115e59",
-  account: "#0f766e",
-  user: "#34d399",
-  group: "#d946ef",
-  role: "#ea580c",
-  policy: "#d97706",
-  serviceAccount: "#fbbf24",
-  servicePrincipal: "#0f766e",
-  federatedIdentity: "#0e7490",
-  environment: "#14b8a6",
-  fleet: "#22d3ee",
-  cluster: "#38bdf8",
-  server: "#3b82f6",
-  sharedServer: "#22d3ee",
-  package: "#52525b",
-  vulnerability: "#ef4444",
-  credential: "#f59e0b",
-  tool: "#a855f7",
-  model: "#8b5cf6",
-  framework: "#06b6d4",
-  dataset: "#06b6d4",
-  container: "#6366f1",
-  cloudResource: "#0ea5e9",
-  misconfiguration: "#f97316",
-  managedIdentity: "#0891b2",
-  accessGrant: "#ca8a04",
-  accessPolicy: "#a16207",
-  driftIncident: "#fb923c",
-  dataStore: "#0284c7",
-  directory: "#0d9488",
-  sourceFile: "#22d3ee",
-  configFile: "#f97316",
-  codeModule: "#06b6d4",
-  ciJob: "#a855f7",
-  apiGateway: "#2563eb",
-  toolCall: "#c084fc",
-  blueprint: "#818cf8",
 };
 
 const NODE_LAYERS: Record<LineageNodeType, string> = {
@@ -798,7 +757,7 @@ function legendForNodeTypes(nodeTypes: Set<LineageNodeType>): LegendItem[] {
   return NODE_TYPE_LEGEND_ORDER.filter((nodeType) => nodeTypes.has(nodeType))
     .map((nodeType) => ({
       label: NODE_LABELS[nodeType],
-      color: NODE_COLORS[nodeType],
+      color: NODE_COLOR_MAP[nodeType],
       layer: NODE_LAYERS[nodeType],
       shape: legendShapeForNodeType(nodeType),
     }));

--- a/ui/tests/graph-schema-color-invariant.test.ts
+++ b/ui/tests/graph-schema-color-invariant.test.ts
@@ -10,8 +10,19 @@
 
 import { describe, expect, it } from "vitest";
 
-import { GRAPH_NODE_KIND_META, RELATIONSHIP_COLOR_MAP, RelationshipType } from "@/lib/graph-schema";
-import { LINEAGE_NODE_GRAPH_KIND, NODE_COLOR_MAP } from "@/lib/graph-utils";
+import {
+  ENTITY_COLOR_MAP,
+  EntityType,
+  GRAPH_NODE_KIND_META,
+  RELATIONSHIP_COLOR_MAP,
+  RelationshipType,
+} from "@/lib/graph-schema";
+import {
+  ATTACK_FLOW_MINIMAP_COLORS,
+  ATTACK_FLOW_NODE_CLASS_MAP,
+  LINEAGE_NODE_GRAPH_KIND,
+  NODE_COLOR_MAP,
+} from "@/lib/graph-utils";
 
 describe("RELATIONSHIP_COLOR_MAP", () => {
   it("has a color for every RelationshipType", () => {
@@ -68,5 +79,18 @@ describe("LINEAGE_NODE_GRAPH_KIND", () => {
     });
 
     expect(mismatches).toEqual([]);
+  });
+
+  it("uses one credential color across lineage and attack-flow views", () => {
+    expect(NODE_COLOR_MAP.credential).toBe(ENTITY_COLOR_MAP[EntityType.CREDENTIAL]);
+    expect(ATTACK_FLOW_MINIMAP_COLORS.credential).toBe(ENTITY_COLOR_MAP[EntityType.CREDENTIAL]);
+  });
+
+  it("keeps attack-flow node backgrounds readable in light and dark themes", () => {
+    for (const [nodeType, classes] of Object.entries(ATTACK_FLOW_NODE_CLASS_MAP)) {
+      const hasPalettePair = /\bbg-[a-z]+-50/.test(classes) && /\bdark:bg-[a-z]+-950/.test(classes);
+      const hasThemeSurface = classes.includes("bg-[color:var(--surface-elevated)]");
+      expect(hasPalettePair || hasThemeSurface, nodeType).toBe(true);
+    }
   });
 });

--- a/ui/tests/proxy-alert-drawer.test.tsx
+++ b/ui/tests/proxy-alert-drawer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 import { ProxyAlertDrawer } from "@/components/proxy-alert-drawer";
 import type { ProxyAlert } from "@/lib/api";
@@ -43,6 +43,21 @@ beforeEach(() => {
 });
 
 describe("ProxyAlertDrawer", () => {
+  it("moves focus into the modal and restores the trigger on close", async () => {
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { unmount } = render(<ProxyAlertDrawer alert={alert} onClose={() => {}} />);
+    const panel = screen.getByRole("dialog").querySelector("aside");
+    expect(panel).not.toBeNull();
+    await waitFor(() => expect(panel).toHaveFocus());
+
+    unmount();
+    expect(trigger).toHaveFocus();
+    trigger.remove();
+  });
+
   it("lays fields out in a grid rather than one card per value", () => {
     render(<ProxyAlertDrawer alert={alert} onClose={() => {}} />);
 

--- a/ui/tests/topology-detail-drawer.test.tsx
+++ b/ui/tests/topology-detail-drawer.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TopologyDetailDrawer } from "@/components/topology-detail-drawer";
+import type { Agent } from "@/lib/api";
+
+const agents = [
+  {
+    name: "claude-desktop",
+    agent_type: "claude",
+    mcp_servers: [
+      {
+        name: "github",
+        packages: [{ name: "octokit", version: "4.0.0", vulnerabilities: [] }],
+        tools: [{ name: "create_issue" }],
+        env: { GITHUB_TOKEN: "***" },
+      },
+    ],
+  },
+] as unknown as Agent[];
+
+describe("TopologyDetailDrawer", () => {
+  it("traps modal focus, closes on Escape, and restores the trigger", async () => {
+    const onClose = vi.fn();
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { unmount } = render(
+      <TopologyDetailDrawer
+        agents={agents}
+        selection={{ kind: "agent", name: "claude-desktop" }}
+        onClose={onClose}
+      />,
+    );
+
+    const panel = screen.getByRole("dialog").querySelector("aside");
+    expect(panel).not.toBeNull();
+    await waitFor(() => expect(panel).toHaveFocus());
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(trigger).toHaveFocus();
+    trigger.remove();
+  });
+
+  it("uses bounded tabs instead of one long detail column", () => {
+    render(
+      <TopologyDetailDrawer
+        agents={agents}
+        selection={{ kind: "agent", name: "claude-desktop" }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.queryByText("github")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: /Services/ }));
+    expect(screen.getByRole("tabpanel")).toHaveAccessibleName("Services1");
+    expect(screen.getByText("github")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Actions" }));
+    expect(screen.getByRole("link", { name: /Open security graph/ })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- replace historical job materialization with indexed tenant-scoped active counts and offload durable per-job scan reads/mutations from the async event loop
- build graph edge lookup once per attack-path batch, preserve relationship semantics, and lock the large-estate serialization path with a scale regression
- unify graph colors and modal behavior, ship a wider tabbed topology investigation drawer with readable landscape framing, and make the README Discover stage show inventory rather than a correlation view

## Verification

- `uv run pytest -q tests/test_scan_jobs_active_gauge.py tests/test_jobs_route_offload.py tests/test_graph_attack_path_serialization_scale.py tests/test_finding.py tests/test_graph_api.py tests/api/test_api_store.py tests/test_postgres_store.py tests/test_postgres_schema.py tests/test_postgres_schema_authority.py tests/test_postgres_schema_parity_gate.py tests/test_postgres_migrations.py tests/test_snowflake_stores.py tests/test_read_path_scale_hardening.py` — 468 passed
- `uv run pytest -q tests/test_public_frontdoor_contract.py tests/test_public_docs_cli_alignment.py` — 27 passed
- `uv run mypy src/agent_bom` — 867 source files clean
- `make preflight`
- Node 24.19.0 repository toolchain: typecheck, ESLint, full Vitest — 197 files / 1,231 tests — and production Next.js build — 52 static routes
- browser QA against a local authenticated demo estate: security graph, proxy alert drawer, and agent topology in light/dark; focus trap/restore, tab navigation, wider drawer, and landscape graph framing verified

## Notes

- the suspected cross-CVE finding-ID collision did not reproduce on current main; a regression was added without changing the correct identifier implementation
- no release tag or publication is included
