### PR TITLE
perf(scan): make large scans fast and lossless

### DIFF
--- a/src/agent_bom/cli/agents/_context.py
+++ b/src/agent_bom/cli/agents/_context.py
@@ -16,6 +16,10 @@ class ScanContext:
     agents: list = field(default_factory=list)
     blast_radii: list = field(default_factory=list)
     report: Any = None
+    # Canonical JSON projection built once after the report is finalized. JSON
+    # and agent-mode renderers consume this instead of rebuilding the complete
+    # finding/inventory graph for the same scan.
+    report_json: Optional[dict[str, Any]] = None
     # benchmark reports
     cis_benchmark_report: Any = None
     sf_cis_benchmark_report: Any = None

--- a/src/agent_bom/cli/agents/_output.py
+++ b/src/agent_bom/cli/agents/_output.py
@@ -147,6 +147,7 @@ def _stdout_serialization(
     *,
     exclude_unfixable: bool,
     offline_html: bool,
+    report_json: dict[str, Any] | None = None,
 ) -> str | None:
     """Best-effort serialize the report for stdout fallback when -o write fails.
 
@@ -162,7 +163,7 @@ def _stdout_serialization(
             from agent_bom.output.badge import to_badge
 
             return json.dumps(to_badge(report), indent=2)
-        return json.dumps(to_redacted_json(report), indent=2)
+        return json.dumps(to_redacted_json(report, report_json=report_json), indent=2)
     if output_format == "cyclonedx":
         return json.dumps(to_cyclonedx(report), indent=2)
     if output_format == "sarif":
@@ -208,6 +209,7 @@ def _enospc_report_fallback(
     *,
     exclude_unfixable: bool,
     offline_html: bool,
+    report_json: dict[str, Any] | None = None,
 ) -> Iterator[None]:
     """Catch a full-disk (or any) failure writing the ``-o`` report.
 
@@ -229,6 +231,7 @@ def _enospc_report_fallback(
             output_format,
             exclude_unfixable=exclude_unfixable,
             offline_html=offline_html,
+            report_json=report_json,
         )
         if serialized is not None:
             con.print(f"\n  [yellow]⚠[/yellow] Could not write report to {target} ({reason}) — emitting results to stdout instead.")
