### PR TITLE
fix(release): make registry publication idempotent and strict

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -210,9 +210,33 @@ jobs:
           echo "::error::Smithery server card does not match the released version/tool/schema contract"
           exit 1
 
+      - name: Check Smithery catalog parity
+        id: smithery_catalog
+        if: steps.smithery_config.outputs.enabled == 'true'
+        run: |
+          set -euo pipefail
+          echo "fresh=false" >> "$GITHUB_OUTPUT"
+          if ! curl -fsS --connect-timeout 10 --max-time 30 \
+              "https://api.smithery.ai/servers/agent-bom/agent-bom" \
+              -o /tmp/smithery-catalog.json; then
+            echo "::notice::Smithery catalog could not be read before publication; creating a release"
+            exit 0
+          fi
+          jq -S '[.tools[].name] | sort' /tmp/smithery-server-card.json > /tmp/smithery-expected-tool-names.json
+          jq -S '[.tools[].name] | sort' /tmp/smithery-catalog.json > /tmp/smithery-actual-tool-names.json
+          if cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-tool-names.json; then
+            TOOL_COUNT=$(jq -r '.tools | length' /tmp/smithery-catalog.json)
+            echo "fresh=true" >> "$GITHUB_OUTPUT"
+            echo "Smithery already exposes the released ${TOOL_COUNT}-tool catalog; skipping a duplicate deployment"
+          else
+            EXPECTED=$(jq -r 'length' /tmp/smithery-expected-tool-names.json)
+            ACTUAL=$(jq -r 'length' /tmp/smithery-actual-tool-names.json)
+            echo "Smithery catalog differs from the released contract (${ACTUAL}/${EXPECTED} tools); publishing a new deployment"
+          fi
+
       - name: Publish to Smithery
         id: smithery_publish
-        if: steps.smithery_config.outputs.enabled == 'true'
+        if: steps.smithery_config.outputs.enabled == 'true' && steps.smithery_catalog.outputs.fresh != 'true'
         env:
           SMITHERY_API_TOKEN: ${{ secrets.SMITHERY_API_TOKEN }}
           SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
@@ -259,30 +283,33 @@ jobs:
 
       - name: Wait for Smithery release
         id: smithery_release
-        if: steps.smithery_config.outputs.enabled == 'true'
+        if: steps.smithery_config.outputs.enabled == 'true' && steps.smithery_catalog.outputs.fresh != 'true'
         env:
           SMITHERY_API_TOKEN: ${{ secrets.SMITHERY_API_TOKEN }}
           RELEASE_ID: ${{ steps.smithery_publish.outputs.release_id }}
         run: |
           set -euo pipefail
-          for ATTEMPT in $(seq 1 18); do
+          for ATTEMPT in $(seq 1 90); do
             STATUS=$(curl -fsS --connect-timeout 10 --max-time 30 \
               "https://api.smithery.ai/servers/agent-bom%2Fagent-bom/releases/${RELEASE_ID}" \
               -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" | jq -er '.status')
-            echo "Smithery release attempt ${ATTEMPT}/18 — ${STATUS}"
+            echo "Smithery release attempt ${ATTEMPT}/90 — ${STATUS}"
             case "$STATUS" in
               SUCCESS)
                 echo "scan_status=SUCCESS" >> "$GITHUB_OUTPUT"
                 exit 0
                 ;;
-              FAILURE|FAILURE_SCAN|AUTH_REQUIRED|AUTH_TIMEOUT|CANCELLED|INTERNAL_ERROR)
+              AUTH_REQUIRED)
+                echo "::notice::Smithery is waiting for publisher authorization; authorize the pending release in the Smithery UI"
+                ;;
+              FAILURE|FAILURE_SCAN|AUTH_TIMEOUT|CANCELLED|INTERNAL_ERROR)
                 echo "::error::Smithery release did not complete successfully (${STATUS})"
                 exit 1
                 ;;
             esac
             sleep 10
           done
-          echo "::error::Smithery release did not finish before the verification timeout"
+          echo "::error::Smithery release did not finish within 15 minutes; authorize the pending release in the Smithery UI and re-run this workflow"
           exit 1
 
       - name: Verify Smithery catalog inventory
@@ -293,16 +320,23 @@ jobs:
         run: |
           set -euo pipefail
           for ATTEMPT in $(seq 1 12); do
