### PR TITLE
fix(graph): prioritize canvas over controls

### DIFF
--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -2833,6 +2833,7 @@ function GraphPageInner() {
           )}
 
           <details
+            data-testid="graph-evidence-controls"
             open={Boolean(
               selectedScenario ||
                 activeScopePreset === "assetDrift" ||

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -82,6 +82,7 @@ import {
   RelationshipType,
   type UnifiedNode,
 } from "@/lib/graph-schema";
+import { resolveSnapshotAttackPathCount } from "@/lib/graph-snapshot-metrics";
 import {
   entityTypesForLayers,
   lineageNodeTypeForEntity,
@@ -1501,6 +1502,11 @@ function GraphPageInner() {
     rollupCanvasPending,
     rollupView,
   ]);
+  const snapshotAttackPathCount = resolveSnapshotAttackPathCount({
+    pageTotal: attackPathQueue?.pagination.total,
+    statsTotal: graphData?.stats.attack_path_count,
+    returnedPaths: flow.summary?.attackPaths ?? 0,
+  });
 
   useEffect(() => {
     if (initializedFocus || flow.agentNames.length === 0) return;
@@ -2015,11 +2021,6 @@ function GraphPageInner() {
   }, [baseDisplayNodes]);
 
   const compressedGroupCount = aggregatedClusterNodes.length;
-  const sourceNodeCount = rollupNavigationActive
-    ? (rollupView?.summary.total_nodes_source ??
-      rollupView?.summary.total_nodes ??
-      estateNodeCount)
-    : (graphData?.nodes.length ?? flow.nodes.length);
   const renderedNodeCount = displayNodes.length;
 
   const baseDisplayEdges = useMemo(() => {
@@ -2703,41 +2704,46 @@ function GraphPageInner() {
               compact
             />
             {flow.summary && (
-              <>
-                <MetricCard value={flow.summary.agents} label="agents" />
-                <MetricCard value={flow.summary.servers} label="servers" />
-                <MetricCard
-                  value={flow.summary.findings}
-                  label="findings"
-                  accent="orange"
-                />
-                <MetricCard
-                  value={flow.summary.critical}
-                  label="critical"
-                  accent="red"
-                />
-                <MetricCard
-                  value={flow.summary.attackPaths}
-                  label="paths"
-                  accent="blue"
-                />
-                {/* Spend is opt-in by data: a tenant with no ingested LLM cost
-                    sees the header exactly as before rather than a $0 tile. */}
+              <div
+                data-testid="graph-headline-metrics"
+                className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-3 py-1.5 text-xs text-[var(--text-secondary)]"
+              >
+                <span className="font-mono text-red-700 dark:text-red-200">
+                  {flow.summary.critical.toLocaleString()}
+                </span>{" "}
+                critical ·{" "}
+                <span className="font-mono text-orange-700 dark:text-orange-200">
+                  {flow.summary.findings.toLocaleString()}
+                </span>{" "}
+                findings ·{" "}
+                <span className="font-mono text-sky-700 dark:text-sky-200">
+                  {snapshotAttackPathCount.toLocaleString()}
+                </span>{" "}
+                snapshot paths
                 {flow.summary.costUsd30d > 0 && (
-                  <MetricCard
-                    value={flow.summary.costUsd30d}
-                    label="spend 30d"
-                    format="usd"
-                  />
+                  <>
+                    {" · "}
+                    <span className="font-mono text-[var(--foreground)]">
+                      {flow.summary.costUsd30d.toLocaleString(undefined, {
+                        style: "currency",
+                        currency: "USD",
+                        maximumFractionDigits:
+                          flow.summary.costUsd30d < 100 ? 2 : 0,
+                      })}
+                    </span>{" "}
+                    spend 30d
+                  </>
                 )}
                 {flow.summary.expensiveExposed > 0 && (
-                  <MetricCard
-                    value={flow.summary.expensiveExposed}
-                    label="expensive & exposed"
-                    accent="red"
-                  />
+                  <>
+                    {" · "}
+                    <span className="font-mono text-red-700 dark:text-red-200">
+                      {flow.summary.expensiveExposed.toLocaleString()}
+                    </span>{" "}
+                    expensive & exposed
+                  </>
                 )}
-              </>
+              </div>
             )}
 
             <select
@@ -2753,26 +2759,6 @@ function GraphPageInner() {
               ))}
             </select>
 
-            <GraphScenarioSelector
-              scenarios={scenarios}
-              selectedId={selectedScenarioId}
-              loading={loadingScenarios}
-              onSelect={(scenarioId) => {
-                setSelectedScenarioId(scenarioId);
-                setScenarioState("current");
-                if (!scenarioId) {
-                  setScenarioComparison(null);
-                  setScenarioError(null);
-                }
-              }}
-            />
-
-            <GraphEvidenceExportButton
-              scanId={selectedScanId || undefined}
-              filenamePrefix={
-                selectedScanId ? `scan-${selectedScanId}-graph` : undefined
-              }
-            />
             <FullscreenButton />
             {presentation.enabled && !captureMode && displayNodes.length > 0 && graphRenderer.kind === "react-flow" && <GraphInteractionToolbar
               editing={presentation.editing}
@@ -2809,36 +2795,103 @@ function GraphPageInner() {
             </button>
           </form>
 
-          <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-secondary)]">
-            <ViewPill
-              label="Scope"
-              value={filters.agentName ? filters.agentName : "all agents"}
-            />
-            <ViewPill label="View" value={graphScopeLabelForFilters(filters)} />
-            <ViewPill
-              label="Severity"
-              value={filters.severity ? `${filters.severity}+` : "all"}
-            />
-            {sourceNodeCount > 0 && !rollupCanvasOwnsPresentation && (
-              <span
-                data-testid="graph-compression-summary"
-                className="graph-chip-neutral"
-              >
-                {compressedGroupCount > 0
-                  ? `${compressedGroupCount} compressed groups`
-                  : `${renderedNodeCount}/${sourceNodeCount} nodes rendered`}
-              </span>
-            )}
-            {loadingGraph && (
-              <span className="graph-chip-sky-soft">
-                <Loader2 className="h-3 w-3 animate-spin" />
-                refreshing
-              </span>
-            )}
-            <div className="ml-auto">
-              <GraphLensSwitcher variant="compact" legendItems={legendItems} />
+          {searchResults.length > 0 && (
+            <div className="mt-2 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/90 p-2">
+              <div className="mb-2 px-1 text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+                Search respects current entity scope
+                {filters.severity ? ` and ${filters.severity}+ severity` : ""}
+              </div>
+              <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+                {searchResults.map((result) => (
+                  <button
+                    key={result.id}
+                    type="button"
+                    data-testid={`graph-search-result-${result.id}`}
+                    onClick={() => void focusSearchResult(result)}
+                    className="graph-page-result"
+                  >
+                    <p className="truncate text-sm font-medium text-[var(--foreground)]">
+                      {result.label}
+                    </p>
+                    <p className="mt-1 text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+                      {String(result.entity_type)}
+                    </p>
+                    <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-[var(--text-tertiary)]">
+                      {result.severity && <span>{result.severity}</span>}
+                      <span>
+                        risk{" "}
+                        {typeof result.risk_score === "number" &&
+                        Number.isFinite(result.risk_score)
+                          ? result.risk_score.toFixed(1)
+                          : "N/A"}
+                      </span>
+                    </div>
+                  </button>
+                ))}
+              </div>
             </div>
-          </div>
+          )}
+
+          <details
+            open={Boolean(
+              selectedScenario ||
+                activeScopePreset === "assetDrift" ||
+                investigationMode ||
+                reachabilitySummary ||
+                loadingReachability ||
+                reachabilityError ||
+                blastRadius ||
+                loadingBlast ||
+                blastError,
+            )}
+            className="mt-3 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 group"
+          >
+            <summary className="graph-drawer-summary">
+              <div>
+                <span className="text-[10px] uppercase tracking-[0.22em] text-[var(--text-tertiary)]">
+                  Evidence & controls
+                </span>
+                <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                  {graphScopeLabelForFilters(filters)} ·{" "}
+                  {activeSnapshot
+                    ? `${activeSnapshot.node_count.toLocaleString()} nodes · ${activeSnapshot.edge_count.toLocaleString()} edges`
+                    : "Snapshot metadata unavailable"}
+                  {graphTruncated ? " · bounded canvas" : " · complete current scope"}
+                  {compressedGroupCount > 0
+                    ? ` · ${compressedGroupCount.toLocaleString()} grouped scopes`
+                    : ""}
+                </p>
+              </div>
+              <span className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] group-open:hidden">
+                show
+              </span>
+              <span className="hidden text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] group-open:inline">
+                hide
+              </span>
+            </summary>
+            <div className="space-y-3 border-t border-[var(--border-subtle)]/80 p-3">
+              <GraphLensSwitcher variant="compact" legendItems={legendItems} />
+              <div className="flex flex-wrap items-center gap-2">
+                <GraphScenarioSelector
+                  scenarios={scenarios}
+                  selectedId={selectedScenarioId}
+                  loading={loadingScenarios}
+                  onSelect={(scenarioId) => {
+                    setSelectedScenarioId(scenarioId);
+                    setScenarioState("current");
+                    if (!scenarioId) {
+                      setScenarioComparison(null);
+                      setScenarioError(null);
+                    }
+                  }}
+                />
+                <GraphEvidenceExportButton
+                  scanId={selectedScanId || undefined}
+                  filenamePrefix={
+                    selectedScanId ? `scan-${selectedScanId}-graph` : undefined
+                  }
+                />
+              </div>
 
           <GraphScenarioComparisonPanel
             scenario={selectedScenario}
@@ -2980,42 +3033,6 @@ function GraphPageInner() {
               />
             )}
 
-          {searchResults.length > 0 && (
-            <div className="mt-2 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/90 p-2">
-              <div className="mb-2 px-1 text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
-                Search respects current entity scope
-                {filters.severity ? ` and ${filters.severity}+ severity` : ""}
-              </div>
-              <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
-                {searchResults.map((result) => (
-                  <button
-                    key={result.id}
-                    type="button"
-                    data-testid={`graph-search-result-${result.id}`}
-                    onClick={() => void focusSearchResult(result)}
-                    className="graph-page-result"
-                  >
-                    <p className="truncate text-sm font-medium text-[var(--foreground)]">
-                      {result.label}
-                    </p>
-                    <p className="mt-1 text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
-                      {String(result.entity_type)}
-                    </p>
-                    <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-[var(--text-tertiary)]">
-                      {result.severity && <span>{result.severity}</span>}
-                      <span>
-                        risk{" "}
-                        {typeof result.risk_score === "number" &&
-                        Number.isFinite(result.risk_score)
-                          ? result.risk_score.toFixed(1)
-                          : "N/A"}
-                      </span>
-                    </div>
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
         </div>
 
         <div className="mt-3 flex flex-wrap items-center gap-4 text-[11px] text-[var(--text-tertiary)]">
@@ -3533,12 +3550,13 @@ function GraphPageInner() {
         )}
           </div>
         </details>
+          </details>
+        </div>
       </div>
 
-      {/* A full viewport, not a letterbox. The header above accumulates to
-          ~600px on arrival, so a 68vh canvas left the graph as a ~300px strip
-          with most of the estate below the fold. The canvas is the content;
-          it gets a screen of its own. */}
+      {/* A full viewport, not a letterbox. Secondary evidence and controls stay
+          in the disclosure above so this canvas begins in the first viewport
+          and still gets a screen of its own. */}
       <div className="flex-1 flex relative min-h-[calc(100vh-3.5rem)]">
         <div className="flex-1 relative min-h-0 flex flex-col">
           {selectedAttackPath && (
@@ -3760,51 +3778,6 @@ async function quarantineAgentByLabel(label: string): Promise<string> {
   }
   await api.quarantineFleetAgent(match.agent_id);
   return match.agent_id;
-}
-
-function MetricCard({
-  value,
-  label,
-  accent = "zinc",
-  format = "count",
-}: {
-  value: number;
-  label: string;
-  accent?: "zinc" | "red" | "orange" | "blue";
-  format?: "count" | "usd";
-}) {
-  const accentClass =
-    accent === "red"
-      ? "border-red-500/20 bg-red-500/10 text-red-700 dark:text-red-200"
-      : accent === "orange"
-        ? "border-orange-500/20 bg-orange-500/10 text-orange-700 dark:text-orange-200"
-        : accent === "blue"
-          ? "border-sky-500/20 bg-sky-500/10 text-sky-700 dark:text-sky-200"
-          : "border-[var(--border-subtle)] bg-[var(--surface)]/80 text-[var(--text-secondary)]";
-
-  const rendered =
-    format === "usd"
-      ? value.toLocaleString(undefined, {
-          style: "currency",
-          currency: "USD",
-          maximumFractionDigits: value < 100 ? 2 : 0,
-        })
-      : value.toLocaleString();
-
-  return (
-    <div className={`rounded-xl border px-3 py-1.5 text-xs ${accentClass}`}>
-      <span className="font-mono text-[var(--foreground)]">{rendered}</span> {label}
-    </div>
-  );
-}
-
-function ViewPill({ label, value }: { label: string; value: string }) {
-  return (
-    <span className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-2.5 py-1">
-      <span className="text-[var(--text-tertiary)]">{label}</span>
-      <span className="ml-1 text-[var(--text-secondary)]">{value}</span>
-    </span>
-  );
 }
 
 function ReachabilityDrillInPanel({

--- a/ui/components/graph-rollup-decision-surface.tsx
+++ b/ui/components/graph-rollup-decision-surface.tsx
@@ -88,6 +88,14 @@ export function GraphRollupDecisionSurface({
   }, [filter, items]);
   const pages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
   const visible = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+  const compactLayout = visible.length <= 3;
+  const cardGridClass = compactLayout
+    ? visible.length === 1
+      ? "grid-cols-1"
+      : visible.length === 2
+        ? "grid-cols-1 md:grid-cols-2"
+        : "grid-cols-1 md:grid-cols-2 xl:grid-cols-3"
+    : "grid-cols-1 flex-1 auto-rows-fr md:grid-cols-2 xl:grid-cols-3";
   const nodeScopeLabel = completeness?.truncated
     ? `${items.length.toLocaleString()} returned from a bounded node scope`
     : `${items.length.toLocaleString()} containers`;
@@ -106,7 +114,8 @@ export function GraphRollupDecisionSurface({
   return (
     <section
       data-testid="graph-rollup-decision-surface"
-      className="flex h-full min-h-[32rem] flex-col overflow-hidden rounded-2xl bg-[var(--surface)]"
+      data-layout={compactLayout ? "compact" : "paged"}
+      className={`flex flex-col overflow-hidden rounded-2xl bg-[var(--surface)] ${compactLayout ? "min-h-0" : "h-full min-h-[32rem]"}`}
       aria-label="Risk-prioritized estate scopes"
     >
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--border-subtle)] px-4 py-3">
@@ -158,7 +167,10 @@ export function GraphRollupDecisionSurface({
         </span>
       </div>
 
-      <div className="grid flex-1 auto-rows-fr gap-2 overflow-y-auto p-4 md:grid-cols-2 xl:grid-cols-3">
+      <div
+        data-testid="graph-rollup-card-grid"
+        className={`grid gap-2 overflow-y-auto p-4 ${cardGridClass}`}
+      >
         {visible.map((item) => {
           const relation = relationEvidence(item.id, edges);
           const severity = item.aggregate.worst_severity || item.severity || "none";

--- a/ui/components/graph-text-alternative.tsx
+++ b/ui/components/graph-text-alternative.tsx
@@ -88,8 +88,8 @@ export function GraphTextAlternative({
       <h3>Connections</h3>
       <p>{text.connectionsNote}</p>
       <ul>
-        {text.connections.map((sentence) => (
-          <li key={sentence}>{sentence}</li>
+        {text.connections.map((sentence, index) => (
+          <li key={`${index}:${sentence}`}>{sentence}</li>
         ))}
       </ul>
     </section>

--- a/ui/e2e/lineage-graph-readability.spec.ts
+++ b/ui/e2e/lineage-graph-readability.spec.ts
@@ -214,12 +214,14 @@ async function routeGraphPage(page: Page) {
 
 async function captureGraphScreenshot(page: Page, testInfo: TestInfo, theme: "dark" | "light") {
   await expect(page.getByRole("heading", { name: "Lineage Graph" })).toBeVisible();
-  await expect(page.getByText("Relevant paths", { exact: true }).first()).toBeVisible();
-  // View controls, operator details, and the attack-path queue now live inside
-  // one collapsed-by-default "Advanced controls" shelf so the canvas owns the
-  // fold (#3932). The shelf summary stays visible; its contents open on demand.
-  await expect(page.getByText("Advanced controls", { exact: true })).toBeVisible();
-  await expect(page.getByTestId("graph-compression-summary")).toContainText(/compressed|rendered/);
+  await expect(page.getByText("Relevant paths", { exact: true }).first()).toBeHidden();
+  // Evidence, lens selection, and advanced controls now share one
+  // collapsed-by-default shelf so the canvas owns the fold. Nested controls
+  // remain available on demand without becoming first-view chrome.
+  await expect(page.getByText("Advanced controls", { exact: true })).toBeHidden();
+  const evidenceControls = page.getByTestId("graph-evidence-controls");
+  await expect(evidenceControls).not.toHaveAttribute("open", "");
+  await expect(evidenceControls.getByText("Evidence & controls", { exact: true })).toBeVisible();
 
   const largeOverview = page.getByTestId("large-graph-overview");
   const application = page.getByRole("application");
@@ -237,7 +239,6 @@ async function captureGraphScreenshot(page: Page, testInfo: TestInfo, theme: "da
   } else {
     await expect(desktopNode).toBeVisible();
     await expect(application.getByText("CVE-2026-103", { exact: true })).toBeVisible();
-    await expect(page.getByText("Legend").first()).toBeVisible();
     // Topology with the legend collapsed — proves the nodes fill the canvas
     // and read clearly at default zoom.
     await application.screenshot({
@@ -247,14 +248,15 @@ async function captureGraphScreenshot(page: Page, testInfo: TestInfo, theme: "da
     const legendToggle = page.getByRole("button", { name: /show legend/i });
     if (await legendToggle.isVisible()) {
       await legendToggle.click();
+    } else {
+      await evidenceControls.locator(":scope > summary").click();
     }
-    // Graph chrome may render the legend as a details dock (without a
-    // persistent hide button) on focused views. Verify the legend remains
-    // readable after the optional toggle instead of coupling the test to one
-    // control implementation.
-    await expect(page.getByText("Legend").first()).toBeVisible();
-    await application.screenshot({
+    // Graph chrome may render the legend in the evidence shelf instead of on
+    // the canvas. Verify that either route keeps the legend readable.
+    await expect(page.getByText("Legend", { exact: true }).first()).toBeVisible();
+    await page.screenshot({
       path: testInfo.outputPath(`lineage-graph-legend-${theme}.png`),
+      fullPage: false,
     });
   }
   await page.screenshot({

--- a/ui/e2e/security-graph-cockpit.spec.ts
+++ b/ui/e2e/security-graph-cockpit.spec.ts
@@ -639,6 +639,16 @@ test("mobile ranked path selection moves the selected graph into view", async ({
   await expect.poll(async () => (await detail.boundingBox())?.y ?? Number.POSITIVE_INFINITY).toBeLessThan(120);
 });
 
+async function openEvidenceControls(page: Page) {
+  const controls = page.getByTestId("graph-evidence-controls");
+  await expect(controls).toBeVisible();
+  if ((await controls.getAttribute("open")) === null) {
+    await controls.locator(":scope > summary").click();
+  }
+  await expect(controls).toHaveAttribute("open", "");
+  return controls;
+}
+
 for (const theme of ["dark", "light"] as const) {
 test(`large estates lead with non-overlapping clusters in ${theme}`, async ({ page }, testInfo: TestInfo) => {
   await routeCockpit(page, 1_241);
@@ -670,6 +680,7 @@ test(`large estates lead with non-overlapping clusters in ${theme}`, async ({ pa
   await expect(page).toHaveURL(/scan=scan-cockpit-fixture/);
   await expect(page).toHaveURL(/rollup=1/);
   await rollupRequest;
+  await openEvidenceControls(page);
   await expect(page.getByText("Scope navigation", { exact: true })).toBeVisible();
   // The roll-up used to emit no edges, so this banner had to disclaim that the
   // cards were "not rendered relationship evidence". It now draws the real
@@ -705,6 +716,7 @@ test("36-node snapshots default to real topology and forced roll-up still draws 
 
   await page.goto(`/graph?scan=${scanId}&rollup=1`);
   await page.waitForLoadState("networkidle");
+  await openEvidenceControls(page);
   await expect(page.getByText("Scope navigation", { exact: true })).toBeVisible();
   await expect(page.locator('[data-rollup-container="true"]')).toHaveCount(2);
   // Collapsing the estate changes what a relationship is drawn *between*, never
@@ -719,6 +731,7 @@ test("200-node snapshots default to roll-up and explicit raw topology persists",
 
   await page.goto(`/graph?scan=${scanId}`);
   await page.waitForLoadState("networkidle");
+  await openEvidenceControls(page);
   await expect(page.getByText("Scope navigation", { exact: true })).toBeVisible();
   await expect(page.getByText(/200 nodes in snapshot/i)).toBeVisible();
 
@@ -735,14 +748,16 @@ test("empty forced roll-up preserves operator preference and falls back to real 
   await page.goto(`/graph?scan=${scanId}&rollup=1`);
   await page.waitForLoadState("networkidle");
   await expect(page).toHaveURL(/rollup=1/);
+  await openEvidenceControls(page);
   await expect(page.getByText(/Roll-up unavailable/i)).toBeVisible();
   expect(await page.locator(".react-flow__edge").count()).toBeGreaterThan(0);
 });
 
 test("eligible roll-up shows a loading surface without raw-topology counts", async ({ page }) => {
-  await routeCockpit(page, 200, { rollupDelayMs: 750 });
+  await routeCockpit(page, 200, { rollupDelayMs: 3_000 });
 
   await page.goto(`/graph?scan=${scanId}`);
+  await openEvidenceControls(page);
   await expect(page.getByText("Loading scope navigation")).toBeVisible();
   await expect(page.getByTestId("graph-compression-summary")).toHaveCount(0);
   await expect(page.locator(".react-flow__edge")).toHaveCount(0);
@@ -785,7 +800,10 @@ for (const proof of [
     await page.waitForLoadState("networkidle");
 
     await expect(page.getByRole("heading", { name: "Investigation Canvas" })).toBeVisible();
-    await expect(page.getByRole("button", { name: /Estate/ })).toHaveAttribute("aria-pressed", "true");
+    const evidenceControls = page.getByTestId("graph-evidence-controls");
+    await expect(evidenceControls).toBeVisible();
+    await expect(evidenceControls).not.toHaveAttribute("open", "");
+    await expect(evidenceControls.getByRole("button", { name: /Estate/ })).toBeHidden();
     await expect(page.getByTestId("graph-rollup-decision-surface")).toBeVisible();
     await expect(page.getByTestId("graph-rollup-relationship-completeness")).toHaveText(
       "1 aggregated relationship rows · complete for this scope",

--- a/ui/lib/graph-snapshot-metrics.ts
+++ b/ui/lib/graph-snapshot-metrics.ts
@@ -1,0 +1,16 @@
+type SnapshotAttackPathCountInput = {
+  pageTotal: number | null | undefined;
+  statsTotal: number | null | undefined;
+  returnedPaths: number;
+};
+
+/**
+ * Keep bounded API pages from masquerading as snapshot totals in the graph UI.
+ */
+export function resolveSnapshotAttackPathCount({
+  pageTotal,
+  statsTotal,
+  returnedPaths,
+}: SnapshotAttackPathCountInput): number {
+  return pageTotal ?? statsTotal ?? returnedPaths;
+}

--- a/ui/tests/graph-rollup-decision-surface.test.tsx
+++ b/ui/tests/graph-rollup-decision-surface.test.tsx
@@ -32,6 +32,29 @@ function item(
 }
 
 describe("GraphRollupDecisionSurface", () => {
+  it("uses a compact full-width layout when one scope matches", () => {
+    render(
+      <GraphRollupDecisionSurface
+        items={[item("only-scope")]}
+        edges={[]}
+        onDrill={vi.fn()}
+        onInvestigate={vi.fn()}
+        onShowMap={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("graph-rollup-decision-surface")).toHaveAttribute(
+      "data-layout",
+      "compact",
+    );
+    expect(screen.getByTestId("graph-rollup-card-grid")).toHaveClass(
+      "grid-cols-1",
+    );
+    expect(screen.getByTestId("graph-rollup-card-grid")).not.toHaveClass(
+      "flex-1",
+    );
+  });
+
   it("opens large estate levels as paged risk decisions instead of an unreadable canvas", () => {
     const critical = item("critical", {
       severity: "critical",

--- a/ui/tests/graph-snapshot-metrics.test.ts
+++ b/ui/tests/graph-snapshot-metrics.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSnapshotAttackPathCount } from "@/lib/graph-snapshot-metrics";
+
+describe("resolveSnapshotAttackPathCount", () => {
+  it("prefers the persisted snapshot total over the bounded path page", () => {
+    expect(
+      resolveSnapshotAttackPathCount({
+        pageTotal: 2_155,
+        statsTotal: 2_155,
+        returnedPaths: 75,
+      }),
+    ).toBe(2_155);
+  });
+
+  it("falls back through graph stats to returned rows", () => {
+    expect(
+      resolveSnapshotAttackPathCount({
+        pageTotal: null,
+        statsTotal: 820,
+        returnedPaths: 75,
+      }),
+    ).toBe(820);
+    expect(
+      resolveSnapshotAttackPathCount({
+        pageTotal: null,
+        statsTotal: null,
+        returnedPaths: 18,
+      }),
+    ).toBe(18);
+  });
+});

--- a/ui/tests/graph-text-alternative.test.tsx
+++ b/ui/tests/graph-text-alternative.test.tsx
@@ -6,7 +6,7 @@
  * severity. The product's core value has to have a text equivalent.
  */
 import { render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { GraphTextAlternative } from "@/components/graph-text-alternative";
 import { buildGraphTextAlternative } from "@/lib/graph-text-alternative";
@@ -176,6 +176,28 @@ describe("buildGraphTextAlternative", () => {
 });
 
 describe("<GraphTextAlternative>", () => {
+  it("keeps parallel relationship sentences keyed independently", () => {
+    const first = edge("a1", "s1", "calls");
+    const second = { ...edge("a1", "s1", "calls"), id: "a1->s1:duplicate" };
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <GraphTextAlternative
+        id="overview-text"
+        renderer="2D canvas overview"
+        model={model({ edges: [first, second] })}
+        summary={SUMMARY}
+      />,
+    );
+
+    expect(
+      consoleError.mock.calls.some((args) =>
+        args.map(String).join(" ").includes("same key"),
+      ),
+    ).toBe(false);
+    consoleError.mockRestore();
+  });
+
   it("exposes the graph as a named region a screen reader can reach", () => {
     render(
       <GraphTextAlternative


### PR DESCRIPTION
Summary
- collapse secondary lenses, evidence metadata, scenarios, export, and advanced controls behind one disclosure so the investigation canvas begins in the first viewport
- show persisted snapshot attack-path totals instead of the bounded 75-row queue length
- use a compact full-width roll-up for one to three matching scopes and keep parallel text-equivalent relationships keyed independently

Verification
- `npm run verify:toolchain`
- `npm run typecheck`
- targeted ESLint on changed UI files
- `npm test -- --run` (208 files, 1,278 tests)
- `npm run build`
- browser review on `/security-graph` with the 6,802-node showcase in light and dark themes; verified roll-up and WebGL overview, bounded-canvas disclosure, and `2,155 snapshot paths`

Notes
- the canvas still discloses node and draw-budget truncation; secondary evidence remains available without occupying the default path