@@ -356,7 +359,7 @@ def render_output(
             elif agent_mode:
                 payload = success_envelope(
                     command="agents",
-                    report_json=to_redacted_json(report),
+                    report_json=to_redacted_json(report, report_json=ctx.report_json),
                     exit_code=ctx.exit_code,
                     token_budget=agent_token_budget,
                     full=agent_mode_full,
@@ -364,7 +367,7 @@ def render_output(
                 )
                 click.echo(dumps_envelope(payload), nl=False)
             else:
-                safe_json = json.dumps(to_redacted_json(report), indent=2)
+                safe_json = json.dumps(to_redacted_json(report, report_json=ctx.report_json), indent=2)
                 click.echo(safe_json, nl=False)
             sys.stdout.write("\n")
         elif _is_null_device(output) and output_format in ("console", "text", "plain"):
@@ -462,11 +465,11 @@ def render_output(
             _print_text(report, blast_radii)
         elif output_format == "json":
             if output in (None, "", "-"):
-                safe_json = json.dumps(to_redacted_json(report), indent=2)
+                safe_json = json.dumps(to_redacted_json(report, report_json=ctx.report_json), indent=2)
                 click.echo(safe_json)
             else:
                 out_path = _resolve_output_path(output, output_format)
-                export_json(report, out_path)
+                export_json(report, out_path, report_json=ctx.report_json)
                 con.print(f"\n  [green]✓[/green] JSON report: {out_path}")
         elif output_format == "cyclonedx":
             out_path = _resolve_output_path(output, output_format)
@@ -580,7 +583,7 @@ def render_output(
             if output.endswith(".cdx.json"):
                 export_cyclonedx(report, output)
             elif output.endswith(".json"):
-                export_json(report, output)
+                export_json(report, output, report_json=ctx.report_json)
             elif output.endswith(".sarif"):
                 export_sarif(report, output, exclude_unfixable=exclude_unfixable)
             elif output.endswith(".spdx.json"):
@@ -627,6 +630,7 @@ def render_output(
             output_format,
             exclude_unfixable=exclude_unfixable,
             offline_html=offline_html,
+            report_json=ctx.report_json,
         ):
             _emit_report()
 

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -3022,6 +3022,8 @@ def scan(
             except (FileNotFoundError, ValueError) as exc:
                 logger.warning("Delta baseline error: %s — skipping delta filter", exc)
 
+    ctx.report_json = current_report_json
+
     if not save_report:
         try:
             from agent_bom.db.local_analytics import record_scan_report_best_effort
@@ -3097,19 +3099,9 @@ def scan(
         render_posture_summary(agents, blast_radii)
         return
 
-    # Step 6: Save report to history + asset tracking
-    # Mirror every CLI scan to the local analytics store so `agent-bom report query`
-    # sees CLI-tier scans (not only --save'd or API-tier writes). Best-effort: a
-    # write failure must never fail the scan.
-    try:
-        import logging as _logging
-
-        from agent_bom.db.local_analytics import record_scan_report_best_effort
-
-        record_scan_report_best_effort(current_report_json, source="cli")
-    except Exception as _local_analytics_exc:  # noqa: BLE001
-        _logging.getLogger(__name__).debug("Local analytics mirror failed: %s", _local_analytics_exc, exc_info=True)
-
+    # Step 6: Save report to history + asset tracking. History saving owns the
+    # analytics write for ``--save`` scans; ordinary scans were mirrored once
+    # above. This keeps one persisted run per CLI invocation.
     if save_report:
         from agent_bom.history import save_report as _save
 

--- a/src/agent_bom/db/local_analytics.py
+++ b/src/agent_bom/db/local_analytics.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import uuid
+from collections import defaultdict
 from contextlib import closing
 from datetime import datetime, timezone
 from pathlib import Path
@@ -262,6 +263,7 @@ class LocalAnalyticsStore:
         raw_summary = report_json.get("summary")
         summary: dict[str, Any] = raw_summary if isinstance(raw_summary, dict) else {}
         findings = list(_iter_findings(report_json))
+        finding_rows = _finding_rows(run_id, scan_id, findings)
         package_rows = list(_iter_packages(report_json))
 
         with closing(self._connect()) as conn:
@@ -300,8 +302,8 @@ class LocalAnalyticsStore:
                     _int(summary.get("total_packages")),
                     _int(summary.get("total_vulnerabilities")),
                     _int(summary.get("critical_findings")),
-                    sum(1 for item in findings if _finding_severity(item) == "high"),
-                    len(findings),
+                    sum(1 for row in finding_rows if row[8] == "high"),
+                    len(finding_rows),
                     len(package_rows),
                 ),
             )
@@ -317,7 +319,7 @@ class LocalAnalyticsStore:
                 )
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                [_finding_row(run_id, scan_id, finding) for finding in findings],
+                finding_rows,
             )
             conn.executemany(
                 """
@@ -503,7 +505,103 @@ def _iter_packages(report_json: dict[str, Any]) -> Iterable[dict[str, Any]]:
                     }
 
 
-def _finding_row(run_id: str, scan_id: str, finding: dict[str, Any]) -> tuple[Any, ...]:
+_OCCURRENCE_FIELDS = (
+    "occurrence_id",
+    "occurrence_key",
+    "finding_id",
+    "source_finding_id",
+    "path",
+    "file",
+    "file_path",
+    "manifest_path",
+    "config_path",
+    "location",
+    "locations",
+    "source_location",
+    "line",
+    "line_number",
+    "start_line",
+    "column",
+    "column_number",
+    "start_column",
+    "rule",
+    "rule_id",
+    "check_id",
+    "control_id",
+    "resource_id",
+    "resource_arn",
+)
+
+
+def _finding_rows(run_id: str, scan_id: str, findings: list[dict[str, Any]]) -> list[tuple[Any, ...]]:
+    """Build deterministic occurrence rows without changing canonical identity.
+
+    ``finding_key`` is the SQLite row boundary. A unique semantic finding keeps
+    its existing key for compatibility. When one semantic key has multiple
+    occurrences, each stored row gets a deterministic occurrence suffix; exact
+    duplicate producer rows collapse instead of aborting the transaction.
+    """
+    entries: dict[tuple[str, str], dict[str, Any]] = {}
+    occurrences_by_semantic: dict[str, set[str]] = defaultdict(set)
+    for finding in findings:
+        vulnerability_id = _vulnerability_id_from_finding(finding)
+        package_ref = str(finding.get("package") or "")
+        ecosystem = str(finding.get("ecosystem") or "")
+        semantic_key = _finding_key(finding, vulnerability_id, package_ref, ecosystem)
+        occurrence_key = _finding_occurrence_key(finding, package_ref, ecosystem)
+        entries.setdefault((semantic_key, occurrence_key), finding)
+        occurrences_by_semantic[semantic_key].add(occurrence_key)
+
+    rows: list[tuple[Any, ...]] = []
+    for (semantic_key, occurrence_key), finding in entries.items():
+        if len(occurrences_by_semantic[semantic_key]) == 1:
+            storage_key = semantic_key
+        else:
+            suffix = uuid.uuid5(uuid.NAMESPACE_URL, f"agent-bom:local-finding-occurrence:{occurrence_key}")
+            storage_key = f"{semantic_key}:{suffix}"
+        rows.append(_finding_row(run_id, scan_id, finding, finding_key=storage_key))
+    return rows
+
+
+def _finding_occurrence_key(finding: dict[str, Any], package_ref: str, ecosystem: str) -> str:
+    raw_asset = finding.get("asset")
+    asset: dict[str, Any] = raw_asset if isinstance(raw_asset, dict) else {}
+    raw_evidence = finding.get("evidence")
+    evidence: dict[str, Any] = raw_evidence if isinstance(raw_evidence, dict) else {}
+    occurrence = {
+        "explicit": {key: finding.get(key) for key in _OCCURRENCE_FIELDS if finding.get(key) not in (None, "", [], {})},
+        "asset": {
+            key: asset.get(key)
+            for key in (
+                "canonical_id",
+                "stable_id",
+                "asset_type",
+                "identifier",
+                "location",
+                "name",
+                "provider",
+                "account_ref",
+                "region",
+                "environment",
+            )
+            if asset.get(key) not in (None, "", [], {})
+        },
+        "evidence": {key: evidence.get(key) for key in _OCCURRENCE_FIELDS if evidence.get(key) not in (None, "", [], {})},
+        "affected_agents": sorted(str(item) for item in finding.get("affected_agents") or []),
+        "affected_servers": sorted(str(item) for item in finding.get("affected_servers") or []),
+        "package": package_ref,
+        "ecosystem": ecosystem,
+    }
+    return json.dumps(occurrence, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _finding_row(
+    run_id: str,
+    scan_id: str,
+    finding: dict[str, Any],
+    *,
+    finding_key: str | None = None,
+) -> tuple[Any, ...]:
     raw_asset = finding.get("asset")
     asset: dict[str, Any] = raw_asset if isinstance(raw_asset, dict) else {}
     vulnerability_id = _vulnerability_id_from_finding(finding)
@@ -511,11 +609,11 @@ def _finding_row(run_id: str, scan_id: str, finding: dict[str, Any]) -> tuple[An
     package_name = str(finding.get("package_name") or _package_name_from_ref(package_ref))
     package_version = str(finding.get("package_version") or _package_version_from_ref(package_ref))
     ecosystem = str(finding.get("ecosystem") or "")
-    finding_key = _finding_key(finding, vulnerability_id, package_ref, ecosystem)
+    storage_key = finding_key or _finding_key(finding, vulnerability_id, package_ref, ecosystem)
     return (
         run_id,
         scan_id,
-        finding_key,
+        storage_key,
         vulnerability_id,
         package_name,
         package_version,

--- a/src/agent_bom/db/local_analytics.py
+++ b/src/agent_bom/db/local_analytics.py
@@ -8,6 +8,7 @@ history JSON file.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 import uuid
@@ -542,22 +543,24 @@ def _finding_rows(run_id: str, scan_id: str, findings: list[dict[str, Any]]) -> 
     duplicate producer rows collapse instead of aborting the transaction.
     """
     entries: dict[tuple[str, str], dict[str, Any]] = {}
-    occurrences_by_semantic: dict[str, set[str]] = defaultdict(set)
+    projections_by_semantic: dict[str, set[str]] = defaultdict(set)
     for finding in findings:
         vulnerability_id = _vulnerability_id_from_finding(finding)
         package_ref = str(finding.get("package") or "")
         ecosystem = str(finding.get("ecosystem") or "")
         semantic_key = _finding_key(finding, vulnerability_id, package_ref, ecosystem)
         occurrence_key = _finding_occurrence_key(finding, package_ref, ecosystem)
-        entries.setdefault((semantic_key, occurrence_key), finding)
-        occurrences_by_semantic[semantic_key].add(occurrence_key)
+        projection_key = _finding_projection_key(finding)
+        storage_discriminator = f"{occurrence_key}:{projection_key}"
+        entries.setdefault((semantic_key, storage_discriminator), finding)
+        projections_by_semantic[semantic_key].add(storage_discriminator)
 
     rows: list[tuple[Any, ...]] = []
-    for (semantic_key, occurrence_key), finding in entries.items():
-        if len(occurrences_by_semantic[semantic_key]) == 1:
+    for (semantic_key, storage_discriminator), finding in entries.items():
+        if len(projections_by_semantic[semantic_key]) == 1:
             storage_key = semantic_key
         else:
-            suffix = uuid.uuid5(uuid.NAMESPACE_URL, f"agent-bom:local-finding-occurrence:{occurrence_key}")
+            suffix = uuid.uuid5(uuid.NAMESPACE_URL, f"agent-bom:local-finding-occurrence:{storage_discriminator}")
             storage_key = f"{semantic_key}:{suffix}"
         rows.append(_finding_row(run_id, scan_id, finding, finding_key=storage_key))
     return rows
@@ -593,6 +596,12 @@ def _finding_occurrence_key(finding: dict[str, Any], package_ref: str, ecosystem
         "ecosystem": ecosystem,
     }
     return json.dumps(occurrence, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _finding_projection_key(finding: dict[str, Any]) -> str:
+    """Return a stable full-row key so only structurally exact duplicates collapse."""
+    canonical = json.dumps(finding, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 def _finding_row(

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -53,6 +53,7 @@ from agent_bom.output.json_fmt import (  # noqa: E402
     _build_remediation_json,  # noqa: F401
     _risk_narrative,  # noqa: F401
     export_json,  # noqa: F401
+    redact_json_payload,  # noqa: F401
     to_json,  # noqa: F401
     to_redacted_json,  # noqa: F401
 )

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -1527,17 +1527,35 @@ def to_json(report: AIBOMReport) -> dict:
     return result
 
 
-def to_redacted_json(report: AIBOMReport) -> dict[str, Any]:
-    """Return a JSON report payload safe for stdout and on-disk export."""
-    data = sanitize_sensitive_payload(to_json(report))
+def redact_json_payload(report_json: dict[str, Any]) -> dict[str, Any]:
+    """Redact an existing canonical report projection for public output."""
+    data = sanitize_sensitive_payload(report_json)
     if isinstance(data, dict):
         return data
     return {"document_type": "AI-BOM", "redaction_error": "report sanitizer returned a non-object payload"}
 
 
-def export_json(report: AIBOMReport, output_path: str) -> None:
+def to_redacted_json(
+    report: AIBOMReport,
+    *,
+    report_json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a JSON report payload safe for stdout and on-disk export.
+
+    ``report_json`` lets finalized scan paths reuse their canonical projection;
+    direct callers retain the original build-and-redact behavior.
+    """
+    return redact_json_payload(report_json if report_json is not None else to_json(report))
+
+
+def export_json(
+    report: AIBOMReport,
+    output_path: str,
+    *,
+    report_json: dict[str, Any] | None = None,
+) -> None:
     """Export report as JSON file."""
-    data = to_redacted_json(report)
+    data = to_redacted_json(report, report_json=report_json)
     with Path(output_path).open("w", encoding="utf-8") as fh:
         json.dump(data, fh, indent=2)
         fh.write("\n")

--- a/src/agent_bom/scanners/package_scan.py
+++ b/src/agent_bom/scanners/package_scan.py
@@ -493,9 +493,9 @@ def _db_covered_ecosystems(ecosystems: set[str] | None = None) -> set[str]:
     missing/unreadable (callers treat that as "no offline coverage at all").
 
     When ``ecosystems`` is provided, bound the legacy row-inference query to
-    those inventory ecosystems. The affected table can contain millions of
-    rows and thousands of distro-scoped ecosystems; a scan only needs coverage
-    truth for the ecosystems it is actually evaluating.
+    those inventory ecosystems. If none match, retain one catalog-presence
+    witness so callers can distinguish an uncovered ecosystem from a wholly
+    empty DB without enumerating the multi-million-row catalog.
     """
     try:
         from agent_bom.db.schema import (
@@ -541,6 +541,18 @@ def _db_covered_ecosystems(ecosystems: set[str] | None = None) -> set[str]:
                     placeholders = ", ".join("?" for _ in chunk)
                     query = f"SELECT DISTINCT ecosystem FROM affected WHERE ecosystem IN ({placeholders})"  # nosec B608
                     rows.extend(conn.execute(query, chunk).fetchall())
+                if not rows:
+                    # Preserve the existing populated-catalog signal without
+                    # enumerating every ecosystem.  Callers use a non-empty set
+                    # to distinguish "this inventory ecosystem is uncovered"
+                    # from "the advisory DB is completely empty"; the sampled
+                    # ecosystem cannot satisfy membership for the uncovered
+                    # package, so its verdict remains conservative.
+                    sample = conn.execute(
+                        "SELECT ecosystem FROM affected WHERE ecosystem IS NOT NULL AND ecosystem <> '' LIMIT 1"
+                    ).fetchone()
+                    if sample is not None:
+                        rows.append(sample)
         finally:
             conn.close()
         # Ecosystem-specific OSV archives can contain cross-ecosystem aliases.

--- a/src/agent_bom/scanners/package_scan.py
+++ b/src/agent_bom/scanners/package_scan.py
@@ -455,7 +455,8 @@ def _flag_remote_lookup_gap(osv_targets: list[Package]) -> None:
 
     if not any(warning.get("kind") == "remote_lookup_error" for warning in peek_coverage_warnings()):
         return
-    covered_ecos = _scanners_patchable("_db_covered_ecosystems")()
+    target_ecosystems = {eco for package in osv_targets for eco in _db_ecosystems_for_package(package)}
+    covered_ecos = _scanners_patchable("_db_covered_ecosystems")(target_ecosystems)
     uncovered = [pkg for pkg in osv_targets if not any(eco in covered_ecos for eco in _db_ecosystems_for_package(pkg))]
     if not uncovered:
         return
@@ -480,7 +481,7 @@ def _flag_remote_lookup_gap(osv_targets: list[Package]) -> None:
     )
 
 
-def _db_covered_ecosystems() -> set[str]:
+def _db_covered_ecosystems(ecosystems: set[str] | None = None) -> set[str]:
     """Return the lowercased ecosystems the local vulnerability DB has advisories for.
 
     An advisory DB only stores *vulnerable* package-versions, so it cannot
@@ -490,6 +491,11 @@ def _db_covered_ecosystems() -> set[str]:
     package in that ecosystem with no rows is clean; an ecosystem with zero
     advisories is a real coverage gap. Returns an empty set when the DB is
     missing/unreadable (callers treat that as "no offline coverage at all").
+
+    When ``ecosystems`` is provided, bound the legacy row-inference query to
+    those inventory ecosystems. The affected table can contain millions of
+    rows and thousands of distro-scoped ecosystems; a scan only needs coverage
+    truth for the ecosystems it is actually evaluating.
     """
     try:
         from agent_bom.db.schema import (
@@ -502,7 +508,6 @@ def _db_covered_ecosystems() -> set[str]:
             return set()
         conn = open_existing_db_readonly(DB_PATH)
         try:
-            rows = conn.execute("SELECT DISTINCT ecosystem FROM affected").fetchall()
             declared: set[str] = set()
             coverage_mode = "legacy"
             columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(sync_meta)").fetchall()}
@@ -515,9 +520,27 @@ def _db_covered_ecosystems() -> set[str]:
                         metadata = {}
                     if isinstance(metadata, dict):
                         coverage_mode = str(metadata.get("coverage", "legacy"))
-                        ecosystems = metadata.get("ecosystems")
-                        if isinstance(ecosystems, list):
-                            declared = {str(item).lower() for item in ecosystems if isinstance(item, str) and item}
+                        declared_ecosystems = metadata.get("ecosystems")
+                        if isinstance(declared_ecosystems, list):
+                            declared = {str(item).lower() for item in declared_ecosystems if isinstance(item, str) and item}
+            requested = {str(item).lower() for item in ecosystems or set() if str(item).strip()}
+            if coverage_mode == "selected_ecosystems":
+                return declared & requested if ecosystems is not None else declared
+            if coverage_mode == "partial":
+                return set()
+
+            if ecosystems is None:
+                rows = conn.execute("SELECT DISTINCT ecosystem FROM affected").fetchall()
+            elif not requested:
+                rows = []
+            else:
+                rows = []
+                requested_list = sorted(requested)
+                for start in range(0, len(requested_list), 400):
+                    chunk = requested_list[start : start + 400]
+                    placeholders = ", ".join("?" for _ in chunk)
+                    query = f"SELECT DISTINCT ecosystem FROM affected WHERE ecosystem IN ({placeholders})"  # nosec B608
+                    rows.extend(conn.execute(query, chunk).fetchall())
         finally:
             conn.close()
         # Ecosystem-specific OSV archives can contain cross-ecosystem aliases.
@@ -525,11 +548,10 @@ def _db_covered_ecosystems() -> set[str]:
         # ecosystem's complete archive was synchronized. Scoped metadata is
         # therefore authoritative; row inference remains only for legacy/full
         # databases that predate the explicit coverage contract.
-        if coverage_mode == "selected_ecosystems":
-            return declared
-        if coverage_mode == "partial":
-            return set()
-        return {str(r[0]).lower() for r in rows if r[0]} | declared
+        inferred = {str(r[0]).lower() for r in rows if r[0]}
+        if ecosystems is not None:
+            declared &= requested
+        return inferred | declared
     except Exception as exc:  # noqa: BLE001
         _logger.debug("Could not read local DB ecosystem coverage: %s", exc)
         return set()
@@ -1544,7 +1566,8 @@ async def scan_packages(
     from agent_bom.coverage import osv_fallback_db_keys
 
     force_osv_keys = osv_fallback_db_keys(scannable, gaps=coverage_gaps) if not scan_offline else set()
-    covered_ecos = _scanners_patchable("_db_covered_ecosystems")()
+    inventory_ecosystems = {eco for package in scannable for eco in _db_ecosystems_for_package(package)}
+    covered_ecos = _scanners_patchable("_db_covered_ecosystems")(inventory_ecosystems)
     # Either an exact package hit or a declared complete ecosystem archive is
     # sufficient local evidence. Sparse-release fallbacks deliberately override
     # both so EOL coverage cannot be mistaken for a clean result.

--- a/tests/test_check_incomplete_on_remote_failure.py
+++ b/tests/test_check_incomplete_on_remote_failure.py
@@ -36,7 +36,7 @@ def _run(monkeypatch, *, db_ecosystems: set[str], osv_failed: bool, args: list[s
 
     # package_scan resolves these through ``agent_bom.scanners`` so tests can
     # replace them; patch them where the runtime actually looks them up.
-    monkeypatch.setattr(scanners_mod, "_db_covered_ecosystems", lambda: db_ecosystems, raising=False)
+    monkeypatch.setattr(scanners_mod, "_db_covered_ecosystems", lambda *_args: db_ecosystems, raising=False)
     monkeypatch.setattr(scanners_mod, "_scan_packages_local_db", lambda packages: (0, set()), raising=False)
     monkeypatch.setattr("agent_bom.parsers.os_parsers.enrich_os_package_context", lambda pkg: True)
 

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -426,10 +426,12 @@ def test_scan_json_reuses_canonical_report_projection(monkeypatch, tmp_path):
     output = tmp_path / "report.json"
     original_to_json = scan_cmd.to_json
     projection_calls = 0
+    projected_reports = []
 
     def _count_projection(report):
         nonlocal projection_calls
         projection_calls += 1
+        projected_reports.append(report)
         return original_to_json(report)
 
     def _unexpected_reprojection(_report):
@@ -457,7 +459,14 @@ def test_scan_json_reuses_canonical_report_projection(monkeypatch, tmp_path):
 
     assert result.exit_code == 0, result.output
     assert projection_calls == 1
-    assert json.loads(output.read_text(encoding="utf-8"))["document_type"] == "AI-BOM"
+    actual = json.loads(output.read_text(encoding="utf-8"))
+    expected = json_fmt.redact_json_payload(original_to_json(projected_reports[0]))
+    # Full equality pins summaries, finding counts, reachability/verdict fields,
+    # and enrichment—not merely the outer document marker.
+    assert actual == expected
+    assert actual["document_type"] == "AI-BOM"
+    assert actual["summary"] == expected["summary"]
+    assert actual.get("findings") == expected.get("findings")
 
 
 def test_scan_agent_mode_reuses_canonical_report_projection(monkeypatch):
@@ -467,10 +476,12 @@ def test_scan_agent_mode_reuses_canonical_report_projection(monkeypatch):
 
     original_to_json = scan_cmd.to_json
     projection_calls = 0
+    projected_reports = []
 
     def _count_projection(report):
         nonlocal projection_calls
         projection_calls += 1
+        projected_reports.append(report)
         return original_to_json(report)
 
     def _unexpected_reprojection(_report):
@@ -484,7 +495,18 @@ def test_scan_agent_mode_reuses_canonical_report_projection(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert projection_calls == 1
-    assert json.loads(result.output)["data"]["document_type"] == "AI-BOM"
+    actual = json.loads(result.output)["data"]
+    expected_report = json_fmt.redact_json_payload(original_to_json(projected_reports[0]))
+    expected = success_envelope(
+        command="agents",
+        report_json=expected_report,
+        exit_code=0,
+        token_budget=0,
+        full=False,
+        output_path=None,
+    )["data"]
+    assert actual == expected
+    assert actual["document_type"] == "AI-BOM"
 
 
 def test_scan_save_records_local_analytics_once(monkeypatch, tmp_path):

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -414,8 +414,93 @@ def test_scan_records_local_analytics_without_save():
         result = _run(["scan", "--demo", "--no-scan", "--quiet"])
 
     assert result.exit_code == 0
-    assert calls
+    assert len(calls) == 1
     assert calls[0][1]["source"] == "cli"
+
+
+def test_scan_json_reuses_canonical_report_projection(monkeypatch, tmp_path):
+    """JSON output must not rebuild the full report after scan finalization."""
+    import agent_bom.cli.agents.scan_cmd as scan_cmd
+    import agent_bom.output.json_fmt as json_fmt
+
+    output = tmp_path / "report.json"
+    original_to_json = scan_cmd.to_json
+    projection_calls = 0
+
+    def _count_projection(report):
+        nonlocal projection_calls
+        projection_calls += 1
+        return original_to_json(report)
+
+    def _unexpected_reprojection(_report):
+        raise AssertionError("JSON output rebuilt the finalized report projection")
+
+    monkeypatch.setattr(scan_cmd, "to_json", _count_projection)
+    monkeypatch.setattr(json_fmt, "to_json", _unexpected_reprojection)
+    monkeypatch.setattr("agent_bom.db.local_analytics.record_scan_report_best_effort", lambda *_args, **_kwargs: None)
+
+    result = _run(
+        [
+            "scan",
+            "--demo",
+            "--no-scan",
+            "--offline",
+            "--no-auto-update-db",
+            "--format",
+            "json",
+            "--output",
+            str(output),
+            "--exit-zero",
+            "--quiet",
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert projection_calls == 1
+    assert json.loads(output.read_text(encoding="utf-8"))["document_type"] == "AI-BOM"
+
+
+def test_scan_agent_mode_reuses_canonical_report_projection(monkeypatch):
+    """Agent envelopes must reuse the report dict persisted by the CLI."""
+    import agent_bom.cli.agents.scan_cmd as scan_cmd
+    import agent_bom.output.json_fmt as json_fmt
+
+    original_to_json = scan_cmd.to_json
+    projection_calls = 0
+
+    def _count_projection(report):
+        nonlocal projection_calls
+        projection_calls += 1
+        return original_to_json(report)
+
+    def _unexpected_reprojection(_report):
+        raise AssertionError("agent-mode output rebuilt the finalized report projection")
+
+    monkeypatch.setattr(scan_cmd, "to_json", _count_projection)
+    monkeypatch.setattr(json_fmt, "to_json", _unexpected_reprojection)
+    monkeypatch.setattr("agent_bom.db.local_analytics.record_scan_report_best_effort", lambda *_args, **_kwargs: None)
+
+    result = _run(["agents", "--agent-mode", "--demo", "--no-scan", "--offline", "--no-auto-update-db"])
+
+    assert result.exit_code == 0, result.output
+    assert projection_calls == 1
+    assert json.loads(result.output)["data"]["document_type"] == "AI-BOM"
+
+
+def test_scan_save_records_local_analytics_once(monkeypatch, tmp_path):
+    """History saving is the one analytics write for ``--save`` scans."""
+    import agent_bom.history as history
+
+    calls = []
+    monkeypatch.setattr(history, "HISTORY_DIR", tmp_path / "history")
+    monkeypatch.setattr("agent_bom.db.local_analytics.record_scan_report_best_effort", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    result = _run(["scan", "--demo", "--save", "--no-scan", "--quiet"])
+
+    assert result.exit_code == 0, result.output
+    assert len(calls) == 1
+    assert calls[0][1]["source"] == "cli"
+    assert calls[0][1]["artifact_path"].suffix == ".json"
 
 
 def test_scan_empty_state_shows_real_client_paths(monkeypatch):

--- a/tests/test_first_run_sample.py
+++ b/tests/test_first_run_sample.py
@@ -127,7 +127,7 @@ async def test_generated_first_run_manifests_resolve_vulnerability_findings(
         return 0
 
     monkeypatch.setattr("agent_bom.scanners._scan_packages_local_db", lambda _packages: (0, set()))
-    monkeypatch.setattr("agent_bom.scanners._db_covered_ecosystems", lambda: set())
+    monkeypatch.setattr("agent_bom.scanners._db_covered_ecosystems", lambda *_args: set())
     monkeypatch.setattr("agent_bom.scanners.query_osv_batch", fake_osv_batch)
     monkeypatch.setattr("agent_bom.scanners.ghsa_advisory.check_github_advisories", fake_github_advisories)
 

--- a/tests/test_local_analytics.py
+++ b/tests/test_local_analytics.py
@@ -221,7 +221,7 @@ def test_cli_agents_scan_mirrors_to_local_analytics(monkeypatch, tmp_path):
 
     with sqlite3.connect(db_path) as conn:
         count = conn.execute("SELECT COUNT(*) FROM scan_runs").fetchone()[0]
-    assert count >= 1, "CLI scan must persist to local-analytics scan_runs"
+    assert count == 1, "one CLI scan must persist exactly one local-analytics run"
 
 
 def test_cli_local_analytics_mirror_is_best_effort(monkeypatch, tmp_path):

--- a/tests/test_local_analytics.py
+++ b/tests/test_local_analytics.py
@@ -182,6 +182,70 @@ def test_local_analytics_store_records_unified_non_cve_findings(tmp_path):
     assert '"asset_type": "prompt_template"' in rows[0]["asset_json"]
 
 
+def test_local_analytics_preserves_distinct_occurrences_with_shared_identity(tmp_path):
+    """One semantic finding may have multiple independently stored occurrences."""
+    store = LocalAnalyticsStore(tmp_path / "local.sqlite")
+    report = _report("scan-occurrences")
+    report["scan_run"] = {"run_id": "run-occurrences"}
+    report.pop("blast_radius")
+    first = {
+        "schema_version": "1",
+        "id": "semantic-finding-1",
+        "canonical_id": "semantic-finding-1",
+        "occurrence_id": "semantic-finding-1",
+        "finding_type": "CIS_FAIL",
+        "source": "CLOUD_SECURITY",
+        "severity": "high",
+        "title": "Shared policy failure",
+        "asset": {
+            "name": "service-a",
+            "asset_type": "iac_resource",
+            "identifier": "service-a",
+            "canonical_id": "asset-a",
+            "location": "deploy/a.yaml",
+        },
+        "affected_agents": ["agent-a"],
+        "evidence": {"path": "deploy/a.yaml", "line": 12},
+    }
+    second = {
+        **first,
+        "asset": {
+            "name": "service-b",
+            "asset_type": "iac_resource",
+            "identifier": "service-b",
+            "canonical_id": "asset-b",
+            "location": "deploy/b.yaml",
+        },
+        "affected_agents": ["agent-b"],
+        "evidence": {"path": "deploy/b.yaml", "line": 27},
+    }
+    # Exact duplicate producer rows collapse, but the distinct occurrence must
+    # survive with the same semantic/canonical identity.
+    report["findings"] = [first, dict(first), second]
+
+    store.record_scan_report(report, source="cli")
+    first_rows = store.query(
+        "SELECT finding_key, canonical_id, affected_agents_json, asset_json FROM scan_findings WHERE run_id = ? ORDER BY finding_key",
+        ("run-occurrences",),
+    )
+
+    assert len(first_rows) == 2
+    assert {row["canonical_id"] for row in first_rows} == {"semantic-finding-1"}
+    assert len({row["finding_key"] for row in first_rows}) == 2
+    assert all(row["finding_key"].startswith("semantic-finding-1:") for row in first_rows)
+    assert {row["affected_agents_json"] for row in first_rows} == {'["agent-a"]', '["agent-b"]'}
+
+    # Re-recording the same durable run replaces its occurrence rows with the
+    # same deterministic storage keys instead of multiplying them.
+    store.record_scan_report(report, source="cli")
+    second_rows = store.query(
+        "SELECT finding_key, canonical_id, affected_agents_json, asset_json FROM scan_findings WHERE run_id = ? ORDER BY finding_key",
+        ("run-occurrences",),
+    )
+    assert second_rows == first_rows
+    assert store.query("SELECT COUNT(*) AS count FROM scan_runs WHERE run_id = ?", ("run-occurrences",)) == [{"count": 1}]
+
+
 def test_history_save_dual_writes_local_analytics(monkeypatch, tmp_path):
     import agent_bom.db.local_analytics as local_analytics
     import agent_bom.history as history

--- a/tests/test_local_analytics.py
+++ b/tests/test_local_analytics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 
 from click.testing import CliRunner
@@ -244,6 +245,106 @@ def test_local_analytics_preserves_distinct_occurrences_with_shared_identity(tmp
     )
     assert second_rows == first_rows
     assert store.query("SELECT COUNT(*) AS count FROM scan_runs WHERE run_id = ?", ("run-occurrences",)) == [{"count": 1}]
+
+
+def test_local_analytics_preserves_conflicting_projections_order_independently(tmp_path):
+    """Same-location projections with different truth must not be first-row-wins."""
+    store = LocalAnalyticsStore(tmp_path / "local.sqlite")
+    report = _report("scan-projections")
+    report["scan_run"] = {"run_id": "run-projections"}
+    report.pop("blast_radius")
+    high = {
+        "schema_version": "1",
+        "id": "semantic-finding-1",
+        "canonical_id": "semantic-finding-1",
+        "finding_type": "CIS_FAIL",
+        "source": "CLOUD_SECURITY",
+        "severity": "high",
+        "risk_score": 7.0,
+        "title": "Shared policy failure",
+        "description": "producer-A",
+        "asset": {
+            "name": "service-a",
+            "asset_type": "iac_resource",
+            "identifier": "service-a",
+            "canonical_id": "asset-a",
+            "location": "deploy/a.yaml",
+        },
+        "evidence": {"path": "deploy/a.yaml", "line": 12},
+    }
+    critical = {
+        **high,
+        "severity": "critical",
+        "risk_score": 9.9,
+        "description": "producer-B",
+    }
+
+    def _stored_rows():
+        return store.query(
+            "SELECT finding_key, severity, risk_score, raw_json FROM scan_findings WHERE run_id = ? ORDER BY finding_key",
+            ("run-projections",),
+        )
+
+    report["findings"] = [high, critical]
+    store.record_scan_report(report, source="cli")
+    first_rows = _stored_rows()
+
+    assert len(first_rows) == 2
+    assert {(row["severity"], row["risk_score"]) for row in first_rows} == {("high", 7.0), ("critical", 9.9)}
+    assert {json.loads(row["raw_json"])["description"] for row in first_rows} == {"producer-A", "producer-B"}
+
+    report["findings"] = [critical, high]
+    store.record_scan_report(report, source="cli")
+    assert _stored_rows() == first_rows
+
+
+def test_local_analytics_preserves_pii_and_credential_occurrences(tmp_path):
+    """PII and credential exposure occurrences retain distinct source truth."""
+    store = LocalAnalyticsStore(tmp_path / "local.sqlite")
+    report = _report("scan-sensitive-occurrences")
+    report["scan_run"] = {"run_id": "run-sensitive-occurrences"}
+    report.pop("blast_radius")
+    common = {
+        "schema_version": "1",
+        "id": "sensitive-exposure",
+        "canonical_id": "sensitive-exposure",
+        "source": "SECRET_SCANNER",
+        "severity": "high",
+        "title": "Sensitive source occurrence",
+    }
+    report["findings"] = [
+        {
+            **common,
+            "finding_type": "PII_EXPOSURE",
+            "asset": {"canonical_id": "source-a", "asset_type": "source_file", "location": "src/a.py"},
+            "evidence": {"path": "src/a.py", "line": 10},
+        },
+        {
+            **common,
+            "finding_type": "CREDENTIAL_EXPOSURE",
+            "asset": {"canonical_id": "source-b", "asset_type": "source_file", "location": "src/b.py"},
+            "evidence": {"path": "src/b.py", "line": 20},
+        },
+    ]
+
+    store.record_scan_report(report, source="cli")
+    rows = store.query(
+        "SELECT finding_type, canonical_id, asset_canonical_id FROM scan_findings WHERE run_id = ? ORDER BY finding_type",
+        ("run-sensitive-occurrences",),
+    )
+
+    assert rows == [
+        {
+            "finding_type": "CREDENTIAL_EXPOSURE",
+            "canonical_id": "sensitive-exposure",
+            "asset_canonical_id": "source-b",
+        },
+        {
+            "finding_type": "PII_EXPOSURE",
+            "canonical_id": "sensitive-exposure",
+            "asset_canonical_id": "source-a",
+        },
+    ]
 
 
 def test_history_save_dual_writes_local_analytics(monkeypatch, tmp_path):

--- a/tests/test_local_db_scan.py
+++ b/tests/test_local_db_scan.py
@@ -480,6 +480,8 @@ def test_db_covered_ecosystems_includes_declared_scoped_sync_with_zero_advisorie
 
     monkeypatch.setattr("agent_bom.db.schema.DB_PATH", db_file)
     assert _db_covered_ecosystems() == {"pypi"}
+    assert _db_covered_ecosystems({"pypi", "npm"}) == {"pypi"}
+    assert _db_covered_ecosystems({"npm"}) == set()
 
 
 def test_db_covered_ecosystems_does_not_infer_scope_from_cross_ecosystem_rows(tmp_path, monkeypatch):
@@ -558,6 +560,13 @@ def test_db_covered_ecosystems_bounds_legacy_query_to_requested_ecosystems(tmp_p
     assert len(coverage_queries) == 1
     assert "WHERE ecosystem IN" in coverage_queries[0]
     assert "npm" not in coverage_queries[0]
+
+    statements.clear()
+    requested = {f"synthetic-{index}" for index in range(400)} | {"pypi"}
+    assert _db_covered_ecosystems(requested) == {"pypi"}
+    chunked_queries = [statement for statement in statements if "FROM affected" in statement]
+    assert len(chunked_queries) == 2
+    assert all("WHERE ecosystem IN" in statement for statement in chunked_queries)
 
 
 def test_scan_packages_offline_uncovered_ecosystem_warns_without_discarding(monkeypatch):

--- a/tests/test_local_db_scan.py
+++ b/tests/test_local_db_scan.py
@@ -569,6 +569,36 @@ def test_db_covered_ecosystems_bounds_legacy_query_to_requested_ecosystems(tmp_p
     assert all("WHERE ecosystem IN" in statement for statement in chunked_queries)
 
 
+def test_db_covered_ecosystems_keeps_populated_catalog_truth_for_uncovered_scope(tmp_path, monkeypatch):
+    """A bounded miss must not make a populated legacy catalog look empty."""
+    from agent_bom.db import schema
+    from agent_bom.db.schema import init_db
+    from agent_bom.scanners import _db_covered_ecosystems
+
+    db_file = tmp_path / "legacy.db"
+    conn = init_db(db_file)
+    conn.execute(
+        "INSERT INTO vulns(id,summary,severity,source) VALUES (?,?,?,?)",
+        ("OSV-NPM-1", "node advisory", "high", "osv"),
+    )
+    conn.execute(
+        "INSERT INTO affected(vuln_id,ecosystem,package_name,introduced,fixed,last_affected) VALUES (?,?,?,?,?,?)",
+        ("OSV-NPM-1", "npm", "express", "0", "5.0.0", ""),
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO sync_meta(source,last_synced,record_count,metadata_json) VALUES (?,?,?,?)",
+        ("osv", "2026-08-24T12:00:00+00:00", 1, "{}"),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(schema, "DB_PATH", db_file)
+
+    covered = _db_covered_ecosystems({"pypi"})
+    assert covered
+    assert "pypi" not in covered
+
+
 def test_scan_packages_offline_uncovered_ecosystem_warns_without_discarding(monkeypatch):
     """A package in an ecosystem the DB has zero advisories for warns, not raises."""
     from agent_bom.scanners import scan_packages

--- a/tests/test_local_db_scan.py
+++ b/tests/test_local_db_scan.py
@@ -513,6 +513,53 @@ def test_db_covered_ecosystems_does_not_infer_scope_from_cross_ecosystem_rows(tm
     assert _db_covered_ecosystems() == {"pypi"}
 
 
+def test_db_covered_ecosystems_bounds_legacy_query_to_requested_ecosystems(tmp_path, monkeypatch):
+    """Scan coverage must not enumerate an entire multi-million-row catalog."""
+    from agent_bom.db import schema
+    from agent_bom.db.schema import init_db
+    from agent_bom.scanners import _db_covered_ecosystems
+
+    db_file = tmp_path / "legacy.db"
+    conn = init_db(db_file)
+    conn.executemany(
+        "INSERT INTO vulns(id,summary,severity,source) VALUES (?,?,?,?)",
+        [
+            ("OSV-PYPI-1", "python advisory", "high", "osv"),
+            ("OSV-NPM-1", "node advisory", "high", "osv"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO affected(vuln_id,ecosystem,package_name,introduced,fixed,last_affected) VALUES (?,?,?,?,?,?)",
+        [
+            ("OSV-PYPI-1", "pypi", "requests", "0", "3.0.0", ""),
+            ("OSV-NPM-1", "npm", "express", "0", "5.0.0", ""),
+        ],
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO sync_meta(source,last_synced,record_count,metadata_json) VALUES (?,?,?,?)",
+        ("osv", "2026-08-24T12:00:00+00:00", 2, "{}"),
+    )
+    conn.commit()
+    conn.close()
+
+    statements: list[str] = []
+    original_open = schema.open_existing_db_readonly
+
+    def _traced_open(path):
+        traced = original_open(path)
+        traced.set_trace_callback(statements.append)
+        return traced
+
+    monkeypatch.setattr(schema, "DB_PATH", db_file)
+    monkeypatch.setattr(schema, "open_existing_db_readonly", _traced_open)
+
+    assert _db_covered_ecosystems({"pypi"}) == {"pypi"}
+    coverage_queries = [statement for statement in statements if "FROM affected" in statement]
+    assert len(coverage_queries) == 1
+    assert "WHERE ecosystem IN" in coverage_queries[0]
+    assert "npm" not in coverage_queries[0]
+
+
 def test_scan_packages_offline_uncovered_ecosystem_warns_without_discarding(monkeypatch):
     """A package in an ecosystem the DB has zero advisories for warns, not raises."""
     from agent_bom.scanners import scan_packages


### PR DESCRIPTION
## Summary

- Reuse the finalized canonical report projection for JSON and agent output, and keep one local analytics write per CLI scan.
- Bound legacy advisory coverage queries to ecosystems present in the current inventory instead of enumerating the full advisory catalog.
- Persist every structurally distinct finding projection with deterministic occurrence keys; collapse only exact duplicates and keep replay idempotent.

## Verification

- `uv run pytest -q tests/test_cli_scan.py tests/test_local_analytics.py tests/test_local_db_scan.py tests/test_check_incomplete_on_remote_failure.py tests/test_first_run_sample.py` — 188 passed.
- Focused cached-output, occurrence, PII/credential, scoped-coverage, and chunk-boundary regressions — 7 passed.
- `uv run ruff check ...` and `uv run ruff format --check ...` — clean for all touched files.
- `uv run mypy ...` — clean for all six touched source files.
- `make preflight` — passed, including OpenAPI/schema/product-surface/release/count drift gates.
- Offline ordinary-repository scan completed in 1.06s with the same summary, findings, blast-radius, package, and coverage projection digest as exact main.
- On the local 5,317,925-row advisory database, the five-call median coverage lookup was 0.1633s on exact main and 0.0108s when bounded to `pypi` and `npm`.
- A 41 MB real scan report persisted 757 distinct finding projections with 757 unique keys; replay retained one run and the same 757 rows. Two writes completed in 0.92s.
- `git diff --check` — clean.

## Notes

- Canonical finding identity is unchanged. Storage-only occurrence suffixes distinguish multiple projections under one semantic finding.
- Selected and partial advisory-coverage metadata remain authoritative; bounded row inference applies only to legacy/full catalogs.
