### PR TITLE
fix(image): restore truthful release gates

### DIFF
--- a/.github/workflows/accuracy-nightly.yml
+++ b/.github/workflows/accuracy-nightly.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 

--- a/.github/workflows/refresh-latest-container.yml
+++ b/.github/workflows/refresh-latest-container.yml
@@ -203,6 +203,7 @@ jobs:
         id: release
         run: |
           set -euo pipefail
+          MAIN_SHA=$(git rev-parse HEAD)
           git fetch --tags --force
           TAG=$(git tag -l 'v*.*.*' --sort=-version:refname | head -n1)
           if [ -z "$TAG" ]; then
@@ -212,7 +213,19 @@ jobs:
           VERSION="${TAG#v}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "main_sha=$MAIN_SHA" >> "$GITHUB_OUTPUT"
           git checkout "$TAG"
+
+      - name: Apply current UI runtime security overlay
+        run: |
+          set -euo pipefail
+          # UI application code stays pinned to the release tag. The floating
+          # image still absorbs reviewed base-image and runtime hardening from
+          # the default branch instead of rebuilding an old digest forever.
+          git checkout "${{ steps.release.outputs.main_sha }}" -- \
+            ui/Dockerfile \
+            .image-scan-ignore \
+            security/image-exceptions.yaml
 
       - name: Verify UI package version matches release tag
         run: |

--- a/src/agent_bom/image.py
+++ b/src/agent_bom/image.py
@@ -36,6 +36,7 @@ from typing import Optional
 
 from agent_bom.config import _bool
 from agent_bom.models import Package, PermissionProfile, Severity, Vulnerability
+from agent_bom.oci_parser import is_node_package_manifest_path
 from agent_bom.package_utils import parse_debian_source_name
 from agent_bom.sbom import parse_cyclonedx
 from agent_bom.scanners.risk import cvss_to_severity, severity_from_label
@@ -549,7 +550,7 @@ def _packages_from_tar(tar_path: Path) -> list[Package]:
 
             # --- Node: node_modules/*/package.json ---
             for member_name in names:
-                if "/node_modules/" in member_name and member_name.endswith("package.json") and member_name.count("/node_modules/") == 1:
+                if is_node_package_manifest_path(member_name):
                     try:
                         member = tf.getmember(member_name)
                         f = tf.extractfile(member)

--- a/src/agent_bom/oci_parser.py
+++ b/src/agent_bom/oci_parser.py
@@ -293,6 +293,25 @@ class OCIParseResult:
 _PACKAGE_METADATA_WARNING_DETAIL = "Container package metadata could not be parsed; image inventory is incomplete."
 
 
