### PR TITLE
fix(ci): stabilize graph parity timestamp test

### DIFF
--- a/tests/graph/test_store_backed_build_wiring.py
+++ b/tests/graph/test_store_backed_build_wiring.py
@@ -332,7 +332,11 @@ def test_store_backed_producer_peak_advantage_widens_with_scale() -> None:
 # ── Default-off: no container -> in-RAM path, identical output ────────────────
 
 
-def test_default_off_uses_in_ram_container() -> None:
+def test_default_off_uses_in_ram_container(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Both builds mint nodes and edges independently. Freeze their default
+    # timestamps so this test compares container behavior, not wall-clock drift.
+    monkeypatch.setattr("agent_bom.graph.node._now_iso", lambda: _FIXED_CREATED_AT)
+    monkeypatch.setattr("agent_bom.graph.edge._now_iso", lambda: _FIXED_CREATED_AT, raising=False)
     report = _constructed_report()
     default = build_unified_graph_from_report(report, scan_id="c", tenant_id="t1")
     assert type(default) is UnifiedGraph


### PR DESCRIPTION
## Summary

- freeze graph node and edge timestamps in the default-vs-explicit container parity regression
- keep the assertion focused on container behavior instead of wall-clock drift between independent builds
- address the sole failure from exact-main CI run 32761308544; relates to #4930

## Verification

- `UV_CACHE_DIR=/private/tmp/uv-cache-agent-bom-main uv run pytest -q tests/graph/test_store_backed_build_wiring.py -k default_off` — 1 passed
- `UV_CACHE_DIR=/private/tmp/uv-cache-agent-bom-main uv run pytest -q tests/graph/test_store_backed_build_wiring.py -m "not graph_performance"` — 5 passed, 1 deselected
- `UV_CACHE_DIR=/private/tmp/uv-cache-agent-bom-main make lint` — ruff passed; mypy passed across 867 source files
- `UV_CACHE_DIR=/private/tmp/uv-cache-agent-bom-main make preflight` — passed
- `git diff --check` — passed

## Notes

The production graph behavior is unchanged. The failed comparison differed only in auto-generated `first_seen` and `last_seen` values after the two builds crossed a one-second boundary.