### PR TITLE
feat(scan): inventory GitHub Actions dependencies

### DIFF
--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -1268,10 +1268,11 @@ def _run_scan_sync(job: ScanJob) -> None:
 
         if effective_gha_path:
             pipeline.update_step("discovery", f"Scanning GitHub Actions: {effective_gha_path}")
-            from agent_bom.github_actions import scan_github_actions
+            from agent_bom.github_actions import attach_github_action_packages, discover_github_action_packages, scan_github_actions
 
             gha_agents, gha_warnings = scan_github_actions(effective_gha_path)
             agents.extend(gha_agents)
+            attach_github_action_packages(agents, effective_gha_path, discover_github_action_packages(effective_gha_path))
             warnings_all.extend(gha_warnings)
 
         for ap in effective_agent_projects:
@@ -1790,6 +1791,12 @@ def _run_scan_sync(job: ScanJob) -> None:
 
         _apply_tenant_workflow_metadata(report, tenant_id=job.tenant_id or "default")
         report_json = to_json(report)
+        if req.no_scan and any(
+            result is not None for result in (skill_audit_data, iac_findings_data, repo_ai_inventory_data, repo_sast_data)
+        ):
+            # Adding inventory evidence must not erase the established status
+            # of a static-findings-only repository scan.
+            report_json["status"] = "findings_only"
         result_document, document_note = _rendered_result_document(job, report)
         with lock:
             job.result = report_json

