### PR TITLE
feat(reachability): model non-MCP application entrypoints

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-23",
+  "generated_on": "2026-08-24",
   "version": "0.102.0",
   "metrics": [
     {
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 867,
+      "value": 868,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-23`
+- Generated on: `2026-08-24`
 - Version: `0.102.0`
 
 | Metric | Value | Source | Notes |
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 48 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 867 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 868 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -906,8 +906,11 @@ def _ast_result_for_symbol_reach(paths: Iterable[str]) -> Any | None:
             continue
         if merged is None:
             merged = result
-        elif result.dependency_symbol_reach:
-            merged.dependency_symbol_reach.extend(result.dependency_symbol_reach)
+        else:
+            if result.application_entrypoints:
+                merged.application_entrypoints.extend(result.application_entrypoints)
+            if result.dependency_symbol_reach:
+                merged.dependency_symbol_reach.extend(result.dependency_symbol_reach)
     return merged
 
 

--- a/src/agent_bom/ast/application_entrypoints.py
+++ b/src/agent_bom/ast/application_entrypoints.py
@@ -1,0 +1,516 @@
+"""Conservative discovery of externally invokable application entrypoints.
+
+Application roots are deliberately separate from MCP/agent tools.  A symbol is
+only promoted when source or packaging metadata provides concrete invocation
+evidence; ordinary exported functions are not roots.
+"""
+
+from __future__ import annotations
+
+import ast
+import configparser
+import re
+import tomllib
+from pathlib import Path
+from typing import Iterable
+
+from agent_bom.ast_models import ApplicationEntrypoint
+from agent_bom.ast_source_mask import mask_line_comments_and_strings
+
+_ROUTE_METHODS = frozenset({"delete", "get", "head", "options", "patch", "post", "put", "route", "websocket"})
+_MAX_SOURCE_SIZE_BYTES = 2_000_000
+_LANGUAGE_BY_SUFFIX = {
+    ".cs": "csharp",
+    ".go": "go",
+    ".java": "java",
+    ".js": "javascript_typescript",
+    ".jsx": "javascript_typescript",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
+    ".php": "php",
+    ".rb": "ruby",
+    ".rs": "rust",
+    ".swift": "swift",
+    ".ts": "javascript_typescript",
+    ".tsx": "javascript_typescript",
+}
+
+
+def _line_number(source: str, offset: int) -> int:
+    return source.count("\n", 0, offset) + 1
+
+
+def _code_matches(
+    pattern: str | re.Pattern[str],
+    source: str,
+    masked_source: str,
+    flags: int = 0,
+) -> Iterable[re.Match[str]]:
+    """Yield source matches whose span still contains executable code."""
+    for match in re.finditer(pattern, source, flags):
+        if any(not char.isspace() for char in masked_source[match.start() : match.end()]):
+            yield match
+
+
+def _expr_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _expr_name(node.value)
+        return f"{parent}.{node.attr}" if parent else node.attr
+    if isinstance(node, ast.Call):
+        return _expr_name(node.func)
+    return ""
+
+
+def _python_entries(project: Path, path: Path, source: str) -> list[ApplicationEntrypoint]:
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except (SyntaxError, ValueError):
+        return []
+    rel = path.relative_to(project).as_posix()
+    functions = {node.name: node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))}
+    imports: set[str] = set()
+    imported_names: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                bound = alias.asname or alias.name.split(".", 1)[0]
+                imports.add(bound)
+                imported_names[bound] = alias.name
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                bound = alias.asname or alias.name
+                imported_names[bound] = f"{module}.{alias.name}" if module else alias.name
+
+    instances: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        value = node.value
+        if not isinstance(value, ast.Call):
+            continue
+        constructor = _expr_name(value.func)
+        resolved = imported_names.get(constructor, constructor)
+        framework = ""
+        if resolved.endswith("FastAPI"):
+            framework = "FastAPI"
+        elif resolved.endswith("Flask"):
+            framework = "Flask"
+        elif resolved.endswith("Typer"):
+            framework = "Typer"
+        if not framework:
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        for target in targets:
+            if isinstance(target, ast.Name):
+                instances[target.id] = framework
+
+    entries: list[ApplicationEntrypoint] = []
+    for node in functions.values():
+        for decorator in node.decorator_list:
+            name = _expr_name(decorator)
+            if not name:
+                continue
+            owner, _, method = name.rpartition(".")
+            framework = instances.get(owner, "")
+            kind = ""
+            if framework in {"FastAPI", "Flask"} and method in _ROUTE_METHODS:
+                kind = "http_route"
+            elif framework == "Typer" and method in {"callback", "command"}:
+                kind = "cli_command"
+            elif owner == "click" and "click" in imports and method in {"command", "group"}:
+                framework = "Click"
+                kind = "cli_command"
+            if kind:
+                entries.append(
+                    ApplicationEntrypoint(
+                        name=node.name,
+                        handler=node.name,
+                        kind=kind,
+                        framework=framework,
+                        language="python",
+                        file_path=rel,
+                        line_number=node.lineno,
+                        provenance=f"decorator:{name}",
+                    )
+                )
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If) or not isinstance(node.test, ast.Compare):
+            continue
+        left = node.test.left
+        comparators = node.test.comparators
+        if not (
+            isinstance(left, ast.Name)
+            and left.id == "__name__"
+            and comparators
+            and isinstance(comparators[0], ast.Constant)
+            and comparators[0].value == "__main__"
+        ):
+            continue
+        for candidate in ast.walk(node):
+            if not isinstance(candidate, ast.Call) or not isinstance(candidate.func, ast.Name):
+                continue
+            handler = candidate.func.id
+            target_function = functions.get(handler)
+            if target_function is None:
+                continue
+            entries.append(
+                ApplicationEntrypoint(
+                    name=handler,
+                    handler=handler,
+                    kind="language_main",
+                    framework="Python",
+                    language="python",
+                    file_path=rel,
+                    line_number=target_function.lineno,
+                    provenance='guard:__name__ == "__main__"',
+                )
+            )
+    return entries
+
+
+def _regex_entry(
+    *,
+    project: Path,
+    path: Path,
+    source: str,
+    language: str,
+    kind: str,
+    handler: str,
+    framework: str,
+    provenance: str,
+    offset: int,
+    name: str | None = None,
+) -> ApplicationEntrypoint:
+    return ApplicationEntrypoint(
+        name=name or handler,
+        handler=handler,
+        kind=kind,
+        framework=framework,
+        language=language,
+        file_path=path.relative_to(project).as_posix(),
+        line_number=_line_number(source, offset),
+        provenance=provenance,
+    )
+
+
+def _non_python_entries(project: Path, path: Path, source: str) -> list[ApplicationEntrypoint]:
+    language = _LANGUAGE_BY_SUFFIX.get(path.suffix.lower())
+    if language is None:
+        return []
+    entries: list[ApplicationEntrypoint] = []
+    masked_source = mask_line_comments_and_strings(
+        source,
+        hash_comments=language in {"php", "ruby"},
+        hash_attributes=language == "php",
+        heredoc=language == "php",
+        backtick_strings=language == "go",
+        single_line_quotes=language == "javascript_typescript",
+    )
+
+    main_patterns: dict[str, tuple[re.Pattern[str], str]] = {
+        "go": (re.compile(r"(?m)^\s*func\s+(main)\s*\("), "Go"),
+        "rust": (re.compile(r"(?m)^\s*(?:pub\s+)?(?:async\s+)?fn\s+(main)\s*\("), "Rust"),
+        "java": (re.compile(r"(?m)\bstatic\s+void\s+(main)\s*\("), "Java"),
+        "kotlin": (re.compile(r"(?m)^\s*fun\s+(main)\s*\("), "Kotlin"),
+        "csharp": (re.compile(r"(?m)\bstatic\s+(?:void|int|Task(?:<int>)?)\s+(Main)\s*\("), ".NET"),
+        "swift": (re.compile(r"(?m)\bstatic\s+func\s+(main)\s*\("), "Swift"),
+    }
+    main_spec = main_patterns.get(language)
+    if main_spec is not None:
+        match = next(iter(_code_matches(main_spec[0], source, masked_source)), None)
+        if match:
+            entries.append(
+                _regex_entry(
+                    project=project,
+                    path=path,
+                    source=source,
+                    language=language,
+                    kind="language_main",
+                    handler=match.group(1),
+                    framework=main_spec[1],
+                    provenance=f"declaration:{match.group(0).strip()}",
+                    offset=match.start(),
+                )
+            )
+
+    if language == "javascript_typescript":
+        pattern = re.compile(
+            r"(?m)\b(?P<owner>[A-Za-z_$][\w$]*)\.(?P<method>get|post|put|patch|delete|options|head|use)\s*\(\s*"
+            r"(?P<quote>['\"])(?P<path>[^'\"]+)\3\s*,\s*(?P<handler>[A-Za-z_$][\w$]*)\s*\)"
+        )
+        for match in _code_matches(pattern, source, masked_source):
+            entries.append(
+                _regex_entry(
+                    project=project,
+                    path=path,
+                    source=source,
+                    language=language,
+                    kind="http_route",
+                    handler=match.group("handler"),
+                    framework="Express-compatible router",
+                    provenance=f"registration:{match.group('owner')}.{match.group('method')} {match.group('path')}",
+                    offset=match.start(),
+                    name=f"{match.group('method').upper()} {match.group('path')}",
+                )
+            )
+    elif language == "go":
+        for match in _code_matches(
+            r"(?m)\b(?:http\.)?HandleFunc\s*\(\s*['\"]([^'\"]+)['\"]\s*,\s*([A-Za-z_]\w*)",
+            source,
+            masked_source,
+        ):
+            entries.append(
+                _regex_entry(
+                    project=project,
+                    path=path,
+                    source=source,
+                    language=language,
+                    kind="http_route",
+                    handler=match.group(2),
+                    framework="net/http",
+                    provenance=f"registration:HandleFunc {match.group(1)}",
+                    offset=match.start(),
+                    name=f"HTTP {match.group(1)}",
+                )
+            )
+    elif language in {"java", "kotlin"}:
+        route_pattern = re.compile(
+            r"(?ms)@(?P<annotation>GetMapping|PostMapping|PutMapping|PatchMapping|DeleteMapping|RequestMapping|GET|POST|PUT|PATCH|DELETE)"
+            r"[^\n]*\n\s*(?:public\s+|private\s+|protected\s+)?(?:suspend\s+)?(?:[\w<>?,.\[\]]+\s+)?(?:fun\s+)?(?P<handler>\w+)\s*\("
+        )
+        for match in _code_matches(route_pattern, source, masked_source):
+            entries.append(
+                _regex_entry(
+                    project=project,
+                    path=path,
+                    source=source,
+                    language=language,
+                    kind="http_route",
+                    handler=match.group("handler"),
+                    framework="Spring/JAX-RS",
+                    provenance=f"annotation:@{match.group('annotation')}",
+                    offset=match.start(),
+                )
+            )
+    elif language == "csharp":
+        for match in _code_matches(
+            r"(?ms)\[(?P<annotation>HttpGet|HttpPost|HttpPut|HttpPatch|HttpDelete|Route)[^\]]*\]\s*"
+            r"(?:public|internal|private|protected)\s+[\w<>?,.\[\]]+\s+(?P<handler>\w+)\s*\(",
+            source,
+            masked_source,
+        ):
+            entries.append(
+                _regex_entry(
+                    project=project,
+                    path=path,
+                    source=source,
+                    language=language,
+                    kind="http_route",
+                    handler=match.group("handler"),
+                    framework="ASP.NET",
+                    provenance=f"attribute:[{match.group('annotation')}]",
+                    offset=match.start(),
+                )
+            )
+        for match in _code_matches(
+            r"\bapp\.Map(?:Get|Post|Put|Patch|Delete)\s*\(\s*['\"]([^'\"]+)['\"]\s*,\s*([A-Za-z_]\w*)",
+            source,
+            masked_source,
+        ):
+            entries.append(
+                _regex_entry(
+                    project=project,
+                    path=path,
+                    source=source,
+                    language=language,
+                    kind="http_route",
+                    handler=match.group(2),
+                    framework="ASP.NET Minimal API",
+                    provenance=f"registration:{match.group(0).split('(')[0]} {match.group(1)}",
+                    offset=match.start(),
+                )
+            )
+    elif language == "rust":
+        rust_route_pattern = (
+            r"(?ms)#\[(?P<method>get|post|put|patch|delete)\([^\]]*\)\]\s*"
+            r"(?:pub\s+)?(?:async\s+)?fn\s+(?P<handler>\w+)\s*\("
+        )
+        for match in _code_matches(rust_route_pattern, source, masked_source):
+            entries.append(
+                _regex_entry(
+                    project=project,
+                    path=path,
+                    source=source,
+                    language=language,
+                    kind="http_route",
+                    handler=match.group("handler"),
+                    framework="Rust web route",
+                    provenance=f"attribute:#[{match.group('method')}]",
+                    offset=match.start(),
+                )
+            )
+    elif language == "php":
+        for match in _code_matches(
+            r"Route::(?P<method>get|post|put|patch|delete)\s*\(\s*['\"](?P<path>[^'\"]+)['\"]\s*,\s*"
+            r"\[\s*(?P<class>\w+)::class\s*,\s*['\"](?P<handler>\w+)['\"]\s*\]",
+            source,
+            masked_source,
+            re.IGNORECASE,
+        ):
+            handler = f"{match.group('class')}.{match.group('handler')}"
+            entries.append(
+                _regex_entry(
+                    project=project,
+                    path=path,
+                    source=source,
+                    language=language,
+                    kind="http_route",
+                    handler=handler,
+                    framework="Laravel",
+                    provenance=f"registration:Route::{match.group('method')} {match.group('path')}",
+                    offset=match.start(),
+                    name=f"{match.group('method').upper()} {match.group('path')}",
+                )
+            )
+    elif language == "ruby":
+        for match in _code_matches(
+            r"(?m)^\s*(?P<method>get|post|put|patch|delete)\s+['\"](?P<path>[^'\"]+)['\"]\s*,\s*to:\s*['\"]"
+            r"(?P<controller>[\w/]+)#(?P<handler>\w+)['\"]",
+            source,
+            masked_source,
+        ):
+            controller = "".join(part.capitalize() for part in match.group("controller").split("_")) + "Controller"
+            handler = f"{controller}.{match.group('handler')}"
+            entries.append(
+                _regex_entry(
+                    project=project,
+                    path=path,
+                    source=source,
+                    language=language,
+                    kind="http_route",
+                    handler=handler,
+                    framework="Rails",
+                    provenance=f"registration:{match.group('method')} {match.group('path')}",
+                    offset=match.start(),
+                    name=f"{match.group('method').upper()} {match.group('path')}",
+                )
+            )
+    elif language == "swift":
+        for match in _code_matches(
+            r"\bapp\.(?P<method>get|post|put|patch|delete)\s*\([^\n]*?use:\s*(?P<handler>\w+)",
+            source,
+            masked_source,
+        ):
+            entries.append(
+                _regex_entry(
+                    project=project,
+                    path=path,
+                    source=source,
+                    language=language,
+                    kind="http_route",
+                    handler=match.group("handler"),
+                    framework="Vapor",
+                    provenance=f"registration:app.{match.group('method')}",
+                    offset=match.start(),
+                )
+            )
+    return entries
+
+
+def _packaging_entries(project: Path) -> list[ApplicationEntrypoint]:
+    scripts: list[tuple[str, str, str]] = []
+    pyproject = project / "pyproject.toml"
+    if pyproject.is_file():
+        try:
+            data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+            project_scripts = data.get("project", {}).get("scripts", {})
+            if isinstance(project_scripts, dict):
+                scripts.extend((str(name), str(target), "pyproject.toml:[project.scripts]") for name, target in project_scripts.items())
+        except (OSError, tomllib.TOMLDecodeError, UnicodeError):
+            pass
+    setup_cfg = project / "setup.cfg"
+    if setup_cfg.is_file():
+        parser = configparser.ConfigParser()
+        try:
+            parser.read(setup_cfg, encoding="utf-8")
+            raw = parser.get("options.entry_points", "console_scripts", fallback="")
+            for line in raw.splitlines():
+                if "=" in line:
+                    name, target = line.split("=", 1)
+                    scripts.append((name.strip(), target.strip(), "setup.cfg:[options.entry_points]"))
+        except (configparser.Error, OSError, UnicodeError):
+            pass
+
+    entries: list[ApplicationEntrypoint] = []
+    for name, target, provenance in scripts:
+        module, separator, handler = target.partition(":")
+        handler = handler.split("[", 1)[0].strip()
+        if not separator or not module or not handler or not re.fullmatch(r"[A-Za-z_]\w*", handler):
+            continue
+        candidate = project.joinpath(*module.split(".")).with_suffix(".py")
+        if not candidate.is_file():
+            package_candidate = project.joinpath(*module.split("."), "__init__.py")
+            candidate = package_candidate if package_candidate.is_file() else candidate
+        rel = candidate.relative_to(project).as_posix() if candidate.is_file() else module.replace(".", "/") + ".py"
+        line_number = 1
+        if candidate.is_file():
+            try:
+                parsed = ast.parse(candidate.read_text(encoding="utf-8"), filename=str(candidate))
+                function = next(
+                    (
+                        node
+                        for node in ast.walk(parsed)
+                        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == handler
+                    ),
+                    None,
+                )
+                if function is not None:
+                    line_number = function.lineno
+            except (OSError, SyntaxError, UnicodeError, ValueError):
+                pass
+        entries.append(
+            ApplicationEntrypoint(
+                name=name,
+                handler=handler,
+                kind="console_script",
+                framework="Python packaging",
+                language="python",
+                file_path=rel,
+                line_number=line_number,
+                provenance=f"metadata:{provenance}={target}",
+            )
+        )
+    return entries
+
+
+def detect_application_entrypoints(project: Path, source_files: Iterable[Path]) -> list[ApplicationEntrypoint]:
+    """Return evidence-backed application roots in deterministic order."""
+    root = project.resolve()
+    entries = _packaging_entries(root)
+    for raw_path in source_files:
+        path = raw_path.resolve()
+        try:
+            path.relative_to(root)
+            if path.stat().st_size > _MAX_SOURCE_SIZE_BYTES:
+                continue
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError, ValueError):
+            continue
+        if path.suffix.lower() == ".py":
+            entries.extend(_python_entries(root, path, source))
+        else:
+            entries.extend(_non_python_entries(root, path, source))
+
+    deduped: list[ApplicationEntrypoint] = []
+    seen: set[tuple[str, str, str, str, int]] = set()
+    for entry in sorted(entries, key=lambda item: (item.file_path, item.line_number, item.kind, item.name, item.handler)):
+        key = (entry.kind, entry.name, entry.handler, entry.file_path, entry.line_number)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(entry)
+    return deduped

--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -8,14 +8,15 @@ Extends the regex-based scanner with semantic analysis:
 - **Credential flow analysis** — tracks env var → agent parameter paths
 - **Framework-specific patterns** — LangChain chains, CrewAI crews, MCP servers, etc.
 - **Call graph extraction** — function-to-function edges for Python entrypoints
+- **Application entrypoints** — evidence-backed CLI, main, and route invocation roots
 - **Bounded helper-chain findings** — lightweight call-path detection from tool entrypoints to dangerous sinks
 
 Python files use full AST parsing. JS/TS files contribute prompt/tool/guardrail
 signals plus parser-backed import, handler, and call-chain extraction so
 non-Python agent projects participate in the same inventory and flow model.
-Go, Rust, Java, Kotlin, C#, Ruby, PHP (Composer), and Swift sources also contribute MCP
-tool entrypoints and dependency-symbol reach for Cargo/Maven/NuGet/RubyGems/Composer/SPM
-CVE join.
+Go, Rust, Java, Kotlin, C#, Ruby, PHP (Composer), and Swift sources also contribute
+MCP tool and application entrypoints plus dependency-symbol reach for
+Cargo/Maven/NuGet/RubyGems/Composer/SPM CVE joins.
 
 Compliance mapping:
 - OWASP LLM01 (Prompt Injection) — prompt inventory and risk review signals
@@ -27,12 +28,11 @@ Compliance mapping:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Any, Mapping
 
-if TYPE_CHECKING:
-    from agent_bom.ast.js_ts import JSTSFunction, JSTSToolRegistration
+from agent_bom.ast.application_entrypoints import detect_application_entrypoints
 from agent_bom.ast.js_ts import JS_TS_EXTS as _JS_TS_EXTS
-from agent_bom.ast.js_ts import build_js_ts_dependency_symbol_reach
+from agent_bom.ast.js_ts import JSTSFunction, JSTSToolRegistration, build_js_ts_dependency_symbol_reach
 from agent_bom.ast.js_ts import build_js_ts_flow_findings as _build_js_ts_flow_findings
 from agent_bom.ast.js_ts import js_ts_function_key as _js_ts_function_key
 from agent_bom.ast.js_ts import scan_js_ts_file as _scan_js_ts_file
@@ -48,8 +48,10 @@ from agent_bom.ast_go import scan_go_file as _scan_go_file
 from agent_bom.ast_java import _java_method_key, _load_maven_dependency_map, build_java_dependency_symbol_reach
 from agent_bom.ast_java import scan_java_file as _scan_java_file
 from agent_bom.ast_models import (
+    ApplicationEntrypoint,
     ASTAnalysisResult,
     CallEdge,
+    DependencySymbolReach,
     _CSharpMethodAnalysis,
     _CSharpToolRegistration,
     _FunctionAnalysis,
@@ -116,6 +118,46 @@ _HIGH_SIGNAL_SOURCE_NAMES = frozenset(
 _TEST_SOURCE_PARTS = frozenset({"test", "tests", "testing", "__tests__", "fixtures", "__fixtures__"})
 
 
+def _application_handler(
+    entry: ApplicationEntrypoint,
+    analyses: Mapping[str, Any],
+) -> tuple[str, Any] | None:
+    """Resolve a declared application handler to one parsed function only."""
+    handler_name = entry.handler.rsplit(".", 1)[-1]
+    class_hint = entry.handler.rsplit(".", 1)[0] if "." in entry.handler else ""
+    candidates: list[tuple[str, Any]] = []
+    for key, analysis in analyses.items():
+        if getattr(analysis, "name", "") != handler_name:
+            continue
+        owner = str(getattr(analysis, "class_name", "") or getattr(analysis, "scope_name", ""))
+        if class_hint and owner and owner.rsplit(".", 1)[-1] != class_hint.rsplit(".", 1)[-1]:
+            continue
+        candidates.append((key, analysis))
+    same_file = [candidate for candidate in candidates if getattr(candidate[1], "file_path", "") == entry.file_path]
+    if len(same_file) == 1:
+        return same_file[0]
+    if len(candidates) == 1:
+        return candidates[0]
+    return None
+
+
+def _stamp_application_reaches(
+    reaches: list[DependencySymbolReach],
+    entries_by_token: Mapping[str, ApplicationEntrypoint],
+) -> None:
+    """Replace internal traversal tokens with public entrypoint evidence."""
+    for reach in reaches:
+        entry = entries_by_token.get(reach.entrypoint)
+        if entry is None:
+            continue
+        reach.entrypoint = entry.name
+        if reach.call_path:
+            reach.call_path[0] = entry.name
+        reach.entrypoint_kind = entry.kind
+        reach.entrypoint_framework = entry.framework
+        reach.entrypoint_provenance = entry.provenance
+
+
 def _is_test_source_path(path: str) -> bool:
     """Return whether analysis evidence came from test-only source material."""
     candidate = Path(path)
@@ -156,10 +198,9 @@ def project_has_analyzable_sources(project_path: str | Path) -> bool:
 def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
     """Analyze a project directory for prompts, tools, and risky call paths.
 
-    Extracts system prompts, guardrails, tool signatures, taint/data-flow
-    findings, and a lightweight CFG/call graph from Python source code. Also
-    performs prompt/tool/guardrail and dangerous-call extraction for JS/TS and
-    Go source files so non-Python MCP projects show up in the same path.
+    Extracts system prompts, guardrails, tool signatures, explicit application
+    entrypoints, taint/data-flow findings, and a lightweight CFG/call graph.
+    Non-Python source participates in the same inventory and reachability model.
 
     Args:
         project_path: Root directory to scan.
@@ -314,6 +355,8 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
         + len(swift_files)
         + len(kotlin_files)
     )
+    selected_source_files = [path for group in file_groups for path in group if path in selected]
+    result.application_entrypoints = detect_application_entrypoints(project, selected_source_files)
     function_analyses: list[_FunctionAnalysis] = []
     js_ts_functions: dict[str, JSTSFunction] = {}
     js_ts_tool_registrations: list[JSTSToolRegistration] = []
@@ -333,6 +376,15 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
     swift_tool_registrations: list[_SwiftToolRegistration] = []
     kotlin_functions: dict[str, _KotlinFunctionAnalysis] = {}
     kotlin_tool_registrations: list[_KotlinToolRegistration] = []
+    js_ts_application_registrations: list[JSTSToolRegistration] = []
+    go_application_registrations: list[_GoToolRegistration] = []
+    rust_application_registrations: list[_RustToolRegistration] = []
+    java_application_registrations: list[_JavaToolRegistration] = []
+    csharp_application_registrations: list[_CSharpToolRegistration] = []
+    ruby_application_registrations: list[_RubyToolRegistration] = []
+    php_application_registrations: list[_PhpToolRegistration] = []
+    swift_application_registrations: list[_SwiftToolRegistration] = []
+    kotlin_application_registrations: list[_KotlinToolRegistration] = []
     maven_dependency_map = _load_maven_dependency_map(project)
     nuget_namespace_map = load_nuget_namespace_map(project)
     ruby_gem_map = load_ruby_gem_map(project)
@@ -505,10 +557,152 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
                 kotlin_functions[_kotlin_function_key(kotlin_function.scope_name, kotlin_function.name)] = kotlin_function
             kotlin_tool_registrations.extend(kotlin_analysis.tool_registrations)
 
+    application_entries_by_token: dict[str, ApplicationEntrypoint] = {}
+    for index, entry in enumerate(result.application_entrypoints):
+        if entry.language == "python":
+            continue
+        token = f"__application_entrypoint_{index}"
+        if entry.language == "javascript_typescript":
+            resolved = _application_handler(entry, js_ts_functions)
+            if resolved is None:
+                continue
+            handler_key, _handler = resolved
+            js_ts_application_registrations.append(
+                JSTSToolRegistration(tool_name=token, handler_name=handler_key, line_number=entry.line_number)
+            )
+        elif entry.language == "go":
+            resolved = _application_handler(entry, go_functions)
+            if resolved is None:
+                continue
+            _handler_key, handler = resolved
+            go_application_registrations.append(
+                _GoToolRegistration(
+                    tool_name=token,
+                    handler_name=handler.name,
+                    line_number=entry.line_number,
+                    file_path=entry.file_path,
+                    scope_name=handler.scope_name,
+                    imported_aliases=handler.imported_aliases,
+                )
+            )
+        elif entry.language == "rust":
+            resolved = _application_handler(entry, rust_functions)
+            if resolved is None:
+                continue
+            handler_key, handler = resolved
+            rust_application_registrations.append(
+                _RustToolRegistration(
+                    tool_name=token,
+                    handler_name=handler_key,
+                    line_number=entry.line_number,
+                    file_path=entry.file_path,
+                    module_name=handler.module_name,
+                    crate_bindings=handler.crate_bindings,
+                )
+            )
+        elif entry.language == "java":
+            resolved = _application_handler(entry, java_methods)
+            if resolved is None:
+                continue
+            handler_key, handler = resolved
+            java_application_registrations.append(
+                _JavaToolRegistration(
+                    tool_name=token,
+                    handler_name=handler_key,
+                    line_number=entry.line_number,
+                    file_path=entry.file_path,
+                    class_name=handler.class_name,
+                    import_bindings=handler.import_bindings,
+                )
+            )
+        elif entry.language == "csharp":
+            resolved = _application_handler(entry, csharp_methods)
+            if resolved is None:
+                continue
+            handler_key, handler = resolved
+            csharp_application_registrations.append(
+                _CSharpToolRegistration(
+                    tool_name=token,
+                    handler_name=handler_key,
+                    line_number=entry.line_number,
+                    file_path=entry.file_path,
+                    class_name=handler.class_name,
+                    import_bindings=handler.import_bindings,
+                )
+            )
+        elif entry.language == "ruby":
+            resolved = _application_handler(entry, ruby_methods)
+            if resolved is None:
+                continue
+            handler_key, handler = resolved
+            ruby_application_registrations.append(
+                _RubyToolRegistration(
+                    tool_name=token,
+                    handler_name=handler_key,
+                    line_number=entry.line_number,
+                    file_path=entry.file_path,
+                    class_name=handler.class_name,
+                    import_bindings=handler.import_bindings,
+                )
+            )
+        elif entry.language == "php":
+            resolved = _application_handler(entry, php_methods)
+            if resolved is None:
+                continue
+            handler_key, handler = resolved
+            php_application_registrations.append(
+                _PhpToolRegistration(
+                    tool_name=token,
+                    handler_name=handler_key,
+                    line_number=entry.line_number,
+                    file_path=entry.file_path,
+                    class_name=handler.class_name,
+                    import_bindings=handler.import_bindings,
+                )
+            )
+        elif entry.language == "swift":
+            resolved = _application_handler(entry, swift_functions)
+            if resolved is None:
+                continue
+            handler_key, handler = resolved
+            swift_application_registrations.append(
+                _SwiftToolRegistration(
+                    tool_name=token,
+                    handler_name=handler_key,
+                    line_number=entry.line_number,
+                    file_path=entry.file_path,
+                    scope_name=handler.scope_name,
+                    import_bindings=handler.import_bindings,
+                )
+            )
+        elif entry.language == "kotlin":
+            resolved = _application_handler(entry, kotlin_functions)
+            if resolved is None:
+                continue
+            handler_key, handler = resolved
+            kotlin_application_registrations.append(
+                _KotlinToolRegistration(
+                    tool_name=token,
+                    handler_name=handler_key,
+                    line_number=entry.line_number,
+                    file_path=entry.file_path,
+                    scope_name=handler.scope_name,
+                    import_bindings=handler.import_bindings,
+                )
+            )
+        else:
+            continue
+        application_entries_by_token[token] = entry
+
     python_call_edges, interprocedural_findings = _build_call_graph(function_analyses)
     result.call_edges.extend(python_call_edges)
     result.flow_findings.extend(interprocedural_findings)
-    result.dependency_symbol_reach.extend(_build_dependency_symbol_reach(function_analyses))
+    result.dependency_symbol_reach.extend(
+        _build_dependency_symbol_reach(
+            function_analyses,
+            [entry for entry in result.application_entrypoints if entry.language == "python"],
+        )
+    )
     result.flow_findings.extend(_build_taint_findings(function_analyses))
     js_ts_call_edges, js_ts_interprocedural_findings = _build_js_ts_flow_findings(
         functions=js_ts_functions,
@@ -587,6 +781,75 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
             max_depth=_python_max_taint_depth(),
         )
     )
+
+    application_reaches: list[DependencySymbolReach] = []
+    application_reaches.extend(
+        build_js_ts_dependency_symbol_reach(
+            functions=js_ts_functions,
+            tool_registrations=js_ts_application_registrations,
+            max_depth=_python_max_taint_depth(),
+        )
+    )
+    application_reaches.extend(
+        build_go_dependency_symbol_reach(
+            functions=go_functions,
+            tool_registrations=go_application_registrations,
+            max_depth=_python_max_taint_depth(),
+        )
+    )
+    application_reaches.extend(
+        build_rust_dependency_symbol_reach(
+            functions=rust_functions,
+            tool_registrations=rust_application_registrations,
+            max_depth=_python_max_taint_depth(),
+        )
+    )
+    application_reaches.extend(
+        build_java_dependency_symbol_reach(
+            methods=java_methods,
+            tool_registrations=java_application_registrations,
+            max_depth=_python_max_taint_depth(),
+        )
+    )
+    application_reaches.extend(
+        build_csharp_dependency_symbol_reach(
+            methods=csharp_methods,
+            tool_registrations=csharp_application_registrations,
+            max_depth=_python_max_taint_depth(),
+        )
+    )
+    application_reaches.extend(
+        build_ruby_dependency_symbol_reach(
+            methods=ruby_methods,
+            tool_registrations=ruby_application_registrations,
+            max_depth=_python_max_taint_depth(),
+        )
+    )
+    application_reaches.extend(
+        build_php_dependency_symbol_reach(
+            methods=php_methods,
+            tool_registrations=php_application_registrations,
+            package_map=composer_package_map,
+            max_depth=_python_max_taint_depth(),
+        )
+    )
+    application_reaches.extend(
+        build_swift_dependency_symbol_reach(
+            functions=swift_functions,
+            tool_registrations=swift_application_registrations,
+            package_map=swift_package_map,
+            max_depth=_python_max_taint_depth(),
+        )
+    )
+    application_reaches.extend(
+        build_kotlin_dependency_symbol_reach(
+            functions=kotlin_functions,
+            tool_registrations=kotlin_application_registrations,
+            max_depth=_python_max_taint_depth(),
+        )
+    )
+    _stamp_application_reaches(application_reaches, application_entries_by_token)
+    result.dependency_symbol_reach.extend(application_reaches)
 
     # Test fixtures remain visible in inventory, but are not production
     # reachability evidence. Otherwise dev-only imports become build-blocking

--- a/src/agent_bom/ast_models.py
+++ b/src/agent_bom/ast_models.py
@@ -83,7 +83,7 @@ class FlowFinding:
 
 @dataclass
 class DependencySymbolReach:
-    """Imported dependency symbol reachable from a tool entrypoint."""
+    """Imported dependency symbol reachable from an externally invokable root."""
 
     entrypoint: str
     package: str
@@ -95,6 +95,23 @@ class DependencySymbolReach:
     depth: int = 0
     confidence: str = "import-symbol"
     ecosystem: str = "pypi"
+    entrypoint_kind: str = "mcp_tool"
+    entrypoint_framework: str = ""
+    entrypoint_provenance: str = ""
+
+
+@dataclass
+class ApplicationEntrypoint:
+    """Evidence-backed non-MCP application invocation root."""
+
+    name: str
+    handler: str
+    kind: str
+    framework: str
+    language: str
+    file_path: str
+    line_number: int
+    provenance: str
 
 
 @dataclass
@@ -107,6 +124,7 @@ class ASTAnalysisResult:
     call_edges: list[CallEdge] = field(default_factory=list)
     cfg_edges: list[ControlFlowEdge] = field(default_factory=list)
     flow_findings: list[FlowFinding] = field(default_factory=list)
+    application_entrypoints: list[ApplicationEntrypoint] = field(default_factory=list)
     dependency_symbol_reach: list[DependencySymbolReach] = field(default_factory=list)
     frameworks_detected: list[str] = field(default_factory=list)
     files_analyzed: int = 0
@@ -184,6 +202,19 @@ class ASTAnalysisResult:
                 }
                 for finding in self.flow_findings
             ],
+            "application_entrypoints": [
+                {
+                    "name": entry.name,
+                    "handler": entry.handler,
+                    "kind": entry.kind,
+                    "framework": entry.framework,
+                    "language": entry.language,
+                    "file": entry.file_path,
+                    "line": entry.line_number,
+                    "provenance": entry.provenance,
+                }
+                for entry in self.application_entrypoints
+            ],
             "dependency_symbol_reach": [
                 {
                     "entrypoint": reach.entrypoint,
@@ -196,6 +227,15 @@ class ASTAnalysisResult:
                     "depth": reach.depth,
                     "confidence": reach.confidence,
                     "ecosystem": reach.ecosystem,
+                    **(
+                        {
+                            "entrypoint_kind": reach.entrypoint_kind,
+                            "entrypoint_framework": reach.entrypoint_framework,
+                            "entrypoint_provenance": reach.entrypoint_provenance,
+                        }
+                        if reach.entrypoint_kind != "mcp_tool"
+                        else {}
+                    ),
                 }
                 for reach in self.dependency_symbol_reach
             ],
@@ -209,6 +249,7 @@ class ASTAnalysisResult:
                 "total_call_edges": len(self.call_edges),
                 "total_cfg_edges": len(self.cfg_edges),
                 "total_flow_findings": len(self.flow_findings),
+                "total_application_entrypoints": len(self.application_entrypoints),
                 "total_dependency_symbol_reach": len(self.dependency_symbol_reach),
                 "prompts_with_risks": sum(1 for p in self.prompts if p.risk_flags),
             },

--- a/src/agent_bom/ast_python_analysis.py
+++ b/src/agent_bom/ast_python_analysis.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from agent_bom.ast.source_reader import read_source_for_analysis
 from agent_bom.ast_models import (
+    ApplicationEntrypoint,
     CallEdge,
     ControlFlowEdge,
     DependencySymbolReach,
@@ -1895,8 +1896,11 @@ def _build_taint_findings(functions: list[_FunctionAnalysis]) -> list[FlowFindin
     return aggregated_findings
 
 
-def _build_dependency_symbol_reach(functions: list[_FunctionAnalysis]) -> list[DependencySymbolReach]:
-    """Build bounded tool-entrypoint → imported dependency symbol reach evidence."""
+def _build_dependency_symbol_reach(
+    functions: list[_FunctionAnalysis],
+    application_entrypoints: list[ApplicationEntrypoint] | None = None,
+) -> list[DependencySymbolReach]:
+    """Build bounded externally-invokable-root → dependency symbol evidence."""
     by_name: dict[str, list[_FunctionAnalysis]] = {}
     by_module_and_name: dict[tuple[str, str], _FunctionAnalysis] = {}
     for func in functions:
@@ -1915,10 +1919,16 @@ def _build_dependency_symbol_reach(functions: list[_FunctionAnalysis]) -> list[D
     max_depth = _max_taint_depth()
     reached: list[DependencySymbolReach] = []
     seen: set[tuple[str, str, str, str, int]] = set()
-    for tool in functions:
-        if not tool.is_tool:
-            continue
-        queue: list[tuple[str, list[str]]] = [(tool.qualified_name, [tool.simple_name])]
+    roots: list[tuple[str, _FunctionAnalysis, ApplicationEntrypoint | None]] = [
+        (func.simple_name, func, None) for func in functions if func.is_tool
+    ]
+    for index, entry in enumerate(application_entrypoints or []):
+        matches = [func for func in functions if func.simple_name == entry.handler.rsplit(".", 1)[-1] and func.file_path == entry.file_path]
+        if len(matches) == 1:
+            roots.append((f"__application_entrypoint_{index}", matches[0], entry))
+
+    for root_name, root, application_entrypoint in roots:
+        queue: list[tuple[str, list[str]]] = [(root.qualified_name, [root.simple_name])]
         visited: set[str] = set()
         while queue:
             current_id, path = queue.pop(0)
@@ -1933,20 +1943,26 @@ def _build_dependency_symbol_reach(functions: list[_FunctionAnalysis]) -> list[D
                 if external is None:
                     continue
                 package, module_name, symbol = external
-                dedup_key = (tool.simple_name, module_name, symbol, current.file_path, line_num)
+                dedup_key = (root_name, module_name, symbol, current.file_path, line_num)
                 if dedup_key in seen:
                     continue
                 seen.add(dedup_key)
                 reached.append(
                     DependencySymbolReach(
-                        entrypoint=tool.simple_name,
+                        entrypoint=application_entrypoint.name if application_entrypoint else root.simple_name,
                         package=package,
                         module=module_name,
                         symbol=symbol,
                         file_path=current.file_path,
                         line_number=line_num,
-                        call_path=[*path, f"{module_name}.{symbol}"],
+                        call_path=[
+                            *([application_entrypoint.name, *path[1:]] if application_entrypoint else path),
+                            f"{module_name}.{symbol}",
+                        ],
                         depth=max(0, len(path) - 1),
+                        entrypoint_kind=application_entrypoint.kind if application_entrypoint else "mcp_tool",
+                        entrypoint_framework=application_entrypoint.framework if application_entrypoint else "",
+                        entrypoint_provenance=application_entrypoint.provenance if application_entrypoint else "",
                     )
                 )
             for child in adjacency.get(current_id, []):

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -2622,17 +2622,26 @@ def scan(
             try:
                 _ast_result = _ast_analyze(project)
                 _ast_result_for_reach = _ast_result
-                if _ast_result.prompts or _ast_result.guardrails or _ast_result.tools or _ast_result.flow_findings:
+                if (
+                    _ast_result.prompts
+                    or _ast_result.guardrails
+                    or _ast_result.tools
+                    or _ast_result.flow_findings
+                    or _ast_result.application_entrypoints
+                    or _ast_result.dependency_symbol_reach
+                ):
                     report.ai_inventory_data = report.ai_inventory_data or {}
                     report.ai_inventory_data["ast_analysis"] = _ast_result.to_dict()
                     _n_prompts = len(_ast_result.prompts)
                     _n_guards = len(_ast_result.guardrails)
                     _n_tools = len(_ast_result.tools)
+                    _n_entrypoints = len(_ast_result.application_entrypoints)
                     _n_risky = sum(1 for p in _ast_result.prompts if p.risk_flags)
-                    if _n_prompts or _n_guards or _n_tools:
+                    if _n_prompts or _n_guards or _n_tools or _n_entrypoints:
                         con.print(
                             f"  [cyan]>[/cyan] Code analysis: {_n_prompts} prompts, "
-                            f"{_n_guards} guardrails, {_n_tools} tools" + (f" [red]({_n_risky} risky prompts)[/red]" if _n_risky else "")
+                            f"{_n_guards} guardrails, {_n_tools} tools, {_n_entrypoints} application entrypoints"
+                            + (f" [red]({_n_risky} risky prompts)[/red]" if _n_risky else "")
                         )
                     _scan_sources.append("ast_analysis")
             except Exception as exc:  # noqa: BLE001

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -1349,7 +1349,7 @@ def _apply_repo_structure_overlay(graph: UnifiedGraph, report_json: Mapping[str,
 
 
 def _apply_ast_tool_overlay(graph: UnifiedGraph, report_json: Mapping[str, Any]) -> None:
-    """Materialise source-defined tool entrypoints with file provenance."""
+    """Materialise source-defined tool and application entrypoints."""
     inventory = report_json.get("ai_inventory")
     if not isinstance(inventory, Mapping):
         return
@@ -1357,8 +1357,11 @@ def _apply_ast_tool_overlay(graph: UnifiedGraph, report_json: Mapping[str, Any])
     if not isinstance(analysis, Mapping):
         return
     raw_tools = analysis.get("tools")
+    raw_entrypoints = analysis.get("application_entrypoints")
     if not isinstance(raw_tools, list):
-        return
+        raw_tools = []
+    if not isinstance(raw_entrypoints, list):
+        raw_entrypoints = []
 
     for raw in raw_tools:
         if not isinstance(raw, Mapping):
@@ -1411,6 +1414,69 @@ def _apply_ast_tool_overlay(graph: UnifiedGraph, report_json: Mapping[str, Any])
                 target=tool_id,
                 relationship=RelationshipType.DEFINES,
                 evidence={"source": "ast_analysis", "line": raw.get("line")},
+            )
+        )
+
+    for raw in raw_entrypoints:
+        if not isinstance(raw, Mapping):
+            continue
+        entry_name = sanitize_text(raw.get("name", ""), max_len=200).strip()
+        handler = sanitize_text(raw.get("handler", ""), max_len=200).strip()
+        source_file = sanitize_text(raw.get("file", ""), max_len=500).strip().replace("\\", "/")
+        while source_file.startswith("./"):
+            source_file = source_file[2:]
+        if not entry_name or not handler or not source_file:
+            continue
+
+        file_id = f"{EntityType.SOURCE_FILE.value}:{source_file}"
+        if file_id not in graph.nodes:
+            graph.add_node(
+                UnifiedNode(
+                    id=file_id,
+                    entity_type=EntityType.SOURCE_FILE,
+                    label=source_file.rsplit("/", 1)[-1],
+                    attributes={
+                        "path": source_file,
+                        "evidence_tier": "static_scan",
+                        "canonical_id": canonical_graph_node_id(EntityType.SOURCE_FILE.value, file_id),
+                    },
+                    data_sources=["ast_analysis"],
+                    dimensions=NodeDimensions(surface="code"),
+                )
+            )
+
+        entry_id = f"application_entrypoint:source:{stable_node_id(source_file, entry_name, handler)}"
+        graph.add_node(
+            UnifiedNode(
+                id=entry_id,
+                entity_type=EntityType.CODE_MODULE,
+                label=entry_name,
+                attributes={
+                    "node_kind": "application_entrypoint",
+                    "handler": handler,
+                    "entrypoint_kind": sanitize_text(raw.get("kind", ""), max_len=100),
+                    "framework": sanitize_text(raw.get("framework", ""), max_len=100),
+                    "language": sanitize_text(raw.get("language", ""), max_len=100),
+                    "provenance": sanitize_text(raw.get("provenance", ""), max_len=500),
+                    "source_file": source_file,
+                    "line": raw.get("line") if isinstance(raw.get("line"), int) else None,
+                    "discovery_source": "ast_analysis",
+                    "canonical_id": canonical_graph_node_id(EntityType.CODE_MODULE.value, entry_id),
+                },
+                data_sources=["ast_analysis"],
+                dimensions=NodeDimensions(surface="code"),
+            )
+        )
+        graph.add_edge(
+            UnifiedEdge(
+                source=file_id,
+                target=entry_id,
+                relationship=RelationshipType.DEFINES,
+                evidence={
+                    "source": "ast_analysis",
+                    "line": raw.get("line"),
+                    "provenance": sanitize_text(raw.get("provenance", ""), max_len=500),
+                },
             )
         )
 

--- a/src/agent_bom/output/graph.py
+++ b/src/agent_bom/output/graph.py
@@ -475,7 +475,7 @@ def build_graph_elements(
 
 
 def _append_source_tool_elements(elements: list[dict], report: "AIBOMReport") -> None:
-    """Append AST-discovered MCP tools and their defining source files."""
+    """Append AST-discovered tools/application roots and defining source files."""
     inventory = report.ai_inventory_data
     if not isinstance(inventory, dict):
         return
@@ -483,7 +483,12 @@ def _append_source_tool_elements(elements: list[dict], report: "AIBOMReport") ->
     if not isinstance(analysis, dict):
         return
     raw_tools = analysis.get("tools")
+    raw_entrypoints = analysis.get("application_entrypoints")
     if not isinstance(raw_tools, list):
+        raw_tools = []
+    if not isinstance(raw_entrypoints, list):
+        raw_entrypoints = []
+    if not raw_tools and not raw_entrypoints:
         return
 
     known_nodes = {str(item["data"]["id"]) for item in elements if "id" in item.get("data", {})}
@@ -547,6 +552,74 @@ def _append_source_tool_elements(elements: list[dict], report: "AIBOMReport") ->
                     "data": {
                         "source": file_id,
                         "target": tool_id,
+                        "type": "defines",
+                        "line": raw.get("line") if isinstance(raw.get("line"), int) else None,
+                    }
+                }
+            )
+
+    for raw in raw_entrypoints:
+        if not isinstance(raw, dict):
+            continue
+        entry_name = sanitize_text(raw.get("name", ""), max_len=200).strip()
+        handler = sanitize_text(raw.get("handler", ""), max_len=200).strip()
+        source_file = sanitize_text(raw.get("file", ""), max_len=500).strip().replace("\\", "/")
+        while source_file.startswith("./"):
+            source_file = source_file[2:]
+        if not entry_name or not handler or not source_file:
+            continue
+
+        file_id = f"source_file:{source_file}"
+        if file_id not in known_nodes:
+            known_nodes.add(file_id)
+            elements.append(
+                {
+                    "data": {
+                        "id": file_id,
+                        "label": source_file.rsplit("/", 1)[-1],
+                        "type": "source_file",
+                        "path": source_file,
+                        "tip": f"Source file: {source_file}",
+                        "searchText": source_file.lower(),
+                    }
+                }
+            )
+
+        entry_id = f"application_entrypoint:source:{stable_node_id(source_file, entry_name, handler)}"
+        if entry_id not in known_nodes:
+            known_nodes.add(entry_id)
+            line = raw.get("line") if isinstance(raw.get("line"), int) else None
+            kind = sanitize_text(raw.get("kind", "application_entrypoint"), max_len=100)
+            framework = sanitize_text(raw.get("framework", ""), max_len=100)
+            provenance = sanitize_text(raw.get("provenance", ""), max_len=500)
+            elements.append(
+                {
+                    "data": {
+                        "id": entry_id,
+                        "label": entry_name,
+                        "type": "application_entrypoint",
+                        "entrypointKind": kind,
+                        "handler": handler,
+                        "framework": framework,
+                        "provenance": provenance,
+                        "tip": f"Application entrypoint: {entry_name}\nHandler: {handler}\nSource: {source_file}"
+                        + (f":{line}" if line else ""),
+                        "sourceFile": source_file,
+                        "line": line,
+                        "discovery_source": "ast_analysis",
+                        "searchText": f"{entry_name} {handler} {kind} {framework} {source_file}".lower(),
+                    }
+                }
+            )
+
+        edge_key = (file_id, entry_id, "defines")
+        if edge_key not in known_edges:
+            known_edges.add(edge_key)
+            elements.append(
+                {
+                    "data": {
+                        "source": file_id,
+                        "target": entry_id,
                         "type": "defines",
                         "line": raw.get("line") if isinstance(raw.get("line"), int) else None,
                     }

--- a/src/agent_bom/output/graph_export.py
+++ b/src/agent_bom/output/graph_export.py
@@ -310,7 +310,10 @@ def _merge_unified_graph_evidence(graph: DepGraph, data: dict[str, Any]) -> None
         etype = node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type)
         is_ast_tool = etype == "tool" and node.attributes.get("discovery_source") == "ast_analysis"
         is_ast_source = etype == "source_file" and "ast_analysis" in node.data_sources
-        if (etype not in _CLOUD_ENTITY_TYPES and not is_ast_tool and not is_ast_source) or node.id in graph._nodes:
+        is_ast_entrypoint = etype == "code_module" and node.attributes.get("node_kind") == "application_entrypoint"
+        if (
+            etype not in _CLOUD_ENTITY_TYPES and not is_ast_tool and not is_ast_source and not is_ast_entrypoint
+        ) or node.id in graph._nodes:
             continue
         graph.add_node(
             node.id,

--- a/tests/fixtures/ordinary-python-app/ordinary_app/__init__.py
+++ b/tests/fixtures/ordinary-python-app/ordinary_app/__init__.py
@@ -1,0 +1,1 @@
+"""Ordinary application fixture without MCP or AI tool decorators."""

--- a/tests/fixtures/ordinary-python-app/ordinary_app/cli.py
+++ b/tests/fixtures/ordinary-python-app/ordinary_app/cli.py
@@ -1,0 +1,17 @@
+import requests
+
+
+def fetch_status(url: str) -> int:
+    return requests.get(url, timeout=5).status_code
+
+
+def exported_but_unused() -> str:
+    return "not an application root"
+
+
+def main() -> int:
+    return fetch_status("https://example.com")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/ordinary-python-app/ordinary_app/cli.py
+++ b/tests/fixtures/ordinary-python-app/ordinary_app/cli.py
@@ -1,8 +1,9 @@
-import requests
+import rich
 
 
-def fetch_status(url: str) -> int:
-    return requests.get(url, timeout=5).status_code
+def emit_status(message: str) -> int:
+    rich.print(message)
+    return 0
 
 
 def exported_but_unused() -> str:
@@ -10,7 +11,7 @@ def exported_but_unused() -> str:
 
 
 def main() -> int:
-    return fetch_status("https://example.com")
+    return emit_status("ordinary application ready")
 
 
 if __name__ == "__main__":

--- a/tests/fixtures/ordinary-python-app/pyproject.toml
+++ b/tests/fixtures/ordinary-python-app/pyproject.toml
@@ -2,8 +2,8 @@
 name = "ordinary-python-app"
 version = "0.1.0"
 dependencies = [
-  "requests==2.32.5",
-  "httpx==0.28.1",
+  "rich==14.1.0",
+  "attrs==25.3.0",
 ]
 
 [project.scripts]

--- a/tests/fixtures/ordinary-python-app/pyproject.toml
+++ b/tests/fixtures/ordinary-python-app/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "ordinary-python-app"
+version = "0.1.0"
+dependencies = [
+  "requests==2.32.5",
+  "httpx==0.28.1",
+]
+
+[project.scripts]
+ordinary-fetch = "ordinary_app.cli:main"

--- a/tests/test_ast_application_entrypoints.py
+++ b/tests/test_ast_application_entrypoints.py
@@ -27,11 +27,11 @@ def test_ordinary_repository_reaches_used_dependency_only() -> None:
     assert result.tools == []
     assert {entry.kind for entry in result.application_entrypoints} == {"console_script", "language_main"}
     assert {entry.handler for entry in result.application_entrypoints} == {"main"}
-    assert {reach.package for reach in result.dependency_symbol_reach} == {"requests"}
-    assert all(reach.package != "httpx" for reach in result.dependency_symbol_reach)
+    assert {reach.package for reach in result.dependency_symbol_reach} == {"rich"}
+    assert all(reach.package != "attrs" for reach in result.dependency_symbol_reach)
     reach_index = SymbolReachIndex.from_ast_result(result)
-    assert reach_index.is_package_reached("requests", ecosystem="pypi") is True
-    assert reach_index.is_package_reached("httpx", ecosystem="pypi") is False
+    assert reach_index.is_package_reached("rich", ecosystem="pypi") is True
+    assert reach_index.is_package_reached("attrs", ecosystem="pypi") is False
     assert all(reach.entrypoint_kind in {"console_script", "language_main"} for reach in result.dependency_symbol_reach)
     assert all(reach.entrypoint_provenance for reach in result.dependency_symbol_reach)
     assert payload["stats"]["total_application_entrypoints"] == 2

--- a/tests/test_ast_application_entrypoints.py
+++ b/tests/test_ast_application_entrypoints.py
@@ -1,0 +1,170 @@
+"""Application roots populate symbol reach without MCP tool declarations."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from agent_bom.ast.application_entrypoints import detect_application_entrypoints
+from agent_bom.ast_analyzer import analyze_project
+from agent_bom.reachability_cve import SymbolReachIndex
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "ordinary-python-app"
+
+
+def _js_ts_parser_available() -> bool:
+    return all(
+        importlib.util.find_spec(module) is not None for module in ("tree_sitter", "tree_sitter_javascript", "tree_sitter_typescript")
+    )
+
+
+def test_ordinary_repository_reaches_used_dependency_only() -> None:
+    result = analyze_project(_FIXTURE)
+    payload = result.to_dict()
+
+    assert result.tools == []
+    assert {entry.kind for entry in result.application_entrypoints} == {"console_script", "language_main"}
+    assert {entry.handler for entry in result.application_entrypoints} == {"main"}
+    assert {reach.package for reach in result.dependency_symbol_reach} == {"requests"}
+    assert all(reach.package != "httpx" for reach in result.dependency_symbol_reach)
+    reach_index = SymbolReachIndex.from_ast_result(result)
+    assert reach_index.is_package_reached("requests", ecosystem="pypi") is True
+    assert reach_index.is_package_reached("httpx", ecosystem="pypi") is False
+    assert all(reach.entrypoint_kind in {"console_script", "language_main"} for reach in result.dependency_symbol_reach)
+    assert all(reach.entrypoint_provenance for reach in result.dependency_symbol_reach)
+    assert payload["stats"]["total_application_entrypoints"] == 2
+    assert payload["application_entrypoints"][0]["provenance"]
+    assert payload["dependency_symbol_reach"][0]["entrypoint_provenance"]
+
+
+def test_python_framework_routes_and_commands_are_explicit_roots(tmp_path: Path) -> None:
+    source = tmp_path / "app.py"
+    source.write_text(
+        "from fastapi import FastAPI\n"
+        "from flask import Flask\n"
+        "import click\n"
+        "import typer\n\n"
+        "api = FastAPI()\n"
+        "web = Flask(__name__)\n"
+        "cli = typer.Typer()\n\n"
+        "@api.get('/health')\n"
+        "def health(): return {'ok': True}\n\n"
+        "@web.route('/ready')\n"
+        "def ready(): return 'ready'\n\n"
+        "@click.command()\n"
+        "def click_run(): return 0\n\n"
+        "@cli.command()\n"
+        "def typer_run(): return 0\n\n"
+        "def exported_but_unused(): return 0\n"
+    )
+
+    entries = detect_application_entrypoints(tmp_path, [source])
+
+    assert {(entry.kind, entry.handler, entry.framework) for entry in entries} == {
+        ("http_route", "health", "FastAPI"),
+        ("http_route", "ready", "Flask"),
+        ("cli_command", "click_run", "Click"),
+        ("cli_command", "typer_run", "Typer"),
+    }
+    assert "exported_but_unused" not in {entry.handler for entry in entries}
+
+
+def test_go_main_populates_dependency_reach_without_tool_registration(tmp_path: Path) -> None:
+    (tmp_path / "main.go").write_text(
+        "package main\n\n"
+        'import "net/http"\n\n'
+        'func fetch() { http.Get("https://example.com") }\n'
+        "func exportedButUnused() {}\n"
+        "func main() { fetch() }\n"
+    )
+
+    result = analyze_project(tmp_path)
+
+    assert result.tools == []
+    entry = next(entry for entry in result.application_entrypoints if entry.language == "go")
+    assert entry.handler == "main"
+    reach = next(reach for reach in result.dependency_symbol_reach if reach.ecosystem == "go")
+    assert reach.package == "net/http"
+    assert reach.symbol == "Get"
+    assert reach.entrypoint_kind == "language_main"
+    assert reach.entrypoint_provenance == entry.provenance
+
+
+def test_js_route_populates_dependency_reach_without_export_promotion(tmp_path: Path) -> None:
+    (tmp_path / "server.ts").write_text(
+        'import axios from "axios";\n'
+        "function health() { return axios.get('/health'); }\n"
+        "export function exportedButUnused() { return axios.post('/unused'); }\n"
+        "app.get('/health', health);\n"
+    )
+
+    result = analyze_project(tmp_path)
+
+    if _js_ts_parser_available():
+        assert result.tools == []
+        entry = next(entry for entry in result.application_entrypoints if entry.language == "javascript_typescript")
+        assert entry.handler == "health"
+        reaches = [reach for reach in result.dependency_symbol_reach if reach.ecosystem == "npm"]
+        assert {(reach.package, reach.symbol) for reach in reaches} == {("axios", "get")}
+        assert all("exportedButUnused" not in reach.call_path for reach in reaches)
+        assert all(reach.entrypoint_provenance == entry.provenance for reach in reaches)
+
+
+@pytest.mark.parametrize(
+    ("filename", "source", "expected"),
+    [
+        ("main.go", "package main\nfunc main() {}\n", ("go", "language_main", "main")),
+        ("main.rs", "fn main() {}\n", ("rust", "language_main", "main")),
+        (
+            "Application.java",
+            "class Application { public static void main(String[] args) {} }\n",
+            ("java", "language_main", "main"),
+        ),
+        ("Main.kt", "fun main() {}\n", ("kotlin", "language_main", "main")),
+        ("Program.cs", "class Program { static void Main(string[] args) {} }\n", ("csharp", "language_main", "Main")),
+        ("main.swift", "@main struct App { static func main() {} }\n", ("swift", "language_main", "main")),
+        (
+            "server.ts",
+            "import express from 'express';\nconst app = express();\nfunction health() {}\napp.get('/health', health);\n",
+            ("javascript_typescript", "http_route", "health"),
+        ),
+        (
+            "routes.php",
+            "<?php Route::get('/health', [HealthController::class, 'show']);\n",
+            ("php", "http_route", "HealthController.show"),
+        ),
+        (
+            "routes.rb",
+            "Rails.application.routes.draw do\n  get '/health', to: 'health#show'\nend\n",
+            ("ruby", "http_route", "HealthController.show"),
+        ),
+    ],
+)
+def test_supported_language_main_and_route_registrations_are_detected(
+    tmp_path: Path,
+    filename: str,
+    source: str,
+    expected: tuple[str, str, str],
+) -> None:
+    path = tmp_path / filename
+    path.write_text(source)
+
+    entries = detect_application_entrypoints(tmp_path, [path])
+
+    assert (entries[0].language, entries[0].kind, entries[0].handler) == expected
+    assert entries[0].provenance
+
+
+def test_commented_or_quoted_registrations_are_not_entrypoints(tmp_path: Path) -> None:
+    go_source = tmp_path / "commented.go"
+    go_source.write_text('package helper\n// func main() {}\nvar example = "func main() {}"\n// http.HandleFunc("/health", health)\n')
+    js_source = tmp_path / "commented.ts"
+    js_source.write_text(
+        '// app.get(\'/health\', health);\nconst example = "app.post(\\"/ready\\", ready)";\nexport function health() {}\n'
+    )
+
+    entries = detect_application_entrypoints(tmp_path, [go_source, js_source])
+
+    assert entries == []

--- a/tests/test_graph_source_tool_evidence.py
+++ b/tests/test_graph_source_tool_evidence.py
@@ -22,7 +22,19 @@ _AST_TOOLS = {
                 "line": 42,
                 "parameters": ["customer_id"],
             }
-        ]
+        ],
+        "application_entrypoints": [
+            {
+                "name": "ordinary-fetch",
+                "handler": "main",
+                "kind": "console_script",
+                "framework": "Python packaging",
+                "language": "python",
+                "file": "src/cli.py",
+                "line": 12,
+                "provenance": "metadata:pyproject.toml:[project.scripts]=ordinary.cli:main",
+            }
+        ],
     }
 }
 
@@ -80,3 +92,26 @@ def test_source_discovered_tool_is_in_cytoscape_export() -> None:
         and item["data"].get("type") == "defines"
         for item in elements
     )
+
+
+def test_application_entrypoint_provenance_survives_graph_projections() -> None:
+    unified = build_unified_graph_from_report(_scan_json())
+    entry = next(node for node in unified.nodes.values() if node.attributes.get("node_kind") == "application_entrypoint")
+    assert entry.attributes["handler"] == "main"
+    assert entry.attributes["entrypoint_kind"] == "console_script"
+    assert entry.attributes["provenance"].startswith("metadata:pyproject.toml")
+
+    standalone = build_graph_from_scan_data(_scan_json())
+    exported = next(node for node in standalone.nodes if node.attributes.get("node_kind") == "application_entrypoint")
+    assert exported.attributes["provenance"] == entry.attributes["provenance"]
+
+    report = AIBOMReport(
+        generated_at=datetime(2026, 8, 20, tzinfo=timezone.utc),
+        scan_id="source-entrypoint-scan",
+        tool_version="0.102.0",
+        ai_inventory_data=_AST_TOOLS,
+    )
+    elements = build_graph_elements(report, [])
+    cytoscape = next(item["data"] for item in elements if item.get("data", {}).get("type") == "application_entrypoint")
+    assert cytoscape["handler"] == "main"
+    assert cytoscape["provenance"] == entry.attributes["provenance"]

--- a/tests/test_symbol_reachability_export.py
+++ b/tests/test_symbol_reachability_export.py
@@ -229,7 +229,7 @@ def test_ast_result_for_symbol_reach_reads_ordinary_application_project() -> Non
     assert result is not None
     assert result.tools == []
     assert result.application_entrypoints
-    assert {reach.package for reach in result.dependency_symbol_reach} == {"requests"}
+    assert {reach.package for reach in result.dependency_symbol_reach} == {"rich"}
     assert all(reach.entrypoint_provenance for reach in result.dependency_symbol_reach)
 
 

--- a/tests/test_symbol_reachability_export.py
+++ b/tests/test_symbol_reachability_export.py
@@ -221,6 +221,18 @@ def test_ast_result_for_symbol_reach_reads_python_project(tmp_path: Path) -> Non
     assert result.dependency_symbol_reach
 
 
+def test_ast_result_for_symbol_reach_reads_ordinary_application_project() -> None:
+    fixture = Path(__file__).parent / "fixtures" / "ordinary-python-app"
+
+    result = _ast_result_for_symbol_reach([str(fixture)])
+
+    assert result is not None
+    assert result.tools == []
+    assert result.application_entrypoints
+    assert {reach.package for reach in result.dependency_symbol_reach} == {"requests"}
+    assert all(reach.entrypoint_provenance for reach in result.dependency_symbol_reach)
+
+
 def test_ast_result_for_symbol_reach_reads_php_only_project(tmp_path: Path) -> None:
     project = tmp_path / "php-mcp"
     project.mkdir()


### PR DESCRIPTION
## Summary

- Model evidence-backed application entrypoints separately from MCP tools, covering Python main guards, packaging console scripts, Click/Typer commands, FastAPI/Flask routes, and supported-language main/route registrations.
- Traverse dependency symbols from those roots without promoting ordinary exported functions; attach invocation kind, framework, and source provenance to JSON, API, CLI, unified graph, standalone graph, and Cytoscape projections.
- Add an ordinary Python repository fixture where Rich is imported and reached while manifest-only attrs remains outside the symbol-reach index.

## Verification

- `uv run pytest -q tests/test_ast_application_entrypoints.py tests/test_ast_analyzer.py tests/test_symbol_reachability_export.py tests/test_graph_source_tool_evidence.py tests/test_reachability_cve.py` — 155 passed
- `uv run pytest -q tests/test_ast_application_entrypoints.py tests/test_ast_analyzer.py tests/test_symbol_reachability_export.py tests/test_graph_source_tool_evidence.py tests/test_reachability_cve.py tests/test_cli_scan.py` — 281 passed
- `uv run agent-bom scan --project tests/fixtures/ordinary-python-app --offline --format json --output /private/tmp/ordinary-app-scan.json` — 2 dependencies, 0 tools, 2 application entrypoints, Rich-only symbol reach, no coverage warnings
- `uv run agent-bom fs . --ignore .image-scan-ignore --exclude-unfixable --fail-on-severity medium` — no known vulnerabilities
- `make lint` — Ruff passed; MyPy passed across 868 source files
- `make preflight` — passed
- `git diff --check` — passed

## Notes

- Application-root detection is conservative: comments and quoted examples are masked, ambiguous handlers are not traversed, and exported functions are not roots without invocation evidence.
- The product metrics snapshot was regenerated with `scripts/product_metrics_snapshot.py --write` for the added package module.