+def is_node_package_manifest_path(member_path: str) -> bool:
+    """Return whether a path is an npm package-root manifest.
+
+    Packages may contain subpath ``package.json`` files for export conditions
+    (for example ``nanoid/non-secure/package.json``).  Those are not inventory
+    candidates and a missing name/version there is not incomplete coverage.
+    """
+    normalized = member_path.replace("\\", "/")
+    marker = "/node_modules/"
+    if marker not in normalized or not normalized.endswith("/package.json"):
+        return False
+    if normalized.count(marker) != 1:
+        return False
+    relative = normalized.split(marker, 1)[1].split("/")
+    if len(relative) == 2:
+        return not relative[0].startswith("@") and relative[1] == "package.json"
+    return len(relative) == 3 and relative[0].startswith("@") and relative[2] == "package.json"
+
+
 def _append_oci_warning(
     warnings: list[str],
     coverage_warnings: list[OCIInputWarning],
@@ -811,9 +830,7 @@ def _extract_packages_from_layer(
 
     # --- Node: node_modules/*/package.json ---
     for member_name in names:
-        if "/node_modules/" not in member_name or not member_name.endswith("package.json"):
-            continue
-        if member_name.count("/node_modules/") != 1:
+        if not is_node_package_manifest_path(member_name):
             continue
         if _is_deleted(member_name):
             continue

--- a/src/agent_bom/scanners/package_scan.py
+++ b/src/agent_bom/scanners/package_scan.py
@@ -433,6 +433,33 @@ def _apply_distro_release_ambiguity(pkg: Any, vulns: list[Vulnerability]) -> Non
     )
 
 
+def _scope_advisory_to_package_release(vuln_data: dict, package: Package) -> dict | None:
+    """Keep only affected entries for the package's observed OS release.
+
+    OSV query responses are release-scoped, but their enriched advisory record
+    contains every distro branch.  Passing that full record to fix extraction
+    lets a Debian 14 fix appear actionable on Debian 12/13.  Preserve the
+    conservative unscoped behavior when release metadata is absent; otherwise
+    an explicitly different release is not evidence for this package.
+    """
+    if package.ecosystem.lower() not in {"deb", "apk"} or ambiguous_distro_releases(package):
+        return vuln_data
+    expected = {value.lower() for value in _resolve_osv_ecosystems(package, for_local_db=False)}
+    if not expected:
+        return vuln_data
+    expected_families = {value.split(":", 1)[0] for value in expected}
+    affected = list(vuln_data.get("affected", []))
+    same_family = [
+        entry for entry in affected if str(entry.get("package", {}).get("ecosystem", "")).lower().split(":", 1)[0] in expected_families
+    ]
+    if not same_family:
+        return vuln_data
+    release_entries = [entry for entry in same_family if str(entry.get("package", {}).get("ecosystem", "")).lower() in expected]
+    if not release_entries:
+        return None
+    return {**vuln_data, "affected": release_entries}
+
+
 def _osv_ecosystems_for_package(pkg: Package) -> list[str]:
     """Return one or more OSV ecosystem identifiers for a package (live API path)."""
     return _resolve_osv_ecosystems(pkg, for_local_db=False)
@@ -848,7 +875,10 @@ def build_vulnerabilities(vuln_data_list: list[dict], package: Package) -> list[
     vulns = []
     seen_ids: set[str] = set()
 
-    for vuln_data in vuln_data_list:
+    for raw_vuln_data in vuln_data_list:
+        vuln_data = _scope_advisory_to_package_release(raw_vuln_data, package)
+        if vuln_data is None:
+            continue
         vuln_id = vuln_data.get("id", "unknown")
 
         # Version-range filter: skip vulns that don't affect our version

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -779,6 +779,19 @@ def test_refresh_latest_container_keeps_release_code_but_applies_runtime_securit
     assert "The application code and version stay pinned to the latest release tag" in workflow
 
 
+def test_refresh_latest_ui_applies_current_runtime_security_overlay():
+    """The floating UI image must absorb reviewed base-image updates from main."""
+    workflow = (ROOT / ".github" / "workflows" / "refresh-latest-container.yml").read_text()
+    ui_job = workflow.split("refresh-ui-latest:", 1)[1].split("refresh-collector-latest:", 1)[0]
+
+    assert "main_sha=$MAIN_SHA" in ui_job
+    assert "Apply current UI runtime security overlay" in ui_job
+    assert 'git checkout "${{ steps.release.outputs.main_sha }}" -- \\' in ui_job
+    assert "ui/Dockerfile \\" in ui_job
+    assert ".image-scan-ignore \\" in ui_job
+    assert "security/image-exceptions.yaml" in ui_job
+
+
 def test_refresh_latest_container_has_publish_budget_and_buildkit_cache():
     """Daily latest refresh should not rebuild multi-arch images from cold every run."""
     workflow = (ROOT / ".github" / "workflows" / "refresh-latest-container.yml").read_text()

--- a/tests/test_oci_candidate_coverage.py
+++ b/tests/test_oci_candidate_coverage.py
@@ -117,6 +117,34 @@ def test_clean_oci_package_artifact_does_not_record_partial_coverage(tmp_path: P
     assert consume_coverage_warnings() == []
 
 
+def test_node_package_subpath_manifest_is_not_a_package_metadata_gap(tmp_path: Path) -> None:
+    """Node export-condition manifests beneath a package root are not packages."""
+    image_path = _docker_save_tar(
+        tmp_path,
+        "usr/lib/node_modules/nanoid/non-secure/package.json",
+        b'{"type":"module"}',
+    )
+
+    packages, _strategy = scan_oci(image_path)
+
+    assert packages == []
+    assert consume_coverage_warnings() == []
+
+
+def test_scoped_node_package_root_manifest_remains_inventory(tmp_path: Path) -> None:
+    """Scoped npm package roots remain candidates after subpath filtering."""
+    image_path = _docker_save_tar(
+        tmp_path,
+        "usr/lib/node_modules/@scope/example/package.json",
+        b'{"name":"@scope/example","version":"1.2.3"}',
+    )
+
+    packages, _strategy = scan_oci(image_path)
+
+    assert [(package.name, package.version, package.ecosystem) for package in packages] == [("@scope/example", "1.2.3", "npm")]
+    assert consume_coverage_warnings() == []
+
+
 def test_oci_coverage_warning_surfaces_in_scan_report(tmp_path: Path) -> None:
     image_path = _docker_save_tar(tmp_path, "app/broken.deps.json", b"{not-json")
     output_path = tmp_path / "report.json"

--- a/tests/test_osv_fixed_version_accuracy.py
+++ b/tests/test_osv_fixed_version_accuracy.py
@@ -103,6 +103,53 @@ def test_build_vulnerabilities_reports_django_fix_not_jquery(monkeypatch):
     assert vulns[0].fixed_version == "2.2.2"
 
 
+def test_debian_fix_does_not_bleed_across_release_branches() -> None:
+    """A Debian 14 fix is not an available upgrade for Debian 12."""
+    advisory = {
+        "id": "DEBIAN-CVE-2026-6791",
+        "aliases": ["CVE-2026-6791"],
+        "summary": "glibc wordexp stack exhaustion",
+        "affected": [
+            {
+                "package": {"name": "glibc", "ecosystem": "Debian:12"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}]}],
+            },
+            {
+                "package": {"name": "glibc", "ecosystem": "Debian:13"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}]}],
+            },
+            {
+                "package": {"name": "glibc", "ecosystem": "Debian:14"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "2.43-3"}]}],
+            },
+        ],
+    }
+    bookworm = Package(
+        name="libc6",
+        source_package="glibc",
+        version="2.36-9+deb12u14",
+        ecosystem="deb",
+        distro_name="debian",
+        distro_version="12",
+    )
+    forky = Package(
+        name="libc6",
+        source_package="glibc",
+        version="2.42-1",
+        ecosystem="deb",
+        distro_name="debian",
+        distro_version="14",
+    )
+
+    bookworm_vulns = build_vulnerabilities([advisory], bookworm)
+    forky_vulns = build_vulnerabilities([advisory], forky)
+
+    assert len(bookworm_vulns) == 1
+    assert bookworm_vulns[0].fixed_version is None
+    assert len(forky_vulns) == 1
+    assert forky_vulns[0].fixed_version == "2.43-3"
+
+
 # --- Defect 3: versions-list trailing-zero false negative ------------------
 
 


