### PR TITLE
fix(gateway): reject spoofed forwarded client identity

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-25",
+  "generated_on": "2026-08-26",
   "version": "0.102.0",
   "metrics": [
     {
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 872,
+      "value": 873,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-25`
+- Generated on: `2026-08-26`
 - Version: `0.102.0`
 
 | Metric | Value | Source | Notes |
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 49 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 872 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 873 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/api/forwarded_identity.py
+++ b/src/agent_bom/api/forwarded_identity.py
@@ -1,0 +1,60 @@
+"""Trusted reverse-proxy client identity resolution.
+
+Forwarded address headers are caller-controlled unless the transport peer and
+proxy depth are both explicitly configured.  Keep that invariant in one place
+so authentication throttles and runtime conditional-access policy cannot drift.
+"""
+
+from __future__ import annotations
+
+import os
+from ipaddress import IPv4Network, IPv6Network, ip_address, ip_network
+
+
+def trusted_proxy_hops() -> int:
+    """Return the configured positive proxy depth, or zero when invalid."""
+    raw = (os.environ.get("AGENT_BOM_TRUSTED_PROXY_HOPS") or "").strip()
+    if not raw:
+        return 0
+    try:
+        value = int(raw)
+    except ValueError:
+        return 0
+    return value if 1 <= value <= 32 else 0
+
+
+def trusted_proxy_networks() -> tuple[IPv4Network | IPv6Network, ...]:
+    """Return explicitly trusted transport-peer networks, or none on error."""
+    raw = (os.environ.get("AGENT_BOM_TRUSTED_PROXY_CIDRS") or "").strip()
+    if not raw:
+        return ()
+    try:
+        return tuple(ip_network(part.strip(), strict=False) for part in raw.split(",") if part.strip())
+    except ValueError:
+        return ()
+
+
+def resolve_forwarded_client_ip(*, peer_host: str, forwarded_for: str, fallback: str = "") -> str:
+    """Resolve a client address only through a declared trusted proxy chain.
+
+    The direct transport peer remains authoritative unless it belongs to an
+    allowlisted proxy CIDR and a bounded positive hop count is configured.
+    Malformed, oversized, or shorter-than-declared chains fall back to the
+    transport peer instead of trusting caller-supplied input.
+    """
+    host = str(peer_host or fallback)
+    hops = trusted_proxy_hops()
+    networks = trusted_proxy_networks()
+    try:
+        peer = ip_address(host)
+    except ValueError:
+        peer = None
+    if hops > 0 and networks and peer is not None and any(peer in network for network in networks):
+        forwarded = [part.strip() for part in str(forwarded_for or "").split(",") if part.strip()]
+        if hops <= len(forwarded) <= 32:
+            candidate = forwarded[-hops]
+            try:
+                host = str(ip_address(candidate))
+            except ValueError:
+                pass
+    return host

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -47,6 +47,7 @@ from fastapi import APIRouter, Header, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse, PlainTextResponse, RedirectResponse
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
+from agent_bom.api.forwarded_identity import resolve_forwarded_client_ip, trusted_proxy_hops, trusted_proxy_networks
 from agent_bom.api.models import (
     CreateKeyRequest,
     ExceptionRequest,
@@ -101,36 +102,12 @@ _TRIAGE_PREFIX = "[finding_triage]"
 _LEGACY_FALSE_POSITIVE_PREFIX = "[false_positive]"
 
 
-def _trusted_proxy_hops() -> int:
-    raw = (os.environ.get("AGENT_BOM_TRUSTED_PROXY_HOPS") or "").strip()
-    if not raw:
-        return 0
-    try:
-        value = int(raw)
-    except ValueError:
-        return 0
-    return value if 1 <= value <= 32 else 0
-
-
-def _trusted_proxy_networks() -> tuple[Any, ...]:
-    """Return explicitly trusted transport-peer networks, or none on any error."""
-    from ipaddress import ip_network
-
-    raw = (os.environ.get("AGENT_BOM_TRUSTED_PROXY_CIDRS") or "").strip()
-    if not raw:
-        return ()
-    try:
-        return tuple(ip_network(part.strip(), strict=False) for part in raw.split(",") if part.strip())
-    except ValueError:
-        return ()
-
-
 def _auth_session_client_identity_posture() -> dict[str, Any]:
     """Describe whether forwarded client identity is safely active."""
     raw_hops = (os.environ.get("AGENT_BOM_TRUSTED_PROXY_HOPS") or "").strip()
     raw_cidrs = (os.environ.get("AGENT_BOM_TRUSTED_PROXY_CIDRS") or "").strip()
-    hops = _trusted_proxy_hops()
-    networks = _trusted_proxy_networks()
+    hops = trusted_proxy_hops()
+    networks = trusted_proxy_networks()
     active = bool(hops and networks)
     warning = None
     if raw_hops and not hops:
@@ -162,24 +139,11 @@ def _client_fingerprint(request: Request) -> str:
     Nth-from-rightmost entry and fall back to the transport peer when the chain
     is missing, malformed, oversized, or shorter than declared.
     """
-    host = request.client.host if request.client else "unknown"
-    hops = _trusted_proxy_hops()
-    networks = _trusted_proxy_networks()
-    try:
-        from ipaddress import ip_address
-
-        peer = ip_address(host)
-    except ValueError:
-        peer = None
-    if hops > 0 and networks and peer is not None and any(peer in network for network in networks):
-        forwarded = [part.strip() for part in (request.headers.get("x-forwarded-for") or "").split(",") if part.strip()]
-        if hops <= len(forwarded) <= 32:
-            candidate = forwarded[-hops]
-            try:
-                host = str(ip_address(candidate))
-            except ValueError:
-                pass
-    return (host or "unknown")[:128]
+    return resolve_forwarded_client_ip(
+        peer_host=request.client.host if request.client else "",
+        forwarded_for=request.headers.get("x-forwarded-for") or "",
+        fallback="unknown",
+    )[:128]
 
 
 def _auth_session_limit() -> int:

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -53,6 +53,7 @@ from agent_bom.agent_identity import (
     scopes_from_claims,
 )
 from agent_bom.api.auth import Role, get_key_store
+from agent_bom.api.forwarded_identity import resolve_forwarded_client_ip
 from agent_bom.api.metrics import record_gateway_relay, record_rate_limit_hit
 from agent_bom.api.middleware import InMemoryRateLimitStore, PostgresRateLimitStore
 from agent_bom.api.oauth_as import OAuthAuthorizationServer, build_oauth_as_router
@@ -549,16 +550,16 @@ def _evaluate_control_plane_bundle(
 def _request_source_ip(request: Request) -> str:
     """Resolve the caller IP for conditional-access CIDR conditions.
 
-    Prefers the first hop of ``X-Forwarded-For`` (the original client behind a
-    trusted reverse proxy), falling back to the direct socket peer.
+    The transport peer is authoritative unless the deployment declares both a
+    bounded proxy depth and trusted transport-peer CIDRs.  This prevents a
+    direct caller from satisfying an allowlisted CIDR by spoofing
+    ``X-Forwarded-For``.
     """
-    forwarded = request.headers.get("x-forwarded-for", "")
-    if forwarded:
-        first = forwarded.split(",")[0].strip()
-        if first:
-            return first
     client = getattr(request, "client", None)
-    return getattr(client, "host", "") or ""
+    return resolve_forwarded_client_ip(
+        peer_host=getattr(client, "host", "") or "",
+        forwarded_for=request.headers.get("x-forwarded-for", ""),
+    )
 
 
 def _request_environment(request: Request) -> str:

--- a/tests/test_agent_identity_lifecycle.py
+++ b/tests/test_agent_identity_lifecycle.py
@@ -508,6 +508,38 @@ def test_conditional_access_blocks_at_gateway(store):
     assert allowed.status_code == 200 and allowed.json()["result"] == {"ok": True}
 
 
+def test_conditional_access_ignores_spoofed_forwarded_ip_from_direct_caller(store, monkeypatch):
+    """A direct caller cannot satisfy a CIDR policy by supplying its own XFF."""
+    from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+    from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+
+    monkeypatch.delenv("AGENT_BOM_TRUSTED_PROXY_HOPS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_TRUSTED_PROXY_CIDRS", raising=False)
+    create_conditional_policy(
+        store,
+        tenant_id="default",
+        name="private-network-only",
+        effect="require",
+        allowed_source_cidrs=["10.0.0.0/8"],
+    )
+
+    async def ok_caller(upstream, message, extra_headers):
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    settings = GatewaySettings(
+        registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://fs.local:8100")]),
+        policy={},
+        upstream_caller=ok_caller,
+    )
+    client = TestClient(create_gateway_app(settings))
+    message = {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "list_files", "arguments": {}}}
+
+    blocked = client.post("/mcp/filesystem", json=message, headers={"x-forwarded-for": "10.1.2.3"})
+
+    assert blocked.json().get("error", {}).get("code") == -32001, blocked.text
+    assert blocked.json()["error"]["data"]["policy_source"] == "conditional_access"
+
+
 def _gateway_client_with_audit(store, audit_events):
     from agent_bom.gateway_server import GatewaySettings, create_gateway_app
     from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry

--- a/tests/test_gateway_policy_hardening.py
+++ b/tests/test_gateway_policy_hardening.py
@@ -22,12 +22,13 @@ from __future__ import annotations
 
 import logging
 import random
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from starlette.testclient import TestClient
 
-from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+from agent_bom.gateway_server import GatewaySettings, _request_source_ip, create_gateway_app
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
 from agent_bom.proxy_policy import (
     DecisionContext,
@@ -77,6 +78,24 @@ def _settings(audit: list[dict[str, Any]] | None = None, **kwargs: Any) -> Gatew
 def _is_blocked(resp) -> bool:
     body = resp.json()
     return resp.status_code == 200 and isinstance(body.get("error"), dict) and body["error"].get("code") == -32001
+
+
+def test_gateway_source_ip_requires_declared_trusted_proxy_topology(monkeypatch):
+    request = SimpleNamespace(
+        headers={"x-forwarded-for": "192.0.2.40, 10.0.0.20"},
+        client=SimpleNamespace(host="10.0.0.5"),
+    )
+
+    monkeypatch.delenv("AGENT_BOM_TRUSTED_PROXY_HOPS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_TRUSTED_PROXY_CIDRS", raising=False)
+    assert _request_source_ip(request) == "10.0.0.5"
+
+    monkeypatch.setenv("AGENT_BOM_TRUSTED_PROXY_HOPS", "2")
+    monkeypatch.setenv("AGENT_BOM_TRUSTED_PROXY_CIDRS", "10.0.0.0/24")
+    assert _request_source_ip(request) == "192.0.2.40"
+
+    request.client.host = "203.0.113.10"
+    assert _request_source_ip(request) == "203.0.113.10"
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

- resolve forwarded client addresses only through an explicitly bounded proxy depth received from allowlisted transport peers
- share the same fail-closed resolver between browser-auth throttling and gateway conditional-access evaluation
- add an end-to-end regression proving a direct caller cannot spoof a private CIDR through X-Forwarded-For

## Verification

- red regression before implementation: direct caller with X-Forwarded-For: 10.1.2.3 incorrectly passed a 10.0.0.0/8 requirement
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_agent_identity_lifecycle.py tests/test_gateway_policy_hardening.py tests/api/test_api_hardening.py tests/api/test_auth_scope_boundaries.py tests/api/test_api_operator_policy.py tests/test_shared_auth_state.py tests/test_websocket_auth_fails_closed.py — 263 passed
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check on changed Python files
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff format --check on changed Python files
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom — 873 source files clean
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight
- exception sanitization, package layout, and public-doc hygiene guards
- git diff --check

## Notes

- Fail-closed behavior: absent, invalid, incomplete, or untrusted proxy topology uses the transport peer and ignores forwarded address claims.
- No API ceiling, route contract, or deployment default changed.