-            ACTUAL=$(curl -fsS --connect-timeout 10 --max-time 30 \
-              "https://api.smithery.ai/servers/agent-bom/agent-bom" | jq -er '.tools | length')
-            if [ "$ACTUAL" = "$EXPECTED_TOOL_COUNT" ]; then
+            if curl -fsS --connect-timeout 10 --max-time 30 \
+                "https://api.smithery.ai/servers/agent-bom/agent-bom" \
+                -o /tmp/smithery-catalog.json; then
+              jq -S '[.tools[].name] | sort' /tmp/smithery-catalog.json > /tmp/smithery-actual-tool-names.json
+              ACTUAL=$(jq -r 'length' /tmp/smithery-actual-tool-names.json)
+            else
+              ACTUAL=unavailable
+            fi
+            if [ "$ACTUAL" = "$EXPECTED_TOOL_COUNT" ] && \
+              cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-tool-names.json; then
               echo "Smithery catalog exposes all ${ACTUAL} tools for v${VERSION}"
               exit 0
             fi
-            echo "Smithery catalog attempt ${ATTEMPT}/12 exposes ${ACTUAL}/${EXPECTED_TOOL_COUNT} tools"
+            echo "Smithery catalog attempt ${ATTEMPT}/12 does not match the released ${EXPECTED_TOOL_COUNT}-tool name set (actual=${ACTUAL})"
             sleep 10
           done
-          echo "::error::Smithery catalog did not converge to ${EXPECTED_TOOL_COUNT} tools"
+          echo "::error::Smithery catalog did not converge to the released ${EXPECTED_TOOL_COUNT}-tool name set"
           exit 1
 
   glama:
@@ -333,6 +367,7 @@ jobs:
         env:
           GLAMA_WEBHOOK_URL: ${{ secrets.GLAMA_WEBHOOK_URL }}
           GLAMA_REPAIR: ${{ inputs.glama_repair }}
+          REGISTRY_PUBLISH_REQUIRED: ${{ github.event_name == 'workflow_run' }}
           RELEASE_REF: ${{ needs.release.outputs.release_ref }}
           RELEASE_SHA: ${{ needs.release.outputs.release_sha }}
           VERSION: ${{ needs.release.outputs.version }}
@@ -343,8 +378,8 @@ jobs:
           fail_or_warn() {
             local message="$1"
             echo "rebuild_triggered=false" >> "$GITHUB_OUTPUT"
-            if [ "$GLAMA_REPAIR" = "true" ]; then
-              echo "::error::Requested Glama repair ${message}"
+            if [ "$REGISTRY_PUBLISH_REQUIRED" = "true" ] || [ "$GLAMA_REPAIR" = "true" ]; then
+              echo "::error::Required Glama publication ${message}"
               return 1
             fi
             echo "::warning::Automatic Glama rebuild ${message}; the freshness issue will remain open"
@@ -380,27 +415,16 @@ jobs:
             exit $?
           fi
 
-      # Glama re-crawls listings on its own cadence (can be hours), so a tight
-      # post-trigger freshness window can legitimately fail on release day.
-      # Preserve the distinction between a successful trigger and no trigger.
       - name: Verify Glama listing freshness
-        continue-on-error: true
         env:
           EXPECTED_VERSION: ${{ needs.release.outputs.version }}
           EXPECTED_TOOL_COUNT: ${{ needs.release.outputs.tool_count }}
-          REBUILD_TRIGGERED: ${{ steps.glama_trigger.outputs.rebuild_triggered }}
         run: |
-          if ! python scripts/check_glama_listing.py \
-              --expected "$EXPECTED_VERSION" \
-              --expected-tool-count "$EXPECTED_TOOL_COUNT" \
-              --retries 6 \
-              --delay-seconds 30; then
-            if [ "$REBUILD_TRIGGERED" = "true" ]; then
-              echo "::warning::Glama listing has not refreshed yet after the rebuild trigger. Glama re-crawls asynchronously and may take hours. Listing: https://glama.ai/mcp/servers/msaad00/agent-bom"
-            else
-              echo "::warning::Glama listing remains stale and no rebuild was triggered. Configure the repository Actions secret GLAMA_WEBHOOK_URL or rebuild the exact release manually. Listing: https://glama.ai/mcp/servers/msaad00/agent-bom"
-            fi
-          fi
+          python scripts/check_glama_listing.py \
+            --expected "$EXPECTED_VERSION" \
+            --expected-tool-count "$EXPECTED_TOOL_COUNT" \
+            --retries 6 \
+            --delay-seconds 30
 
   clawhub:
     name: Publish to ClawHub

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -44,7 +44,10 @@ remote deployment metadata, and non-empty tools.
 5. Click **Continue**
 
 **Option B — Automated**:
-The `publish-registries.yml` workflow auto-publishes to Smithery on each release using:
+The `publish-registries.yml` workflow compares the released server-card tool
+names with Smithery's public catalog before publishing. If they already match,
+the workflow skips a duplicate deployment. If capabilities changed, it creates
+an external release using:
 - `SMITHERY_API_TOKEN`
 
 `SMITHERY_MCP_URL` is retained only for the external-upstream publish mode. It
@@ -52,8 +55,11 @@ must never point at Smithery's hosted proxy URL. Freshness monitoring no longer
 depends on that variable; it uses the Smithery catalog API directly.
 
 Do not add the upstream bearer token to Smithery `configSchema`. Smithery
-reserves the `Authorization` header for OAuth, and the release workflow treats
-OAuth/auth-timeout status or a stale catalog count as publication failure.
+reserves the `Authorization` header for OAuth. A new authenticated capability
+scan can pause as `AUTH_REQUIRED`; authorize that pending release in Smithery's
+**Releases** UI. The workflow waits up to 15 minutes and otherwise fails
+honestly. After authorization, re-running the workflow verifies catalog parity
+without creating another deployment.
 
 ### Verification
 
@@ -122,6 +128,25 @@ multipart API shim, so local publishing and CI stay aligned.
 
 ```bash
 clawhub install agent-bom-scan
+```
+
+---
+
+## 4. Glama
+
+Glama indexes the repository README and builds the MCP schema from
+`integrations/glama/Dockerfile`. Automatic forward releases require the
+`GLAMA_WEBHOOK_URL` Actions secret; a missing webhook or a stale public listing
+fails the registry workflow rather than reporting a green publication.
+
+For a manual repair, open the server's **Admin → Repository** page and run
+**Sync**, then dispatch **Publish to Registries** again. Verification requires
+both the released version marker and the exact released MCP tool count.
+
+```bash
+python scripts/check_glama_listing.py \
+  --expected 0.102.0 \
+  --expected-tool-count 84
 ```
 
 ---

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -649,15 +649,14 @@ def test_postgres_ci_upgrade_checks_preserved_queue_through_scoped_maintenance_r
     ) not in workflow
 
 