--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -792,18 +792,24 @@ def run_local_discovery(
 
     # Step 1f: GitHub Actions scan (--gha)
     if not skill_only and gha_path:
-        from agent_bom.github_actions import scan_github_actions
+        from agent_bom.github_actions import attach_github_action_packages, discover_github_action_packages, scan_github_actions
 
         con.print(f"\n[bold blue]Scanning GitHub Actions workflows in {gha_path}...[/bold blue]\n")
         gha_agents, gha_warnings = scan_github_actions(gha_path)
+        gha_packages = discover_github_action_packages(gha_path)
         for w in gha_warnings:
             con.print(f"  [yellow]⚠[/yellow] {w}")
-        if gha_agents:
+        if gha_agents or gha_packages:
             cred_count = sum(len(s.credential_names) for a in gha_agents for s in a.mcp_servers)
-            con.print(f"  [green]✓[/green] {len(gha_agents)} workflow(s) with AI usage, {cred_count} credential(s) detected")
+            con.print(
+                f"  [green]✓[/green] {len(gha_agents)} workflow(s) with AI usage, "
+                f"{len(gha_packages)} action/reusable-workflow dependency(ies), "
+                f"{cred_count} credential(s) detected"
+            )
             ctx.agents.extend(gha_agents)
+            attach_github_action_packages(ctx.agents, gha_path, gha_packages)
         else:
-            con.print("  [dim]  No AI-using workflows found[/dim]")
+            con.print("  [dim]  No remote action dependencies or AI-using workflows found[/dim]")
 
     # Step 1g: Python agent framework scan (--agent-project)
     if not skill_only and agent_projects:

--- a/src/agent_bom/github_actions.py
+++ b/src/agent_bom/github_actions.py
@@ -1,6 +1,7 @@
 """GitHub Actions workflow scanner for agent-bom.
 
 Scans ``.github/workflows/*.yml`` files to discover:
+- **Action and reusable-workflow dependencies** declared by ``uses:``
 - **AI API credentials** exposed as ``env:`` variables or ``secrets:`` references
 - **AI SDK usage** in ``run:`` steps (openai, anthropic, langchain, etc.)
 - **Third-party AI actions** (e.g. ``openai/openai-github-action``)
@@ -17,9 +18,10 @@ there are no extra dependencies.
 
 Usage::
 
-    from agent_bom.github_actions import scan_github_actions
+    from agent_bom.github_actions import discover_github_action_packages, scan_github_actions
 
     agents, warnings = scan_github_actions("/path/to/repo")
+    packages = discover_github_action_packages("/path/to/repo")
 """
 
 from __future__ import annotations
@@ -27,7 +29,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
+from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, ServerSurface, TransportType
 
 # ─── AI-related env var name patterns ────────────────────────────────────────
 
@@ -70,6 +72,7 @@ _AI_RUN_PATTERNS = [
 _PIP_RE = re.compile(r"pip\s+install\s+([^\n&;]+)", re.IGNORECASE)
 _NPM_RE = re.compile(r"npm\s+(?:install|i)\s+([^\n&;]+)", re.IGNORECASE)
 _FULL_COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?$")
+_REMOTE_ACTION_PREFIX_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[^\s]+)*$")
 
 # NOTE: These are *ecosystem-specific* package lists for detecting AI SDK
 # installs in GitHub Actions workflow run-steps.  They are intentionally
@@ -213,6 +216,51 @@ def _strip_yaml_scalar(value: str) -> str:
     return scalar
 
 
+def _extract_used_action_references(content: str) -> list[tuple[str, int]]:
+    """Return ``uses:`` scalar values with their one-based source lines."""
+    references: list[tuple[str, int]] = []
+    for line_number, raw_line in enumerate(content.splitlines(), start=1):
+        uses_match = re.match(r"\s*-?\s*uses\s*:\s*(.+)", raw_line)
+        if uses_match is None:
+            continue
+        scalar = _strip_yaml_scalar(uses_match.group(1))
+        if scalar:
+            references.append((scalar, line_number))
+    return references
+
+
+def _parse_remote_action_reference(reference: str) -> tuple[str, str, str] | None:
+    """Parse one evidence-backed remote action or reusable-workflow locator.
+
+    Local actions and Docker step images are execution inputs but not GitHub
+    repository dependencies. Dynamic owners/repositories cannot be assigned an
+    honest identity, so they are omitted; a static locator with a dynamic ref
+    remains useful inventory with explicitly unknown resolution confidence.
+    """
+    scalar = _strip_yaml_scalar(reference)
+    if not scalar or scalar.startswith(("./", "../", "docker://")):
+        return None
+
+    locator, separator, revision = scalar.rpartition("@")
+    if not separator:
+        locator = scalar
+        revision = ""
+    locator = locator.strip()
+    revision = revision.strip()
+    if "${{" in locator or not _REMOTE_ACTION_PREFIX_RE.fullmatch(locator):
+        return None
+
+    ecosystem = "github-action-workflow" if "/.github/workflows/" in locator else "github-action"
+    return ecosystem, locator, revision or "unknown"
+
+
+def _workflow_files(repo: Path) -> list[Path]:
+    workflows_dir = repo / ".github" / "workflows"
+    if not workflows_dir.is_dir():
+        return []
+    return sorted((*workflows_dir.glob("*.yml"), *workflows_dir.glob("*.yaml")))
+
+
 def _workflow_hardening_warnings(content: str, filename: str, used_actions: list[str]) -> list[str]:
     """Return conservative pipeline-security warnings for one workflow.
 
@@ -268,6 +316,152 @@ def _workflow_hardening_warnings(content: str, filename: str, used_actions: list
 # ─── Public API ───────────────────────────────────────────────────────────────
 
 
+def discover_github_action_packages(repo_path: str) -> list[Package]:
+    """Inventory remote action and reusable-workflow dependencies.
+
+    The returned coordinates preserve the declared Git ref without pretending
+    that a mutable tag, branch, or expression is a resolved release. Repeated
+    coordinates collapse to one package while retaining each workflow location
+    as bounded version evidence.
+    """
+    repo = Path(repo_path).expanduser().resolve()  # lgtm[py/path-injection]
+    if not repo.is_dir():
+        return []
+
+    packages: dict[tuple[str, str, str], Package] = {}
+    for workflow_path in _workflow_files(repo):
+        try:
+            content = workflow_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        source_file = workflow_path.relative_to(repo).as_posix()
+        for raw_reference, line_number in _extract_used_action_references(content):
+            parsed = _parse_remote_action_reference(raw_reference)
+            if parsed is None:
+                continue
+            ecosystem, name, version = parsed
+            key = (ecosystem, name, version)
+            evidence = {
+                "type": "command_pin" if version != "unknown" else "unknown",
+                "source_file": source_file,
+                "line": line_number,
+                "parser": "github_actions",
+            }
+            existing = packages.get(key)
+            if existing is not None:
+                if evidence not in existing.version_evidence:
+                    existing.version_evidence.append(evidence)
+                continue
+
+            exact_pin = bool(_FULL_COMMIT_SHA_RE.fullmatch(version))
+            dynamic_ref = "${{" in version
+            version_source = "command_pin" if version != "unknown" else "unknown"
+            confidence = "exact" if exact_pin else ("unknown" if dynamic_ref or version == "unknown" else "low")
+            floating = not exact_pin
+            floating_reason: str | None = None
+            if floating:
+                floating_reason = (
+                    "GitHub Actions expression reference is resolved only at workflow runtime"
+                    if dynamic_ref
+                    else "GitHub Actions tag or branch references are mutable"
+                )
+
+            packages[key] = Package(
+                name=name,
+                version=version,
+                ecosystem=ecosystem,
+                version_source=version_source,
+                declared_version=None if version == "unknown" else version,
+                resolved_version=version if exact_pin else None,
+                version_confidence=confidence,
+                version_evidence=[evidence],
+                floating_reference=floating,
+                floating_reference_reason=floating_reason,
+                discovery_provenance={
+                    "source_type": "local_discovery",
+                    "observed_via": ["github_actions"],
+                    "source": "github-actions",
+                    "collector": "github_actions",
+                    "resource_type": ecosystem,
+                    "resource_name": name,
+                    "location": source_file,
+                    "confidence": confidence,
+                    "version_source": version_source,
+                },
+            )
+
+    return list(packages.values())
+
+
+def attach_github_action_packages(agents: list[Agent], repo_path: str | Path, packages: list[Package]) -> None:
+    """Attach workflow dependencies to one repository inventory container."""
+    if not packages:
+        return
+
+    repo_root = Path(repo_path).expanduser().resolve()
+    project_agent: Agent | None = None
+    for candidate in agents:
+        if candidate.source != "project":
+            continue
+        try:
+            candidate_root = Path(candidate.config_path).expanduser().resolve()
+        except (OSError, RuntimeError, TypeError, ValueError):
+            continue
+        if candidate_root == repo_root:
+            project_agent = candidate
+            break
+
+    if project_agent is None:
+        project_agent = Agent(
+            name=f"project:{repo_root.name or str(repo_root)}",
+            agent_type=AgentType.CUSTOM,
+            config_path=str(repo_root),
+            source="project",
+            mcp_servers=[],
+            discovery_provenance={
+                "source_type": "local_discovery",
+                "observed_via": ["github_actions"],
+                "source": "github-actions",
+                "collector": "github_actions",
+                "resource_type": "repository",
+                "resource_name": repo_root.name,
+                "location": str(repo_root),
+                "confidence": "high",
+            },
+        )
+        agents.append(project_agent)
+
+    action_server = next((server for server in project_agent.mcp_servers if server.name == "github-actions"), None)
+    if action_server is None:
+        action_server = MCPServer(
+            name="github-actions",
+            command="github-actions",
+            args=[],
+            transport=TransportType.STDIO,
+            packages=[],
+            config_path=str(repo_root / ".github" / "workflows"),
+            surface=ServerSurface.OTHER,
+            discovery_provenance={
+                "source_type": "local_discovery",
+                "observed_via": ["github_actions"],
+                "source": "github-actions",
+                "collector": "github_actions",
+                "resource_type": "workflow_dependency_inventory",
+                "resource_name": "github-actions",
+                "location": ".github/workflows",
+                "confidence": "high",
+            },
+        )
+        project_agent.mcp_servers.append(action_server)
+
+    known_package_ids = {package.stable_id for package in action_server.packages}
+    for package in packages:
+        if package.stable_id in known_package_ids:
+            continue
+        action_server.packages.append(package)
+        known_package_ids.add(package.stable_id)
+
+
 def scan_github_actions(repo_path: str) -> tuple[list[Agent], list[str]]:
     """Scan GitHub Actions workflows in a repository for AI usage and credential exposure.
 
@@ -291,12 +485,7 @@ def scan_github_actions(repo_path: str) -> tuple[list[Agent], list[str]]:
     repo = Path(repo_path).expanduser().resolve()  # lgtm[py/path-injection]
     if not repo.is_dir():
         return [], [f"Not a directory: {repo_path}"]
-    workflows_dir = repo / ".github" / "workflows"
-
-    if not workflows_dir.is_dir():
-        return [], []
-
-    workflow_files = sorted(list(workflows_dir.glob("*.yml")) + list(workflows_dir.glob("*.yaml")))
+    workflow_files = _workflow_files(repo)
     if not workflow_files:
         return [], []
 

--- a/src/agent_bom/github_actions.py
+++ b/src/agent_bom/github_actions.py
@@ -72,7 +72,7 @@ _AI_RUN_PATTERNS = [
 _PIP_RE = re.compile(r"pip\s+install\s+([^\n&;]+)", re.IGNORECASE)
 _NPM_RE = re.compile(r"npm\s+(?:install|i)\s+([^\n&;]+)", re.IGNORECASE)
 _FULL_COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?$")
-_REMOTE_ACTION_PREFIX_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[^\s]+)*$")
+_REMOTE_ACTION_COMPONENT_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 # NOTE: These are *ecosystem-specific* package lists for detecting AI SDK
 # installs in GitHub Actions workflow run-steps.  They are intentionally
@@ -229,6 +229,14 @@ def _extract_used_action_references(content: str) -> list[tuple[str, int]]:
     return references
 
 
+def _is_remote_action_locator(locator: str) -> bool:
+    """Validate a static ``owner/repository[/path]`` locator in linear time."""
+    components = locator.split("/")
+    return len(components) >= 2 and all(
+        component not in {"", ".", ".."} and _REMOTE_ACTION_COMPONENT_RE.fullmatch(component) for component in components
+    )
+
+
 def _parse_remote_action_reference(reference: str) -> tuple[str, str, str] | None:
     """Parse one evidence-backed remote action or reusable-workflow locator.
 
@@ -247,7 +255,7 @@ def _parse_remote_action_reference(reference: str) -> tuple[str, str, str] | Non
         revision = ""
     locator = locator.strip()
     revision = revision.strip()
-    if "${{" in locator or not _REMOTE_ACTION_PREFIX_RE.fullmatch(locator):
+    if "${{" in locator or not _is_remote_action_locator(locator):
         return None
 
     ecosystem = "github-action-workflow" if "/.github/workflows/" in locator else "github-action"

--- a/src/agent_bom/output/spdx_fmt.py
+++ b/src/agent_bom/output/spdx_fmt.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 from uuid import NAMESPACE_URL, uuid5
 
-from agent_bom.asset_provenance import package_version_provenance
+from agent_bom.asset_provenance import package_discovery_provenance, package_version_provenance
 from agent_bom.checksums import integrity_verdict, integrity_verdict_statements, spdx3_verified_using
 from agent_bom.compliance_utils import framework_qualified_finding_tags
 from agent_bom.models import AIBOMReport
@@ -185,6 +185,12 @@ def to_spdx(report: AIBOMReport) -> dict:
                             "type": "Annotation",
                             "annotationType": "other",
                             "subject": pkg_id,
+                            "statement": f"agent-bom:ecosystem={pkg.ecosystem}",
+                        },
+                        {
+                            "type": "Annotation",
+                            "annotationType": "other",
+                            "subject": pkg_id,
                             "statement": f"agent-bom:version-provenance-source={version_provenance.get('version_source', 'unknown')}",
                         },
                         {
@@ -194,6 +200,18 @@ def to_spdx(report: AIBOMReport) -> dict:
                             "statement": f"agent-bom:version-provenance-confidence={version_provenance.get('confidence', 'unknown')}",
                         },
                     ]
+                    discovery_provenance = package_discovery_provenance(pkg)
+                    for field_name in ("source_type", "collector", "resource_type", "location"):
+                        value = (discovery_provenance or {}).get(field_name)
+                        if value:
+                            pkg_annotations.append(
+                                {
+                                    "type": "Annotation",
+                                    "annotationType": "other",
+                                    "subject": pkg_id,
+                                    "statement": f"agent-bom:discovery-provenance-{field_name.replace('_', '-')}={value}",
+                                }
+                            )
                     if pkg.is_malicious:
                         # Surface the malicious flag so a MAL- package is
                         # distinguishable from an ordinary library in the SBOM.

--- a/src/agent_bom/scanners/package_scan.py
+++ b/src/agent_bom/scanners/package_scan.py
@@ -1504,6 +1504,16 @@ async def scan_packages(
     # Inventory-only ecosystems do not have advisory sources. Exclude them from
     # local DB coverage accounting as well as live OSV queries so offline scans
     # do not misreport a deliberate inventory artifact as incomplete SCA.
+    non_osv_packages = [p for p in packages if p.ecosystem.lower() in _NON_OSV_ECOSYSTEMS]
+    for package in non_osv_packages:
+        _logger.debug(
+            "Skipping package %s/%s: ecosystem %r is not OSV-queryable (handled by other pipeline)",
+            package.ecosystem,
+            package.name,
+            package.ecosystem,
+        )
+    if non_osv_packages:
+        _bump_scan_perf("skipped_non_osv_ecosystems", len(non_osv_packages))
     scannable = [p for p in packages if not _is_unresolved_version(p.version) and p.ecosystem.lower() not in _NON_OSV_ECOSYSTEMS]
 
     # Warn about packages that could not be resolved — no silent failures

--- a/src/agent_bom/scanners/package_scan.py
+++ b/src/agent_bom/scanners/package_scan.py
@@ -297,6 +297,8 @@ _NON_OSV_ECOSYSTEMS: frozenset[str] = frozenset(
         "docker",  # Image stubs from MCP configs / docker-compose / running containers
         "container",  # GPU infra image refs (cuda-toolkit, cudnn)
         "container-image",  # CoreWeave / Nebius pod images
+        "github-action",  # Remote GitHub Action repository references
+        "github-action-workflow",  # Remote reusable-workflow references
         "ollama",  # Ollama model names — no OSV advisory DB
         "smithery",  # Smithery MCP marketplace stubs
         "mcp-registry",  # MCP Registry stubs
@@ -1499,11 +1501,13 @@ async def scan_packages(
                 _logger.warning("Transitive resolution failed, scanning direct dependencies only: %s", exc)
                 _emit_scan_warning("transitive dependency resolution failed")
 
-    # SAST packages already carry vulns from Semgrep — skip OSV query for them
-    scannable = [p for p in packages if not _is_unresolved_version(p.version) and p.ecosystem.lower() != "sast"]
+    # Inventory-only ecosystems do not have advisory sources. Exclude them from
+    # local DB coverage accounting as well as live OSV queries so offline scans
+    # do not misreport a deliberate inventory artifact as incomplete SCA.
+    scannable = [p for p in packages if not _is_unresolved_version(p.version) and p.ecosystem.lower() not in _NON_OSV_ECOSYSTEMS]
 
     # Warn about packages that could not be resolved — no silent failures
-    still_unresolved = [p for p in packages if _is_unresolved_version(p.version) and p.ecosystem.lower() != "sast"]
+    still_unresolved = [p for p in packages if _is_unresolved_version(p.version) and p.ecosystem.lower() not in _NON_OSV_ECOSYSTEMS]
     if still_unresolved:
         names = ", ".join(f"{p.name}@{p.version}" for p in still_unresolved[:10])
         suffix = f" (+{len(still_unresolved) - 10} more)" if len(still_unresolved) > 10 else ""

--- a/tests/api/test_api_scan_repo_url.py
+++ b/tests/api/test_api_scan_repo_url.py
@@ -32,6 +32,20 @@ def test_run_scan_sync_clones_repo_url_and_cleans_up(monkeypatch: pytest.MonkeyP
     cloned = tmp_path / "cloned-repo"
     cloned.mkdir()
     (cloned / "requirements.txt").write_text("requests==2.31.0\n", encoding="utf-8")
+    workflow_dir = cloned / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    workflow_dir.joinpath("ci.yml").write_text(
+        """name: CI
+on: push
+permissions: {}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567
+""",
+        encoding="utf-8",
+    )
     clone_calls: list[str] = []
     cleanup_calls: list[str] = []
 
@@ -86,3 +100,13 @@ def test_run_scan_sync_clones_repo_url_and_cleans_up(monkeypatch: pytest.MonkeyP
     assert job.result.get("iac_findings", {}).get("total") == 1
     assert job.result.get("sast", {}).get("execution_status") == "clean"
     assert job.result.get("status") == "findings_only"
+    action_packages = [
+        package
+        for agent in job.result["agents"]
+        for server in agent["mcp_servers"]
+        for package in server["packages"]
+        if package["ecosystem"] == "github-action"
+    ]
+    assert [(package["name"], package["version"]) for package in action_packages] == [
+        ("actions/checkout", "0123456789abcdef0123456789abcdef01234567")
+    ]

--- a/tests/test_github_actions_dependencies.py
+++ b/tests/test_github_actions_dependencies.py
@@ -123,6 +123,7 @@ jobs:
     steps:
       - uses: ${{ matrix.owner }}/action@v1
       - uses: owner/action@${{ matrix.ref }}
+      - uses: -/-/!/-/!/-/!/-/!/-/!/-/!@v1
 """,
     )
 

