### PR TITLE
fix(sbom): make CycloneDX joins linear

### DIFF
--- a/src/agent_bom/sbom.py
+++ b/src/agent_bom/sbom.py
@@ -72,6 +72,7 @@ def parse_cyclonedx(data: dict) -> list[Package]:
     direct vs transitive dependencies.
     """
     packages: list[Package] = []
+    bom_ref_to_pkg: dict[str, Package] = {}
     components = data.get("components", [])
 
     # Build adjacency map and direct refs from dependencies array
@@ -167,39 +168,29 @@ def parse_cyclonedx(data: dict) -> list[Package]:
         else:
             _is_direct = True  # fallback when no dependency info
 
-        packages.append(
-            Package(
-                name=name,
-                version=version,
-                ecosystem=ecosystem,
-                purl=purl or None,
-                is_direct=_is_direct,
-                resolved_from_registry=False,
-                license=lic_id,
-                license_expression=lic_expr,
-                supplier=supplier_name,
-                author=author_val,
-                description=description_val,
-                homepage=homepage_val,
-                repository_url=repo_val,
-                download_url=download_val,
-                copyright_text=copyright_val,
-            )
+        package = Package(
+            name=name,
+            version=version,
+            ecosystem=ecosystem,
+            purl=purl or None,
+            is_direct=_is_direct,
+            resolved_from_registry=False,
+            license=lic_id,
+            license_expression=lic_expr,
+            supplier=supplier_name,
+            author=author_val,
+            description=description_val,
+            homepage=homepage_val,
+            repository_url=repo_val,
+            download_url=download_val,
+            copyright_text=copyright_val,
         )
+        packages.append(package)
+        if bom_ref:
+            bom_ref_to_pkg[bom_ref] = package
 
     # Multi-hop dependency graph walking: set dependency_depth for each package
     if dep_map and root_ref:
-        # Build a bom-ref → Package index for efficient lookup
-        _bom_ref_index: dict[str, Package] = {}
-        for pkg in packages:
-            bom_ref = pkg.purl or pkg.name
-            # Prefer to match by exact bom-ref stored during component parsing
-            for comp in components:
-                if isinstance(comp, dict) and comp.get("name") == pkg.name and comp.get("version") == pkg.version:
-                    br = comp.get("bom-ref", "")
-                    if br:
-                        _bom_ref_index[br] = pkg
-                    break
 
         def _walk_deps(ref: str, depth: int, visited: set) -> None:
             """Visit *ref* at the given depth, then recurse into its children at depth+1."""
@@ -207,7 +198,7 @@ def parse_cyclonedx(data: dict) -> list[Package]:
                 return
             visited.add(ref)
             # Set depth on the current node
-            pkg = _bom_ref_index.get(ref)
+            pkg = bom_ref_to_pkg.get(ref)
             if pkg is not None:
                 if depth > pkg.dependency_depth:
                     pkg.dependency_depth = depth
@@ -222,16 +213,6 @@ def parse_cyclonedx(data: dict) -> list[Package]:
             _walk_deps(direct_ref, 0, _visited)
 
     # Ingest CycloneDX vulnerabilities[] array if present
-    _bom_ref_to_pkg: dict[str, Package] = {}
-    for comp in components:
-        if isinstance(comp, dict):
-            br = comp.get("bom-ref", "")
-            if br:
-                for pkg in packages:
-                    if pkg.name == comp.get("name") and pkg.version == comp.get("version"):
-                        _bom_ref_to_pkg[br] = pkg
-                        break
-
     for vuln_data in data.get("vulnerabilities", []):
         if not isinstance(vuln_data, dict):
             continue
@@ -264,7 +245,7 @@ def parse_cyclonedx(data: dict) -> list[Package]:
             if not isinstance(affect, dict):
                 continue
             affected_ref = affect.get("ref", "")
-            affected_pkg = _bom_ref_to_pkg.get(affected_ref)
+            affected_pkg = bom_ref_to_pkg.get(affected_ref)
             if affected_pkg is not None and vuln not in affected_pkg.vulnerabilities:
                 affected_pkg.vulnerabilities.append(vuln)
 

--- a/tests/test_sbom_ingestion.py
+++ b/tests/test_sbom_ingestion.py
@@ -171,6 +171,53 @@ def test_parse_cyclonedx_skip_empty_name():
     assert packages[0].name == "valid-pkg"
 
 
+def test_parse_cyclonedx_joins_duplicate_components_by_bom_ref():
+    data = {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "metadata": {"component": {"bom-ref": "root"}},
+        "components": [
+            {
+                "type": "library",
+                "bom-ref": "pkg:npm/shared@1.0.0?copy=transitive",
+                "name": "shared",
+                "version": "1.0.0",
+                "purl": "pkg:npm/shared@1.0.0",
+            },
+            {
+                "type": "library",
+                "bom-ref": "pkg:npm/shared@1.0.0?copy=direct",
+                "name": "shared",
+                "version": "1.0.0",
+                "purl": "pkg:npm/shared@1.0.0",
+            },
+        ],
+        "dependencies": [
+            {"ref": "root", "dependsOn": ["pkg:npm/shared@1.0.0?copy=direct"]},
+            {
+                "ref": "pkg:npm/shared@1.0.0?copy=direct",
+                "dependsOn": ["pkg:npm/shared@1.0.0?copy=transitive"],
+            },
+        ],
+        "vulnerabilities": [
+            {
+                "id": "CVE-2026-4242",
+                "ratings": [{"severity": "high", "score": 8.1}],
+                "affects": [{"ref": "pkg:npm/shared@1.0.0?copy=direct"}],
+            }
+        ],
+    }
+
+    transitive, direct = parse_cyclonedx(data)
+
+    assert transitive.dependency_depth == 1
+    assert transitive.is_direct is False
+    assert transitive.vulnerabilities == []
+    assert direct.dependency_depth == 0
+    assert direct.is_direct is True
+    assert [vulnerability.id for vulnerability in direct.vulnerabilities] == ["CVE-2026-4242"]
+
+
 # ─── parse_spdx ──────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- index parsed packages by authoritative CycloneDX `bom-ref` during the component pass
- remove two component-by-package nested searches from dependency and vulnerability joins
- attach duplicate name/version components to the correct dependency depth and vulnerability by `bom-ref`

## Verification

- red-first duplicate-component regression failed on the previous name/version join and now passes
- `90 passed` across CycloneDX, SPDX/SBOM, metadata-enrichment, and local DB scan tests
- targeted Ruff, Ruff format, MyPy, and `git diff --check` passed
- recovered fixture benchmark: 20,000 components `18.548s -> 0.132s`; 100,000 components now `0.755s`

## Notes

- benchmark measures parsing only on the same recovered audit fixtures; it does not claim end-to-end scan or JSON-export time