### PR TITLE
fix(graph): preserve exposure path topology

### DIFF
--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -1519,9 +1519,32 @@ def blast_radius_to_finding(br: object) -> "Finding":
     vuln = br.vulnerability
     pkg = br.package
 
-    # Asset: primary server or package
-    if br.affected_servers:
-        primary_server = br.affected_servers[0]
+    affected_server_surfaces = {
+        server.name: getattr(getattr(server, "surface", None), "value", str(getattr(server, "surface", "")))
+        for server in br.affected_servers
+    }
+    affected_server_ids = {getattr(server, "stable_id", ""): server.name for server in br.affected_servers}
+    agent_server_links: list[dict[str, str]] = []
+    for agent in br.affected_agents:
+        for server in getattr(agent, "mcp_servers", []) or []:
+            server_name = affected_server_ids.get(getattr(server, "stable_id", ""))
+            if server_name:
+                agent_server_links.append(
+                    {
+                        "agent": getattr(agent, "name", str(agent)),
+                        "server": server_name,
+                    }
+                )
+
+    # Asset: a real MCP server when the vulnerable package is installed behind
+    # one; otherwise the package itself. Filesystem, SBOM, image, repository,
+    # and AI-inventory wrappers share the server-shaped storage model but must
+    # not be published as MCP server assets.
+    primary_server = next(
+        (server for server in br.affected_servers if getattr(server, "is_mcp_surface", False)),
+        None,
+    )
+    if primary_server is not None:
         from agent_bom.security import sanitize_launch_command
 
         asset = Asset(
@@ -1548,6 +1571,8 @@ def blast_radius_to_finding(br: object) -> "Finding":
         "package_dependency_scope": pkg.dependency_scope,
         "package_reachability_evidence": pkg.reachability_evidence,
         "affected_server_count": len(br.affected_servers),
+        "affected_server_surfaces": _sanitized_evidence_field(affected_server_surfaces),
+        "agent_server_links": _sanitized_evidence_field(agent_server_links),
         "exposed_credential_count": len(br.exposed_credentials),
         "exposed_tool_count": len(br.exposed_tools),
         "hop_depth": getattr(br, "hop_depth", 1),

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -1519,8 +1519,14 @@ def blast_radius_to_finding(br: object) -> "Finding":
     vuln = br.vulnerability
     pkg = br.package
 
+    def entity_name(entity: object) -> str:
+        """Return the cheap display name without eagerly rendering dataclasses."""
+
+        name = getattr(entity, "name", None)
+        return str(name) if name else str(entity)
+
     affected_server_surfaces = {
-        server.name: getattr(getattr(server, "surface", None), "value", str(getattr(server, "surface", "")))
+        server.name: str(getattr(getattr(server, "surface", None), "value", None) or getattr(server, "surface", ""))
         for server in br.affected_servers
     }
     affected_server_ids = {getattr(server, "stable_id", ""): server.name for server in br.affected_servers}
@@ -1531,7 +1537,7 @@ def blast_radius_to_finding(br: object) -> "Finding":
             if server_name:
                 agent_server_links.append(
                     {
-                        "agent": getattr(agent, "name", str(agent)),
+                        "agent": entity_name(agent),
                         "server": server_name,
                     }
                 )
@@ -1763,9 +1769,9 @@ def blast_radius_to_finding(br: object) -> "Finding":
         ai_summary=getattr(br, "ai_summary", None),
         attack_vector_summary=getattr(br, "attack_vector_summary", None),
         affected_servers=[s.name for s in br.affected_servers],
-        affected_agents=[getattr(a, "name", str(a)) for a in br.affected_agents],
+        affected_agents=[entity_name(a) for a in br.affected_agents],
         exposed_credentials=list(br.exposed_credentials),
-        exposed_tools=[getattr(t, "name", str(t)) for t in br.exposed_tools],
+        exposed_tools=[entity_name(t) for t in br.exposed_tools],
     )
     return apply_hub_classification(finding)
 