--- a/tests/test_github_actions_dependencies.py
+++ b/tests/test_github_actions_dependencies.py
@@ -1,0 +1,228 @@
+"""GitHub Actions dependency inventory regressions."""
+
+from __future__ import annotations
+
+from agent_bom.github_actions import attach_github_action_packages, discover_github_action_packages, scan_github_actions
+from agent_bom.models import Agent, AgentType, MCPServer, Package, ServerSurface
+
+
+def _write_workflow(tmp_path, name: str, content: str) -> None:
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    (workflow_dir / name).write_text(content, encoding="utf-8")
+
+
+def test_non_ai_workflow_actions_are_inventory_dependencies(tmp_path) -> None:
+    sha = "0123456789abcdef0123456789abcdef01234567"
+    _write_workflow(
+        tmp_path,
+        "ci.yml",
+        f"""name: CI
+on: push
+permissions: {{}}
+jobs:
+  test:
+    uses: octo-org/automation/.github/workflows/python.yml@main
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@{sha} # v4
+      - uses: actions/setup-python@v5
+      - uses: ./local-action
+      - uses: docker://alpine:3.20
+      - run: pytest
+""",
+    )
+
+    agents, warnings = scan_github_actions(str(tmp_path))
+    packages = discover_github_action_packages(str(tmp_path))
+
+    assert agents == []
+    assert len(packages) == 3
+    assert {(package.ecosystem, package.name, package.version) for package in packages} == {
+        ("github-action", "actions/checkout", sha),
+        ("github-action", "actions/setup-python", "v5"),
+        ("github-action-workflow", "octo-org/automation/.github/workflows/python.yml", "main"),
+    }
+    assert not any("local-action" in package.name or "alpine" in package.name for package in packages)
+    assert any("actions/setup-python@v5" in warning for warning in warnings)
+    assert any("python.yml@main" in warning for warning in warnings)
+
+    exact = next(package for package in packages if package.name == "actions/checkout")
+    assert exact.version_source == "command_pin"
+    assert exact.declared_version == sha
+    assert exact.resolved_version == sha
+    assert exact.version_confidence == "exact"
+    assert exact.floating_reference is False
+    assert exact.version_evidence == [
+        {
+            "type": "command_pin",
+            "source_file": ".github/workflows/ci.yml",
+            "line": 10,
+            "parser": "github_actions",
+        }
+    ]
+
+    floating = next(package for package in packages if package.name == "actions/setup-python")
+    assert floating.declared_version == "v5"
+    assert floating.resolved_version is None
+    assert floating.version_confidence == "low"
+    assert floating.floating_reference is True
+    assert "mutable" in (floating.floating_reference_reason or "")
+
+
+def test_duplicate_action_coordinates_preserve_each_workflow_evidence(tmp_path) -> None:
+    _write_workflow(
+        tmp_path,
+        "build.yml",
+        """name: Build
+on: push
+permissions: {}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+""",
+    )
+    _write_workflow(
+        tmp_path,
+        "test.yaml",
+        """name: Test
+on: pull_request
+permissions: {}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+""",
+    )
+
+    packages = discover_github_action_packages(str(tmp_path))
+
+    assert len(packages) == 1
+    assert packages[0].name == "actions/checkout"
+    assert packages[0].version == "v4"
+    assert [item["source_file"] for item in packages[0].version_evidence] == [
+        ".github/workflows/build.yml",
+        ".github/workflows/test.yaml",
+    ]
+
+
+def test_dynamic_action_owner_is_not_invented_as_a_package(tmp_path) -> None:
+    _write_workflow(
+        tmp_path,
+        "dynamic.yml",
+        """name: Dynamic
+on: push
+permissions: {}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${{ matrix.owner }}/action@v1
+      - uses: owner/action@${{ matrix.ref }}
+""",
+    )
+
+    packages = discover_github_action_packages(str(tmp_path))
+
+    assert [(package.name, package.version) for package in packages] == [
+        ("owner/action", "${{ matrix.ref }}"),
+    ]
+    assert packages[0].floating_reference is True
+    assert packages[0].resolved_version is None
+    assert packages[0].version_confidence == "unknown"
+
+
+def test_action_dependencies_attach_to_existing_project_inventory(tmp_path) -> None:
+    project_agent = Agent(
+        name=f"project:{tmp_path.name}",
+        agent_type=AgentType.CUSTOM,
+        config_path=str(tmp_path),
+        source="project",
+        mcp_servers=[
+            MCPServer(
+                name=tmp_path.name,
+                command="project",
+                surface=ServerSurface.OTHER,
+                packages=[Package(name="click", version="8.3.1", ecosystem="pypi")],
+            )
+        ],
+    )
+    action_package = Package(name="actions/checkout", version="v4", ecosystem="github-action")
+    agents = [project_agent]
+
+    attach_github_action_packages(agents, tmp_path, [action_package])
+    attach_github_action_packages(agents, tmp_path, [action_package])
+
+    assert len(agents) == 1
+    action_server = next(server for server in project_agent.mcp_servers if server.name == "github-actions")
+    assert action_server.surface == ServerSurface.OTHER
+    assert action_server.packages == [action_package]
+
+
+def test_action_only_repository_gets_a_project_inventory_container(tmp_path) -> None:
+    action_package = Package(name="actions/checkout", version="v4", ecosystem="github-action")
+    agents: list[Agent] = []
+
+    attach_github_action_packages(agents, tmp_path, [action_package])
+
+    assert len(agents) == 1
+    assert agents[0].name == f"project:{tmp_path.name}"
+    assert agents[0].source == "project"
+    assert agents[0].mcp_servers[0].name == "github-actions"
+    assert agents[0].mcp_servers[0].packages == [action_package]
+
+
+def test_action_dependency_identity_reaches_json_sboms_and_graph(tmp_path) -> None:
+    from agent_bom.graph.builder import build_unified_graph_from_report
+    from agent_bom.models import AIBOMReport
+    from agent_bom.output import to_cyclonedx, to_json, to_spdx
+
+    sha = "0123456789abcdef0123456789abcdef01234567"
+    _write_workflow(
+        tmp_path,
+        "ci.yml",
+        f"""name: CI
+on: push
+permissions: {{}}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@{sha}
+""",
+    )
+    packages = discover_github_action_packages(str(tmp_path))
+    agents: list[Agent] = []
+    attach_github_action_packages(agents, tmp_path, packages)
+    report = AIBOMReport(agents=agents, tool_version="0.102.0")
+
+    payload = to_json(report)
+    json_package = payload["agents"][0]["mcp_servers"][0]["packages"][0]
+    assert json_package["ecosystem"] == "github-action"
+    assert json_package["version_provenance"]["confidence"] == "exact"
+    assert json_package["discovery_provenance"]["source_type"] == "local_discovery"
+    assert json_package["discovery_provenance"]["collector"] == "github_actions"
+
+    cyclonedx = to_cyclonedx(report)
+    cdx_package = next(component for component in cyclonedx["components"] if component["name"] == "actions/checkout")
+    cdx_properties = {item["name"]: item["value"] for item in cdx_package["properties"]}
+    assert cdx_properties["agent-bom:ecosystem"] == "github-action"
+    assert cdx_properties["agent-bom:discovery-provenance:source-type"] == "local_discovery"
+    assert cdx_properties["agent-bom:discovery-provenance:collector"] == "github_actions"
+
+    spdx = to_spdx(report)
+    spdx_package = next(element for element in spdx["@graph"] if element.get("name") == "actions/checkout")
+    spdx_statements = {annotation["statement"] for annotation in spdx_package["annotation"]}
+    assert "agent-bom:ecosystem=github-action" in spdx_statements
+    assert "agent-bom:discovery-provenance-source-type=local_discovery" in spdx_statements
+    assert "agent-bom:discovery-provenance-collector=github_actions" in spdx_statements
+
+    graph = build_unified_graph_from_report(payload)
+    package_node = next(node for node in graph.nodes.values() if node.label == f"actions/checkout@{sha}")
+    assert package_node.attributes["ecosystem"] == "github-action"
+    assert package_node.attributes["version_provenance"]["confidence"] == "exact"
+    assert package_node.attributes["discovery_provenance"]["collector"] == "github_actions"

