### PR TITLE
fix(reachability): analyze framework-registered tools

### DIFF
--- a/src/agent_bom/ast_models.py
+++ b/src/agent_bom/ast_models.py
@@ -43,6 +43,10 @@ class ToolSignature:
     line_number: int
     decorators: list[str] = field(default_factory=list)
     is_async: bool = False
+    handler: str = ""
+    registration_kind: str = ""
+    framework: str = ""
+    provenance: str = ""
 
 
 @dataclass
@@ -166,6 +170,16 @@ class ASTAnalysisResult:
                     "line": t.line_number,
                     "is_async": t.is_async,
                     "decorators": t.decorators,
+                    **(
+                        {
+                            "handler": t.handler,
+                            "registration_kind": t.registration_kind,
+                            "framework": t.framework,
+                            "provenance": t.provenance,
+                        }
+                        if t.registration_kind
+                        else {}
+                    ),
                 }
                 for t in self.tools
             ],
@@ -544,3 +558,17 @@ class _FunctionAnalysis:
     dangerous_calls: list[tuple[str, int, bool]] = field(default_factory=list)
     imported_modules: dict[str, str] = field(default_factory=dict, repr=False)
     imported_functions: dict[str, tuple[str, str]] = field(default_factory=dict, repr=False)
+    entrypoint_name: str = ""
+    entrypoint_kind: str = "mcp_tool"
+    entrypoint_framework: str = ""
+    entrypoint_provenance: str = ""
+
+
+@dataclass(frozen=True)
+class _PythonToolRegistration:
+    """Evidence-backed Python framework tool registration."""
+
+    tool_name: str
+    handler_name: str
+    framework: str
+    provenance: str

--- a/src/agent_bom/ast_python_analysis.py
+++ b/src/agent_bom/ast_python_analysis.py
@@ -18,6 +18,7 @@ from agent_bom.ast_models import (
     FlowFinding,
     ToolSignature,
     _FunctionAnalysis,
+    _PythonToolRegistration,
 )
 from agent_bom.ast_signal_utils import _GUARDRAIL_CALL_PATTERNS
 from agent_bom.ast_signal_utils import check_prompt_risks as _check_prompt_risks
