### PR TITLE
perf(scan): reuse materialized CVE findings

### DIFF
--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -1505,20 +1505,45 @@ class AIBOMReport:
         secret findings are always appended so machine consumers (JSON/SARIF/CSV)
         see them, not just the console.
         """
-        from agent_bom.finding import blast_radius_to_finding
+        from agent_bom.finding import FindingType, blast_radius_to_finding
 
         # Keep explicit non-CVE findings even when the legacy blast-radius
         # projection is also present. API/VEX paths can update the projection
         # after the unified stream was built; dropping either side makes JSON
         # disagree with CSV/SARIF and hides policy findings from consumers.
         base = list(self.findings)
-        existing_ids = {getattr(f, "canonical_id", getattr(f, "id", None)) for f in base}
-        for br in self.blast_radii:
-            finding = blast_radius_to_finding(br)
-            finding_id = getattr(finding, "canonical_id", getattr(finding, "id", None))
-            if finding_id not in existing_ids:
-                base.append(finding)
-                existing_ids.add(finding_id)
+
+        def _materialized_cve_key(finding: "Finding") -> tuple[str, str, str, str, tuple[str, ...], tuple[str, ...]]:
+            evidence = finding.evidence if isinstance(finding.evidence, dict) else {}
+            return (
+                str(finding.vulnerability_id or ""),
+                str(evidence.get("package_name") or ""),
+                str(evidence.get("package_version") or ""),
+                str(evidence.get("ecosystem") or ""),
+                tuple(sorted(finding.affected_agents or [])),
+                tuple(sorted(finding.affected_servers or [])),
+            )
+
+        materialized_cve_keys = sorted(_materialized_cve_key(finding) for finding in base if finding.finding_type is FindingType.CVE)
+        blast_radius_keys = sorted(
+            (
+                str(br.vulnerability.id or ""),
+                str(br.package.name or ""),
+                str(br.package.version or ""),
+                str(br.package.ecosystem or ""),
+                tuple(sorted(str(getattr(agent, "name", "") or "") for agent in br.affected_agents)),
+                tuple(sorted(str(getattr(server, "name", "") or "") for server in br.affected_servers)),
+            )
+            for br in self.blast_radii
+        )
+        if materialized_cve_keys != blast_radius_keys:
+            existing_ids = {getattr(f, "canonical_id", getattr(f, "id", None)) for f in base}
+            for br in self.blast_radii:
+                finding = blast_radius_to_finding(br)
+                finding_id = getattr(finding, "canonical_id", getattr(finding, "id", None))
+                if finding_id not in existing_ids:
+                    base.append(finding)
+                    existing_ids.add(finding_id)
         # Avoid double-counting if a dual-write path ever adds the same secret
         # finding, but do not suppress unrelated secret findings in the side block.
         existing_ids = {getattr(f, "canonical_id", getattr(f, "id", None)) for f in base}

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -844,6 +844,21 @@ def test_cve_findings_reuses_dual_write_projection():
     assert all(item.finding_type == FindingType.CVE for item in projected)
 
 
+def test_report_to_findings_reuses_dual_write_cve_projection(monkeypatch):
+    """The unified stream must not rebuild CVEs already materialized by scan."""
+    import agent_bom.finding as finding_module
+
+    report = _make_report_with_blast_radii(2)
+    report.findings = [finding_module.blast_radius_to_finding(br) for br in report.blast_radii]
+
+    def unexpected_conversion(_blast_radius):
+        raise AssertionError("materialized CVE projection was rebuilt")
+
+    monkeypatch.setattr(finding_module, "blast_radius_to_finding", unexpected_conversion)
+
+    assert report.to_findings() == report.findings
+
+
 def test_report_to_findings_merges_explicit_and_blast_radius_findings():
     """A report must expose CVEs and explicit policy findings together."""
     report = _make_report_with_blast_radii(1)


### PR DESCRIPTION
## Summary

- reuse the scan dual-write CVE projection when it exactly matches the blast-radius stream
- key the match on vulnerability, package, ecosystem, and affected agent/server context
- preserve the existing conversion fallback for incomplete, legacy, or changed projections

## Verification

- red-first regression proved `AIBOMReport.to_findings()` rebuilt already-materialized CVEs
- `pytest -q tests/test_finding.py tests/test_output_formats.py tests/test_cli_scan.py tests/test_scan_surface_parity.py` — 270 passed
- `pytest -q tests/test_finding.py tests/test_symbol_reachability_export.py tests/test_api_findings_surface_parity.py` — 81 passed
- targeted Ruff, Ruff format, and MyPy passed
- ordinary-repo scan: 6.67s on exact main, 4.90s patched
- `blast_radius_to_finding` calls: 2,088 on exact main, 696 patched
- output size unchanged at 12,641,036 bytes; summary, packages, blast-radius rows, and timestamp-normalized findings are identical
- `git diff --check`

## Notes

- no cross-run cache is introduced
- post-reachability resync remains intact so JSON, CSV, SARIF, Parquet, and graph evidence continue to agree