--- a/tests/test_scanner_ecosystems.py
+++ b/tests/test_scanner_ecosystems.py
@@ -337,7 +337,17 @@ def test_non_osv_ecosystems_not_empty():
     """_NON_OSV_ECOSYSTEMS must cover docker and other known non-queryable ecosystems."""
     from agent_bom.scanners import _NON_OSV_ECOSYSTEMS
 
-    for eco in ("docker", "container", "container-image", "ollama", "smithery", "sast", "unknown"):
+    for eco in (
+        "docker",
+        "container",
+        "container-image",
+        "github-action",
+        "github-action-workflow",
+        "ollama",
+        "smithery",
+        "sast",
+        "unknown",
+    ):
         assert eco in _NON_OSV_ECOSYSTEMS, f"Expected {eco!r} in _NON_OSV_ECOSYSTEMS"
 
 
@@ -364,3 +374,27 @@ async def test_docker_ecosystem_skipped_at_debug_not_warning(caplog):
     # Should emit a DEBUG skip message
     debug_msgs = [r for r in caplog.records if r.levelno == logging.DEBUG and "not OSV-queryable" in r.message]
     assert debug_msgs, "Expected a DEBUG skip message for docker ecosystem"
+
+
+@pytest.mark.asyncio
+async def test_github_action_inventory_skips_offline_advisory_coverage(monkeypatch):
+    """Inventory-only action coordinates are not an offline SCA coverage gap."""
+    from agent_bom.scanners import scan_packages
+
+    package = Package(
+        name="actions/checkout",
+        version="0123456789abcdef0123456789abcdef01234567",
+        ecosystem="github-action",
+    )
+    monkeypatch.setattr("agent_bom.scanners.offline_mode", True)
+
+    warnings: list[str] = []
+    with (
+        patch("agent_bom.scanners._scan_packages_local_db") as local_scan,
+        patch("agent_bom.scanners.record_scan_warning", side_effect=warnings.append),
+    ):
+        count = await scan_packages([package])
+
+    assert count == 0
+    local_scan.assert_not_called()
+    assert warnings == []