@@ -134,6 +135,8 @@ _GUARDRAIL_IMPORTS = {
 # to it, so Python-only projects reported no framework.
 _FRAMEWORK_IMPORTS: dict[str, str] = {
     "langchain": "LangChain",
+    "langchain_core": "LangChain",
+    "langchain_community": "LangChain",
     "langgraph": "LangGraph",
     "crewai": "CrewAI",
     "autogen": "AutoGen",
@@ -376,6 +379,217 @@ def _call_name(node: ast.AST) -> str:
     if isinstance(node, ast.Call):
         return _call_name(node.func)
     return ""
+
+
+def _keyword_value(call: ast.Call, name: str) -> ast.expr | None:
+    for keyword in call.keywords:
+        if keyword.arg == name:
+            return keyword.value
+    return None
+
+
+_FRAMEWORK_TOOL_ROOTS: dict[str, str] = {
+    "langchain": "LangChain",
+    "langchain_core": "LangChain",
+    "langchain_community": "LangChain",
+    "langgraph": "LangGraph",
+    "crewai": "CrewAI",
+    "llama_index": "LlamaIndex",
+    "autogen": "AutoGen",
+    "autogen_agentchat": "AutoGen",
+    "pydantic_ai": "Pydantic AI",
+    "semantic_kernel": "Semantic Kernel",
+}
+_FRAMEWORK_AGENT_CONSTRUCTORS = frozenset(
+    {
+        "Agent",
+        "AgentExecutor",
+        "Crew",
+        "create_react_agent",
+        "create_openai_functions_agent",
+        "initialize_agent",
+    }
+)
+_FRAMEWORK_TOOL_CONSTRUCTORS = frozenset({"Tool", "StructuredTool", "FunctionTool", "DynamicTool", "ToolWrapper", "tool"})
+_FRAMEWORK_TOOL_HANDLER_KEYWORDS = ("func", "coroutine", "function", "callback", "handler")
+
+
+def _framework_for_imported_call(
+    call: ast.Call,
+    imported_modules: dict[str, str],
+    imported_functions: dict[str, tuple[str, str]],
+) -> str:
+    """Resolve a constructor's framework from explicit import evidence."""
+    call_name = _call_name(call.func)
+    head = call_name.split(".", 1)[0]
+    imported = imported_functions.get(head)
+    module_name = imported[0] if imported else imported_modules.get(head, "")
+    root = module_name.split(".", 1)[0]
+    return _FRAMEWORK_TOOL_ROOTS.get(root, "")
+
+
+def _canonical_imported_call_name(
+    call: ast.Call,
+    imported_functions: dict[str, tuple[str, str]],
+) -> str:
+    """Return a call name with a directly imported alias resolved."""
+    call_name = _call_name(call.func)
+    head, separator, tail = call_name.partition(".")
+    imported = imported_functions.get(head)
+    if imported is None:
+        return call_name
+    symbol = imported[1]
+    return f"{symbol}.{tail}" if separator and tail else symbol
+
+
+def _module_assignments(tree: ast.Module) -> dict[str, ast.expr]:
+    assignments: dict[str, ast.expr] = {}
+    for statement in tree.body:
+        if isinstance(statement, ast.Assign):
+            for target in statement.targets:
+                if isinstance(target, ast.Name):
+                    assignments[target.id] = statement.value
+        elif isinstance(statement, ast.AnnAssign) and isinstance(statement.target, ast.Name) and statement.value is not None:
+            assignments[statement.target.id] = statement.value
+    return assignments
+
+
+def _resolve_framework_tool_exprs(
+    node: ast.expr | None,
+    assignments: dict[str, ast.expr],
+    *,
+    depth: int = 0,
+) -> list[tuple[str, ast.Call]]:
+    """Resolve a static tools collection to constructor calls and bindings."""
+    if node is None or depth > 6:
+        return []
+    if isinstance(node, ast.Name):
+        assigned = assignments.get(node.id)
+        if assigned is None:
+            return []
+        if isinstance(assigned, ast.Call):
+            return [(node.id, assigned)]
+        return _resolve_framework_tool_exprs(assigned, assignments, depth=depth + 1)
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        resolved: list[tuple[str, ast.Call]] = []
+        for item in node.elts:
+            resolved.extend(_resolve_framework_tool_exprs(item, assignments, depth=depth + 1))
+        return resolved
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return [
+            *_resolve_framework_tool_exprs(node.left, assignments, depth=depth + 1),
+            *_resolve_framework_tool_exprs(node.right, assignments, depth=depth + 1),
+        ]
+    if isinstance(node, ast.Call):
+        return [("inline", node)]
+    return []
+
+
+def _framework_tool_from_call(
+    binding: str,
+    call: ast.Call,
+    *,
+    framework: str,
+    agent_constructor: str,
+    index: int,
+    imported_modules: dict[str, str],
+    imported_functions: dict[str, tuple[str, str]],
+    function_names: set[str],
+) -> _PythonToolRegistration | None:
+    call_name = _canonical_imported_call_name(call, imported_functions)
+    short_name = call_name.rsplit(".", 1)[-1]
+    constructor_name = short_name
+    handler_node: ast.expr | None = None
+
+    if short_name == "from_function":
+        owner = call_name.rsplit(".", 1)[0].rsplit(".", 1)[-1]
+        if owner not in _FRAMEWORK_TOOL_CONSTRUCTORS:
+            return None
+        constructor_name = f"{owner}.from_function"
+        if call.args:
+            handler_node = call.args[0]
+    elif short_name in _FRAMEWORK_TOOL_CONSTRUCTORS:
+        for keyword_name in _FRAMEWORK_TOOL_HANDLER_KEYWORDS:
+            handler_node = _keyword_value(call, keyword_name)
+            if handler_node is not None:
+                break
+        if handler_node is None and short_name == "Tool" and len(call.args) >= 2:
+            handler_node = call.args[1]
+    else:
+        return None
+
+    constructor_framework = _framework_for_imported_call(call, imported_modules, imported_functions)
+    if not constructor_framework:
+        # ``StructuredTool.from_function`` resolves through the imported owner,
+        # not the terminal method name.
+        owner = call_name.split(".", 1)[0]
+        imported = imported_functions.get(owner)
+        module_name = imported[0] if imported else imported_modules.get(owner, "")
+        constructor_framework = _FRAMEWORK_TOOL_ROOTS.get(module_name.split(".", 1)[0], "")
+    if not constructor_framework or not isinstance(handler_node, ast.Name) or handler_node.id not in function_names:
+        return None
+
+    tool_name = ""
+    name_node = _keyword_value(call, "name")
+    if name_node is not None:
+        tool_name = _extract_string_value(name_node) or ""
+    if not tool_name and call.args and isinstance(call.args[0], ast.Constant) and isinstance(call.args[0].value, str):
+        tool_name = call.args[0].value
+    if not tool_name:
+        tool_name = handler_node.id
+    tool_name = tool_name.strip()
+    if not tool_name:
+        return None
+
+    provenance = f"python:{framework}:{agent_constructor}.tools[{index}]:{binding}->{constructor_name}(func={handler_node.id})"
+    return _PythonToolRegistration(
+        tool_name=tool_name,
+        handler_name=handler_node.id,
+        framework=framework,
+        provenance=provenance,
+    )
+
+
+def _collect_framework_tool_registrations(
+    tree: ast.Module,
+    imported_modules: dict[str, str],
+    imported_functions: dict[str, tuple[str, str]],
+) -> list[_PythonToolRegistration]:
+    """Collect only tools statically wired to a recognized framework agent."""
+    assignments = _module_assignments(tree)
+    function_names = {node.name for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))}
+    registrations: list[_PythonToolRegistration] = []
+    seen: set[tuple[str, str, str]] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        agent_constructor = _canonical_imported_call_name(node, imported_functions).rsplit(".", 1)[-1]
+        if agent_constructor not in _FRAMEWORK_AGENT_CONSTRUCTORS:
+            continue
+        framework = _framework_for_imported_call(node, imported_modules, imported_functions)
+        if not framework:
+            continue
+        tools_node = _keyword_value(node, "tools")
+        if tools_node is None and agent_constructor == "create_react_agent" and len(node.args) >= 2:
+            tools_node = node.args[1]
+        for index, (binding, tool_call) in enumerate(_resolve_framework_tool_exprs(tools_node, assignments)):
+            registration = _framework_tool_from_call(
+                binding,
+                tool_call,
+                framework=framework,
+                agent_constructor=agent_constructor,
+                index=index,
+                imported_modules=imported_modules,
+                imported_functions=imported_functions,
+                function_names=function_names,
+            )
+            if registration is None:
+                continue
+            key = (registration.tool_name, registration.handler_name, registration.provenance)
+            if key not in seen:
+                seen.add(key)
+                registrations.append(registration)
+    return registrations
 
 
 def _call_references_sensitive_credential_path(call: ast.Call) -> bool:
@@ -776,6 +990,10 @@ def _is_untrusted_source_call(call_name: str) -> bool:
 
 def _is_sanitizer_call_name(call_name: str) -> bool:
     lower_name = call_name.lower()