-def test_publish_registries_workflow_validates_smithery_best_effort_and_curated_clawhub_set():
+def test_publish_registries_workflow_validates_registry_gates_and_curated_clawhub_set():
     """Smithery publishing must never use Smithery's proxy as its upstream."""
     workflow = (ROOT / ".github" / "workflows" / "publish-registries.yml").read_text()
     assert "SMITHERY_MCP_URL" in workflow
     assert "server.smithery.ai" in workflow
     assert "avoid publishing the proxy back to itself" in workflow
-    # The Smithery probe no longer hard-fails the publish on async rebuild lag.
     assert "--forbid-auth-required" not in workflow
-    assert "continue-on-error: true" in workflow
+    assert "continue-on-error: true" not in workflow
     assert "integrations/openclaw/scan" in workflow
     assert "integrations/openclaw/compliance" in workflow
     assert "integrations/openclaw/registry" in workflow
@@ -731,17 +730,15 @@ def test_glama_rebuild_webhook_is_secret_and_missing_secret_is_honest():
     assert 'echo "rebuild_triggered=false" >> "$GITHUB_OUTPUT"' in workflow
     assert "No Glama rebuild was triggered" in workflow
     assert "set GLAMA_WEBHOOK_URL as a repository Actions secret" in workflow
-    assert "REBUILD_TRIGGERED: ${{ steps.glama_trigger.outputs.rebuild_triggered }}" in workflow
-    assert 'if [ "$REBUILD_TRIGGERED" = "true" ]; then' in workflow
     assert 'HTTP_STATUS" -lt 300' in workflow
     assert 'HTTP_STATUS" -lt 400' not in workflow
-    # The gate reads the operator's stated intent, not merely that the run was
-    # dispatched. Gating on event_name made every manual re-publish a "repair",
-    # so an unconfigured optional webhook failed the whole multi-registry run
-    # and blocked releases (#4651). Repair is now opt-in.
+    assert "REGISTRY_PUBLISH_REQUIRED: ${{ github.event_name == 'workflow_run' }}" in workflow
     assert "GLAMA_REPAIR: ${{ inputs.glama_repair }}" in workflow