--- a/src/agent_bom/output/exposure_path.py
+++ b/src/agent_bom/output/exposure_path.py
@@ -163,7 +163,11 @@ def exposure_path_chain(path: dict[str, Any], *, include_tool: bool = True) -> s
         if candidate and candidate not in spine:
             spine.append(candidate)
     if include_tool:
-        tool = first("tool:")
+        # Tools are side nodes provided by the selected server, not sequential
+        # topology hops after the finding. Preserve the established human chain
+        # without corrupting the primary graph spine.
+        nodes = [node for node in (path.get("nodeIds") or []) if node]
+        tool = first("tool:") or next((node for node in nodes if node.startswith("tool:")), None)
         if tool and tool not in spine:
             spine.append(tool)
     return " → ".join(_chain_token(hop) for hop in spine)

--- a/src/agent_bom/output/exposure_path.py
+++ b/src/agent_bom/output/exposure_path.py
@@ -43,21 +43,12 @@ def exposure_path_for_finding(
     package_ref = f"pkg:{ecosystem}:{display_name}@{pkg_version or 'unknown'}"
     vuln_id = finding.cve_id or finding.title or finding.asset.name
     finding_ref = f"finding:{vuln_id}"
-    source_ref = _source_ref_for_finding(finding, display_name, pkg_version, ecosystem)
+    source_ref, server_refs = _primary_runtime_spine_for_finding(finding, package_ref)
     target_ref = finding_ref
-    server_refs = _server_refs_for_finding(finding)
     tool_refs = _tool_refs_for_finding(finding)
     credential_refs = _credential_refs_for_finding(finding)
-    nodes = _ordered_unique(
-        [
-            source_ref,
-            *server_refs[:3],
-            package_ref,
-            target_ref,
-            *tool_refs[:3],
-            *credential_refs[:3],
-        ]
-    )
+    hops = _ordered_unique([source_ref, *server_refs, package_ref, target_ref])
+    nodes = _ordered_unique([*hops, *tool_refs[:3], *credential_refs[:3]])
     relationships = _relationships_for_finding(
         finding,
         source_ref,
@@ -100,7 +91,7 @@ def exposure_path_for_finding(
         "severity": severity,
         "source": source_ref,
         "target": target_ref,
-        "hops": nodes,
+        "hops": hops,
         "relationships": relationships,
         "nodeIds": nodes,
         "edgeIds": [rel["id"] for rel in relationships],
@@ -240,6 +231,43 @@ def _source_ref_for_finding(
     return f"pkg:{ecosystem}:{package_name_value}@{package_version_value or 'unknown'}"
 
 
+def _primary_runtime_spine_for_finding(finding: Finding, package_ref: str) -> tuple[str, list[str]]:
+    """Choose one evidence-backed agent → MCP server spine for a finding.
+
+    Package, repository, image, SBOM, and AI-inventory wrappers reuse the
+    ``Agent``/``MCPServer`` storage shape, but they are not runtime MCP hops.
+    Treat them as finding context only. When several real MCP servers are
+    affected, select one observed agent/server association instead of splicing
+    every affected asset into a single path.
+    """
+
+    evidence = finding.evidence if isinstance(finding.evidence, dict) else {}
+    surfaces = evidence.get("affected_server_surfaces")
+    if isinstance(surfaces, dict):
+        runtime_servers = [server for server in finding.affected_servers if str(surfaces.get(server) or "") == "mcp-server"]
+    else:
+        # Findings created before surface provenance was added retain their
+        # first server as a conservative legacy-compatible spine.
+        runtime_servers = list(finding.affected_servers[:1])
+
+    if not runtime_servers:
+        return package_ref, []
+
+    primary_server = runtime_servers[0]
+    links = evidence.get("agent_server_links")
+    if isinstance(links, list):
+        for link in links:
+            if not isinstance(link, dict) or str(link.get("server") or "") != primary_server:
+                continue
+            agent = str(link.get("agent") or "").strip()
+            if agent and agent in finding.affected_agents:
+                return f"agent:{agent}", [f"server:{primary_server}"]
+
+    if finding.affected_agents:
+        return f"agent:{finding.affected_agents[0]}", [f"server:{primary_server}"]
+    return f"server:{primary_server}", [f"server:{primary_server}"]
+
+
 def _server_refs(br: BlastRadius) -> list[str]:
     return [f"server:{_server_label(server)}" for server in br.affected_servers]
 
@@ -297,16 +325,18 @@ def _relationships_for_finding(
     def add(rel_type: str, source: str, target: str) -> None:
         rels.append({"id": f"{source}->{rel_type}->{target}", "type": rel_type, "source": source, "target": target})
 
-    for server_ref in server_refs[:3]:
-        add("uses", source_ref, server_ref)
+    for server_ref in server_refs[:1]:
+        if source_ref != server_ref:
+            add("uses", source_ref, server_ref)
         add("depends_on", server_ref, package_ref)
-    if not finding.affected_servers:
+    if not server_refs and source_ref != package_ref:
         add("depends_on", source_ref, package_ref)
     add("vulnerable_to", package_ref, finding_ref)
+    exposure_owner = server_refs[0] if server_refs else source_ref
     for tool_ref in tool_refs[:3]:
-        add("provides_tool", source_ref, tool_ref)
+        add("provides_tool", exposure_owner, tool_ref)
     for credential_ref in credential_refs[:3]:
-        add("exposes_credential", source_ref, credential_ref)
+        add("exposes_credential", exposure_owner, credential_ref)
     return rels
 
 

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -266,8 +266,13 @@ def _exposure_related_locations(exposure_path: dict[str, Any]) -> list[dict]:
     """
 
     hops = [hop for hop in (exposure_path.get("hops") or []) if isinstance(hop, str) and hop]
+    # Side nodes (tools and credential references) remain outside the primary
+    # topology spine, but SARIF logical locations must retain the full bounded
+    # exposure context for viewers and downstream automation.
+    nodes = [node for node in (exposure_path.get("nodeIds") or []) if isinstance(node, str) and node]
+    locations = list(dict.fromkeys([*hops, *nodes]))
     related: list[dict] = []
-    for index, hop in enumerate(hops):
+    for index, hop in enumerate(locations):
         kind, _, name = hop.partition(":")
         related.append(
             {

--- a/tests/test_exposure_path_finding.py
+++ b/tests/test_exposure_path_finding.py
@@ -3,7 +3,19 @@
 from __future__ import annotations
 
 from agent_bom.finding import blast_radius_to_finding
-from agent_bom.models import Agent, AgentStatus, AgentType, BlastRadius, MCPServer, MCPTool, Package, Severity, TransportType, Vulnerability
+from agent_bom.models import (
+    Agent,
+    AgentStatus,
+    AgentType,
+    BlastRadius,
+    MCPServer,
+    MCPTool,
+    Package,
+    ServerSurface,
+    Severity,
+    TransportType,
+    Vulnerability,
+)
 from agent_bom.output.exposure_path import exposure_path_for_blast_radius, exposure_path_for_finding
 
 
@@ -74,6 +86,79 @@ def test_exposure_path_for_blast_radius_keeps_legacy_id_prefix() -> None:
     path = exposure_path_for_blast_radius(br, rank=2)
     assert path["id"].startswith("blast:")
     assert path["rank"] == 2
+
+
+def test_non_runtime_inventory_surfaces_do_not_fabricate_agent_server_hops() -> None:
+    package = _pkg(name="chromadb", version="1.1.1", ecosystem="pypi")
+    inventory_server = MCPServer(name="ai-inventory", surface=ServerSurface.AI_INVENTORY, packages=[package])
+    project_server = MCPServer(name="crewai", surface=ServerSurface.OTHER, packages=[package])
+    inventory_agent = Agent(
+        name="ai-inventory",
+        agent_type=AgentType.CUSTOM,
+        config_path="/tmp/crewai",
+        source="ai-inventory",
+        mcp_servers=[inventory_server],
+    )
+    project_agent = Agent(
+        name="project:crewai",
+        agent_type=AgentType.CUSTOM,
+        config_path="/tmp/crewai",
+        source="project",
+        mcp_servers=[project_server],
+    )
+    br = BlastRadius(
+        package=package,
+        vulnerability=_vuln("CVE-2026-45829"),
+        affected_agents=[inventory_agent, project_agent],
+        affected_servers=[inventory_server, project_server],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+
+    finding = blast_radius_to_finding(br)
+    path = exposure_path_for_blast_radius(br, rank=1)
+
+    assert finding.asset.asset_type == "package"
+    assert finding.asset.name == "chromadb"
+    assert path["source"] == "pkg:pypi:chromadb@1.1.1"
+    assert path["hops"] == ["pkg:pypi:chromadb@1.1.1", "finding:CVE-2026-45829"]
+    assert path["relationships"] == [
+        {
+            "id": "pkg:pypi:chromadb@1.1.1->vulnerable_to->finding:CVE-2026-45829",
+            "type": "vulnerable_to",
+            "source": "pkg:pypi:chromadb@1.1.1",
+            "target": "finding:CVE-2026-45829",
+        }
+    ]
+    assert path["affectedAgents"] == ["ai-inventory", "project:crewai"]
+    assert path["affectedServers"] == ["ai-inventory", "crewai"]
+
+
+def test_exposure_path_chooses_one_observed_agent_mcp_server_pair() -> None:
+    package = _pkg()
+    primary_server = _server("primary-mcp")
+    secondary_server = _server("secondary-mcp")
+    primary_agent = _agent("primary-agent", [primary_server])
+    secondary_agent = _agent("secondary-agent", [secondary_server])
+    br = BlastRadius(
+        package=package,
+        vulnerability=_vuln(),
+        affected_agents=[secondary_agent, primary_agent],
+        affected_servers=[primary_server, secondary_server],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+
+    path = exposure_path_for_finding(blast_radius_to_finding(br), rank=1)
+
+    assert path["source"] == "agent:primary-agent"
+    assert path["hops"] == [
+        "agent:primary-agent",
+        "server:primary-mcp",
+        "pkg:npm:lodash@4.17.20",
+        "finding:CVE-2024-0001",
+    ]
+    assert "server:secondary-mcp" not in path["nodeIds"]
 
 
 def test_json_and_sarif_exposure_paths_use_finding_native_projection() -> None:

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -449,6 +449,27 @@ def test_blast_radius_to_finding_cve_type():
     assert finding.source == FindingSource.MCP_SCAN
 
 
+def test_blast_radius_to_finding_does_not_render_named_graph_entities():
+    """Named agents and tools must not recursively stringify their full graph."""
+    br = _make_blast_radius()
+
+    class NamedEntity:
+        def __init__(self, name, *, mcp_servers=None):
+            self.name = name
+            self.mcp_servers = mcp_servers or []
+
+        def __str__(self):
+            raise AssertionError("named graph entity was eagerly stringified")
+
+    br.affected_agents = [NamedEntity("test-agent")]
+    br.exposed_tools = [NamedEntity("test-tool")]
+
+    finding = blast_radius_to_finding(br)
+
+    assert finding.affected_agents == [br.affected_agents[0].name]
+    assert finding.exposed_tools == [br.exposed_tools[0].name]
+
+
 def test_blast_radius_to_finding_uses_sbom_source_for_non_mcp_surfaces():
     server = _make_server("sbom-package")
     server.surface = ServerSurface.SBOM


### PR DESCRIPTION
## Summary

- keep AI-inventory, repository, image, SBOM, and other non-runtime wrappers out of MCP attack-path spines
- select one observed agent-to-MCP-server association instead of combining unrelated affected assets into one path
- model non-MCP vulnerability findings as package assets while retaining affected agent/server context

## Verification

- red-first CrewAI-shaped regression reproduced the fabricated `ai-inventory -> ai-inventory -> crewai -> package` path
- `256 passed` across finding, exposure-path, output-format, MCP posture, and compliance-hub tests
- targeted Ruff, Ruff format, MyPy, and `git diff --check` passed

## Notes

- file-report exposure paths remain bounded and retain affected asset context; only evidence-backed runtime hops enter the path spine