### PR DESCRIPTION
## Summary

- scope Debian/Alpine advisory ranges to the observed release before selecting a fix, so later-branch fixes cannot become invalid remediation for older images
- ignore nested npm export-condition `package.json` files as inventory candidates while preserving scoped package roots
- pin the nightly setup action and apply current reviewed UI runtime-security overlays during the floating latest rebuild

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-image-gate-uv uv run pytest -q tests/test_osv_fixed_version_accuracy.py tests/test_distro_release_ambiguity.py tests/test_osv_os_package_matching.py tests/test_os_package_scanning.py tests/test_oci_candidate_coverage.py tests/test_oci_parser.py tests/test_image_scan_parity.py tests/test_deployment.py tests/test_container_supply_chain_repair.py` — 214 passed
- `UV_CACHE_DIR=/tmp/agent-bom-image-gate-uv uv run ruff check ...` — passed
- `UV_CACHE_DIR=/tmp/agent-bom-image-gate-uv uv run ruff format --check ...` — passed
- `UV_CACHE_DIR=/tmp/agent-bom-image-gate-uv uv run mypy src/agent_bom` — 873 source files clean
- `UV_CACHE_DIR=/tmp/agent-bom-image-gate-uv make preflight` — passed
- `actionlint -ignore 'SC2129' .github/workflows/accuracy-nightly.yml .github/workflows/refresh-latest-container.yml` — passed
- `python scripts/check_workflow_timeouts.py` — passed
- `git diff origin/main...HEAD --check` — passed
- `UV_CACHE_DIR=/tmp/agent-bom-image-gate-uv uv run agent-bom scan --demo --offline --format json --output /tmp/agent-bom-image-gate-demo.json` — complete report; exit 1 was the expected critical finding verdict
- cached `agentbom/agent-bom-ui:0.102.0` scan — 110 packages, zero coverage warnings; 173 release-unfixed OS findings suppressed and no cross-release critical fix recommendations
- exact pinned UI base repository check — `liblzma5` candidate `5.4.1-1+deb12u1` is available for the runtime overlay rebuild
- `git verify-commit HEAD` — good ED25519 signature

## Notes

The cached released UI image still contains `liblzma5 5.4.1-1`, so the exact medium gate remains red until the refreshed image is rebuilt with this PR's current UI Dockerfile overlay. The scheduled/manual workflow after merge is the live publication proof; local scans are not presented as hosted proof.