-    assert 'if [ "$GLAMA_REPAIR" = "true" ]; then' in workflow
-    assert "::error::Requested Glama repair" in workflow
+    assert 'if [ "$REGISTRY_PUBLISH_REQUIRED" = "true" ] || [ "$GLAMA_REPAIR" = "true" ]; then' in workflow
+    assert "::error::Required Glama publication" in workflow
+    glama_job = workflow.split("  glama:\n", 1)[1].split("  clawhub:\n", 1)[0]
+    assert "continue-on-error: true" not in glama_job
+    assert "python scripts/check_glama_listing.py" in glama_job
     assert "exit 1" in workflow
 
 
@@ -753,11 +750,16 @@ def test_smithery_publish_is_gated_on_server_card_and_catalog_parity():
     assert "(.tools | length) == $tool_count" in workflow
     assert '(.inputSchema | type == "object")' in workflow
     assert '(.authentication.schemes | index("oauth2") != null)' in workflow
+    assert "Check Smithery catalog parity" in workflow
+    assert "smithery_catalog.outputs.fresh != 'true'" in workflow
+    assert "smithery-expected-tool-names.json" in workflow
+    assert "smithery-actual-tool-names.json" in workflow
     assert "Wait for Smithery release" in workflow
-    assert "FAILURE|FAILURE_SCAN|AUTH_REQUIRED|AUTH_TIMEOUT|CANCELLED|INTERNAL_ERROR" in workflow
+    assert "AUTH_REQUIRED)" in workflow
+    assert "FAILURE|FAILURE_SCAN|AUTH_TIMEOUT|CANCELLED|INTERNAL_ERROR" in workflow
     assert "caller-supplied bearerToken by design" not in workflow
     assert "Verify Smithery catalog inventory" in workflow
-    assert 'if [ "$ACTUAL" = "$EXPECTED_TOOL_COUNT" ]; then' in workflow
+    assert 'cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-tool-names.json' in workflow
 
 
 def test_refresh_latest_container_keeps_release_code_but_applies_runtime_security_overlay():

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -759,7 +759,7 @@ def test_smithery_publish_is_gated_on_server_card_and_catalog_parity():
     assert "FAILURE|FAILURE_SCAN|AUTH_TIMEOUT|CANCELLED|INTERNAL_ERROR" in workflow
     assert "caller-supplied bearerToken by design" not in workflow
     assert "Verify Smithery catalog inventory" in workflow
-    assert 'cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-tool-names.json' in workflow
+    assert "cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-tool-names.json" in workflow
 
 
 def test_refresh_latest_container_keeps_release_code_but_applies_runtime_security_overlay():

--- a/tests/test_publish_registries_release_auth_gate.py
+++ b/tests/test_publish_registries_release_auth_gate.py
@@ -23,6 +23,19 @@ def test_automatic_forward_release_cannot_report_success_when_smithery_is_skippe
     assert "Smithery publication is required for an automatic forward release" in workflow
 
 
+def test_smithery_publication_is_idempotent_and_waits_for_publisher_authorization() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Check Smithery catalog parity" in workflow
+    assert "smithery_catalog.outputs.fresh != 'true'" in workflow
+    assert "smithery-expected-tool-names.json" in workflow
+    assert "skipping a duplicate deployment" in workflow
+    assert "for ATTEMPT in $(seq 1 90)" in workflow
+    assert "AUTH_REQUIRED)" in workflow
+    assert "authorize the pending release in the Smithery UI" in workflow
+    assert "within 15 minutes" in workflow
+
+
 def test_surface_freshness_rechecks_immediately_after_registry_publication() -> None:
     workflow = (ROOT / ".github/workflows/surface-freshness.yml").read_text(encoding="utf-8")
     assert 'workflows: ["Publish to Registries"]' in workflow


### PR DESCRIPTION
## Summary

- skip duplicate Smithery deployments when the public catalog already matches the released tool-name set
- wait up to 15 minutes for required Smithery publisher authorization, then verify the exact released tool-name set
- require automatic Glama releases to trigger a rebuild and fail when the public version/tool contract remains stale
- document the Smithery authorization and Glama manual-repair paths

## Verification

- `uv run pytest -q tests/test_publish_registries_release_auth_gate.py tests/test_deployment.py` — 67 passed
- `actionlint .github/workflows/publish-registries.yml`
- `.venv/bin/python scripts/check_workflow_timeouts.py`
- `.venv/bin/python scripts/check_ci_pipefail.py .github/workflows/publish-registries.yml`
- `uv run ruff check tests/test_publish_registries_release_auth_gate.py tests/test_deployment.py`
- `.venv/bin/python scripts/check_public_docs_hygiene.py`
- `git diff --check`

## Notes

- Related to #4915. The issue should remain open until the public Smithery and Glama catalogs both expose all 84 released tools.
- This PR does not tag or publish a release.