+    # Security-sensitive APIs whose names happen to contain a validation hint
+    # (notably ``subprocess.check_output``) are sinks, never sanitizers.
+    if lower_name in {name.lower() for name in _DANGEROUS_CALLS}:
+        return False
     if lower_name in _SANITIZER_CALLS:
         return True
     return any(hint in lower_name for hint in _VALIDATION_HINTS)
@@ -827,6 +1045,12 @@ def _analyze_file(
         current_module=current_module,
         rel_path=rel_path,
     )
+    framework_tool_registrations = _collect_framework_tool_registrations(
+        tree,
+        imported_modules,
+        imported_functions,
+    )
+    framework_registration_by_handler = {registration.handler_name: registration for registration in framework_tool_registrations}
 
     # Pass 1: Detect frameworks and guardrails from imports
     for node in ast.walk(tree):
@@ -919,14 +1143,14 @@ def _analyze_file(
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             decorators = []
-            is_tool = False
+            is_decorated_tool = False
             is_dispatch_handler = False
             for dec in node.decorator_list:
                 dec_name = _get_decorator_name(dec)
                 if dec_name:
                     decorators.append(dec_name)
                     if _is_agent_tool_decorator(dec_name):
-                        is_tool = True
+                        is_decorated_tool = True
                     if dec_name.rsplit(".", 1)[-1] in _MCP_DISPATCH_SEGMENTS:
                         is_dispatch_handler = True
 
@@ -937,7 +1161,16 @@ def _analyze_file(
             if is_dispatch_handler and low_level_tools:
                 is_tool_signature = False
             else:
-                is_tool_signature = is_tool
+                is_tool_signature = is_decorated_tool
+
+            framework_registration = framework_registration_by_handler.get(node.name)
+            is_tool = is_decorated_tool or framework_registration is not None
+            entrypoint_name = framework_registration.tool_name if framework_registration else node.name
+            entrypoint_kind = "framework_tool" if framework_registration else "mcp_tool"
+            entrypoint_framework = framework_registration.framework if framework_registration else ""
+            entrypoint_provenance = framework_registration.provenance if framework_registration else ""
+            if framework_registration is not None:
+                is_tool_signature = True
 
             if is_tool_signature:
                 params = _extract_params(node)
@@ -945,7 +1178,7 @@ def _analyze_file(
                 docstring = ast.get_docstring(node) or ""
                 tools.append(
                     ToolSignature(
-                        name=node.name,
+                        name=entrypoint_name,
                         parameters=params,
                         return_type=return_type,
                         description=docstring[:300],
@@ -953,6 +1186,10 @@ def _analyze_file(
                         line_number=node.lineno,
                         decorators=decorators,
                         is_async=isinstance(node, ast.AsyncFunctionDef),
+                        handler=node.name if framework_registration else "",
+                        registration_kind=entrypoint_kind if framework_registration else "",
+                        framework=entrypoint_framework,
+                        provenance=entrypoint_provenance,
                     )
                 )
 
@@ -969,6 +1206,10 @@ def _analyze_file(
                 cfg_edges=_build_function_cfg_edges(node, rel_path),
                 imported_modules=dict(imported_modules),
                 imported_functions=dict(imported_functions),
+                entrypoint_name=entrypoint_name,
+                entrypoint_kind=entrypoint_kind,
+                entrypoint_framework=entrypoint_framework,
+                entrypoint_provenance=entrypoint_provenance,
             )
             dynamic_string_names: set[str] = set()
             for inner_stmt in ast.walk(node):
@@ -994,14 +1235,14 @@ def _analyze_file(
                                 category="unguarded_tool_sink",
                                 title="Tool entrypoint reaches dangerous sink without validation",
                                 detail=(
-                                    f"Tool `{node.name}` in {rel_path} calls `{call_name}` without an obvious "
+                                    f"Tool `{entrypoint_name}` in {rel_path} calls `{call_name}` without an obvious "
                                     "validation or authorization branch."
                                 ),
                                 file_path=rel_path,
                                 line_number=line_num,
-                                entrypoint=node.name,
+                                entrypoint=entrypoint_name,
                                 sink=call_name,
-                                call_path=[node.name, call_name],
+                                call_path=[entrypoint_name, call_name],
                             )
                         )
                 if is_tool and call_name and _is_path_access_call_name(call_name) and _call_references_sensitive_credential_path(inner):
@@ -1009,12 +1250,12 @@ def _analyze_file(
                         FlowFinding(
                             category="credential_file_access",
                             title="Tool entrypoint reads a credential file",
-                            detail=(f"Tool `{node.name}` in {rel_path} reads a known credential-file location."),
+                            detail=(f"Tool `{entrypoint_name}` in {rel_path} reads a known credential-file location."),
                             file_path=rel_path,
                             line_number=getattr(inner, "lineno", node.lineno),
-                            entrypoint=node.name,
+                            entrypoint=entrypoint_name,
                             sink=call_name,
-                            call_path=[node.name, call_name],
+                            call_path=[entrypoint_name, call_name],
                         )
                     )
                 if is_tool and call_name and _is_privilege_escalation_call_name(call_name):
@@ -1022,12 +1263,12 @@ def _analyze_file(
                         FlowFinding(
                             category="privilege_escalation",
                             title="Tool entrypoint can assume another identity",
-                            detail=f"Tool `{node.name}` in {rel_path} calls an identity-assumption API.",
+                            detail=f"Tool `{entrypoint_name}` in {rel_path} calls an identity-assumption API.",
                             file_path=rel_path,
                             line_number=getattr(inner, "lineno", node.lineno),
-                            entrypoint=node.name,
+                            entrypoint=entrypoint_name,
                             sink=call_name,
-                            call_path=[node.name, call_name],
+                            call_path=[entrypoint_name, call_name],
                         )
                     )
                 if _is_unsafe_deserialization_call_name(call_name) and not _uses_safe_yaml_loader(inner):
@@ -1040,9 +1281,9 @@ def _analyze_file(
                             ),
                             file_path=rel_path,
                             line_number=getattr(inner, "lineno", node.lineno),
-                            entrypoint=node.name,
+                            entrypoint=entrypoint_name,
                             sink=call_name,
-                            call_path=[node.name, call_name],
+                            call_path=[entrypoint_name, call_name],
                         )
                     )
                 if _is_command_execution_call_name(call_name) and _is_shell_execution_call(call_name, inner):
@@ -1058,9 +1299,9 @@ def _analyze_file(
                                 ),
                                 file_path=rel_path,
                                 line_number=getattr(inner, "lineno", node.lineno),
-                                entrypoint=node.name,
+                                entrypoint=entrypoint_name,
                                 sink=call_name,
-                                call_path=[node.name, call_name],
+                                call_path=[entrypoint_name, call_name],
                             )
                         )
                 if _is_http_client_call_name(call_name):
