### PR TITLE
fix(graph): rank and dedupe operator paths

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -25045,6 +25045,24 @@
                       "items": {
                         "additionalProperties": true,
                         "properties": {
+                          "affected": {
+                            "additionalProperties": true,
+                            "properties": {
+                              "finding_labels": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "findings": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
                           "exposure_path": {
                             "description": "Investigation-first exposure path shared by graph views and report exports.",
                             "properties": {
@@ -25171,6 +25189,47 @@
                               "relationships"
                             ],
                             "type": "object"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "occurrence_count": {
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "occurrence_path_ids": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "rank": {
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "rank_meta": {
+                            "additionalProperties": true,
+                            "properties": {
+                              "raw_severity": {
+                                "type": "string"
+                              },
+                              "reachability": {
+                                "enum": [
+                                  "confirmed",
+                                  "likely",
+                                  "unknown",
+                                  "unlikely"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "semantic_key": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
                           }
                         },
                         "type": "object"

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -16736,6 +16736,18 @@ paths:
                     items:
                       additionalProperties: true
                       properties:
+                        affected:
+                          additionalProperties: true
+                          properties:
+                            finding_labels:
+                              items:
+                                type: string
+                              type: array
+                            findings:
+                              items:
+                                type: string
+                              type: array
+                          type: object
                         exposure_path:
                           description: Investigation-first exposure path shared by
                             graph views and report exports.
@@ -16828,6 +16840,35 @@ paths:
                           - hops
                           - relationships
                           type: object
+                        id:
+                          type: string
+                        occurrence_count:
+                          minimum: 1
+                          type: integer
+                        occurrence_path_ids:
+                          items:
+                            type: string
+                          type: array
+                        rank:
+                          minimum: 1
+                          type: integer
+                        rank_meta:
+                          additionalProperties: true
+                          properties:
+                            raw_severity:
+                              type: string
+                            reachability:
+                              enum:
+                              - confirmed
+                              - likely
+                              - unknown
+                              - unlikely
+                              type: string
+                          type: object
+                        semantic_key:
+                          type: string
+                        title:
+                          type: string
                       type: object
                     type: array
                   created_at:

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -233,7 +233,32 @@ _FIX_FIRST_VIEW_OPENAPI_RESPONSE: dict[str, Any] = {
                         "items": {
                             "type": "object",
                             "properties": {
+                                "id": {"type": "string"},
+                                "semantic_key": {"type": "string"},
+                                "occurrence_count": {"type": "integer", "minimum": 1},
+                                "occurrence_path_ids": {"type": "array", "items": {"type": "string"}},
+                                "rank": {"type": "integer", "minimum": 1},
+                                "title": {"type": "string"},
                                 "exposure_path": _EXPOSURE_PATH_OPENAPI_SCHEMA,
+                                "rank_meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "reachability": {
+                                            "type": "string",
+                                            "enum": ["confirmed", "likely", "unknown", "unlikely"],
+                                        },
+                                        "raw_severity": {"type": "string"},
+                                    },
+                                    "additionalProperties": True,
+                                },
+                                "affected": {
+                                    "type": "object",
+                                    "properties": {
+                                        "findings": {"type": "array", "items": {"type": "string"}},
+                                        "finding_labels": {"type": "array", "items": {"type": "string"}},
+                                    },
+                                    "additionalProperties": True,
+                                },
                             },
                             "additionalProperties": True,
                         },
@@ -426,6 +451,82 @@ def _node_labels_for_types(graph: UnifiedGraph, path_hops: list[str], entity_typ
 
 def _finding_ids_for_path(graph: UnifiedGraph, path_hops: list[str], vuln_ids: list[str]) -> list[str]:
     return _finding_ids_for_nodes(graph.nodes, path_hops, vuln_ids)
+
+
+def _finding_labels_for_path(graph: UnifiedGraph, path_hops: list[str], vuln_ids: list[str]) -> list[str]:
+    """Return operator-readable advisory/node labels, never canonical UUIDs."""
+    from agent_bom.graph.asset_entity import finding_id_from_node_attributes
+
+    labels: list[str] = []
+    seen: set[str] = set()
+
+    def add(value: object) -> None:
+        text = str(value or "").strip()
+        if not text or text.lower() in seen:
+            return
+        labels.append(text)
+        seen.add(text.lower())
+
+    for hop in path_hops:
+        node = graph.nodes.get(hop)
+        if not node or node.entity_type not in {EntityType.VULNERABILITY, EntityType.MISCONFIGURATION}:
+            continue
+        attrs = node.attributes if isinstance(node.attributes, dict) else {}
+        canonical = finding_id_from_node_attributes(attrs)
+        for key in ("cve_id", "vulnerability_id", "advisory_id", "rule_id", "title"):
+            if attrs.get(key):
+                add(attrs[key])
+                break
+        else:
+            if node.label and node.label != canonical:
+                add(node.label)
+    for value in vuln_ids:
+        if value and value not in _finding_ids_for_nodes(graph.nodes, path_hops, []):
+            add(value)
+    return labels
+
+
+def _identity_finding_ids_for_path(graph: UnifiedGraph, path: AttackPath) -> list[str]:
+    """Canonical finding identities, falling back to advisory ids on legacy rows."""
+    from agent_bom.graph.asset_entity import finding_id_from_node_attributes
+
+    stamped = [
+        finding_id
+        for hop in path.hops
+        if (node := graph.nodes.get(hop)) is not None
+        if (finding_id := finding_id_from_node_attributes(node.attributes if isinstance(node.attributes, dict) else None))
+    ]
+    candidates = stamped or list(path.finding_ids) or _finding_ids_for_path(graph, path.hops, path.vuln_ids)
+    return list(dict.fromkeys(value for value in candidates if value))
+
+
+def _node_ids_for_types(graph: UnifiedGraph, path_hops: list[str], entity_types: set[EntityType]) -> list[str]:
+    return sorted({hop for hop in path_hops if (node := graph.nodes.get(hop)) is not None and node.entity_type in entity_types})
+
+
+def _path_identity(path: AttackPath) -> str:
+    return f"{path.source}::{path.target}::{'->'.join(path.hops)}"
+
+
+def _path_semantic_key(graph: UnifiedGraph, path: AttackPath) -> str:
+    """Stable presentation identity; asset/agent dimensions prevent over-collapse."""
+    findings = sorted(label.lower() for label in _finding_labels_for_path(graph, path.hops, path.vuln_ids))
+    if not findings:
+        findings = sorted(_identity_finding_ids_for_path(graph, path)) or [path.target]
+    agents = _node_ids_for_types(
+        graph,
+        path.hops,
+        {EntityType.AGENT, EntityType.USER, EntityType.GROUP, EntityType.SERVICE_ACCOUNT},
+    ) or [path.source]
+    packages = _node_ids_for_types(graph, path.hops, {EntityType.PACKAGE})
+    assets = _node_ids_for_types(graph, path.hops, {EntityType.SERVER, EntityType.CONTAINER, EntityType.CLOUD_RESOURCE})
+    parts = (
+        ("finding", findings),
+        ("agent", agents),
+        ("package", packages),
+        ("asset", assets),
+    )
+    return "&".join(f"{name}={quote(','.join(values), safe='')}" for name, values in parts)
 
 
 def _finding_ids_for_nodes(nodes: dict[str, Any], path_hops: list[str], vuln_ids: list[str]) -> list[str]:
@@ -647,8 +748,13 @@ def _risk_reasons_for_path(graph: UnifiedGraph, path: AttackPath) -> list[dict[s
     return reasons[:4]
 
 
-def _next_actions_for_path(graph: UnifiedGraph, path: AttackPath) -> list[dict[str, str]]:
-    findings = _finding_ids_for_path(graph, path.hops, path.vuln_ids)
+def _next_actions_for_path(
+    graph: UnifiedGraph,
+    path: AttackPath,
+    *,
+    finding_ids: list[str] | None = None,
+) -> list[dict[str, str]]:
+    findings = finding_ids if finding_ids is not None else _identity_finding_ids_for_path(graph, path)
     agents = _node_labels_for_types(
         graph,
         path.hops,
@@ -656,11 +762,16 @@ def _next_actions_for_path(graph: UnifiedGraph, path: AttackPath) -> list[dict[s
     )
     actions: list[dict[str, str]] = []
     if findings:
+        finding_href = (
+            f"/findings?cve={quote(findings[0])}"
+            if findings[0].upper().startswith(("CVE-", "GHSA-"))
+            else f"/findings?finding={quote(findings[0])}"
+        )
         actions.append(
             {
                 "title": "Validate lead finding",
                 "detail": "Open the first finding and confirm the root cause before expanding the graph.",
-                "href": f"/findings?cve={quote(findings[0])}",
+                "href": finding_href,
             }
         )
     if agents:
@@ -703,8 +814,14 @@ def _fix_first_card_for_path(
     rank: int,
     *,
     edge_lookup: _EdgeLookup | None = None,
+    occurrence_paths: list[AttackPath] | None = None,
 ) -> dict:
-    findings = _finding_ids_for_path(graph, path.hops, path.vuln_ids)
+    grouped_paths = occurrence_paths or [path]
+    findings = list(dict.fromkeys(finding for item in grouped_paths for finding in _identity_finding_ids_for_path(graph, item)))
+    finding_labels = list(
+        dict.fromkeys(label for item in grouped_paths for label in _finding_labels_for_path(graph, item.hops, item.vuln_ids))
+    )
+    occurrence_path_ids = list(dict.fromkeys(_path_identity(item) for item in grouped_paths))
     agents = _node_labels_for_types(
         graph,
         path.hops,
@@ -713,13 +830,18 @@ def _fix_first_card_for_path(
     servers = _node_labels_for_types(graph, path.hops, {EntityType.SERVER, EntityType.CONTAINER, EntityType.CLOUD_RESOURCE})
     packages = _node_labels_for_types(graph, path.hops, {EntityType.PACKAGE})
     sequence = [graph.nodes[hop].label for hop in path.hops if hop in graph.nodes]
-    title_parts = [findings[0] if findings else "Exposure path"]
+    target_node = graph.nodes.get(path.target)
+    display_finding = finding_labels[0] if finding_labels else target_node.label if target_node and target_node.label else "Exposure path"
+    title_parts = [display_finding]
     if agents:
         title_parts.append(f"via {agents[0]}")
     if path.tool_exposure:
         title_parts.append(f"with {path.tool_exposure[0]}")
     return {
-        "id": f"{path.source}::{path.target}::{'->'.join(path.hops)}",
+        "id": _path_identity(path),
+        "semantic_key": _path_semantic_key(graph, path),
+        "occurrence_count": len(grouped_paths),
+        "occurrence_path_ids": occurrence_path_ids,
         "rank": rank,
         "title": " ".join(title_parts),
         "summary": path.summary or "Review this path before opening the full topology graph.",
@@ -735,12 +857,13 @@ def _fix_first_card_for_path(
         "nodes": [graph.nodes[hop].to_dict() for hop in path.hops if hop in graph.nodes],
         "sequence_labels": sequence,
         "risk_reasons": _risk_reasons_for_path(graph, path),
-        "next_actions": _next_actions_for_path(graph, path),
+        "next_actions": _next_actions_for_path(graph, path, finding_ids=findings),
         "affected": {
             "agents": agents,
             "servers": servers,
             "packages": packages,
             "findings": findings,
+            "finding_labels": finding_labels,
             "credentials": list(path.credential_exposure),
             "tools": list(path.tool_exposure),
         },
@@ -1859,10 +1982,27 @@ def _fix_first_graph_view_payload(graph: UnifiedGraph, *, cve: str, package: str
         key=lambda path: path_rank_tuple(graph, path),
         reverse=True,
     )
+    presentation_paths: list[tuple[AttackPath, list[AttackPath]]] = []
+    presentation_index: dict[str, int] = {}
+    for path in ranked_paths:
+        semantic_key = _path_semantic_key(graph, path)
+        existing = presentation_index.get(semantic_key)
+        if existing is None:
+            presentation_index[semantic_key] = len(presentation_paths)
+            presentation_paths.append((path, [path]))
+        else:
+            presentation_paths[existing][1].append(path)
+
     cards = []
     edge_lookup = _build_edge_lookup(graph.edges)
-    for index, path in enumerate(ranked_paths[:limit]):
-        card = _fix_first_card_for_path(graph, path, index + 1, edge_lookup=edge_lookup)
+    for index, (path, occurrence_paths) in enumerate(presentation_paths[:limit]):
+        card = _fix_first_card_for_path(
+            graph,
+            path,
+            index + 1,
+            edge_lookup=edge_lookup,
+            occurrence_paths=occurrence_paths,
+        )
         card["rank_meta"] = criticality_rank_meta(graph, path)
         cards.append(card)
     covered_findings = {finding for card in cards for finding in card["affected"]["findings"]}
@@ -1877,6 +2017,8 @@ def _fix_first_graph_view_payload(graph: UnifiedGraph, *, cve: str, package: str
         "summary": {
             "total_paths": len(available_paths),
             "matched_paths": len(ranked_paths),
+            "presentation_paths": len(presentation_paths),
+            "collapsed_occurrences": len(ranked_paths) - len(presentation_paths),
             "returned_paths": len(cards),
             "highest_risk": cards[0]["attack_path"]["composite_risk"] if cards else 0.0,
             "covered_findings": len(covered_findings),
@@ -1891,9 +2033,9 @@ def _fix_first_graph_view_payload(graph: UnifiedGraph, *, cve: str, package: str
         },
         "completeness": graph_completeness(
             returned=len(cards),
-            total=len(ranked_paths),
-            truncated=len(ranked_paths) > len(cards),
-            reason="path_card_limit" if len(ranked_paths) > len(cards) else "",
+            total=len(presentation_paths),
+            truncated=len(presentation_paths) > len(cards),
+            reason="path_card_limit" if len(presentation_paths) > len(cards) else "",
         ),
     }
 

--- a/src/agent_bom/graph/path_ranking.py
+++ b/src/agent_bom/graph/path_ranking.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from agent_bom.graph.severity import severity_rank
 from agent_bom.risk_analyzer import CAPABILITY_WEIGHTS, ToolCapability
 
 if TYPE_CHECKING:
@@ -17,6 +18,12 @@ if TYPE_CHECKING:
 
 _PROD_ENVIRONMENTS = frozenset({"prod", "production", "prd", "live"})
 _STAGING_ENVIRONMENTS = frozenset({"staging", "stage", "preprod", "pre-production"})
+_REACHABILITY_ORDER = {
+    "unlikely": 0,
+    "unknown": 1,
+    "likely": 2,
+    "confirmed": 3,
+}
 
 
 def environment_weight(node: UnifiedNode) -> float:
@@ -59,8 +66,13 @@ def tool_capability_boost(node: UnifiedNode) -> float:
     return min(8.0, max(weights) * 0.8)
 
 
-def path_rank_tuple(graph: UnifiedGraph, path: AttackPath) -> tuple[float, float, int, int, int]:
-    """Sort key for fix-first ranking (higher is worse / fix first)."""
+def path_rank_tuple(graph: UnifiedGraph, path: AttackPath) -> tuple[int, float, float, int, int, int]:
+    """Sort key for fix-first ranking (higher is worse / fix first).
+
+    Reachability is an ordinal evidence tier, not a new arithmetic score:
+    confirmed > likely > unknown > unlikely. Existing composite risk,
+    environment, and capability weighting remain unchanged within each tier.
+    """
     env_mult = 1.0
     cap_boost = 0.0
     for hop in path.hops:
@@ -71,6 +83,7 @@ def path_rank_tuple(graph: UnifiedGraph, path: AttackPath) -> tuple[float, float
         cap_boost = max(cap_boost, tool_capability_boost(node))
     weighted_risk = float(path.composite_risk) * env_mult + cap_boost
     return (
+        _REACHABILITY_ORDER.get(str(path.reachability).strip().lower(), _REACHABILITY_ORDER["unknown"]),
         weighted_risk,
         float(path.composite_risk),
         len(path.hops),
@@ -84,12 +97,16 @@ def criticality_rank_meta(graph: UnifiedGraph, path: AttackPath) -> dict[str, ob
     environments: list[str] = []
     capabilities: list[str] = []
     max_env = 1.0
+    raw_severity = "unknown"
     for hop in path.hops:
         node = graph.nodes.get(hop)
         if node is None:
             continue
         max_env = max(max_env, environment_weight(node))
         attrs = node.attributes or {}
+        severity = str(getattr(node, "severity", "") or "").strip().lower()
+        if severity and severity_rank(severity) > severity_rank(raw_severity):
+            raw_severity = severity
         env = attrs.get("environment") or getattr(getattr(node, "dimensions", None), "environment", "")
         if isinstance(env, str) and env and env not in environments:
             environments.append(env)
@@ -102,6 +119,8 @@ def criticality_rank_meta(graph: UnifiedGraph, path: AttackPath) -> dict[str, ob
                     if text and text not in capabilities:
                         capabilities.append(text)
     return {
+        "reachability": str(path.reachability or "unknown").strip().lower(),
+        "raw_severity": raw_severity,
         "environment_weight": round(max_env, 3),
         "environments": environments[:4],
         "tool_capabilities": capabilities[:8],

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -1817,6 +1817,8 @@ class TestGraphStoreBackendSelection:
         assert body["cards"][0]["exposure_path"]["reachableTools"] == ["run_shell"]
         assert body["cards"][0]["exposure_path"]["reachability"] == "confirmed"
         assert body["cards"][0]["exposure_path"]["reachabilityBasis"] == ["graph_path"]
+        assert body["cards"][0]["rank_meta"]["reachability"] == "confirmed"
+        assert body["cards"][0]["rank_meta"]["raw_severity"] == "critical"
         assert {reason["kind"] for reason in body["cards"][0]["risk_reasons"]} >= {
             "critical_reach",
             "credential_exposure",
@@ -1824,6 +1826,74 @@ class TestGraphStoreBackendSelection:
         }
         assert body["cards"][0]["next_actions"][0]["href"] == "/findings?cve=CVE-2026-1"
         assert any(call[0] == "load_graph" for call in recording_graph_store.calls)
+
+    def test_fix_first_cards_dedupe_presentational_duplicates_but_keep_identity_and_assets(self, recording_graph_store):
+        graph = recording_graph_store.graph
+        graph.add_node(UnifiedNode(id="agent:b", entity_type=EntityType.AGENT, label="agent-b"))
+        graph.add_node(UnifiedNode(id="server:one", entity_type=EntityType.SERVER, label="asset-one"))
+        graph.add_node(UnifiedNode(id="server:two", entity_type=EntityType.SERVER, label="asset-two"))
+        graph.add_node(UnifiedNode(id="pkg:shared", entity_type=EntityType.PACKAGE, label="shared-lib"))
+        graph.add_node(
+            UnifiedNode(
+                id="vuln:uuid",
+                entity_type=EntityType.VULNERABILITY,
+                label="CVE-2026-4242",
+                severity="critical",
+                attributes={"finding_id": "8ac0c0e8-cc5a-4a7c-aad8-e9b26c7b10d2"},
+            )
+        )
+        graph.add_node(
+            UnifiedNode(
+                id="vuln:uuid-2",
+                entity_type=EntityType.VULNERABILITY,
+                label="CVE-2026-4242",
+                severity="critical",
+                attributes={"finding_id": "6a1e5de4-20ad-4afd-8e3f-e5bb690df5ac"},
+            )
+        )
+
+        def add_path(agent: str, server: str, *, summary: str, finding_node: str = "vuln:uuid") -> None:
+            finding_id = str(graph.nodes[finding_node].attributes["finding_id"])
+            graph.attack_paths.append(
+                AttackPath(
+                    source=agent,
+                    target=finding_node,
+                    hops=[agent, server, "pkg:shared", finding_node],
+                    edges=["uses", "depends_on", "vulnerable_to"],
+                    composite_risk=91.0,
+                    summary=summary,
+                    vuln_ids=["CVE-2026-4242"],
+                    finding_ids=[finding_id],
+                    reachability="confirmed",
+                )
+            )
+
+        add_path("agent:a", "server:one", summary="stored occurrence one")
+        add_path("agent:a", "server:one", summary="stored occurrence duplicate")
+        add_path("agent:a", "server:one", summary="distinct stored finding", finding_node="vuln:uuid-2")
+        add_path("agent:b", "server:one", summary="different agent")
+        add_path("agent:a", "server:two", summary="different asset")
+
+        response = TestClient(app).get("/v1/graph/views/fix-first", params={"scan_id": "store-scan", "limit": 10})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(graph.attack_paths) == 5
+        assert body["summary"]["matched_paths"] == 5
+        assert body["summary"]["presentation_paths"] == 3
+        assert body["summary"]["collapsed_occurrences"] == 2
+        assert len(body["cards"]) == 3
+        duplicate_card = next(card for card in body["cards"] if card["occurrence_count"] == 3)
+        assert duplicate_card["title"].startswith("CVE-2026-4242 via agent-a")
+        assert duplicate_card["affected"]["findings"] == [
+            "8ac0c0e8-cc5a-4a7c-aad8-e9b26c7b10d2",
+            "6a1e5de4-20ad-4afd-8e3f-e5bb690df5ac",
+        ]
+        assert duplicate_card["affected"]["finding_labels"] == ["CVE-2026-4242"]
+        assert duplicate_card["next_actions"][0]["href"] == ("/findings?finding=8ac0c0e8-cc5a-4a7c-aad8-e9b26c7b10d2")
+        assert len({card["semantic_key"] for card in body["cards"]}) == 3
+        assert {tuple(card["affected"]["agents"]) for card in body["cards"]} == {("agent-a",), ("agent-b",)}
+        assert {tuple(card["affected"]["servers"]) for card in body["cards"]} == {("asset-one",), ("asset-two",)}
 
     def test_fix_first_graph_view_derives_paths_when_snapshot_has_topology_but_no_path_rows(self, recording_graph_store):
         recording_graph_store.graph.add_node(UnifiedNode(id="server:a:fs", entity_type=EntityType.SERVER, label="mcp-fs"))

--- a/tests/test_graph_path_ranking.py
+++ b/tests/test_graph_path_ranking.py
@@ -86,3 +86,42 @@ def test_path_rank_tuple_raises_prod_paths_above_dev() -> None:
     meta = criticality_rank_meta(graph, high)
     assert "production" in meta["environments"]
     assert "execute" in meta["tool_capabilities"]
+
+
+def test_path_rank_tuple_orders_reachability_without_overwriting_raw_severity() -> None:
+    """Equal-risk findings rank by evidence strength, while severity stays raw."""
+    graph = UnifiedGraph(scan_id="s", tenant_id="default", created_at="2026-08-24T00:00:00Z")
+    graph.add_node(
+        UnifiedNode(
+            id="finding",
+            entity_type=EntityType.VULNERABILITY,
+            label="CVE-2026-4242",
+            severity="critical",
+        )
+    )
+
+    def path(reachability: str) -> AttackPath:
+        return AttackPath(
+            source="finding",
+            target="finding",
+            hops=["finding"],
+            edges=[],
+            composite_risk=80.0,
+            summary=reachability,
+            credential_exposure=[],
+            tool_exposure=[],
+            vuln_ids=["CVE-2026-4242"],
+            reachability=reachability,
+        )
+
+    confirmed = path("confirmed")
+    likely = path("likely")
+    unknown = path("unknown")
+    unlikely = path("unlikely")
+
+    assert path_rank_tuple(graph, confirmed) > path_rank_tuple(graph, likely)
+    assert path_rank_tuple(graph, likely) > path_rank_tuple(graph, unknown)
+    assert path_rank_tuple(graph, unknown) > path_rank_tuple(graph, unlikely)
+    meta = criticality_rank_meta(graph, confirmed)
+    assert meta["reachability"] == "confirmed"
+    assert meta["raw_severity"] == "critical"

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -63,6 +63,7 @@ import {
   buildGraphInvestigationHref,
   buildSecurityGraphHref,
   descriptiveAttackPathTitle,
+  dedupeAttackPathsForPresentation,
   investigationRootForAttackPath,
   labelsForAttackPathType,
   matchesAttackPathFocus,
@@ -361,9 +362,10 @@ function AttackPathInvestigationContent() {
     [campaigns, selectedCampaignId],
   );
 
-  // Authoritative queue is the attack-paths API (offset + has_more). Fix-first
-  // cards enrich titles/actions but must not silently cap the global queue at
-  // FIX_FIRST_CARD_LIMIT when more ranked paths exist server-side.
+  // The attack-paths API remains the authoritative paginated occurrence queue.
+  // Fix-first cards supply the evidence-calibrated presentation order for the
+  // initial shortlist; append every non-enriched occurrence so this never caps
+  // the global queue at FIX_FIRST_CARD_LIMIT.
   const allAttackPaths = useMemo(() => {
     const fromApi = [...(graphData?.attack_paths ?? [])].sort(
       (left, right) => right.composite_risk - left.composite_risk,
@@ -371,20 +373,21 @@ function AttackPathInvestigationContent() {
     const fromFixFirst = fixFirstCards.map((card) => card.attack_path);
     const focusedApiPaths = fromApi.filter((path) => matchesAttackPathFocus(path, graphNodeById, focus));
     const focusedEnrichedPaths = fromFixFirst.filter((path) => matchesAttackPathFocus(path, graphNodeById, focus));
-    const base = hasFocusContext
-      ? focusedApiPaths.length > 0
-        ? focusedApiPaths
-        : focusedEnrichedPaths
-      : fromApi.length > 0
-        ? fromApi
-        : fromFixFirst;
+    const enriched = hasFocusContext ? focusedEnrichedPaths : fromFixFirst;
+    const occurrences = hasFocusContext ? focusedApiPaths : fromApi;
+    const enrichedKeys = new Set(enriched.map(attackPathKey));
+    const base = [...enriched, ...occurrences.filter((path) => !enrichedKeys.has(attackPathKey(path)))];
     if (!selectedCampaign?.member_paths?.length) return base;
     const members = new Set(selectedCampaign.member_paths);
     return base.filter((path) => members.has(`${path.source}->${path.target}`));
   }, [fixFirstCards, focus, graphData?.attack_paths, graphNodeById, hasFocusContext, selectedCampaign]);
+  const presentationAttackPaths = useMemo(
+    () => dedupeAttackPathsForPresentation(allAttackPaths, graphNodeById),
+    [allAttackPaths, graphNodeById],
+  );
   const attackPaths = useMemo(
-    () => filterAttackPathsForInvestigation(allAttackPaths, graphNodeById, investigationFilters),
-    [allAttackPaths, graphNodeById, investigationFilters],
+    () => filterAttackPathsForInvestigation(presentationAttackPaths, graphNodeById, investigationFilters),
+    [graphNodeById, investigationFilters, presentationAttackPaths],
   );
   const pathEnvironments = useMemo(
     () => collectPathEnvironments(allAttackPaths, graphNodeById),

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -345,6 +345,8 @@ export interface FixFirstAction {
 }
 
 export interface FixFirstRankMeta {
+  reachability?: "confirmed" | "likely" | "unknown" | "unlikely" | string;
+  raw_severity?: string;
   environment_weight?: number;
   environments?: string[];
   tool_capabilities?: string[];
@@ -352,6 +354,9 @@ export interface FixFirstRankMeta {
 
 export interface FixFirstPathCard {
   id: string;
+  semantic_key?: string;
+  occurrence_count?: number;
+  occurrence_path_ids?: string[];
   rank: number;
   title: string;
   summary: string;
@@ -367,6 +372,7 @@ export interface FixFirstPathCard {
     servers: string[];
     packages: string[];
     findings: string[];
+    finding_labels?: string[];
     credentials: string[];
     tools: string[];
   };

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -66,6 +66,65 @@ export function attackPathKey(path: AttackPath): string {
   return `${path.source}::${path.target}::${path.hops.join("->")}`;
 }
 
+function pathNodeIdsForTypes(
+  path: AttackPath,
+  nodeById: Map<string, UnifiedNode>,
+  entityTypes: ReadonlySet<string>,
+): string[] {
+  return [...new Set(
+    path.hops.filter((hop) => {
+      const node = nodeById.get(hop);
+      return node ? entityTypes.has(String(node.entity_type)) : false;
+    }),
+  )].sort();
+}
+
+/** Stable presentation key without mutating or collapsing stored path rows. */
+export function attackPathPresentationKey(
+  path: AttackPath,
+  nodeById: Map<string, UnifiedNode>,
+): string {
+  const findingNodeLabels = path.hops.flatMap((hop) => {
+    const node = nodeById.get(hop);
+    if (!node || ![EntityType.VULNERABILITY, EntityType.MISCONFIGURATION].includes(node.entity_type as EntityType)) {
+      return [];
+    }
+    return [node.label.trim().toLowerCase()];
+  });
+  const advisoryLabels = path.vuln_ids.map((value) => value.trim().toLowerCase()).filter(Boolean);
+  const findings = [...new Set(advisoryLabels.length ? advisoryLabels : findingNodeLabels)].sort();
+  const agents = pathNodeIdsForTypes(
+    path,
+    nodeById,
+    new Set([EntityType.AGENT, EntityType.USER, EntityType.GROUP, EntityType.SERVICE_ACCOUNT]),
+  );
+  const packages = pathNodeIdsForTypes(path, nodeById, new Set([EntityType.PACKAGE]));
+  const assets = pathNodeIdsForTypes(
+    path,
+    nodeById,
+    new Set([EntityType.SERVER, EntityType.CONTAINER, EntityType.CLOUD_RESOURCE]),
+  );
+  return JSON.stringify({
+    finding: findings.length ? findings : path.finding_ids?.length ? [...path.finding_ids].sort() : [path.target],
+    agent: agents.length ? agents : [path.source],
+    package: packages,
+    asset: assets,
+  });
+}
+
+export function dedupeAttackPathsForPresentation(
+  paths: AttackPath[],
+  nodeById: Map<string, UnifiedNode>,
+): AttackPath[] {
+  const seen = new Set<string>();
+  return paths.filter((path) => {
+    const key = attackPathPresentationKey(path, nodeById);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 export function moveAttackPathSelection(
   attackPaths: AttackPath[],
   currentKey: string | null,

--- a/ui/lib/dashboard-data.ts
+++ b/ui/lib/dashboard-data.ts
@@ -267,6 +267,7 @@ export function buildExposurePathView(
   scanId?: string,
   _index?: number,
 ): ExposurePathView {
+  void _index; // Retain call compatibility; identity must not depend on fetch order.
   const agents = blastAgents(blast);
   const credentials = blastCredentials(blast);
   const nodes: ExposurePathView["nodes"] = [
@@ -315,6 +316,7 @@ export function buildTopRiskExposurePath(
   risk: OverviewTopRisk,
   _index?: number,
 ): ExposurePathView {
+  void _index; // Retain call compatibility; identity must not depend on fetch order.
   const severity = (risk.severity || "").trim().toLowerCase();
   const nodes: ExposurePathView["nodes"] = [
     severity

--- a/ui/lib/dashboard-data.ts
+++ b/ui/lib/dashboard-data.ts
@@ -237,16 +237,35 @@ export function blastAgents(blast: BlastRadius): string[] {
   return blast.affected_agents ?? [];
 }
 
+function execExposureSemanticKey(
+  finding: string,
+  packageName?: string | null,
+  agent?: string | null,
+  asset?: string | null,
+): string {
+  const dimensions = [finding, packageName || "unknown", agent || "unknown", asset || "unknown"];
+  return dimensions.map((value) => encodeURIComponent(value.trim().toLowerCase())).join("::");
+}
+
+function execExposureAggregateKey(
+  finding: string,
+  packageName?: string | null,
+  agent?: string | null,
+): string {
+  return execExposureSemanticKey(finding, packageName, agent, null);
+}
+
 /**
  * Build the exec→graph exposure-path row for a finding. Threads the finding's
  * own `scanId` into the security-graph drill so the drill lands on the scan
  * that produced the finding — not whichever scan happens to be latest (#3966).
- * `index` disambiguates the key within a shortlist; omit it for a single row.
+ * The key is semantic and stable across fetch order. Identical presentations
+ * dedupe while a different agent or asset remains a distinct occurrence.
  */
 export function buildExposurePathView(
   blast: BlastRadius,
   scanId?: string,
-  index?: number,
+  _index?: number,
 ): ExposurePathView {
   const agents = blastAgents(blast);
   const credentials = blastCredentials(blast);
@@ -259,9 +278,13 @@ export function buildExposurePathView(
   }
   if (agents.length > 0) nodes.push({ type: "agent", label: agents[0]! });
   if (credentials.length > 0) nodes.push({ type: "credential", label: credentials[0]! });
-  const baseKey = `${blast.vulnerability_id}:${blast.package ?? "unknown"}`;
   return {
-    key: index === undefined ? baseKey : `${baseKey}:${index}`,
+    key: execExposureSemanticKey(
+      blast.vulnerability_id,
+      blast.package,
+      agents[0],
+      blast.affected_servers?.[0],
+    ),
     nodes,
     riskScore: blast.risk_score ?? blast.blast_score / 10,
     href: buildSecurityGraphHref({
@@ -290,7 +313,7 @@ const CVE_ID_PATTERN = /^CVE-\d{4}-\d{4,}$/i;
  */
 export function buildTopRiskExposurePath(
   risk: OverviewTopRisk,
-  index?: number,
+  _index?: number,
 ): ExposurePathView {
   const severity = (risk.severity || "").trim().toLowerCase();
   const nodes: ExposurePathView["nodes"] = [
@@ -308,9 +331,8 @@ export function buildTopRiskExposurePath(
       ? `/findings?severity=${encodeURIComponent(severity)}`
       : "/findings";
 
-  const baseKey = `${risk.vulnerability_id}:${risk.package ?? "unknown"}`;
   return {
-    key: index === undefined ? baseKey : `${baseKey}:${index}`,
+    key: execExposureSemanticKey(risk.vulnerability_id, risk.package, agent),
     nodes,
     riskScore: risk.risk_score ?? 0,
     href,
@@ -323,8 +345,10 @@ export function buildTopRiskExposurePath(
  * richest chain (server/credential hops) plus the scan→graph drill, so they lead;
  * the server-reconciled `overview.top_risks` — the authoritative source that also
  * covers hub/bulk-ingested findings, which never create scan jobs — contributes
- * any risk not already represented by a scan blast. Deduped by `vulnerability_id`
- * so scan and hub are never double-counted; ranked worst-first and capped.
+ * any risk not already represented by a scan blast. Presentation rows dedupe
+ * by finding + package + agent + asset; the aggregate overview copy is removed
+ * when a richer scan occurrence covers its finding/package/agent. Different
+ * agents or assets remain distinct. Ranked worst-first and capped.
  */
 export function buildExecExposurePaths(
   allBlast: (BlastRadius & { scanId?: string })[],
@@ -334,13 +358,30 @@ export function buildExecExposurePaths(
   const blastRanked = [...allBlast].sort(
     (a, b) => (b.risk_score ?? b.blast_score) - (a.risk_score ?? a.blast_score),
   );
-  const blastViews = blastRanked.map((blast, index) =>
-    buildExposurePathView(blast, blast.scanId, index),
+  const seen = new Set<string>();
+  const blastViews = blastRanked.flatMap((blast, index) => {
+    const view = buildExposurePathView(blast, blast.scanId, index);
+    if (seen.has(view.key)) return [];
+    seen.add(view.key);
+    return [view];
+  });
+  const covered = new Set(
+    blastRanked.map((blast) =>
+      execExposureAggregateKey(blast.vulnerability_id, blast.package, blastAgents(blast)[0]),
+    ),
   );
-  const covered = new Set(blastRanked.map((b) => b.vulnerability_id).filter(Boolean));
   const topRiskViews = (topRisks ?? [])
-    .filter((r) => r.vulnerability_id && !covered.has(r.vulnerability_id))
-    .map((risk, index) => buildTopRiskExposurePath(risk, blastViews.length + index));
+    .filter(
+      (risk) =>
+        risk.vulnerability_id &&
+        !covered.has(execExposureAggregateKey(risk.vulnerability_id, risk.package, risk.affected_agents?.[0])),
+    )
+    .flatMap((risk, index) => {
+      const view = buildTopRiskExposurePath(risk, blastViews.length + index);
+      if (seen.has(view.key)) return [];
+      seen.add(view.key);
+      return [view];
+    });
   return [...blastViews, ...topRiskViews]
     .sort((a, b) => b.riskScore - a.riskScore)
     .slice(0, limit);

--- a/ui/lib/graph-schema.ts
+++ b/ui/lib/graph-schema.ts
@@ -400,6 +400,9 @@ export interface AttackPath {
   vuln_ids: string[];
   /** Stable Finding.id anchors when stamped (preferred over CVE labels). */
   finding_ids?: string[];
+  /** Executability evidence tier; optional on legacy graph snapshots. */
+  reachability?: "confirmed" | "likely" | "unknown" | "unlikely" | string;
+  reachability_basis?: string[];
   /**
    * Potential ATT&CK/ATLAS techniques mapped from this path's observed
    * evidence, ordered by hop. Optional so older graph snapshots without the

--- a/ui/tests/attack-paths.test.ts
+++ b/ui/tests/attack-paths.test.ts
@@ -8,6 +8,7 @@ import {
   buildSecurityGraphHref,
   decodeGraphInvestigationParams,
   descriptiveAttackPathTitle,
+  dedupeAttackPathsForPresentation,
   investigationRootForAttackPath,
   labelsForAttackPathType,
   mapAttackPathChainType,
@@ -297,6 +298,45 @@ describe("attack path helpers", () => {
       "Finding B via agent-b",
     ]);
     expect(rankedAttackPathRows([pathB], cards)[0]?.card?.title).toBe("Finding B via agent-b");
+  });
+
+  it("dedupes the queue by finding, agent, package, and asset", () => {
+    const nodes = new Map<string, UnifiedNode>([
+      ["finding", graphNode("finding", EntityType.VULNERABILITY, "CVE-2026-4242")],
+      ["agent-a", graphNode("agent-a", EntityType.AGENT, "Agent A")],
+      ["agent-b", graphNode("agent-b", EntityType.AGENT, "Agent B")],
+      ["asset-a", graphNode("asset-a", EntityType.SERVER, "Asset A")],
+      ["asset-b", graphNode("asset-b", EntityType.SERVER, "Asset B")],
+      ["package", graphNode("package", EntityType.PACKAGE, "shared")],
+    ]);
+    const path = (agent: string, asset: string, summary: string): AttackPath => ({
+      source: agent,
+      target: "finding",
+      hops: [agent, asset, "package", "finding"],
+      edges: [],
+      composite_risk: 90,
+      summary,
+      credential_exposure: [],
+      tool_exposure: [],
+      vuln_ids: ["CVE-2026-4242"],
+      finding_ids: ["finding-uuid"],
+    });
+
+    const deduped = dedupeAttackPathsForPresentation(
+      [
+        path("agent-a", "asset-a", "first occurrence"),
+        path("agent-a", "asset-a", "duplicate occurrence"),
+        path("agent-b", "asset-a", "different agent"),
+        path("agent-a", "asset-b", "different asset"),
+      ],
+      nodes,
+    );
+
+    expect(deduped.map((item) => item.summary)).toEqual([
+      "first occurrence",
+      "different agent",
+      "different asset",
+    ]);
   });
 
   it("builds a focused security-graph href from canonical context", () => {

--- a/ui/tests/dashboard-data.test.ts
+++ b/ui/tests/dashboard-data.test.ts
@@ -53,9 +53,10 @@ describe("buildExposurePathView", () => {
     expect(view.href).not.toContain("scan=");
   });
 
-  it("builds the node chain and key, appending an index when provided", () => {
+  it("builds the node chain with a stable semantic key", () => {
     const view = buildExposurePathView(makeBlast(), "scan-1", 3);
-    expect(view.key).toBe("CVE-2026-0002:flask:3");
+    expect(view.key).toBe("cve-2026-0002::flask::claude%20desktop::mcp-fs");
+    expect(buildExposurePathView(makeBlast(), "scan-1", 99).key).toBe(view.key);
     expect(view.riskScore).toBe(9.1);
     expect(view.nodes).toEqual([
       { type: "cve", label: "CVE-2026-0002", severity: "critical" },
@@ -68,7 +69,7 @@ describe("buildExposurePathView", () => {
 
   it("uses an index-less key for a single row", () => {
     const view = buildExposurePathView(makeBlast({ package: undefined }), "scan-1");
-    expect(view.key).toBe("CVE-2026-0002:unknown");
+    expect(view.key).toBe("cve-2026-0002::unknown::claude%20desktop::mcp-fs");
     // Package hop dropped when absent; scan still threaded.
     expect(view.href).toBe(
       "/security-graph?scan=scan-1&cve=CVE-2026-0002&agent=Claude+Desktop",
@@ -80,7 +81,7 @@ describe("buildTopRiskExposurePath", () => {
   it("maps an OverviewTopRisk into a CVE→package→agent chain (#4063)", () => {
     const view = buildTopRiskExposurePath(makeTopRisk(), 0);
     expect(view.riskScore).toBe(9.4);
-    expect(view.key).toBe("CVE-2026-9001:requests:0");
+    expect(view.key).toBe("cve-2026-9001::requests::ingest%20bot::unknown");
     expect(view.nodes).toEqual([
       { type: "cve", label: "CVE-2026-9001", severity: "critical" },
       { type: "package", label: "requests" },
@@ -108,7 +109,7 @@ describe("buildTopRiskExposurePath", () => {
     const view = buildTopRiskExposurePath(
       makeTopRisk({ package: null, affected_agents: [] }),
     );
-    expect(view.key).toBe("CVE-2026-9001:unknown");
+    expect(view.key).toBe("cve-2026-9001::unknown::unknown::unknown");
     expect(view.nodes).toEqual([
       { type: "cve", label: "CVE-2026-9001", severity: "critical" },
     ]);
@@ -135,7 +136,7 @@ describe("buildExecExposurePaths", () => {
       [{ ...makeBlast(), scanId: "scan-xyz" }],
       // The same CVE appears in top_risks (server folds the scan in) — must NOT
       // double-count, and the richer scan row (with scanId graph drill) wins.
-      [makeTopRisk({ vulnerability_id: "CVE-2026-0002" })],
+      [makeTopRisk({ vulnerability_id: "CVE-2026-0002", package: "flask", affected_agents: ["Claude Desktop"] })],
     );
     expect(paths).toHaveLength(1);
     expect(paths[0]!.href).toBe(
@@ -143,11 +144,16 @@ describe("buildExecExposurePaths", () => {
     );
   });
 
-  it("merges hub-only risks alongside scan blasts, deduped and ranked", () => {
+  it("merges hub-only risks alongside scan blasts, semantically deduped and ranked", () => {
     const paths = buildExecExposurePaths(
       [{ ...makeBlast({ vulnerability_id: "CVE-2026-0002", risk_score: 5.0 }), scanId: "s1" }],
       [
-        makeTopRisk({ vulnerability_id: "CVE-2026-0002", risk_score: 9.9 }), // dup of scan
+        makeTopRisk({
+          vulnerability_id: "CVE-2026-0002",
+          package: "flask",
+          affected_agents: ["Claude Desktop"],
+          risk_score: 9.9,
+        }), // semantic dup of scan
         makeTopRisk({ vulnerability_id: "CVE-2026-7777", risk_score: 8.0 }), // hub-only
       ],
     );
@@ -159,6 +165,30 @@ describe("buildExecExposurePaths", () => {
     // Hub-only risk drills to real finding rows.
     const hub = paths.find((p) => p.nodes[0]!.label === "CVE-2026-7777");
     expect(hub!.href).toBe("/findings?cve=CVE-2026-7777");
+  });
+
+  it("dedupes identical presentations but preserves different agents and assets", () => {
+    const duplicate = makeBlast({ vulnerability_id: "CVE-2026-5000", package: "shared" });
+    const paths = buildExecExposurePaths(
+      [
+        { ...duplicate, scanId: "s1" },
+        { ...duplicate, scanId: "s1" },
+        { ...duplicate, affected_agents: ["Other Agent"], scanId: "s1" },
+        { ...duplicate, affected_servers: ["other-server"], scanId: "s1" },
+      ],
+      [],
+      5,
+    );
+
+    expect(paths).toHaveLength(3);
+    expect(new Set(paths.map((path) => path.key)).size).toBe(3);
+    expect(paths.map((path) => path.nodes.map((node) => node.label))).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining(["Claude Desktop", "mcp-fs"]),
+        expect.arrayContaining(["Other Agent", "mcp-fs"]),
+        expect.arrayContaining(["Claude Desktop", "other-server"]),
+      ]),
+    );
   });
 
   it("returns an empty strip when there are genuinely no risks", () => {


### PR DESCRIPTION
## Summary

- Dedupe fix-first and executive operator cards by advisory, agent, package, and asset while retaining distinct stored occurrence IDs and counts.
- Use readable CVE/advisory/node titles for presentation and canonical UUIDs for identity and drill-through; preserve paths for distinct agents and assets.
- Rank confirmed, likely, unknown, and unlikely reachability as ordinal evidence tiers ahead of the existing risk ordering, while exposing raw severity separately.
- Keep the security graph queue complete: ranked presentation cards lead, then remaining stored occurrences continue through pagination.

## Verification

- `UV_CACHE_DIR=/private/tmp/agent-bom-pr3-uv-cache uv run pytest -q tests/test_graph_api.py tests/test_graph_path_ranking.py tests/graph/test_asset_entity.py` — 76 passed
- `UV_CACHE_DIR=/private/tmp/agent-bom-pr3-uv-cache make lint` — Ruff and MyPy passed (868 files)
- `UV_CACHE_DIR=/private/tmp/agent-bom-pr3-uv-cache make preflight` — passed
- `git diff --check` — passed
- `npm run verify:toolchain` — passed with Node 24.19.0 and npm 10.9.7
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm test -- --run` — 200 files, 1,240 tests passed
- `npm run build` — passed; 52 pages generated

## Notes

- Local demo-only browser smoke returned 6,802 nodes, 22,993 edges, and 2,155 stored paths; the ranked queue rendered readable advisory titles and the fix-first API returned 200. This is local evidence, not hosted proof.
