### PR TITLE
perf(graph): reuse scan projection for reachability

### DIFF
--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -2204,11 +2204,17 @@ def scan(
     # and MCP surfaces (all three call one shared build+attach helper). The
     # unified stream (report.to_findings()) is the single source of truth for the
     # toxic COMBINATION count, so the printed count can never contradict it.
+    _dependency_reachability = None
     if agents:
         from agent_bom.cli._tenant import resolve_cli_tenant_id as _resolve_cli_tenant_id
         from agent_bom.graph.scan_findings import surface_graph_derived_findings
 
-        surface_graph_derived_findings(report, scan_id=_scan_id, tenant_id=_resolve_cli_tenant_id())
+        _dependency_reachability = surface_graph_derived_findings(
+            report,
+            scan_id=_scan_id,
+            tenant_id=_resolve_cli_tenant_id(),
+            include_dependency_reachability=True,
+        )
         if not quiet:
             # Non-zero counts here are bad news — warn, don't checkmark.
             _n_toxic = len(report.toxic_combination_findings_data or [])
@@ -2925,7 +2931,12 @@ def scan(
             resync_cve_findings_from_blast_radii,
         )
 
-        apply_dependency_reachability_to_blast_radii(blast_radii, agents, rescore=True)
+        apply_dependency_reachability_to_blast_radii(
+            blast_radii,
+            agents,
+            rescore=True,
+            reachability_report=_dependency_reachability,
+        )
         # Join AST function-level symbol reach to CVE affected-symbols so each
         # Python finding carries a function_reachable / package_reachable /
         # unreachable signal. No-op when no Python entrypoints were analysed.

--- a/src/agent_bom/graph/blast_reach.py
+++ b/src/agent_bom/graph/blast_reach.py
@@ -22,6 +22,7 @@ from agent_bom.graph.dependency_reach import compute_dependency_reach
 if TYPE_CHECKING:
     from agent_bom.ast_models import ASTAnalysisResult
     from agent_bom.finding import Finding
+    from agent_bom.graph.dependency_reach import ReachabilityReport
     from agent_bom.models import Agent, BlastRadius, Package
 
 _logger = logging.getLogger(__name__)
@@ -50,6 +51,7 @@ def apply_dependency_reachability_to_blast_radii(
     agents: list["Agent"],
     *,
     rescore: bool = True,
+    reachability_report: "ReachabilityReport | None" = None,
 ) -> int:
     """Stamp structural dependency-closure fields on each BlastRadius row.
 
@@ -65,16 +67,18 @@ def apply_dependency_reachability_to_blast_radii(
         return 0
 
     try:
-        # Build a minimal report dict — the engine only needs the topology
-        # the graph builder can reconstruct from agents + blast_radii. Using
-        # `to_json` here would couple us to the full output package and
-        # double-build the graph.
-        from agent_bom.models import AIBOMReport
-        from agent_bom.output import to_json
+        if reachability_report is None:
+            # Standalone callers retain the existing self-contained behavior.
+            # Scan surfaces that already projected the unified graph pass the
+            # precomputed report to avoid repeated serialization and building.
+            from agent_bom.models import AIBOMReport
+            from agent_bom.output import to_json
 
-        report = AIBOMReport(agents=agents, blast_radii=blast_radii, scan_id="reachability-scratch")
-        graph = build_unified_graph_from_report(to_json(report))
-        reach = compute_dependency_reach(graph)
+            report = AIBOMReport(agents=agents, blast_radii=blast_radii, scan_id="reachability-scratch")
+            graph = build_unified_graph_from_report(to_json(report))
+            reach = compute_dependency_reach(graph)
+        else:
+            reach = reachability_report
     except Exception as exc:  # noqa: BLE001
         _logger.warning("Graph reachability surfacing skipped: %s", exc)
         return 0

--- a/src/agent_bom/graph/scan_findings.py
+++ b/src/agent_bom/graph/scan_findings.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from agent_bom.graph.container import UnifiedGraph
+    from agent_bom.graph.dependency_reach import ReachabilityReport
     from agent_bom.models import AIBOMReport
 
 _logger = logging.getLogger(__name__)
@@ -140,16 +141,23 @@ def _rewrite_side_block_findings(report: "AIBOMReport", findings: list[Any]) -> 
         report.ciem_over_privilege_findings_data = ciem
 
 
-def surface_graph_derived_findings(report: "AIBOMReport", *, scan_id: str, tenant_id: str) -> None:
+def surface_graph_derived_findings(
+    report: "AIBOMReport",
+    *,
+    scan_id: str,
+    tenant_id: str,
+    include_dependency_reachability: bool = False,
+) -> "ReachabilityReport | None":
     """Build the unified graph from ``report`` and attach graph-derived findings.
 
     The single build+attach entry point shared by the CLI (default path), the API
     scan pipeline, and the MCP scan tool, so every scan surface emits the same
     graph-derived categories (``COMBINATION`` / ``CIEM_OVER_PRIVILEGE`` / ``NHI``).
 
-    The interim JSON and the throwaway graph are locals released when this returns,
-    so the surfacing graph never outlives the call. Best-effort: a graph-build or
-    surfacing failure is logged and swallowed — it must never fail the scan.
+    When ``include_dependency_reachability`` is true, compute and return the
+    structural reachability report from this same graph so callers do not
+    serialize and project the scan a second time. The interim JSON and graph are
+    released when this returns. Best-effort: failures are logged and swallowed.
     """
     try:
         from agent_bom.graph.builder import build_unified_graph_from_report
@@ -157,9 +165,21 @@ def surface_graph_derived_findings(report: "AIBOMReport", *, scan_id: str, tenan
 
         interim_json = to_json(report)
         graph = build_unified_graph_from_report(interim_json, scan_id=scan_id, tenant_id=tenant_id)
-        attach_graph_derived_findings(report, graph)
     except Exception as exc:  # noqa: BLE001 — never fail the scan on findings surfacing
         _logger.debug("graph-derived findings surfacing skipped: %s", exc)
+        return None
+
+    attach_graph_derived_findings(report, graph)
+    if not include_dependency_reachability:
+        return None
+
+    try:
+        from agent_bom.graph.dependency_reach import compute_dependency_reach
+
+        return compute_dependency_reach(graph)
+    except Exception as exc:  # noqa: BLE001 — best-effort enrichment
+        _logger.debug("dependency reachability reuse skipped: %s", exc)
+        return None
 
 
 __all__ = ["attach_graph_derived_findings", "surface_graph_derived_findings"]

--- a/tests/test_blast_reachability_surfacing.py
+++ b/tests/test_blast_reachability_surfacing.py
@@ -131,3 +131,33 @@ def test_engine_failure_is_a_no_op(monkeypatch, reachable_setup) -> None:
     # Untouched.
     assert blast_radii[0].graph_reachable is None
     assert blast_radii[0].graph_reachable_from_agents == []
+
+
+def test_precomputed_reachability_skips_a_second_graph_projection(monkeypatch, reachable_setup) -> None:
+    from agent_bom.graph.scan_findings import surface_graph_derived_findings
+    from agent_bom.models import AIBOMReport
+
+    blast_radii, agents = reachable_setup
+    report = AIBOMReport(agents=agents, blast_radii=blast_radii)
+    reachability = surface_graph_derived_findings(
+        report,
+        scan_id="shared-projection",
+        tenant_id="default",
+        include_dependency_reachability=True,
+    )
+    assert reachability is not None
+
+    def fail_if_rebuilt(*_args, **_kwargs):
+        raise AssertionError("dependency reachability rebuilt the report graph")
+
+    monkeypatch.setattr("agent_bom.graph.blast_reach.build_unified_graph_from_report", fail_if_rebuilt)
+
+    stamped = apply_dependency_reachability_to_blast_radii(
+        blast_radii,
+        agents,
+        rescore=True,
+        reachability_report=reachability,
+    )
+
+    assert stamped == 1
+    assert blast_radii[0].dependency_reachable is True

--- a/tests/test_scan_surface_parity.py
+++ b/tests/test_scan_surface_parity.py
@@ -162,6 +162,7 @@ def test_default_cli_scan_surfaces_combination():
     from click.testing import CliRunner
 
     from agent_bom.cli import main
+    from agent_bom.graph.builder import build_unified_graph_from_report
 
     agents, brs = _seeded_estate()
     pkg = agents[0].mcp_servers[0].packages[0]
@@ -173,6 +174,10 @@ def test_default_cli_scan_surfaces_combination():
         patch("agent_bom.cli.agents.extract_packages", return_value=[pkg]),
         patch("agent_bom.cli.agents.resolve_all_versions_sync", return_value=None),
         patch("agent_bom.vex.is_vex_suppressed", return_value=False),
+        patch(
+            "agent_bom.graph.builder.build_unified_graph_from_report",
+            wraps=build_unified_graph_from_report,
+        ) as build_graph,
     ):
         # No --context-graph flag — the default surface.
         result = runner.invoke(
@@ -187,6 +192,10 @@ def test_default_cli_scan_surfaces_combination():
     payload = json.loads(result.output[result.output.index("{") :])
     cats = _categories_from_json(payload)
     assert "COMBINATION" in cats, f"default CLI dropped graph-derived category; got {cats}"
+    # Graph-derived findings and dependency reachability share the same graph
+    # projection; rebuilding the report graph makes scan completion scale with
+    # the serialized output size rather than with useful topology work.
+    assert build_graph.call_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- compute dependency reachability from the unified graph already projected for graph-derived findings
- retain the standalone fallback for callers that do not have a precomputed reachability report
- lock the default CLI scan to one graph projection instead of serializing and building the same topology twice

## Verification
- `PYTHONPATH=src /Users/mohamedsaad/repos/Agent-Bom/.venv/bin/pytest -q tests/test_blast_reachability_surfacing.py` (6 passed)
- `PYTHONPATH=src /Users/mohamedsaad/repos/Agent-Bom/.venv/bin/pytest -q tests/test_scan_surface_parity.py::test_default_cli_scan_surfaces_combination` (1 passed)
- Ruff check and format verification on changed files
- MyPy on `scan_findings.py` and `blast_reach.py`
- deterministic 20-cycle surface+reach benchmark: 0.381267s on main, 0.246120s patched

## Notes
- dependency reachability semantics are unchanged; only the already-built graph's read-side report is reused
- graph construction retains the existing best-effort fallback when no precomputed report is available