@@ -1076,9 +1317,9 @@ def _analyze_file(
                                 ),
                                 file_path=rel_path,
                                 line_number=getattr(inner, "lineno", node.lineno),
-                                entrypoint=node.name,
+                                entrypoint=entrypoint_name,
                                 sink=call_name,
-                                call_path=[node.name, call_name],
+                                call_path=[entrypoint_name, call_name],
                             )
                         )
                 if _is_sql_call_name(call_name):
@@ -1097,9 +1338,9 @@ def _analyze_file(
                                 ),
                                 file_path=rel_path,
                                 line_number=getattr(inner, "lineno", node.lineno),
-                                entrypoint=node.name,
+                                entrypoint=entrypoint_name,
                                 sink=call_name,
-                                call_path=[node.name, call_name],
+                                call_path=[entrypoint_name, call_name],
                             )
                         )
             function_analyses.append(func_info)
@@ -1885,7 +2126,12 @@ def _build_taint_findings(functions: list[_FunctionAnalysis]) -> list[FlowFindin
     for func in functions:
         if not func.is_tool or not func.param_names:
             continue
-        tool_findings, _ = analyze_function(func, set(func.param_names), [func.simple_name], set())
+        tool_findings, _ = analyze_function(
+            func,
+            set(func.param_names),
+            [func.entrypoint_name or func.simple_name],
+            set(),
+        )
         for finding in tool_findings:
             dedup_key = (finding.category, finding.file_path, finding.sink, finding.line_number, finding.entrypoint)
             if dedup_key in seen_findings:
@@ -1920,7 +2166,7 @@ def _build_dependency_symbol_reach(
     reached: list[DependencySymbolReach] = []
     seen: set[tuple[str, str, str, str, int]] = set()
     roots: list[tuple[str, _FunctionAnalysis, ApplicationEntrypoint | None]] = [
-        (func.simple_name, func, None) for func in functions if func.is_tool
+        (func.entrypoint_name or func.simple_name, func, None) for func in functions if func.is_tool
     ]
     for index, entry in enumerate(application_entrypoints or []):
         matches = [func for func in functions if func.simple_name == entry.handler.rsplit(".", 1)[-1] and func.file_path == entry.file_path]
@@ -1928,7 +2174,8 @@ def _build_dependency_symbol_reach(
             roots.append((f"__application_entrypoint_{index}", matches[0], entry))
 
     for root_name, root, application_entrypoint in roots:
-        queue: list[tuple[str, list[str]]] = [(root.qualified_name, [root.simple_name])]
+        exposed_root_name = root.entrypoint_name or root.simple_name
+        queue: list[tuple[str, list[str]]] = [(root.qualified_name, [exposed_root_name])]
         visited: set[str] = set()
         while queue:
             current_id, path = queue.pop(0)
@@ -1949,7 +2196,7 @@ def _build_dependency_symbol_reach(
                 seen.add(dedup_key)
                 reached.append(
                     DependencySymbolReach(
-                        entrypoint=application_entrypoint.name if application_entrypoint else root.simple_name,
+                        entrypoint=application_entrypoint.name if application_entrypoint else exposed_root_name,
                         package=package,
                         module=module_name,
                         symbol=symbol,
@@ -1960,9 +2207,9 @@ def _build_dependency_symbol_reach(
                             f"{module_name}.{symbol}",
                         ],
                         depth=max(0, len(path) - 1),
-                        entrypoint_kind=application_entrypoint.kind if application_entrypoint else "mcp_tool",
-                        entrypoint_framework=application_entrypoint.framework if application_entrypoint else "",
-                        entrypoint_provenance=application_entrypoint.provenance if application_entrypoint else "",
+                        entrypoint_kind=application_entrypoint.kind if application_entrypoint else root.entrypoint_kind,
+                        entrypoint_framework=(application_entrypoint.framework if application_entrypoint else root.entrypoint_framework),
+                        entrypoint_provenance=(application_entrypoint.provenance if application_entrypoint else root.entrypoint_provenance),
                     )
                 )
             for child in adjacency.get(current_id, []):
@@ -2009,7 +2256,8 @@ def _build_call_graph(functions: list[_FunctionAnalysis]) -> tuple[list[CallEdge
     for func in functions:
         if not func.is_tool:
             continue
-        queue: list[tuple[str, list[str]]] = [(func.qualified_name, [func.simple_name])]
+        entrypoint_name = func.entrypoint_name or func.simple_name
+        queue: list[tuple[str, list[str]]] = [(func.qualified_name, [entrypoint_name])]
         visited: set[str] = set()
         while queue:
             current_id, path = queue.pop(0)
@@ -2028,7 +2276,7 @@ def _build_call_graph(functions: list[_FunctionAnalysis]) -> tuple[list[CallEdge
                     continue
                 if len(path) <= 1:
                     continue
-                dedup_key = (func.simple_name, sink_name, current.file_path, line_num)
+                dedup_key = (entrypoint_name, sink_name, current.file_path, line_num)
                 if dedup_key in seen_findings:
                     continue
                 seen_findings.add(dedup_key)
@@ -2037,11 +2285,11 @@ def _build_call_graph(functions: list[_FunctionAnalysis]) -> tuple[list[CallEdge
                         category="interprocedural_dangerous_flow",
                         title="Tool helper chain reaches dangerous sink",
                         detail=(
-                            f"Tool `{func.simple_name}` reaches `{sink_name}` through a bounded helper-call chain in {current.file_path}."
+                            f"Tool `{entrypoint_name}` reaches `{sink_name}` through a bounded helper-call chain in {current.file_path}."
                         ),
                         file_path=current.file_path,
                         line_number=line_num,
-                        entrypoint=func.simple_name,
+                        entrypoint=entrypoint_name,
                         sink=sink_name,
                         call_path=path + [sink_name],
                     )

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -2609,9 +2609,9 @@ def scan(
         for w in all_tp_warnings:
             con.print(f"  [yellow]⚠[/yellow] {w}")
 
-    # ── Step 1m: AST source code analysis (auto-detect Python AI code) ──
+    # ── Step 1m: AST source code analysis (explicit project scope) ──
     _ast_result_for_reach = None
-    if not skill_only and not no_discover and project and not dry_run:
+    if not skill_only and project and not dry_run:
         from pathlib import Path as _APath
 
         _aproj = _APath(project)

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -1401,6 +1401,10 @@ def _apply_ast_tool_overlay(graph: UnifiedGraph, report_json: Mapping[str, Any])
                     "source_file": source_file,
                     "line": raw.get("line") if isinstance(raw.get("line"), int) else None,
                     "parameters": sanitize_sensitive_payload(raw.get("parameters", [])),
+                    "handler": sanitize_text(raw.get("handler", ""), max_len=200),
+                    "registration_kind": sanitize_text(raw.get("registration_kind", ""), max_len=100),
+                    "framework": sanitize_text(raw.get("framework", ""), max_len=100),
+                    "provenance": sanitize_text(raw.get("provenance", ""), max_len=500),
                     "discovery_source": "ast_analysis",
                     "canonical_id": canonical_graph_node_id(EntityType.TOOL.value, tool_id),
                 },
@@ -1413,7 +1417,13 @@ def _apply_ast_tool_overlay(graph: UnifiedGraph, report_json: Mapping[str, Any])
                 source=file_id,
                 target=tool_id,
                 relationship=RelationshipType.DEFINES,
-                evidence={"source": "ast_analysis", "line": raw.get("line")},
+                evidence={
+                    "source": "ast_analysis",
+                    "line": raw.get("line"),
+                    "registration_kind": sanitize_text(raw.get("registration_kind", ""), max_len=100),
+                    "framework": sanitize_text(raw.get("framework", ""), max_len=100),
+                    "provenance": sanitize_text(raw.get("provenance", ""), max_len=500),
+                },
             )
         )
 

--- a/src/agent_bom/output/graph.py
+++ b/src/agent_bom/output/graph.py
@@ -528,18 +528,27 @@ def _append_source_tool_elements(elements: list[dict], report: "AIBOMReport") ->
             known_nodes.add(tool_id)
             line = raw.get("line") if isinstance(raw.get("line"), int) else None
             description = sanitize_text(raw.get("description", ""), max_len=1_000)
+            handler = sanitize_text(raw.get("handler", ""), max_len=200)
+            registration_kind = sanitize_text(raw.get("registration_kind", ""), max_len=100)
+            framework = sanitize_text(raw.get("framework", ""), max_len=100)
+            provenance = sanitize_text(raw.get("provenance", ""), max_len=500)
+            tool_label = "Framework tool" if registration_kind == "framework_tool" else "MCP tool"
             elements.append(
                 {
                     "data": {
                         "id": tool_id,
                         "label": tool_name,
                         "type": "tool",
-                        "tip": f"MCP tool: {tool_name}\nSource: {source_file}" + (f":{line}" if line else ""),
+                        "tip": f"{tool_label}: {tool_name}\nSource: {source_file}" + (f":{line}" if line else ""),
                         "description": description,
                         "sourceFile": source_file,
                         "line": line,
+                        "handler": handler,
+                        "registration_kind": registration_kind,
+                        "framework": framework,
+                        "provenance": provenance,
                         "discovery_source": "ast_analysis",
-                        "searchText": f"{tool_name} {source_file} {description}".lower(),
+                        "searchText": f"{tool_name} {handler} {framework} {source_file} {description}".lower(),
                     }
                 }
             )
@@ -554,6 +563,9 @@ def _append_source_tool_elements(elements: list[dict], report: "AIBOMReport") ->
                         "target": tool_id,
                         "type": "defines",
                         "line": raw.get("line") if isinstance(raw.get("line"), int) else None,
+                        "registration_kind": sanitize_text(raw.get("registration_kind", ""), max_len=100),
+                        "framework": sanitize_text(raw.get("framework", ""), max_len=100),
+                        "provenance": sanitize_text(raw.get("provenance", ""), max_len=500),
                     }
                 }
             )

--- a/src/agent_bom/output/graph_export.py
+++ b/src/agent_bom/output/graph_export.py
@@ -294,8 +294,9 @@ def _merge_unified_graph_evidence(graph: DepGraph, data: dict[str, Any]) -> None
     ``build_unified_graph_from_report`` (the single source of cloud graph truth)
     and grafts its cloud/identity/posture nodes + edges onto the DepGraph so every
     existing serializer (json/dot/mermaid/graphml/cypher) shows the full estate.
-    Source-discovered MCP tools also originate only in the unified graph; graft
-    those tool/file nodes so graph export does not discard their provenance.
+    Source-discovered MCP and framework tools also originate only in the
+    unified graph; graft those tool/file nodes so graph export does not discard
+    their provenance.
     Best-effort: never raises into the export path.
     """
     try:

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -957,6 +957,24 @@ def to_sarif(
                 "suppressed": finding.suppressed,
                 **(
                     {
+                        key: sanitize_text(value, max_len=500)
+                        for key in ("category", "entrypoint", "sink", "source")
+                        if (value := evidence.get(key))
+                    }
+                    if finding.finding_type == FindingType.SAST
+                    else {}
+                ),
+                **(
+                    {
+                        key: [sanitize_text(item, max_len=500) for item in value]
+                        for key in ("call_path", "detector_categories")
+                        if isinstance((value := evidence.get(key)), list)
+                    }
+                    if finding.finding_type == FindingType.SAST
+                    else {}
+                ),
+                **(
+                    {
                         "workload_runtime_evidence": _sanitize_sarif_property(finding.workload_runtime_evidence),
                     }
                     if isinstance(getattr(finding, "workload_runtime_evidence", None), dict) and finding.workload_runtime_evidence

--- a/tests/test_ast_flow_finding_promotion.py
+++ b/tests/test_ast_flow_finding_promotion.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+from agent_bom.ast_analyzer import analyze_project
 from agent_bom.graph.builder import build_unified_graph_from_report
 from agent_bom.graph.types import EntityType, RelationshipType
 from agent_bom.models import AIBOMReport
@@ -104,3 +107,34 @@ def test_overlapping_detectors_share_one_sink_finding() -> None:
     findings = report.to_findings()
     assert len(findings) == 1
     assert findings[0].severity == "critical"
+
+
+def test_framework_registered_tool_verdict_survives_finding_and_export_surfaces(tmp_path: Path) -> None:
+    (tmp_path / "app.py").write_text(
+        "import subprocess\n"
+        "from langchain.agents import AgentExecutor\n"
+        "from langchain.tools import Tool\n\n"
+        "def run_shell(command: str) -> str:\n"
+        "    return subprocess.check_output(command, shell=True, text=True)\n\n"
+        "shell_tool = Tool(name='shell', func=run_shell, description='Run a command')\n"
+        "agent = AgentExecutor(agent=None, tools=[shell_tool])\n"
+    )
+    analysis = analyze_project(tmp_path).to_dict()
+    report = AIBOMReport(ai_inventory_data={"ast_analysis": analysis}, scan_sources=["ast_analysis"])
+
+    findings = report.to_findings()
+    assert len(findings) == 1
+    assert findings[0].severity == "critical"
+    assert findings[0].evidence["entrypoint"] == "shell"
+
+    payload = to_json(report)
+    assert [finding["evidence"]["entrypoint"] for finding in payload["findings"]] == ["shell"]
+    sarif = to_sarif(report)
+    assert len(sarif["runs"][0]["results"]) == 1
+    assert sarif["runs"][0]["results"][0]["properties"]["entrypoint"] == "shell"
+
+    graph = build_unified_graph_from_report(payload, scan_id="framework-tool-flow")
+    tool = next(node for node in graph.nodes.values() if node.entity_type == EntityType.TOOL)
+    assert tool.label == "shell"
+    assert tool.attributes["handler"] == "run_shell"
+    assert tool.attributes["registration_kind"] == "framework_tool"

--- a/tests/test_ast_tool_detection_precision.py
+++ b/tests/test_ast_tool_detection_precision.py
@@ -380,6 +380,142 @@ def test_tool_records_without_a_list_tools_handler_are_not_agent_tools(tmp_path:
     assert _tool_names(tmp_path) == {"count_tools"}
 
 
+LANGCHAIN_REGISTERED_TOOL = """import subprocess
+
+import requests
+from langchain.agents import AgentExecutor
+from langchain.tools import Tool
+
+
+def fetch_url(url: str) -> str:
+    return requests.get(url).text
+
+
+def run_shell(command: str) -> str:
+    fetch_url("https://example.invalid/audit")
+    return subprocess.check_output(command, shell=True, text=True)
+
+
+shell_tool = Tool(name="shell", func=run_shell, description="Run a shell command")
+agent = AgentExecutor(agent=None, tools=[shell_tool])
+"""
+
+
+LANGCHAIN_UNREGISTERED_TOOL = """import subprocess
+
+from langchain.tools import Tool
+
+
+def run_shell(command: str) -> str:
+    return subprocess.check_output(command, shell=True, text=True)
+
+
+shell_tool = Tool(name="shell", func=run_shell, description="Run a shell command")
+"""
+
+
+def test_framework_registered_constructor_tool_is_a_code_flow_root(tmp_path: Path) -> None:
+    """A framework registration, not the class name alone, makes the handler invokable."""
+    (tmp_path / "app.py").write_text(LANGCHAIN_REGISTERED_TOOL)
+
+    payload = analyze_project(tmp_path).to_dict()
+    assert payload["tools"] == [
+        {
+            "name": "shell",
+            "parameters": [{"name": "command", "type": "str", "default": None}],
+            "return_type": "str",
+            "description": "",
+            "file": "app.py",
+            "line": 12,
+            "is_async": False,
+            "decorators": [],
+            "handler": "run_shell",
+            "registration_kind": "framework_tool",
+            "framework": "LangChain",
+            "provenance": "python:LangChain:AgentExecutor.tools[0]:shell_tool->Tool(func=run_shell)",
+        }
+    ]
+
+    flow = [finding for finding in payload["flow_findings"] if finding["entrypoint"] == "shell"]
+    assert any(finding["category"] == "unguarded_tool_sink" and finding["sink"] == "subprocess.check_output" for finding in flow)
+    assert any(finding["category"] == "tainted_command_execution" and finding["sink"] == "subprocess.check_output" for finding in flow)
+
+    reach = [entry for entry in payload["dependency_symbol_reach"] if entry["entrypoint"] == "shell"]
+    assert {(entry["package"], entry["symbol"]) for entry in reach} == {
+        ("requests", "get"),
+        ("subprocess", "check_output"),
+    }
+    assert all(entry["entrypoint_kind"] == "framework_tool" for entry in reach)
+    assert all(entry["entrypoint_framework"] == "LangChain" for entry in reach)
+    assert all(entry["entrypoint_provenance"].startswith("python:LangChain:AgentExecutor.tools") for entry in reach)
+
+
+def test_unregistered_framework_tool_constructor_is_not_an_invocation_root(tmp_path: Path) -> None:
+    """Importing a framework and constructing a Tool is not proof an agent can invoke it."""
+    (tmp_path / "app.py").write_text(LANGCHAIN_UNREGISTERED_TOOL)
+
+    result = analyze_project(tmp_path)
+
+    assert result.tools == []
+    assert result.flow_findings == []
+    assert result.dependency_symbol_reach == []
+
+
+@pytest.mark.parametrize(
+    "source, expected_name, expected_handler, expected_framework",
+    [
+        (
+            "from langchain.agents import AgentExecutor\n"
+            "from langchain.tools import Tool\n\n"
+            "def lookup(query: str) -> str:\n    return query\n\n"
+            "agent = AgentExecutor(agent=None, tools=[Tool(name='lookup-docs', func=lookup, description='Lookup')])\n",
+            "lookup-docs",
+            "lookup",
+            "LangChain",
+        ),
+        (
+            "from langgraph.prebuilt import create_react_agent as make_agent\n"
+            "from langchain_core.tools import StructuredTool as ST\n\n"
+            "def lookup(query: str) -> str:\n    return query\n\n"
+            "lookup_tool = ST.from_function(lookup, name='lookup-docs')\n"
+            "agent = make_agent(None, [lookup_tool])\n",
+            "lookup-docs",
+            "lookup",
+            "LangGraph",
+        ),
+    ],
+)
+def test_framework_registration_resolves_inline_positional_and_aliased_forms(
+    tmp_path: Path,
+    source: str,
+    expected_name: str,
+    expected_handler: str,
+    expected_framework: str,
+) -> None:
+    (tmp_path / "app.py").write_text(source)
+
+    tools = analyze_project(tmp_path).to_dict()["tools"]
+
+    assert [(tool["name"], tool["handler"], tool["framework"]) for tool in tools] == [(expected_name, expected_handler, expected_framework)]
+
+
+def test_framework_agent_does_not_promote_a_project_local_tool_record(tmp_path: Path) -> None:
+    (tmp_path / "app.py").write_text(
+        "from dataclasses import dataclass\n"
+        "from langchain.agents import AgentExecutor\n\n"
+        "@dataclass\n"
+        "class Tool:\n"
+        "    name: str\n"
+        "    func: object\n\n"
+        "def handler(value: str) -> str:\n"
+        "    return value\n\n"
+        "record = Tool(name='inventory-record', func=handler)\n"
+        "agent = AgentExecutor(agent=None, tools=[record])\n"
+    )
+
+    assert analyze_project(tmp_path).tools == []
+
+
 LOWLEVEL_CALL_TOOL_RUNS_A_SHELL = """import subprocess
 from typing import Any
 

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -950,6 +950,47 @@ def test_scan_no_discover_scans_explicit_project_packages(tmp_path):
     assert [agent["name"] for agent in report["agents"]] == ["project:repo"]
 
 
+def test_scan_no_discover_analyzes_code_in_the_explicit_project(tmp_path):
+    """No-discover excludes ambient inputs, not source inside the named project."""
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "requirements.txt").write_text("langchain==0.3.0\n", encoding="utf-8")
+    (project / "app.py").write_text(
+        "import subprocess\n"
+        "from langchain.agents import AgentExecutor\n"
+        "from langchain.tools import Tool\n\n"
+        "def run_shell(command: str) -> str:\n"
+        "    return subprocess.check_output(command, shell=True, text=True)\n\n"
+        "shell_tool = Tool(name='shell', func=run_shell, description='Run a command')\n"
+        "agent = AgentExecutor(agent=None, tools=[shell_tool])\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "report.json"
+
+    result = _run(
+        [
+            "scan",
+            "--project",
+            str(project),
+            "--no-discover",
+            "--no-scan",
+            "--exit-zero",
+            "--format",
+            "json",
+            "--output",
+            str(out),
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    report = json.loads(out.read_text(encoding="utf-8"))
+    code_findings = [finding for finding in report["findings"] if finding.get("evidence", {}).get("entrypoint") == "shell"]
+    assert len(code_findings) == 1
+    assert code_findings[0]["severity"] == "critical"
+    assert code_findings[0]["evidence"]["sink"] == "subprocess.check_output"
+    assert "ast_analysis" in report["scan_sources"]
+
+
 def test_scan_no_discover_without_artifact_exits_usage_error(tmp_path, monkeypatch):
     # --no-discover with no explicit input artifact has nothing to scan. Exiting
     # 0 "clean" is a false-negative; it must hard-fail as a usage error (exit 2).

--- a/tests/test_graph_source_tool_evidence.py
+++ b/tests/test_graph_source_tool_evidence.py
@@ -1,4 +1,4 @@
-"""Persistence and export parity for source-discovered MCP tools."""
+"""Persistence and export parity for source-discovered application tools."""
 
 from __future__ import annotations
 
@@ -21,6 +21,10 @@ _AST_TOOLS = {
                 "file": "src/mcp_server.py",
                 "line": 42,
                 "parameters": ["customer_id"],
+                "handler": "read_customer_handler",
+                "registration_kind": "framework_tool",
+                "framework": "LangChain",
+                "provenance": "python:LangChain:AgentExecutor.tools[0]:customer_tool->Tool(func=read_customer_handler)",
             }
         ],
         "application_entrypoints": [
@@ -61,6 +65,10 @@ def test_source_discovered_tool_survives_sqlite_graph_persistence(tmp_path: Path
     restored = store.load_graph(scan_id="source-tool-scan")
 
     assert restored.nodes[tool.id].attributes["source_file"] == "src/mcp_server.py"
+    assert restored.nodes[tool.id].attributes["handler"] == "read_customer_handler"
+    assert restored.nodes[tool.id].attributes["registration_kind"] == "framework_tool"
+    assert restored.nodes[tool.id].attributes["framework"] == "LangChain"
+    assert restored.nodes[tool.id].attributes["provenance"].startswith("python:LangChain")
     assert any(
         edge.source == source_file.id and edge.target == tool.id and edge.relationship == RelationshipType.DEFINES
         for edge in restored.edges
@@ -71,6 +79,9 @@ def test_source_discovered_tool_is_in_standalone_graph_export() -> None:
     graph = build_graph_from_scan_data(_scan_json())
 
     tool = next(node for node in graph.nodes if node.kind == "tool" and node.label == "read_customer")
+    assert tool.attributes["handler"] == "read_customer_handler"
+    assert tool.attributes["registration_kind"] == "framework_tool"
+    assert tool.attributes["framework"] == "LangChain"
     source_file = next(node for node in graph.nodes if node.kind == "source_file")
     assert any(edge.source == source_file.id and edge.target == tool.id and edge.kind == "defines" for edge in graph.edges)
 
@@ -85,6 +96,11 @@ def test_source_discovered_tool_is_in_cytoscape_export() -> None:
 
     elements = build_graph_elements(report, [])
     tool = next(item["data"] for item in elements if item.get("data", {}).get("type") == "tool")
+    assert tool["handler"] == "read_customer_handler"
+    assert tool["registration_kind"] == "framework_tool"
+    assert tool["framework"] == "LangChain"
+    assert tool["provenance"].startswith("python:LangChain")
+    assert tool["tip"].startswith("Framework tool: read_customer")
     source_file = next(item["data"] for item in elements if item.get("data", {}).get("type") == "source_file")
     assert any(
         item.get("data", {}).get("source") == source_file["id"]


### PR DESCRIPTION
## Summary

- treat statically resolved framework tool registrations as externally invokable code-flow roots while requiring recognized framework imports, an agent `tools` binding, and a local handler
- preserve the registered tool name, handler, framework, and provenance through unified findings, JSON, SARIF, persisted/standalone/Cytoscape graph projections, and explicit-project `--no-discover` scans
- keep unregistered constructors and project-local `Tool` records excluded; ensure `subprocess.check_output` remains a command sink rather than being mistaken for a sanitizer

## Verification

- red regression: `4 failed, 71 passed` before implementation
- `UV_CACHE_DIR=/private/tmp/agent-bom-uv-cache uv run pytest -q tests/test_ast_analyzer.py tests/test_ast_application_entrypoints.py tests/test_ast_tool_detection_precision.py tests/test_ast_flow_finding_promotion.py tests/test_graph_source_tool_evidence.py tests/test_output_formats.py tests/test_graph_api.py tests/api/test_graph_scope_contract.py tests/test_cli_scan.py tests/test_sast_surface_contract.py` (`462 passed`)
- `UV_CACHE_DIR=/private/tmp/agent-bom-uv-cache uv run ruff check src tests`
- `UV_CACHE_DIR=/private/tmp/agent-bom-uv-cache uv run ruff format --check src tests`
- `UV_CACHE_DIR=/private/tmp/agent-bom-uv-cache uv run mypy src/agent_bom`
- `UV_CACHE_DIR=/private/tmp/agent-bom-uv-cache make preflight`
- `git diff --check`
- `UV_CACHE_DIR=/private/tmp/agent-bom-uv-cache uv run agent-bom code /private/tmp/agent-bom-langchain-repro --format json --output /private/tmp/framework-tool-code.json` (1 tool, 3 flow findings, 1 symbol-reach record)
- `UV_CACHE_DIR=/private/tmp/agent-bom-uv-cache uv run agent-bom scan --project /private/tmp/agent-bom-langchain-repro --no-discover --offline --no-scan --format json --output /private/tmp/framework-tool-scan.json --exit-zero` (1 critical unified SAST finding)
- the same scan with `--format sarif` (1 error result at `app.py:8`, entrypoint `shell`) and `--format graph` (non-empty source-to-tool graph with framework provenance)

## Notes

- dynamic collections, unresolved handlers, nested handlers, and constructors without recognized import provenance remain unclassified rather than being guessed reachable
