### PR TITLE
fix(api): remove exception flow from graph scenario response

### DIFF
--- a/scripts/check_exception_sanitization.py
+++ b/scripts/check_exception_sanitization.py
@@ -144,11 +144,7 @@ def _scan_returned_exception_flows(text: str, label: str) -> list[str]:
         for node in ast.walk(handler):
             if not isinstance(node, ast.Return) or node.value is None:
                 continue
-            uses = [
-                child
-                for child in ast.walk(node.value)
-                if isinstance(child, ast.Name) and child.id == handler.name
-            ]
+            uses = [child for child in ast.walk(node.value) if isinstance(child, ast.Name) and child.id == handler.name]
             if not uses:
                 continue
             start = max(1, node.lineno)

--- a/scripts/check_exception_sanitization.py
+++ b/scripts/check_exception_sanitization.py
@@ -21,6 +21,10 @@ Forbidden patterns (on the scanned trees):
   3. ``logger.<level>(f"...{exc}...")`` — raw exception interpolated into a log
      f-string. Use lazy ``%s`` formatting with a sanitized value:
      ``logger.warning("...: %s", sanitize_text(exc))``.
+  4. A caught exception object used anywhere in an API route's returned
+     response payload. Return a fixed external message instead. This
+     intentionally avoids relying on custom sanitizer modeling in static
+     analyzers such as CodeQL.
 
 Only the bare exception token (``{exc}``, ``{e}``, ``{err}``, ``{error}``,
 ``{ex}`` and their ``{exc!r}`` / ``{exc:...}`` forms) is flagged. Attribute
@@ -36,6 +40,7 @@ Exit 0 = clean. Exit 1 = a violation. Pure stdlib so it runs anywhere in CI.
 
 from __future__ import annotations
 
+import ast
 import re
 import sys
 from pathlib import Path
@@ -118,6 +123,44 @@ def _scan_line(line: str) -> str | None:
     return None
 
 
+def _scan_returned_exception_flows(text: str, label: str) -> list[str]:
+    """Flag caught exception objects that flow into a returned payload.
+
+    ``sanitize_error(exc, generic=True)`` is safe at runtime, but external
+    static analyzers cannot necessarily prove that a project-local sanitizer
+    returns a constant. Keeping the exception object out of a response return
+    entirely gives both runtime and static-analysis proof of the boundary.
+    """
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return []
+
+    lines = text.splitlines()
+    violations: list[str] = []
+    for handler in (node for node in ast.walk(tree) if isinstance(node, ast.ExceptHandler)):
+        if not handler.name:
+            continue
+        for node in ast.walk(handler):
+            if not isinstance(node, ast.Return) or node.value is None:
+                continue
+            uses = [
+                child
+                for child in ast.walk(node.value)
+                if isinstance(child, ast.Name) and child.id == handler.name
+            ]
+            if not uses:
+                continue
+            start = max(1, node.lineno)
+            end = min(len(lines), getattr(node, "end_lineno", node.lineno))
+            if any(PRAGMA in lines[index - 1] for index in range(start, end + 1)):
+                continue
+            violations.append(
+                f"{label}:{uses[0].lineno}: caught exception flows into returned response payload — return a fixed external message"
+            )
+    return violations
+
+
 def scan_text(text: str, label: str) -> list[str]:
     """Scan a blob of source. Used by the test-suite to feed deliberate samples."""
     violations: list[str] = []
@@ -127,6 +170,8 @@ def scan_text(text: str, label: str) -> list[str]:
         reason = _scan_line(line)
         if reason:
             violations.append(f"{label}:{lineno}: {reason}")
+    if label == "sample.py" or label.startswith("src/agent_bom/api/routes/"):
+        violations.extend(_scan_returned_exception_flows(text, label))
     return violations
 
 

--- a/src/agent_bom/api/routes/graph_scenarios.py
+++ b/src/agent_bom/api/routes/graph_scenarios.py
@@ -718,7 +718,7 @@ async def compare_graph_scenario(
             exact_edge_count=current["edge_count"],
             attack_paths=paths_result[2],
         )
-    except (TypeError, ValueError) as exc:
+    except (TypeError, ValueError):
         return {
             "schema": _COMPARISON_SCHEMA,
             "scenario": {**_public_scenario(scenario), "base_status": status},
@@ -733,7 +733,7 @@ async def compare_graph_scenario(
             },
             "difference": _empty_difference(),
             "available": False,
-            "unavailable_reason": sanitize_error(exc, generic=True),
+            "unavailable_reason": "The proposed graph scenario is invalid.",
             "base_status": status,
             "stale": stale,
         }

--- a/tests/test_exception_sanitization_guard.py
+++ b/tests/test_exception_sanitization_guard.py
@@ -70,6 +70,21 @@ def test_flags_logger_fstring_exc() -> None:
         assert "log f-string" in out[0]
 
 
+def test_flags_exception_flow_into_returned_payload_even_through_custom_sanitizer() -> None:
+    source = """
+try:
+    build_response()
+except ValueError as exc:
+    return {
+        "available": False,
+        "unavailable_reason": sanitize_error(exc, generic=True),
+    }
+"""
+    out = GUARD.scan_text(source, "sample.py")
+    assert len(out) == 1
+    assert "returned response payload" in out[0]
+
+
 # ---------------------------------------------------------------------------
 # Safe patterns are NOT flagged.
 # ---------------------------------------------------------------------------

--- a/tests/test_graph_scenario_routes.py
+++ b/tests/test_graph_scenario_routes.py
@@ -268,7 +268,7 @@ def test_invalid_stored_operation_returns_unavailable_without_partial_applicatio
     assert body["available"] is False
     assert body["proposed"]["nodes"] == [] and body["proposed"]["edges"] == []
     assert body["difference"]["nodes_removed"] == []
-    assert body["unavailable_reason"] == "An internal error occurred. Please contact support."
+    assert body["unavailable_reason"] == "The proposed graph scenario is invalid."
     assert "missing-node" not in body["unavailable_reason"]
 
 


### PR DESCRIPTION
## Summary

- remove the caught exception object from the graph scenario comparison response path flagged by CodeQL alert #1851
- return a fixed invalid-scenario message while preserving the existing unavailable comparison contract
- extend the exception-sanitization guard to reject caught exception data flowing into API route return payloads

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-codeql-uv uv run pytest -q tests/test_exception_sanitization_guard.py` — 10 passed
- `UV_CACHE_DIR=/tmp/agent-bom-codeql-uv uv run pytest -q tests/test_graph_scenario_routes.py` — 15 passed
- `UV_CACHE_DIR=/tmp/agent-bom-codeql-uv uv run python scripts/check_exception_sanitization.py`
- `UV_CACHE_DIR=/tmp/agent-bom-codeql-uv uv run ruff check scripts/check_exception_sanitization.py tests/test_exception_sanitization_guard.py src/agent_bom/api/routes/graph_scenarios.py tests/test_graph_scenario_routes.py`
- `UV_CACHE_DIR=/tmp/agent-bom-codeql-uv make preflight`
- `git diff --check`

## Notes

- CodeQL alert #1851 remains open until GitHub analyzes this branch or the merged commit.