### PR DESCRIPTION
## Summary

- inventory every evidence-backed remote `uses:` dependency as `github-action` or `github-action-workflow`, including exact versus mutable ref provenance and deduplicated workflow locations
- carry ordinary non-AI workflow dependencies through CLI and API repository scans into JSON, CycloneDX, SPDX, and UnifiedGraph without fabricating AI agents
- treat action coordinates as inventory-only ecosystems so offline scans do not query unsupported advisory sources or report false coverage gaps

## Verification

- `python -m pytest -q tests/test_github_actions_dependencies.py tests/api/test_api_scan_repo_url.py tests/test_core.py tests/test_scanner_ecosystems.py tests/test_output_cov.py tests/test_interop_schema_conformance.py tests/test_sbom_ingestion.py -k 'github_action or run_scan_sync_clones_repo_url or gha_ or non_osv_ecosystems or spdx or action_dependency_identity'` — 37 passed
- `python -m ruff check src tests`
- `python -m ruff format --check src tests` — 2,122 files formatted
- `python -m mypy src/agent_bom` — 872 source files clean
- `make preflight`
- `python scripts/check_exception_sanitization.py`
- `python scripts/check_package_layout.py`
- `python scripts/check_public_docs_hygiene.py`
- `git diff --check`
- `agent-bom scan --gha . --no-discover --offline --no-auto-update-db --format json --output /tmp/agent-bom-gha-inventory-smoke-rebased.json` — exit 0; 30 `github-action` packages only
- UnifiedGraph smoke from that report — 30 action nodes, 30 dependency edges, 33 total nodes, 32 total edges

## Notes

- On this repository the scanner found 30 distinct action coordinates across 199 workflow occurrences: 29 exact SHA pins and one explicitly mutable `astral-sh/setup-uv@v7` reference. No remote reusable workflow is present in the current tree; fixture coverage proves that ecosystem independently.
- GitHub Action coordinates are retained as inventory and supply-chain provenance. This change does not claim an OSV advisory ecosystem for them.
- Signed head `fea38a097880a05f1cbc737d78038f55c3f6115f` is based exactly on `cb0bb7dd5995cba6e8f3f8b2c38f59f27055256b`.
