### PR TITLE
fix(security): redact outbound evidence surfaces

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 873,
+      "value": 874,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 49 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 873 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 874 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/alerts/dispatcher.py
+++ b/src/agent_bom/alerts/dispatcher.py
@@ -16,12 +16,13 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from agent_bom.event_normalization import build_runtime_alert_relationships
+from agent_bom.security import sanitize_sensitive_payload, sanitize_text
 
 logger = logging.getLogger(__name__)
 
 
 def _escape_slack_text(value: object) -> str:
-    text = str(value).replace("\r", " ").replace("\n", " ").replace("\t", " ")
+    text = sanitize_text(value, max_len=3000).replace("\r", " ").replace("\n", " ").replace("\t", " ")
     text = re.sub(r"[*~`]", "", text)
     text = re.sub(r"_{2,}", "", text)
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")[:3000]
@@ -112,7 +113,7 @@ class SlackChannel:
             payload = _build_slack_payload(alert)
             return await send_slack_payload(self.webhook_url, payload)
         except Exception:
-            logger.exception("Slack channel delivery failed")
+            logger.error("Slack channel delivery failed")
             return False
 
 
@@ -223,7 +224,7 @@ class WebhookChannel:
                     client,
                     "POST",
                     self.url,
-                    json=alert,
+                    json=sanitize_sensitive_payload(alert, max_str_len=3_000),
                     headers={"Content-Type": "application/json", **self.headers},
                     max_retries=0,
                 )
@@ -233,7 +234,7 @@ class WebhookChannel:
 
             # The webhook URL can itself be the secret (Slack-style incoming
             # webhooks embed the token in the path), so never log it verbatim.
-            logger.exception("Webhook channel delivery failed for %s", redact_secret_url(self.url))
+            logger.error("Webhook channel delivery failed for %s", redact_secret_url(self.url))
             return False
 
 
@@ -264,7 +265,7 @@ class ClickHouseChannel:
             self._get_store().record_event(alert)
             return True
         except Exception:
-            logger.exception("ClickHouse channel delivery failed")
+            logger.error("ClickHouse channel delivery failed")
             return False
 
 
@@ -330,6 +331,8 @@ class AlertDispatcher:
         if "ts" not in alert_dict:
             alert_dict["ts"] = datetime.now(timezone.utc).isoformat()
         alert_dict = _normalize_alert_event(alert_dict)
+        sanitized = sanitize_sensitive_payload(alert_dict, max_str_len=3_000)
+        alert_dict = sanitized if isinstance(sanitized, dict) else {"message": "Alert payload redacted", "severity": "info"}
 
         successes = 0
         for ch in self._channels:
@@ -340,7 +343,7 @@ class AlertDispatcher:
                 else:
                     self._stats.total_channel_failures += 1
             except Exception:
-                logger.exception("Channel %s failed", type(ch).__name__)
+                logger.error("Channel %s failed", type(ch).__name__)
                 self._stats.total_channel_failures += 1
 
         self._stats.total_dispatched += 1

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -33,6 +33,7 @@ import json
 import logging
 import math
 import os
+import sys
 import time
 import uuid
 from collections.abc import AsyncIterator, Callable, Mapping
@@ -1276,7 +1277,10 @@ def _redact_scan_result_for_response(result: dict[str, Any] | None) -> dict[str,
 
     findings = result.get("findings")
     envelope = {key: value for key, value in result.items() if key != "findings"}
-    sanitized = sanitize_sensitive_payload(envelope, max_str_len=10_000)
+    # This is the explicit full-result endpoint.  Redact sensitive content but
+    # do not silently truncate legitimate evidence; callers that only need a
+    # bounded polling envelope use ``/{job_id}/status`` instead.
+    sanitized = sanitize_sensitive_payload(envelope, max_str_len=sys.maxsize)
     if not isinstance(sanitized, dict):
         return {"document_type": "AI-BOM", "redaction_error": "scan result sanitizer returned a non-object payload"}
     redacted = cast(dict[str, Any], fail_closed_cis_result(sanitized))

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -980,7 +980,10 @@ def _context_graph_payload(result: dict[str, Any], *, agent: str | None, scan_id
 
     payload = to_serializable(graph, paths, risks)
     payload["stats"]["lateral_paths_truncated"] = paths_truncated
-    return _attach_unified_graph_view(payload, result, scan_id=scan_id, tenant_id=tenant_id)
+    attached = _attach_unified_graph_view(payload, result, scan_id=scan_id, tenant_id=tenant_id)
+    from agent_bom.output.interop_security import sanitize_linked_document
+
+    return sanitize_linked_document(attached)
 
 
 def _graph_export_response(result: dict[str, Any], *, format: str, mermaid_limit: int) -> dict | str | PlainTextResponse:
@@ -1191,7 +1194,7 @@ def _inventory_packages_from_agents(agents: list[dict[str, Any]]) -> list[dict[s
 
 def _job_summary_payload(job: ScanJob) -> dict[str, Any]:
     """Build a lightweight summary payload for list surfaces."""
-    from agent_bom.security import sanitize_sensitive_payload
+    from agent_bom.security import sanitize_sensitive_payload, sanitize_text
 
     result = job.result if isinstance(job.result, dict) else {}
     summary = result.get("summary") if isinstance(result.get("summary"), dict) else None
@@ -1219,16 +1222,16 @@ def _job_summary_payload(job: ScanJob) -> dict[str, Any]:
         "created_at": job.created_at,
         "completed_at": job.completed_at,
         "request": request_payload if isinstance(request_payload, dict) else {},
-        "summary": summary,
-        "aggregation": aggregation,
+        "summary": sanitize_sensitive_payload(summary),
+        "aggregation": sanitize_sensitive_payload(aggregation),
         "scan_timestamp": scan_timestamp,
         "generated_at": generated_at,
-        "scan_run": scan_run,
+        "scan_run": sanitize_sensitive_payload(scan_run),
         "scan_outcome": (scan_run or {}).get("outcome"),
         "warning_count": warning_count,
-        "warnings_preview": [str(item) for item in warnings[:3]],
+        "warnings_preview": sanitize_sensitive_payload(warnings[:3]),
         "pushed": bool(result.get("pushed")),
-        "error": job.error,
+        "error": sanitize_text(job.error, max_len=1_000) if job.error else None,
     }
 
 
@@ -1265,13 +1268,18 @@ async def _load_job_for_request(request: Request, job_id: str) -> ScanJob:
 
 
 def _redact_scan_result_for_response(result: dict[str, Any] | None) -> dict[str, Any] | None:
-    """Drop replay-only fields from top-level scan findings before API return."""
+    """Redact the complete scan envelope and drop replay-only finding fields."""
     if not isinstance(result, dict):
         return result
     from agent_bom.cloud.cis_remediation import fail_closed_cis_result
+    from agent_bom.security import sanitize_sensitive_payload
 
-    redacted = cast(dict[str, Any], fail_closed_cis_result(result))
     findings = result.get("findings")
+    envelope = {key: value for key, value in result.items() if key != "findings"}
+    sanitized = sanitize_sensitive_payload(envelope, max_str_len=10_000)
+    if not isinstance(sanitized, dict):
+        return {"document_type": "AI-BOM", "redaction_error": "scan result sanitizer returned a non-object payload"}
+    redacted = cast(dict[str, Any], fail_closed_cis_result(sanitized))
     if not isinstance(findings, list):
         return redacted
     from agent_bom.finding_scope import safe_finding_response_payload
@@ -1597,7 +1605,7 @@ async def get_attack_flow(
     blast_radius = job.result.get("blast_radius", [])
     agents_data = job.result.get("agents", [])
 
-    return build_attack_flow(
+    payload = build_attack_flow(
         blast_radius,
         agents_data,
         cve=cve,
@@ -1605,6 +1613,9 @@ async def get_attack_flow(
         framework=framework,
         agent_name=agent,
     )
+    from agent_bom.output.interop_security import sanitize_linked_document
+
+    return sanitize_linked_document(payload)
 
 
 @router.get("/scan/{job_id}/context-graph", tags=["scan"])

--- a/src/agent_bom/evidence/policy.py
+++ b/src/agent_bom/evidence/policy.py
@@ -20,7 +20,7 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Iterable
 
-from agent_bom.security import mask_email
+from agent_bom.security import mask_email, sanitize_text
 
 # ─── Tier definition ─────────────────────────────────────────────────────────
 
@@ -445,11 +445,11 @@ def redact_for_persistence(payload: Any, target_tier: EvidenceTier) -> Any:
         return [redact_for_persistence(item, target_tier) for item in payload]
     if isinstance(payload, tuple):
         return tuple(redact_for_persistence(item, target_tier) for item in payload)
-    # Email is sensitive PII: mask any address that survives into a persisted
-    # value (e.g. nested inside a retained tier-A container like ``actor`` or
-    # ``details``). Non-email strings pass through unchanged.
+    # Every retained tier-A string crosses the canonical secret/URL/PII
+    # sanitizer. Field allowlisting alone does not make a title or label safe:
+    # hostile upstream text can still contain a shaped credential.
     if isinstance(payload, str):
-        return mask_email(payload)
+        return sanitize_text(payload, max_len=max(1_000, len(payload)))
     return payload
 
 

--- a/src/agent_bom/mcp_tools/analysis.py
+++ b/src/agent_bom/mcp_tools/analysis.py
@@ -204,7 +204,9 @@ async def context_graph_impl(
             sampled=paths_truncated,
             reason=("multi-source path budget reached; request a source_agent for exhaustive local traversal" if paths_truncated else ""),
         )
-        return _truncate_response(json.dumps(result, indent=2, default=str))
+        from agent_bom.output.interop_security import sanitize_linked_document
+
+        return _truncate_response(json.dumps(sanitize_linked_document(result), indent=2, default=str))
     except Exception as exc:
         logger.exception("MCP tool error")
         return mcp_error_json(CODE_INTERNAL_UNEXPECTED, exc)

--- a/src/agent_bom/mcp_tools/scanning.py
+++ b/src/agent_bom/mcp_tools/scanning.py
@@ -394,7 +394,9 @@ async def _scan_impl_inner(
 
         if scan_warnings:
             result["warnings"] = scan_warnings
-        return _truncate_response(json.dumps(result, indent=2, default=str))
+        from agent_bom.output.json_fmt import redact_json_payload
+
+        return _truncate_response(json.dumps(redact_json_payload(result), indent=2, default=str))
     except Exception as exc:
         from agent_bom.scanners import IncompleteScanError
 

--- a/src/agent_bom/output/compact.py
+++ b/src/agent_bom/output/compact.py
@@ -400,6 +400,8 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
     when MCP agent context is available. Falls back to a clean vuln table for
     scan types without agent context (image, check, iac, CI/CD).
     """
+    from rich.markup import escape
+
     from agent_bom.output import _sev_badge, console
     from agent_bom.output.finding_views import (
         active_cve_findings,
@@ -410,7 +412,11 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
         is_package_direct,
         package_name,
         package_version,
+        sanitize_output_text,
     )
+
+    def safe(value: object) -> str:
+        return escape(sanitize_output_text(value))
 
     active_findings = active_cve_findings(report)
     if not active_findings:
@@ -467,7 +473,7 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
 
     for finding in shown:
         forward_fix = _forward_fix_version(finding)
-        fix = f"[green]{forward_fix}[/green]" if forward_fix else "[dim]no fix[/dim]"
+        fix = f"[green]{safe(forward_fix)}[/green]" if forward_fix else "[dim]no fix[/dim]"
         _exploit_level = exploit_likelihood_value(finding)
         if finding.is_kev:
             kev = " [red bold]KEV[/red bold]"
@@ -484,13 +490,15 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
             epss_style = "red bold" if epss_pct >= 70 else "yellow" if epss_pct >= 30 else "dim"
             epss_display = f"[{epss_style}]{epss_pct}%[/{epss_style}]"
 
-        pkg_display = f"{package_name(finding)}@{package_version(finding)}" + ("" if is_package_direct(finding) else " [dim]T[/dim]")
-        vuln_id = finding.cve_id or finding.id
+        pkg_display = f"{safe(package_name(finding))}@{safe(package_version(finding))}" + (
+            "" if is_package_direct(finding) else " [dim]T[/dim]"
+        )
+        vuln_id = safe(finding.cve_id or finding.id)
 
         if has_blast_context:
-            agent_names = list(finding.affected_agents)
-            cred_names = list(finding.exposed_credentials)
-            server_names = list(finding.affected_servers)
+            agent_names = [safe(value) for value in finding.affected_agents]
+            cred_names = [safe(value) for value in finding.exposed_credentials]
+            server_names = [safe(value) for value in finding.affected_servers]
             chain_parts: list[str] = []
             if agent_names:
                 name = agent_names[0][:16]
@@ -552,26 +560,26 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
         for finding in critical_findings[:5]:
             sev = finding_severity(finding)
             style = sev_style_map.get(sev, "white")
-            summary = finding.description or ""
+            summary = safe(finding.description or "")
             if len(summary) > 80:
                 summary = summary[:77] + "..."
             sev_label = sev.value.upper()
-            pkg_ref = f"{package_name(finding)}@{package_version(finding)}"
-            vuln_id = finding.cve_id or finding.id
+            pkg_ref = f"{safe(package_name(finding))}@{safe(package_version(finding))}"
+            vuln_id = safe(finding.cve_id or finding.id)
             console.print(f"\n  [{style}]{vuln_id}[/{style}] · {pkg_ref} · [{style}]{sev_label}[/{style}]")
             if summary:
                 console.print(f"  {summary}")
             forward_fix = _forward_fix_version(finding)
             if forward_fix:
-                console.print(f"  Fix: [green]upgrade to ≥ {forward_fix}[/green]")
+                console.print(f"  Fix: [green]upgrade to ≥ {safe(forward_fix)}[/green]")
             if has_blast_context and (finding.affected_agents or finding.exposed_credentials):
-                agent_str = ", ".join(finding.affected_agents[:3])
-                cred_str = ", ".join(finding.exposed_credentials[:3])
+                agent_str = ", ".join(safe(value) for value in finding.affected_agents[:3])
+                cred_str = ", ".join(safe(value) for value in finding.exposed_credentials[:3])
                 blast_parts = []
                 if agent_str:
                     blast_parts.append(agent_str)
                 if finding.affected_servers:
-                    blast_parts.append(", ".join(finding.affected_servers[:2]))
+                    blast_parts.append(", ".join(safe(value) for value in finding.affected_servers[:2]))
                 if cred_str:
                     blast_parts.append(f"[yellow]{cred_str}[/yellow]")
                 if blast_parts:
@@ -605,6 +613,10 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5, page: int = 1
         return
 
     plan = build_remediation_plan(cve_rows)
+    from agent_bom.security import sanitize_sensitive_payload
+
+    sanitized_plan = sanitize_sensitive_payload(plan, max_str_len=10_000)
+    plan = sanitized_plan if isinstance(sanitized_plan, list) else []
     fixable = [p for p in plan if p["fix"]]
     if not fixable:
         return

--- a/src/agent_bom/output/compliance_export.py
+++ b/src/agent_bom/output/compliance_export.py
@@ -174,7 +174,10 @@ def _digest(data: bytes) -> str:
 
 
 def _json_bytes(value: object) -> bytes:
-    return json.dumps(value, indent=2, sort_keys=True, default=str).encode("utf-8")
+    from agent_bom.security import sanitize_sensitive_payload
+
+    sanitized = sanitize_sensitive_payload(value, max_str_len=10_000)
+    return json.dumps(sanitized, indent=2, sort_keys=True, default=str).encode("utf-8")
 
 
 def export_compliance_bundle(

--- a/src/agent_bom/output/console_render.py
+++ b/src/agent_bom/output/console_render.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from rich.console import Console
+from rich.markup import escape
 from rich.panel import Panel
 from rich.rule import Rule
 from rich.table import Table
@@ -31,8 +32,9 @@ from agent_bom.output.finding_views import (
     package_ecosystem,
     package_name,
     package_version,
+    sanitize_output_text,
 )
-from agent_bom.security import sanitize_command_args
+from agent_bom.security import sanitize_launch_command, sanitize_path_label
 
 console = Console()
 
@@ -556,8 +558,10 @@ def print_agent_tree(report: AIBOMReport) -> None:
         if total_creds:
             stats_parts.append(f"{total_creds} credential{'s' if total_creds != 1 else ''}")
 
-        agent_tree = Tree(f"\U0001f916 Agent: [bold]{agent.name}[/bold] ({agent.agent_type.value}){status_str}")
-        agent_tree.add(f"[dim]{agent.config_path}[/dim]")
+        agent_name = escape(sanitize_output_text(agent.name))
+        agent_type = escape(sanitize_output_text(agent.agent_type.value))
+        agent_tree = Tree(f"\U0001f916 Agent: [bold]{agent_name}[/bold] ({agent_type}){status_str}")
+        agent_tree.add(f"[dim]{escape(sanitize_path_label(agent.config_path))}[/dim]")
         sep = " \u00b7 "
         agent_tree.add(f"[dim]{sep.join(stats_parts)}[/dim]")
 
@@ -578,17 +582,18 @@ def print_agent_tree(report: AIBOMReport) -> None:
 
             registry_indicator = " [green]✓ registry[/green]" if server.registry_verified else " [dim]unknown registry[/dim]"
 
-            server_args = sanitize_command_args(server.args[:2])
+            server_name = escape(sanitize_output_text(server.name))
+            launch = escape(sanitize_launch_command(server.command or "", server.args[:2]))
             server_branch = agent_tree.add(
-                f"\U0001f50c MCP Server: [bold cyan]{server.name}[/bold cyan] "
-                f"({server.command} {' '.join(server_args)})"
+                f"\U0001f50c MCP Server: [bold cyan]{server_name}[/bold cyan] "
+                f"({launch})"
                 f"{vuln_indicator}{cred_indicator}{priv_indicator}{registry_indicator}"
             )
 
             if server.tools:
                 tools_branch = server_branch.add(f"[dim]\U0001f527 Tools ({len(server.tools)})[/dim]")
                 for tool in server.tools[:10]:  # Limit display
-                    tools_branch.add(f"[dim]{tool.name}[/dim]")
+                    tools_branch.add(f"[dim]{escape(sanitize_output_text(tool.name))}[/dim]")
                 if len(server.tools) > 10:
                     tools_branch.add(f"[dim]...and {len(server.tools) - 10} more[/dim]")
 
@@ -610,7 +615,10 @@ def print_agent_tree(report: AIBOMReport) -> None:
                     if pkg.scorecard_score is not None:
                         sc_color = "green" if pkg.scorecard_score >= 7.0 else "yellow" if pkg.scorecard_score >= 4.0 else "red"
                         sc_str = f" [{sc_color}]SC:{pkg.scorecard_score:.1f}[/{sc_color}]"
-                    pkg_branch.add(f"{pkg.name}@{pkg.version} [{pkg.ecosystem}]{sc_str}{vuln_str}")
+                    pkg_branch.add(
+                        f"{escape(sanitize_output_text(pkg.name))}@{escape(sanitize_output_text(pkg.version))} "
+                        f"[{escape(sanitize_output_text(pkg.ecosystem))}]{sc_str}{vuln_str}"
+                    )
 
                 # Show transitive packages grouped by depth (limit display)
                 if transitive_pkgs:
@@ -620,15 +628,18 @@ def print_agent_tree(report: AIBOMReport) -> None:
                         if pkg.has_vulnerabilities:
                             vuln_str = f" [red]({len(pkg.vulnerabilities)} vuln(s))[/red]"
                         indent = "  " * pkg.dependency_depth
-                        parent_str = f" ← {pkg.parent_package}" if pkg.parent_package else ""
-                        transitive_branch.add(f"[dim]{indent}{pkg.name}@{pkg.version}{parent_str}{vuln_str}[/dim]")
+                        parent_str = f" ← {escape(sanitize_output_text(pkg.parent_package))}" if pkg.parent_package else ""
+                        transitive_branch.add(
+                            f"[dim]{indent}{escape(sanitize_output_text(pkg.name))}@"
+                            f"{escape(sanitize_output_text(pkg.version))}{parent_str}{vuln_str}[/dim]"
+                        )
                     if len(transitive_pkgs) > 20:
                         transitive_branch.add(f"[dim]...and {len(transitive_pkgs) - 20} more[/dim]")
 
             if server.has_credentials:
                 cred_branch = server_branch.add("[yellow]\U0001f511 Credentials[/yellow]")
                 for cred in server.credential_names:
-                    cred_branch.add(f"[yellow]{cred}[/yellow]")
+                    cred_branch.add(f"[yellow]{escape(sanitize_output_text(cred))}[/yellow]")
 
         _console().print(agent_tree)
         _console().print()
@@ -670,7 +681,7 @@ def print_blast_radius(report: AIBOMReport, fixable_only: bool = False) -> None:
         sev = finding_severity(finding)
         sev_style = SEVERITY_TEXT.get(sev, "white")
         if finding.fixed_version:
-            fix = f"[green]✓ {finding.fixed_version}[/green]"
+            fix = f"[green]✓ {escape(sanitize_output_text(finding.fixed_version))}[/green]"
         else:
             fix = "[red dim]No fix[/red dim]"
 
@@ -699,8 +710,9 @@ def print_blast_radius(report: AIBOMReport, fixable_only: bool = False) -> None:
         blast_display = "/".join(blast_parts) if blast_parts else "—"
 
         # Vulnerability: ID + package on two lines
-        vuln_id = finding.cve_id or finding.id
-        vuln_display = f"{vuln_id}\n[dim]{package_name(finding)}@{package_version(finding)}[/dim]"
+        vuln_id = escape(sanitize_output_text(finding.cve_id or finding.id))
+        package_label = escape(f"{sanitize_output_text(package_name(finding))}@{sanitize_output_text(package_version(finding))}")
+        vuln_display = f"{vuln_id}\n[dim]{package_label}[/dim]"
 
         # Threats column: actual framework tag IDs per finding
         threat_lines = []
@@ -825,35 +837,41 @@ def print_attack_flow_tree(report: AIBOMReport) -> None:
         cve_tree = Tree(" · ".join(root_parts))
 
         # Package node
-        pkg_label = f"{package_name(finding)}@{package_version(finding)} ({package_ecosystem(finding)})"
+        pkg_label = escape(
+            f"{sanitize_output_text(package_name(finding))}@{sanitize_output_text(package_version(finding))} "
+            f"({sanitize_output_text(package_ecosystem(finding))})"
+        )
         pkg_branch = cve_tree.add(f"[dim]{pkg_label}[/dim]")
 
         # Server branches
-        for server_name in finding.affected_servers:
+        for raw_server_name in finding.affected_servers:
+            server_name = escape(sanitize_output_text(raw_server_name))
             srv_branch = pkg_branch.add(f"\U0001f50c [bold cyan]{server_name}[/bold cyan] [dim](MCP Server)[/dim]")
 
             # Agents
-            for agent_name in finding.affected_agents:
+            for raw_agent_name in finding.affected_agents:
+                agent_name = escape(sanitize_output_text(raw_agent_name))
                 srv_branch.add(f"\U0001f916 [green]{agent_name}[/green] [dim](Agent)[/dim]")
 
             # Credentials
             for cred in finding.exposed_credentials:
-                srv_branch.add(f"[yellow]🔑 {cred}[/yellow]")
+                srv_branch.add(f"[yellow]🔑 {escape(sanitize_output_text(cred))}[/yellow]")
 
             # Tools (compact, max 5 per line)
             if finding.exposed_tools:
-                tool_names = finding.exposed_tools[:5]
+                tool_names = [escape(sanitize_output_text(tool)) for tool in finding.exposed_tools[:5]]
                 extra = f" +{len(finding.exposed_tools) - 5}" if len(finding.exposed_tools) > 5 else ""
                 srv_branch.add(f"[dim]🔧 {', '.join(tool_names)}{extra}[/dim]")
 
         # If no servers, still show agents/creds/tools under package
         if not finding.affected_servers:
-            for agent_name in finding.affected_agents:
+            for raw_agent_name in finding.affected_agents:
+                agent_name = escape(sanitize_output_text(raw_agent_name))
                 pkg_branch.add(f"\U0001f916 [green]{agent_name}[/green] [dim](Agent)[/dim]")
             for cred in finding.exposed_credentials:
-                pkg_branch.add(f"[yellow]🔑 {cred}[/yellow]")
+                pkg_branch.add(f"[yellow]🔑 {escape(sanitize_output_text(cred))}[/yellow]")
             if finding.exposed_tools:
-                tool_names = finding.exposed_tools[:5]
+                tool_names = [escape(sanitize_output_text(tool)) for tool in finding.exposed_tools[:5]]
                 extra = f" +{len(finding.exposed_tools) - 5}" if len(finding.exposed_tools) > 5 else ""
                 pkg_branch.add(f"[dim]🔧 {', '.join(tool_names)}{extra}[/dim]")
 
@@ -1492,6 +1510,10 @@ def print_remediation_plan(report: AIBOMReport) -> None:
         return
 
     plan = build_remediation_plan(all_cve)
+    from agent_bom.security import sanitize_sensitive_payload
+
+    sanitized_plan = sanitize_sensitive_payload(plan, max_str_len=10_000)
+    plan = sanitized_plan if isinstance(sanitized_plan, list) else []
     # A malicious package sets fix=None to signal REMOVAL (not a version bump),
     # so it must be pulled out of the fix-based buckets. Without this it lands in
     # the "no fix yet — monitor upstream for patches" bucket, which tells the user

--- a/src/agent_bom/output/csv_fmt.py
+++ b/src/agent_bom/output/csv_fmt.py
@@ -20,6 +20,7 @@ from agent_bom.output.finding_views import (
     package_version,
     severity_value,
     unified_export_findings,
+    with_output_sanitizer_cache,
     workflow_status,
 )
 
@@ -82,6 +83,7 @@ def _verdict_cell(finding: Finding, key: str) -> str:
     return str(value)
 
 
+@with_output_sanitizer_cache
 def to_csv(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> str:
     """Convert an AIBOMReport to CSV string with UTF-8 BOM."""
     findings = unified_export_findings(report, blast_radii)
@@ -162,6 +164,9 @@ def _excel_safe_cell(value: object) -> object:
     """
     if not isinstance(value, str):
         return value
+    from agent_bom.output.finding_views import sanitize_output_text
+
+    value = sanitize_output_text(value)
     stripped = value.lstrip(" \t\r\n")
     if stripped.startswith(("=", "+", "-", "@")):
         return "'" + value

--- a/src/agent_bom/output/cyclonedx_fmt.py
+++ b/src/agent_bom/output/cyclonedx_fmt.py
@@ -958,7 +958,9 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
             }
         ]
 
-    return cdx
+    from agent_bom.output.interop_security import sanitize_linked_document
+
+    return sanitize_linked_document(cdx)
 
 
 def export_cyclonedx(report: AIBOMReport, output_path: str) -> None:

--- a/src/agent_bom/output/finding_views.py
+++ b/src/agent_bom/output/finding_views.py
@@ -2,14 +2,55 @@
 
 from __future__ import annotations
 
-from typing import Any
+from contextvars import ContextVar
+from functools import wraps
+from typing import Any, Callable, ParamSpec, TypeVar
 
 from agent_bom.compliance_coverage import COMPLIANCE_TAG_FIELDS
 from agent_bom.finding import Finding, FindingType, blast_radius_to_finding
 from agent_bom.graph.severity import normalize_severity
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
+from agent_bom.security import sanitize_log_label, sanitize_text, text_requires_redaction
 
 _MACHINE_EXPORT_TYPES = (FindingType.CVE, FindingType.MALICIOUS_PACKAGE)
+_OUTPUT_SANITIZER_CACHE_LIMIT = 262_144
+_OUTPUT_SANITIZER_CACHE: ContextVar[dict[str, str] | None] = ContextVar("agent_bom_output_sanitizer_cache", default=None)
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def with_output_sanitizer_cache(func: Callable[_P, _R]) -> Callable[_P, _R]:
+    """Give one render a bounded, request-local redaction cache.
+
+    Reports repeat package, agent, and advisory labels across many cells. The
+    cache avoids running the same secret/PII detectors thousands of times while
+    remaining concurrency-safe and releasing all input strings after the render.
+    """
+
+    @wraps(func)
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        if _OUTPUT_SANITIZER_CACHE.get() is not None:
+            return func(*args, **kwargs)
+        token = _OUTPUT_SANITIZER_CACHE.set({})
+        try:
+            return func(*args, **kwargs)
+        finally:
+            _OUTPUT_SANITIZER_CACHE.reset(token)
+
+    return wrapper
+
+
+def sanitize_output_text(value: object) -> str:
+    """Redact one exported string without imposing the log-label length cap."""
+    text = str(value)
+    cache = _OUTPUT_SANITIZER_CACHE.get()
+    if cache is not None and text in cache:
+        return cache[text]
+    max_len = max(1_000, len(text))
+    sanitized = sanitize_text(text, max_len=max_len) if text_requires_redaction(text) else sanitize_log_label(text, max_len=max_len)
+    if cache is not None and len(cache) < _OUTPUT_SANITIZER_CACHE_LIMIT:
+        cache[text] = sanitized
+    return sanitized
 
 
 def cve_findings(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> list[Finding]:

--- a/src/agent_bom/output/graph.py
+++ b/src/agent_bom/output/graph.py
@@ -1055,7 +1055,7 @@ def _graph_priority_summary(findings: list["Finding"], *, collapse_cves: bool = 
     return priorities
 
 
-def _json_for_script(value: object, *, indent: int = 2) -> str:
+def _json_for_script(value: object, *, indent: int | None = 2) -> str:
     """Serialize already-projected data without allowing HTML breakout."""
     return (
         json.dumps(value, indent=indent)

--- a/src/agent_bom/output/graph.py
+++ b/src/agent_bom/output/graph.py
@@ -1056,7 +1056,7 @@ def _graph_priority_summary(findings: list["Finding"], *, collapse_cves: bool = 
 
 
 def _json_for_script(value: object, *, indent: int = 2) -> str:
-    """Serialize data for a JavaScript block without allowing HTML breakout."""
+    """Serialize already-projected data without allowing HTML breakout."""
     return (
         json.dumps(value, indent=indent)
         .replace("&", r"\u0026")
@@ -1065,6 +1065,73 @@ def _json_for_script(value: object, *, indent: int = 2) -> str:
         .replace("\u2028", r"\u2028")
         .replace("\u2029", r"\u2029")
     )
+
+
+def sanitize_graph_elements(elements: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, str]]:
+    """Redact Cytoscape elements while preserving distinct node coordinates."""
+    from agent_bom.output.finding_views import sanitize_output_text
+    from agent_bom.security import sanitize_sensitive_payload
+
+    id_map: dict[str, str] = {}
+    used_ids: set[str] = set()
+
+    def safe_id(raw: object) -> str:
+        original = str(raw)
+        existing = id_map.get(original)
+        if existing is not None:
+            return existing
+        candidate = sanitize_output_text(original)
+        if candidate in used_ids:
+            suffix = 2
+            while f"{candidate}#{suffix}" in used_ids:
+                suffix += 1
+            candidate = f"{candidate}#{suffix}"
+        id_map[original] = candidate
+        used_ids.add(candidate)
+        return candidate
+
+    for element in elements:
+        data = element.get("data")
+        if isinstance(data, dict) and "source" not in data and "target" not in data and "id" in data:
+            safe_id(data["id"])
+
+    projected: list[dict[str, Any]] = []
+    for element in elements:
+        data = element.get("data")
+        if not isinstance(data, dict):
+            continue
+        safe_data: dict[str, Any] = {}
+        for key, value in data.items():
+            if isinstance(value, str):
+                safe_data[key] = sanitize_output_text(value)
+            elif isinstance(value, dict | list | tuple):
+                safe_data[key] = sanitize_sensitive_payload(value, key=key, max_str_len=10_000)
+            else:
+                safe_data[key] = value
+        if "source" in data or "target" in data:
+            if "source" in data:
+                safe_data["source"] = safe_id(data["source"])
+            if "target" in data:
+                safe_data["target"] = safe_id(data["target"])
+        elif "id" in data:
+            safe_data["id"] = safe_id(data["id"])
+        projected.append({**element, "data": safe_data})
+    return projected, id_map
+
+
+def _sanitize_graph_reference_payload(value: object, id_map: dict[str, str]) -> object:
+    """Sanitize graph side-panel data and remap its node references."""
+    from agent_bom.security import sanitize_sensitive_payload
+
+    sanitized = sanitize_sensitive_payload(value, max_str_len=10_000)
+    if not isinstance(value, list) or not isinstance(sanitized, list):
+        return sanitized
+    projected: list[object] = []
+    for raw, safe in zip(value, sanitized, strict=False):
+        if isinstance(raw, dict) and isinstance(safe, dict) and "nodeId" in raw:
+            safe["nodeId"] = id_map.get(str(raw["nodeId"]), safe.get("nodeId"))
+        projected.append(safe)
+    return projected
 
 
 def _graph_overview(findings: list["Finding"]) -> dict[str, int]:
@@ -1116,7 +1183,7 @@ def export_graph_html(
 
     findings = cve_findings(report, blast_radii)
     policy_findings = _graph_policy_findings(report)
-    elements = build_graph_elements(report, blast_radii, include_cve_nodes=False, collapse_cves=True)
+    elements, graph_id_map = sanitize_graph_elements(build_graph_elements(report, blast_radii, include_cve_nodes=False, collapse_cves=True))
     elements_json = _json_for_script(elements)
 
     total_agents = len(report.agents)
@@ -1124,11 +1191,12 @@ def export_graph_html(
     total_pkgs = sum(a.total_packages for a in report.agents)
     total_vulns = len(findings)
     all_findings = findings + policy_findings
-    top_risks_json = _json_for_script(_graph_priority_summary(all_findings, collapse_cves=True))
+    top_risks = _sanitize_graph_reference_payload(_graph_priority_summary(all_findings, collapse_cves=True), graph_id_map)
+    top_risks_json = _json_for_script(top_risks)
     # The severity chips reconcile with the unified stream: CVE findings plus
     # the graph-derived categories the finding nodes carry.
     overview_json = _json_for_script(_graph_overview(all_findings))
-    category_findings_json = _json_for_script(
+    category_findings = _sanitize_graph_reference_payload(
         [
             {
                 "nodeId": f"finding:{finding.id}",
@@ -1139,7 +1207,9 @@ def export_graph_html(
             }
             for finding in policy_findings
         ],
+        graph_id_map,
     )
+    category_findings_json = _json_for_script(category_findings)
 
     html_content = _GRAPH_HTML_TEMPLATE.format(
         vendor_scripts=_vendor_script_tags(),
@@ -1208,7 +1278,9 @@ def _vendor_script_tags() -> str:
 
 
 def _html_escape(value: object) -> str:
-    return str(value).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
+    from agent_bom.output.finding_views import sanitize_output_text
+
+    return sanitize_output_text(value).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
 
 
 def _to_offline_graph_html(

--- a/src/agent_bom/output/graph_export.py
+++ b/src/agent_bom/output/graph_export.py
@@ -24,6 +24,9 @@ from collections import deque
 from pathlib import Path
 from typing import Any, Union
 
+from agent_bom.output.finding_views import sanitize_output_text, with_output_sanitizer_cache
+from agent_bom.security import sanitize_sensitive_payload
+
 # ── Internal graph representation ──────────────────────────────────────────────
 
 
@@ -97,6 +100,46 @@ def _compact_attributes(attributes: dict[str, Any] | None) -> dict[str, Any]:
     if not isinstance(attributes, dict):
         return {}
     return {key: value for key, value in attributes.items() if value not in (None, "", [], {})}
+
+
+def _sanitized_graph(graph: DepGraph) -> DepGraph:
+    """Project a graph into an outbound-safe copy without mutating analysis state."""
+    safe = DepGraph()
+    id_map: dict[str, str] = {}
+    used_ids: set[str] = set()
+
+    for node in graph.nodes:
+        candidate = sanitize_output_text(node.id)
+        if candidate in used_ids:
+            suffix = 2
+            while f"{candidate}#{suffix}" in used_ids:
+                suffix += 1
+            candidate = f"{candidate}#{suffix}"
+        used_ids.add(candidate)
+        id_map[node.id] = candidate
+
+        attributes = sanitize_sensitive_payload(node.attributes, max_str_len=10_000)
+        safe.add_node(
+            candidate,
+            sanitize_output_text(node.label),
+            sanitize_output_text(node.kind),
+            sanitize_output_text(node.severity),
+            attributes=attributes if isinstance(attributes, dict) else {},
+        )
+
+    for edge in graph.edges:
+        source = id_map.get(edge.source)
+        target = id_map.get(edge.target)
+        if source is None or target is None:
+            continue
+        evidence = sanitize_sensitive_payload(edge.evidence, max_str_len=10_000)
+        safe.add_edge(
+            source,
+            target,
+            sanitize_output_text(edge.kind),
+            evidence=evidence if isinstance(evidence, dict) else {},
+        )
+    return safe
 
 
 def _credential_names_from_server(server: dict[str, Any]) -> list[str]:
@@ -387,9 +430,10 @@ _DOT_SHAPES: dict[str, str] = {
 
 def _dot_id(raw: str) -> str:
     """Sanitize a node ID for DOT format."""
-    return '"' + raw.replace('"', '\\"') + '"'
+    return '"' + raw.replace("\\", "\\\\").replace('"', '\\"').replace("\r", " ").replace("\n", " ") + '"'
 
 
+@with_output_sanitizer_cache
 def to_dot(graph: DepGraph, title: str = "agent-bom dependency graph") -> str:
     """Render a :class:`DepGraph` as Graphviz DOT source.
 
@@ -402,8 +446,10 @@ def to_dot(graph: DepGraph, title: str = "agent-bom dependency graph") -> str:
     Returns:
         DOT-format string.
     """
+    graph = _sanitized_graph(graph)
+    safe_title = sanitize_output_text(title).replace("\r", " ").replace("\n", " ")
     lines = [
-        f"// {title}",
+        f"// {safe_title}",
         "digraph dependency_graph {",
         '    graph [rankdir=LR fontname="Helvetica" bgcolor="#0d1117"]',
         '    node [style=filled fontname="Helvetica" fontcolor="#e6edf3" fontsize=10]',
@@ -488,6 +534,7 @@ def _mermaid_priority_nodes(graph: DepGraph) -> list[_Node]:
     )
 
 
+@with_output_sanitizer_cache
 def to_mermaid(
     graph: DepGraph,
     *,
@@ -509,6 +556,7 @@ def to_mermaid(
     Returns:
         Mermaid flowchart string.
     """
+    graph = _sanitized_graph(graph)
     if max_nodes is not None and max_nodes < 1:
         raise ValueError("max_nodes must be at least 1 or None")
     if max_edges is not None and max_edges < 1:
@@ -594,6 +642,7 @@ def to_mermaid(
     return "\n".join(lines)
 
 
+@with_output_sanitizer_cache
 def to_json(graph: DepGraph) -> dict:
     """Return a JSON-serialisable representation of the graph.
 
@@ -603,6 +652,7 @@ def to_json(graph: DepGraph) -> dict:
     Returns:
         Dict with ``nodes``, ``edges``, and ``stats`` keys.
     """
+    graph = _sanitized_graph(graph)
     return {
         "nodes": [
             {
@@ -668,6 +718,7 @@ def _xml_escape(text: str) -> str:
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;").replace("'", "&apos;")
 
 
+@with_output_sanitizer_cache
 def to_graphml(graph: DepGraph) -> str:
     """Render a :class:`DepGraph` as GraphML with AIBOM-typed attributes.
 
@@ -682,6 +733,7 @@ def to_graphml(graph: DepGraph) -> str:
     Returns:
         GraphML XML string.
     """
+    graph = _sanitized_graph(graph)
     lines = [
         '<?xml version="1.0" encoding="UTF-8"?>',
         '<graphml xmlns="http://graphml.graphdrawing.org/xmlns"',
@@ -728,6 +780,7 @@ def to_graphml(graph: DepGraph) -> str:
     return "\n".join(lines)
 
 
+@with_output_sanitizer_cache
 def to_cypher(graph: DepGraph) -> str:
     """Render a :class:`DepGraph` as Neo4j Cypher import statements.
 
@@ -746,6 +799,7 @@ def to_cypher(graph: DepGraph) -> str:
     Returns:
         Cypher script string.
     """
+    graph = _sanitized_graph(graph)
     lines = [
         "// AIBOM graph import — generated by agent-bom",
         "// Node labels: Provider, AIAgent, MCPServer, Package, Vulnerability",

--- a/src/agent_bom/output/html/_common.py
+++ b/src/agent_bom/output/html/_common.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from agent_bom.output.finding_views import sanitize_output_text
+
 _SEV_COLOR = {
     "critical": "#dc2626",
     "high": "#ea580c",
@@ -27,4 +29,4 @@ def _sev_badge(sev: str) -> str:
 
 
 def _esc(s: object) -> str:
-    return str(s).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
+    return sanitize_output_text(s).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")

--- a/src/agent_bom/output/html/document.py
+++ b/src/agent_bom/output/html/document.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from agent_bom.output.finding_views import cve_findings, severity_value, topology_package_key
+from agent_bom.output.finding_views import cve_findings, severity_value, topology_package_key, with_output_sanitizer_cache
 from agent_bom.output.html._common import _esc
 from agent_bom.output.html.scripts import (
     SCALE_REPORT_SCRIPT,
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from agent_bom.models import AIBOMReport, BlastRadius
 
 
+@with_output_sanitizer_cache
 def to_html(
     report: "AIBOMReport",
     blast_radii: list["BlastRadius"] | None = None,
@@ -84,21 +85,21 @@ def to_html(
             f'<div class="sec-title">&#x26a0;&#xfe0f; Vulnerabilities'
             f'<sup style="font-size:.7rem;color:#475569;margin-left:6px">{len(findings)}</sup>'
             f"</div>"
-            f'<div class="panel">{_vuln_table(report, blast_radii)}</div>'
+            f'<div class="panel">{_vuln_table(report, blast_radii, findings=findings)}</div>'
             f"</section>"
             f'<section id="exposure-paths">'
             f'<div class="sec-title">&#x1f9ed; Exposure Paths'
             f'<sup style="font-size:.65rem;color:#475569;margin-left:6px;font-weight:400">'
             f"ranked investigation briefs from blast-radius evidence"
             f"</sup></div>"
-            f'<div class="panel exposure-paths">{_exposure_path_section(report, blast_radii)}</div>'
+            f'<div class="panel exposure-paths">{_exposure_path_section(report, blast_radii, findings=findings)}</div>'
             f"</section>"
             f'<section id="blast">'
             f'<div class="sec-title">&#x1f4a5; Blast Radius'
             f'<sup style="font-size:.65rem;color:#475569;margin-left:6px;font-weight:400">'
             f"risk = CVSS + agents + creds + tools + KEV/EPSS boosts (max 10)"
             f"</sup></div>"
-            f'<div class="panel">{_blast_table(report, blast_radii)}</div>'
+            f'<div class="panel">{_blast_table(report, blast_radii, findings=findings)}</div>'
             f"</section>"
             f'<section id="remediation">'
             f'<div class="sec-title">&#x1f527; Remediation Plan</div>'

--- a/src/agent_bom/output/html/sections.py
+++ b/src/agent_bom/output/html/sections.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING
 
 from agent_bom.evidence.scan_run import ScanOutcome, effective_scan_run
@@ -92,7 +91,10 @@ def _chart_data(findings: list["Finding"]) -> str:
     blast_scores = [round(float(finding.risk_score or 0.0), 2) for finding in top10]
     blast_colors = [_SEV_COLOR.get(severity_value(finding), "#6b7280") for finding in top10]
 
-    return json.dumps(
+    from agent_bom.output.graph import _json_for_script
+    from agent_bom.security import sanitize_sensitive_payload
+
+    chart = sanitize_sensitive_payload(
         {
             "sev": {
                 "labels": [k.capitalize() for k in sev_counts],
@@ -104,24 +106,26 @@ def _chart_data(findings: list["Finding"]) -> str:
                 "scores": blast_scores,
                 "colors": blast_colors,
             },
-        }
+        },
+        max_str_len=10_000,
     )
+    return _json_for_script(chart)
 
 
 def _cytoscape_elements(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
     """Build Cytoscape element list using the shared graph builder."""
-    from agent_bom.output.graph import build_graph_elements
+    from agent_bom.output.graph import _json_for_script, build_graph_elements, sanitize_graph_elements
 
-    elements = build_graph_elements(report, blast_radii, include_cve_nodes=True)
-    return json.dumps(elements)
+    elements, _ = sanitize_graph_elements(build_graph_elements(report, blast_radii, include_cve_nodes=True))
+    return _json_for_script(elements, indent=None)
 
 
 def _attack_flow_elements(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
     """Build attack flow element list showing CVE → impact propagation."""
-    from agent_bom.output.graph import build_attack_flow_elements
+    from agent_bom.output.graph import _json_for_script, build_attack_flow_elements, sanitize_graph_elements
 
-    elements = build_attack_flow_elements(report, blast_radii)
-    return json.dumps(elements)
+    elements, _ = sanitize_graph_elements(build_attack_flow_elements(report, blast_radii))
+    return _json_for_script(elements, indent=None)
 
 
 # ─── HTML sections ────────────────────────────────────────────────────────────
@@ -230,8 +234,13 @@ def _summary_cards(report: "AIBOMReport", findings: list["Finding"], policy_find
     )
 
 
-def _vuln_table(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
-    findings = cve_findings(report, blast_radii)
+def _vuln_table(
+    report: "AIBOMReport",
+    blast_radii: list["BlastRadius"],
+    *,
+    findings: list["Finding"] | None = None,
+) -> str:
+    findings = findings if findings is not None else cve_findings(report, blast_radii)
     if not findings:
         return '<div class="empty-state">&#x2705; No vulnerabilities found in scanned packages.</div>'
 
@@ -408,8 +417,13 @@ def _vuln_table(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
     )
 
 
-def _blast_table(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
-    findings = cve_findings(report, blast_radii)
+def _blast_table(
+    report: "AIBOMReport",
+    blast_radii: list["BlastRadius"],
+    *,
+    findings: list["Finding"] | None = None,
+) -> str:
+    findings = findings if findings is not None else cve_findings(report, blast_radii)
     if not findings:
         return ""
     sorted_findings = sorted(findings, key=lambda finding: float(finding.risk_score or 0.0), reverse=True)
@@ -454,8 +468,17 @@ def _blast_table(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str
     )
 
 
-def _exposure_path_section(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
-    findings = ranked_cve_findings(report, blast_radii)
+def _exposure_path_section(
+    report: "AIBOMReport",
+    blast_radii: list["BlastRadius"],
+    *,
+    findings: list["Finding"] | None = None,
+) -> str:
+    findings = (
+        sorted(findings, key=lambda finding: float(finding.risk_score or 0.0), reverse=True)[:10]
+        if findings is not None
+        else ranked_cve_findings(report, blast_radii)
+    )
     if not findings:
         return ""
     cards = []

--- a/src/agent_bom/output/interop_security.py
+++ b/src/agent_bom/output/interop_security.py
@@ -1,0 +1,69 @@
+"""Topology-preserving redaction for linked machine-readable documents."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_bom.output.finding_views import sanitize_output_text, with_output_sanitizer_cache
+
+_DEFINITION_KEYS = frozenset({"@id", "SPDXID", "bom-ref", "id", "ruleId", "spdxId"})
+
+
+@with_output_sanitizer_cache
+def sanitize_linked_document(document: dict[str, Any]) -> dict[str, Any]:
+    """Redact a document while keeping distinct IDs and references aligned."""
+    raw_ids: list[str] = []
+
+    def collect(value: object) -> None:
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if key in _DEFINITION_KEYS and isinstance(item, str):
+                    raw_ids.append(item)
+                collect(item)
+        elif isinstance(value, list | tuple):
+            for item in value:
+                collect(item)
+
+    collect(document)
+    id_map: dict[str, str] = {}
+    used_ids: set[str] = set()
+    for raw_id in raw_ids:
+        if raw_id in id_map:
+            continue
+        candidate = sanitize_output_text(raw_id)
+        if candidate in used_ids:
+            suffix = 2
+            while f"{candidate}#{suffix}" in used_ids:
+                suffix += 1
+            candidate = f"{candidate}#{suffix}"
+        id_map[raw_id] = candidate
+        used_ids.add(candidate)
+
+    def sanitize(value: object) -> object:
+        if isinstance(value, str):
+            return sanitize_output_text(value)
+        if isinstance(value, dict):
+            return {str(key): sanitize(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [sanitize(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(sanitize(item) for item in value)
+        return value
+
+    sanitized_document = sanitize(document)
+    if not isinstance(sanitized_document, dict):
+        return {}
+
+    def restore(raw: object, safe: object) -> object:
+        if isinstance(raw, str) and raw in id_map:
+            return id_map[raw]
+        if isinstance(raw, dict) and isinstance(safe, dict):
+            return {key: restore(value, safe.get(key)) for key, value in raw.items() if key in safe}
+        if isinstance(raw, list) and isinstance(safe, list):
+            return [restore(raw_item, safe_item) for raw_item, safe_item in zip(raw, safe, strict=False)]
+        if isinstance(raw, tuple) and isinstance(safe, tuple):
+            return tuple(restore(raw_item, safe_item) for raw_item, safe_item in zip(raw, safe, strict=False))
+        return safe
+
+    restored = restore(document, sanitized_document)
+    return restored if isinstance(restored, dict) else {}

--- a/src/agent_bom/output/markdown.py
+++ b/src/agent_bom/output/markdown.py
@@ -19,13 +19,17 @@ from agent_bom.output.finding_views import (
     package_version,
     ranked_cve_findings,
     reachability_label,
+    sanitize_output_text,
     severity_counts,
     severity_value,
     unified_findings,
+    with_output_sanitizer_cache,
     workflow_status,
 )
+from agent_bom.security import sanitize_sensitive_payload
 
 
+@with_output_sanitizer_cache
 def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> str:
     """Convert an AIBOMReport to Markdown string."""
     brs = blast_radii or report.blast_radii
@@ -53,7 +57,7 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
         lines.append("")
         lines.append("This report does not represent complete coverage; a low or zero finding count is not a clean bill of health.")
         for issue in scan_run.issues:
-            lines.append(f"- **{issue.source}**: {issue.message}")
+            lines.append(f"- **{sanitize_output_text(issue.source)}**: {sanitize_output_text(issue.message)}")
         lines.append("")
     lines.append("| Metric | Count |")
     lines.append("|--------|-------|")
@@ -91,7 +95,7 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
         lines.append("|----------|------|-------|---------|--------|")
         for finding in sorted(policy_findings, key=lambda f: _finding_sev_order(f.severity)):
             asset = _md_cell(finding.asset.name or finding.asset.identifier or "-")
-            location = f"<br>`{finding.asset.location}`" if finding.asset.location else ""
+            location = f"<br>`{_md_cell(finding.asset.location)}`" if finding.asset.location else ""
             title = _md_cell(finding.title or finding.description or finding.finding_type.value)
             source = finding.source.value
             lines.append(
@@ -104,20 +108,21 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
             lines.append("## High-Risk Policy Findings")
             lines.append("")
             for finding in high_policy_findings:
-                title = finding.title or finding.finding_type.value
+                title = _md_cell(finding.title or finding.finding_type.value)
                 lines.append(f"### {title}")
                 lines.append("")
                 lines.append(f"- **Severity**: {finding.severity.upper()}")
                 lines.append(f"- **Type**: {finding.finding_type.value}")
-                lines.append(f"- **Asset**: {finding.asset.name}")
+                lines.append(f"- **Asset**: {_md_cell(finding.asset.name)}")
                 if finding.asset.location:
-                    lines.append(f"- **Location**: `{finding.asset.location}`")
+                    lines.append(f"- **Location**: `{_md_cell(finding.asset.location)}`")
                 if finding.description:
-                    lines.append(f"- **Description**: {finding.description}")
+                    lines.append(f"- **Description**: {sanitize_output_text(finding.description)}")
                 if finding.remediation_guidance:
-                    lines.append(f"- **Remediation**: {finding.remediation_guidance}")
+                    lines.append(f"- **Remediation**: {sanitize_output_text(finding.remediation_guidance)}")
                 if finding.evidence:
-                    evidence_text = ", ".join(f"{key}={value}" for key, value in finding.evidence.items() if value is not None)
+                    safe_evidence = sanitize_sensitive_payload(finding.evidence, max_str_len=10_000)
+                    evidence_text = ", ".join(f"{key}={value}" for key, value in safe_evidence.items() if value is not None)
                     if evidence_text:
                         lines.append(f"- **Evidence**: {evidence_text}")
                 lines.append("")
@@ -139,10 +144,11 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
             cwe = _md_cell(", ".join(finding.cwe_ids) if finding.cwe_ids else "-")
             tags = _md_cell(", ".join(framework_qualified_finding_tags(finding)) or "-")
             source = _md_cell(evidence(finding, "severity_source", "-") or "-")
-            fix = finding.fixed_version or "-"
+            fix = _md_cell(finding.fixed_version or "-")
             agents = str(len(finding.affected_agents))
             lines.append(
-                f"| {sev_badge} | {vuln_id} | {package_name(finding)} | {package_version(finding) or '-'} | {fix} | {cvss} | "
+                f"| {sev_badge} | {_md_cell(vuln_id)} | {_md_cell(package_name(finding))} | "
+                f"{_md_cell(package_version(finding) or '-')} | {fix} | {cvss} | "
                 f"{epss} | {kev} | {reach} | {cwe} | {tags} | {source} | {agents} |"
             )
 
@@ -157,23 +163,23 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
         lines.append("")
         for finding in critical_high:
             vuln_id = finding.cve_id or finding.id
-            lines.append(f"### {vuln_id} — {package_name(finding)}@{package_version(finding) or '?'}")
+            lines.append(f"### {_md_cell(vuln_id)} — {_md_cell(package_name(finding))}@{_md_cell(package_version(finding) or '?')}")
             lines.append("")
             if finding.description:
-                lines.append(f"> {finding.description}")
+                lines.append(f"> {sanitize_output_text(finding.description)}")
                 lines.append("")
             lines.append(f"- **Severity**: {severity_value(finding).upper()}")
             if finding.owner:
-                lines.append(f"- **Owner**: {finding.owner}")
+                lines.append(f"- **Owner**: {sanitize_output_text(finding.owner)}")
             sla_due = finding.to_dict().get("sla_due_at")
             if sla_due:
-                lines.append(f"- **SLA due**: {sla_due}")
+                lines.append(f"- **SLA due**: {sanitize_output_text(sla_due)}")
             status = workflow_status(finding)
             if status:
-                lines.append(f"- **Workflow status**: {status}")
+                lines.append(f"- **Workflow status**: {sanitize_output_text(status)}")
             severity_source = evidence(finding, "severity_source", "")
             if severity_source:
-                lines.append(f"- **Severity source**: {severity_source}")
+                lines.append(f"- **Severity source**: {sanitize_output_text(severity_source)}")
             if finding.cvss_score is not None:
                 lines.append(f"- **CVSS**: {finding.cvss_score}")
             if finding.epss_score is not None:
@@ -185,22 +191,22 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
                 lines.append("- **KEV**: Yes (CISA Known Exploited)")
             kev_date_added = evidence(finding, "kev_date_added", "")
             if kev_date_added:
-                lines.append(f"- **KEV date added**: {kev_date_added}")
+                lines.append(f"- **KEV date added**: {sanitize_output_text(kev_date_added)}")
             kev_due_date = evidence(finding, "kev_due_date", "")
             if kev_due_date:
-                lines.append(f"- **KEV due date**: {kev_due_date}")
+                lines.append(f"- **KEV due date**: {sanitize_output_text(kev_due_date)}")
             if finding.fixed_version:
-                lines.append(f"- **Fix**: Upgrade to {finding.fixed_version}")
+                lines.append(f"- **Fix**: Upgrade to {sanitize_output_text(finding.fixed_version)}")
             if finding.cwe_ids:
-                lines.append(f"- **CWE**: {', '.join(finding.cwe_ids)}")
+                lines.append(f"- **CWE**: {sanitize_output_text(', '.join(finding.cwe_ids))}")
             reach_label, reach_state = reachability_label(finding)
             reach_suffix = " (code reachability not evaluated)" if reach_state == "unknown" else ""
             lines.append(f"- **Reachability**: {reach_label}{reach_suffix}")
             compliance_tags = ", ".join(framework_qualified_finding_tags(finding))
             if compliance_tags:
-                lines.append(f"- **Compliance tags**: {compliance_tags}")
+                lines.append(f"- **Compliance tags**: {sanitize_output_text(compliance_tags)}")
             if finding.affected_agents:
-                lines.append(f"- **Affected agents**: {', '.join(finding.affected_agents)}")
+                lines.append(f"- **Affected agents**: {sanitize_output_text(', '.join(finding.affected_agents))}")
             if finding.exposed_credentials:
                 lines.append(f"- **Exposed credentials**: {len(finding.exposed_credentials)}")
             lines.append("")
@@ -272,7 +278,7 @@ def _severity_text(sev: str) -> str:
 
 def _md_cell(value: object) -> str:
     """Escape Markdown table separators without hiding human-readable context."""
-    return str(value).replace("|", "\\|")
+    return sanitize_output_text(value).replace("|", "\\|")
 
 
 def _exposure_path_section(report: AIBOMReport, blast_radii: list[BlastRadius] | None) -> list[str]:

--- a/src/agent_bom/output/markdown.py
+++ b/src/agent_bom/output/markdown.py
@@ -122,7 +122,11 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
                     lines.append(f"- **Remediation**: {sanitize_output_text(finding.remediation_guidance)}")
                 if finding.evidence:
                     safe_evidence = sanitize_sensitive_payload(finding.evidence, max_str_len=10_000)
-                    evidence_text = ", ".join(f"{key}={value}" for key, value in safe_evidence.items() if value is not None)
+                    evidence_text = (
+                        ", ".join(f"{key}={value}" for key, value in safe_evidence.items() if value is not None)
+                        if isinstance(safe_evidence, dict)
+                        else ""
+                    )
                     if evidence_text:
                         lines.append(f"- **Evidence**: {evidence_text}")
                 lines.append("")

--- a/src/agent_bom/output/mermaid.py
+++ b/src/agent_bom/output/mermaid.py
@@ -21,6 +21,7 @@ import re
 from typing import TYPE_CHECKING
 
 from agent_bom.graph.severity import severity_rank
+from agent_bom.output.finding_views import sanitize_output_text
 
 if TYPE_CHECKING:
     from agent_bom.models import AIBOMReport, BlastRadius
@@ -33,7 +34,7 @@ def _sanitize_id(text: str) -> str:
 
 def _sanitize_label(text: str) -> str:
     """Sanitize a string for use as a Mermaid node label."""
-    return text.replace('"', "'").replace("\n", " ")[:80]
+    return sanitize_output_text(text).replace('"', "'").replace("\n", " ")[:80]
 
 
 class _MermaidIds:
@@ -312,7 +313,7 @@ def to_mermaid_lifecycle(report: AIBOMReport, blast_radii: list[BlastRadius] | N
         task_id += 1
 
         for finding in pkg_findings:
-            vuln_id = finding.cve_id or finding.title
+            vuln_id = sanitize_output_text(finding.cve_id or finding.title)
 
             # Determine discovery date
             discover_date = evidence(finding, "published_at", None) or evidence(finding, "nvd_published", None)
@@ -326,7 +327,7 @@ def to_mermaid_lifecycle(report: AIBOMReport, blast_radii: list[BlastRadius] | N
 
             # Fixed version milestone
             if finding.fixed_version:
-                lines.append(f"    Fix → {finding.fixed_version} :active, t{task_id}, after {prev_id}, 1d")
+                lines.append(f"    Fix → {sanitize_output_text(finding.fixed_version)} :active, t{task_id}, after {prev_id}, 1d")
                 prev_id = f"t{task_id}"
                 task_id += 1
 

--- a/src/agent_bom/output/ocsf.py
+++ b/src/agent_bom/output/ocsf.py
@@ -39,6 +39,11 @@ _ANALYTIC_TYPE: dict[str, str] = {
 }
 
 
+def _sanitize_ocsf_event(event: dict[str, Any]) -> dict[str, Any]:
+    sanitized = sanitize_sensitive_payload(event, max_str_len=10_000)
+    return sanitized if isinstance(sanitized, dict) else {}
+
+
 def alert_to_ocsf(alert: dict, product_version: str = "") -> dict[str, Any]:
     """Convert an agent-bom runtime alert to OCSF v1.1 Security Finding.
 
@@ -62,51 +67,53 @@ def alert_to_ocsf(alert: dict, product_version: str = "") -> dict[str, Any]:
         if safe_provenance:
             safe_details["discovery_provenance"] = safe_provenance
 
-    return {
-        # OCSF metadata
-        "class_uid": 2001,  # Security Finding
-        "class_name": "Security Finding",
-        "category_uid": 2,  # Findings
-        "category_name": "Findings",
-        "severity_id": _SEVERITY_MAP.get(severity, 1),
-        "severity": severity.capitalize(),
-        "activity_id": 1,  # Create
-        "activity_name": "Create",
-        "type_uid": 200101,  # Security Finding: Create
-        "status_id": 1,  # New
-        "status": "New",
-        "time": int(time.time() * 1000),
-        "message": alert.get("message", ""),
-        # Finding details
-        "finding_info": {
-            "title": alert.get("message", ""),
-            "uid": f"{detector}:{details.get('tool', 'unknown')}:{alert.get('ts', '')}",
-            "types": [detector],
-            "analytic": {
-                "type": _ANALYTIC_TYPE.get(detector, "Other"),
-                "name": detector,
-                "uid": detector,
+    return _sanitize_ocsf_event(
+        {
+            # OCSF metadata
+            "class_uid": 2001,  # Security Finding
+            "class_name": "Security Finding",
+            "category_uid": 2,  # Findings
+            "category_name": "Findings",
+            "severity_id": _SEVERITY_MAP.get(severity, 1),
+            "severity": severity.capitalize(),
+            "activity_id": 1,  # Create
+            "activity_name": "Create",
+            "type_uid": 200101,  # Security Finding: Create
+            "status_id": 1,  # New
+            "status": "New",
+            "time": int(time.time() * 1000),
+            "message": alert.get("message", ""),
+            # Finding details
+            "finding_info": {
+                "title": alert.get("message", ""),
+                "uid": f"{detector}:{details.get('tool', 'unknown')}:{alert.get('ts', '')}",
+                "types": [detector],
+                "analytic": {
+                    "type": _ANALYTIC_TYPE.get(detector, "Other"),
+                    "name": detector,
+                    "uid": detector,
+                },
             },
-        },
-        # Resource (the MCP tool being analyzed)
-        "resources": [
-            {
-                "type": "Other",
-                "name": details.get("tool", "unknown") if isinstance(details, dict) else "unknown",
-                "data": {k: v for k, v in safe_details.items() if k != "tool"},
-            }
-        ],
-        # Product metadata
-        "metadata": {
-            "product": {
-                "name": "agent-bom",
-                "vendor_name": "agent-bom",
-                "version": product_version,
+            # Resource (the MCP tool being analyzed)
+            "resources": [
+                {
+                    "type": "Other",
+                    "name": details.get("tool", "unknown") if isinstance(details, dict) else "unknown",
+                    "data": {k: v for k, v in safe_details.items() if k != "tool"},
+                }
+            ],
+            # Product metadata
+            "metadata": {
+                "product": {
+                    "name": "agent-bom",
+                    "vendor_name": "agent-bom",
+                    "version": product_version,
+                },
+                "version": "1.1.0",
+                "profiles": ["security_control"],
             },
-            "version": "1.1.0",
-            "profiles": ["security_control"],
-        },
-    }
+        }
+    )
 
 
 def alerts_to_ocsf(alerts: list[dict], product_version: str = "") -> list[dict]:
@@ -197,39 +204,41 @@ def finding_to_ocsf(finding: "Finding", product_version: str = "") -> dict[str, 
     if suppression:
         unmapped["suppression"] = suppression
 
-    return {
-        "class_uid": 2001,  # Security Finding
-        "class_name": "Security Finding",
-        "category_uid": 2,  # Findings
-        "category_name": "Findings",
-        "severity_id": _SEVERITY_MAP.get(severity, 1),
-        "severity": severity.capitalize(),
-        "activity_id": 1,  # Create
-        "activity_name": "Create",
-        "type_uid": 200101,  # Security Finding: Create
-        "status_id": status_id,
-        "status": status,
-        "time": int(time.time() * 1000),
-        "message": finding.title or finding.description or finding.finding_type.value,
-        "finding_info": finding_info,
-        "resources": [
-            {
-                "type": finding.asset.asset_type,
-                "name": finding.asset.name,
-                "uid": finding.asset.stable_id,
-            }
-        ],
-        "metadata": {
-            "product": {
-                "name": "agent-bom",
-                "vendor_name": "agent-bom",
-                "version": product_version,
+    return _sanitize_ocsf_event(
+        {
+            "class_uid": 2001,  # Security Finding
+            "class_name": "Security Finding",
+            "category_uid": 2,  # Findings
+            "category_name": "Findings",
+            "severity_id": _SEVERITY_MAP.get(severity, 1),
+            "severity": severity.capitalize(),
+            "activity_id": 1,  # Create
+            "activity_name": "Create",
+            "type_uid": 200101,  # Security Finding: Create
+            "status_id": status_id,
+            "status": status,
+            "time": int(time.time() * 1000),
+            "message": finding.title or finding.description or finding.finding_type.value,
+            "finding_info": finding_info,
+            "resources": [
+                {
+                    "type": finding.asset.asset_type,
+                    "name": finding.asset.name,
+                    "uid": finding.asset.stable_id,
+                }
+            ],
+            "metadata": {
+                "product": {
+                    "name": "agent-bom",
+                    "vendor_name": "agent-bom",
+                    "version": product_version,
+                },
+                "version": "1.1.0",
+                "profiles": ["security_control"],
             },
-            "version": "1.1.0",
-            "profiles": ["security_control"],
-        },
-        "unmapped": unmapped,
-    }
+            "unmapped": unmapped,
+        }
+    )
 
 
 def findings_to_ocsf(findings: "list[Finding]", product_version: str = "") -> list[dict]:

--- a/src/agent_bom/output/parquet_fmt.py
+++ b/src/agent_bom/output/parquet_fmt.py
@@ -17,9 +17,11 @@ from agent_bom.output.finding_views import (
     package_ecosystem,
     package_name,
     package_version,
+    sanitize_output_text,
     severity_value,
     unified_export_findings,
 )
+from agent_bom.security import sanitize_sensitive_payload
 
 # Lake/Parquet schema version. v1 = the CVE+malicious 28-column table; v2 added
 # unified finding identity; v3 appends scan provenance, source/asset identity,
@@ -88,7 +90,7 @@ def _require_pyarrow():
 
 def _row_dict(finding, report: AIBOMReport) -> dict[str, Any]:
     workflow = finding.to_dict()
-    return {
+    row = {
         "cve_id": finding.cve_id or finding.id,
         "package": package_name(finding),
         "version": package_version(finding),
@@ -120,7 +122,7 @@ def _row_dict(finding, report: AIBOMReport) -> dict[str, Any]:
         "finding_type": finding.finding_type.value,
         "finding_id": finding.id,
         "title": finding.title or None,
-        "scan_id": report.scan_id or None,
+        "scan_id": sanitize_output_text(report.scan_id) or None,
         "generated_at": report.generated_at.isoformat(),
         "source": finding.source.value,
         "asset_identifier": finding.asset.identifier or None,
@@ -130,6 +132,8 @@ def _row_dict(finding, report: AIBOMReport) -> dict[str, Any]:
         "symbol_reachability_reason": evidence(finding, "symbol_reachability_reason", "") or None,
         "runtime_dependency_chain": ";".join(evidence(finding, "runtime_dependency_chain", []) or []) or None,
     }
+    sanitized = sanitize_sensitive_payload(row, max_str_len=10_000)
+    return sanitized if isinstance(sanitized, dict) else {}
 
 
 def to_arrow_table(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None):

--- a/src/agent_bom/output/pdf.py
+++ b/src/agent_bom/output/pdf.py
@@ -17,6 +17,7 @@ from agent_bom.output.finding_views import (
     package_name,
     package_version,
     ranked_cve_findings,
+    sanitize_output_text,
     severity_value,
     workflow_status,
 )
@@ -31,7 +32,7 @@ _WRAP_WIDTH = 92
 
 
 def _sanitize_text(value: object) -> str:
-    text = str(value)
+    text = sanitize_output_text(value)
     replacements = {
         "\u2014": "-",
         "\u2013": "-",

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -1285,11 +1285,14 @@ def to_sarif(
         run["taxonomies"] = taxonomies
         run["tool"]["extensions"] = _taxonomies_as_tool_extensions(taxonomies)
 
-    return {
+    document = {
         "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
         "version": "2.1.0",
         "runs": [run],
     }
+    from agent_bom.output.interop_security import sanitize_linked_document
+
+    return sanitize_linked_document(document)
 
 
 def export_sarif(

--- a/src/agent_bom/output/scan_document.py
+++ b/src/agent_bom/output/scan_document.py
@@ -23,8 +23,11 @@ SCAN_DOCUMENT_FORMATS: tuple[str, ...] = ("json", "cyclonedx", "sarif", "spdx", 
 
 def to_text(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = None) -> str:
     """Tab-separated plain text for piping to grep/awk."""
+    from agent_bom.output.finding_views import sanitize_output_text
+
+    safe = sanitize_output_text
     lines = [
-        f"agent-bom {report.tool_version}",
+        f"agent-bom {safe(report.tool_version)}",
         f"agents={report.total_agents} servers={report.total_servers} "
         f"packages={report.total_packages} vulnerabilities={report.total_vulnerabilities}",
         "",
@@ -33,7 +36,7 @@ def to_text(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = Non
     for agent in report.agents:
         for server in agent.mcp_servers:
             for pkg in server.packages:
-                lines.append(f"{agent.name}\t{server.name}\t{pkg.ecosystem}\t{pkg.name}\t{pkg.version}")
+                lines.append("\t".join(safe(value) for value in (agent.name, server.name, pkg.ecosystem, pkg.name, pkg.version)))
 
     if blast_radii:
         lines.append("")
@@ -41,8 +44,8 @@ def to_text(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = Non
         for br in blast_radii:
             vuln = br.vulnerability
             lines.append(
-                f"{vuln.id}\t{vuln.severity.value}\t{br.package.name}@{br.package.version}\t"
-                f"{vuln.fixed_version or '-'}\t{len(br.affected_agents)}\t{len(br.exposed_credentials)}"
+                f"{safe(vuln.id)}\t{safe(vuln.severity.value)}\t{safe(br.package.name)}@{safe(br.package.version)}\t"
+                f"{safe(vuln.fixed_version or '-')}\t{len(br.affected_agents)}\t{len(br.exposed_credentials)}"
             )
 
     return "\n".join(lines) + "\n"

--- a/src/agent_bom/output/spdx2_fmt.py
+++ b/src/agent_bom/output/spdx2_fmt.py
@@ -224,7 +224,9 @@ def to_spdx2(report: AIBOMReport, version: str = "2.3") -> dict:
         "relationships": relationships,
         "documentDescribes": described_ids,
     }
-    return document
+    from agent_bom.output.interop_security import sanitize_linked_document
+
+    return sanitize_linked_document(document)
 
 
 def export_spdx2(report: AIBOMReport, output_path: str, version: str = "2.3") -> None:

--- a/src/agent_bom/output/spdx_fmt.py
+++ b/src/agent_bom/output/spdx_fmt.py
@@ -348,10 +348,13 @@ def to_spdx(report: AIBOMReport) -> dict:
     # Canonical JSON-LD: a single flat @graph holding the CreationInfo blank node,
     # the SpdxDocument root, and every element + relationship.
     graph: list[dict[str, Any]] = [creation_info, spdx_document, *elements, *relationships]
-    return {
+    document = {
         "@context": SPDX_3_CONTEXT,
         "@graph": graph,
     }
+    from agent_bom.output.interop_security import sanitize_linked_document
+
+    return sanitize_linked_document(document)
 
 
 def export_spdx(report: AIBOMReport, output_path: str) -> None:

--- a/src/agent_bom/output/svg.py
+++ b/src/agent_bom/output/svg.py
@@ -16,7 +16,7 @@ import html
 from typing import TYPE_CHECKING
 
 from agent_bom.asset_provenance import package_version_provenance
-from agent_bom.output.finding_views import cve_findings, severity_value, topology_package_key
+from agent_bom.output.finding_views import cve_findings, sanitize_output_text, severity_value, topology_package_key
 
 if TYPE_CHECKING:
     from agent_bom.models import AIBOMReport, BlastRadius
@@ -346,12 +346,12 @@ def to_svg(
             ctype = item.get("type", color_key)
             colors = _COLORS.get(ctype, _COLORS.get(color_key, ("#333", "#f5f5f5", "#999")))
             text_color, bg_color, border_color = colors
-            label = html.escape(item["label"][:28])
+            label = html.escape(sanitize_output_text(item["label"])[:28])
             version_attrs = ""
             version_provenance = item.get("version_provenance")
             if isinstance(version_provenance, dict):
-                source = html.escape(str(version_provenance.get("version_source", "unknown")), quote=True)
-                confidence = html.escape(str(version_provenance.get("confidence", "unknown")), quote=True)
+                source = html.escape(sanitize_output_text(version_provenance.get("version_source", "unknown")), quote=True)
+                confidence = html.escape(sanitize_output_text(version_provenance.get("confidence", "unknown")), quote=True)
                 version_attrs = f' data-version-source="{source}" data-version-confidence="{confidence}"'
 
             parts.append(

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -44,7 +44,13 @@ from agent_bom.async_stdin import create_async_stdin_reader, read_async_stdin_li
 from agent_bom.langfuse_otel import set_langfuse_runtime_attributes
 from agent_bom.proxy_sandbox import SandboxConfig, build_sandboxed_command
 from agent_bom.proxy_scanner import ScanConfig, load_scan_config, scan_tool_call, scan_tool_response
-from agent_bom.security import redact_secret_url, require_recognized_launcher, sanitize_text, validate_arguments
+from agent_bom.security import (
+    redact_secret_url,
+    require_recognized_launcher,
+    sanitize_sensitive_payload,
+    sanitize_text,
+    validate_arguments,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -783,7 +789,7 @@ async def _send_webhook(url: str, payload: dict) -> None:
         import httpx
 
         async with httpx.AsyncClient(timeout=httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=5.0)) as client:
-            await client.post(url, json=payload)
+            await client.post(url, json=sanitize_sensitive_payload(payload, max_str_len=3_000))
     except Exception:  # noqa: BLE001
         logger.debug("Failed to send webhook to %s", redact_secret_url(url))
 
@@ -846,7 +852,7 @@ async def _proxy_sse_server(
         for alert in alerts:
             alert_dict = alert.to_dict()
             runtime_alerts.append(alert_dict)
-            logger.warning("Runtime alert: %s", alert_dict.get("message", "runtime alert"))
+            logger.warning("Runtime alert: %s", sanitize_text(alert_dict.get("message", "runtime alert")))
             if log_f:
                 write_audit_record(log_f, alert_dict)
                 log_f.flush()
@@ -1500,7 +1506,7 @@ async def run_proxy(
         for alert in alerts:
             alert_dict = alert.to_dict()
             runtime_alerts.append(alert_dict)
-            logger.warning("Runtime alert: %s", alert.message)
+            logger.warning("Runtime alert: %s", sanitize_text(alert_dict.get("message", "runtime alert")))
             if log_f:
                 write_audit_record(log_f, alert_dict)
                 log_f.flush()

--- a/src/agent_bom/runtime/protection.py
+++ b/src/agent_bom/runtime/protection.py
@@ -612,7 +612,7 @@ class ProtectionEngine:
         # Cross-agent lateral movement — feed HIGH alerts into correlation buffer
         lateral_alerts = self._correlator.detect_lateral_movement()
         for la in lateral_alerts:
-            logger.warning("Cross-agent lateral movement: %s", la.get("message", ""))
+            logger.warning("Cross-agent lateral movement: %s", sanitize_text(la.get("message", ""), max_len=500))
             self._correlation_buffer.append(
                 _CorrelationEntry(
                     timestamp=time.monotonic(),

--- a/src/agent_bom/security.py
+++ b/src/agent_bom/security.py
@@ -224,8 +224,20 @@ _VALUE_CREDENTIAL_PATTERNS = [
     re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY(?: BLOCK)?-----"),  # Private keys
     re.compile(r"eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}"),  # JWTs
     re.compile(r"xox[bpsar]-[A-Za-z0-9-]{10,}"),  # Slack tokens
-    re.compile(r"\w+://[^:]+:[^@]+@"),  # Connection strings with embedded credentials
 ]
+
+# Keep credential-bearing connection URLs on a literal-prefixed fast path.
+# Putting an unbounded scheme expression in ``_VALUE_CREDENTIAL_PATTERNS``
+# makes regex search backtrack from every character of a non-URL model payload,
+# turning a linear redaction pass into minutes of CPU time.
+_CONNECTION_CREDENTIAL_RE = re.compile(r"://[^:\s/@]+:[^@\s/]+@")
+
+
+def _contains_value_credential(value: str) -> bool:
+    return any(pattern.search(value) for pattern in _VALUE_CREDENTIAL_PATTERNS) or (
+        "://" in value and _CONNECTION_CREDENTIAL_RE.search(value) is not None
+    )
+
 
 # Base64 alphabet (standard + URL-safe)
 _B64_RE = re.compile(r"^[A-Za-z0-9+/\-_]+=*$")
@@ -277,7 +289,7 @@ def _is_obfuscated_credential(value: str) -> bool:
             if any(re.search(p, decoded_lower) for p in SENSITIVE_PATTERNS):
                 return True
             # Decoded text matches a known credential value pattern
-            if any(p.search(decoded) for p in _VALUE_CREDENTIAL_PATTERNS):
+            if _contains_value_credential(decoded):
                 return True
         except (ValueError, UnicodeDecodeError, binascii.Error):
             pass  # Not valid base64 — fall through to entropy check
@@ -334,7 +346,7 @@ def sanitize_env_vars(env: dict[str, Any]) -> dict[str, str]:
         else:
             str_value = str(value)
             # Scan values for plaintext credential patterns (catches custom-named vars)
-            if any(p.search(str_value) for p in _VALUE_CREDENTIAL_PATTERNS):
+            if _contains_value_credential(str_value):
                 sanitized[key] = "***REDACTED***"
             # Detect obfuscated secrets: base64-encoded values and high-entropy strings
             elif _is_obfuscated_credential(str_value):
@@ -490,6 +502,8 @@ def sanitize_text(value: object, max_len: int = 1000) -> str:
     text = re.sub(r"https?://[^\s\"'<>]+", lambda match: str(sanitize_url(match.group(0)) or ""), text)
     for pattern in _VALUE_CREDENTIAL_PATTERNS:
         text = pattern.sub("<redacted>", text)
+    if "://" in text:
+        text = _CONNECTION_CREDENTIAL_RE.sub("://<redacted>@", text)
     # The pattern list carries AWS access key *ids* but nothing for the 40-char
     # secret access key, so the harmless half was redacted while the dangerous
     # half was printed verbatim. Anything the shapes above miss is caught by the
@@ -543,8 +557,13 @@ def text_requires_redaction(value: object) -> bool:
     text = str(value)
     if "http://" in text.lower() or "https://" in text.lower():
         return True
-    if _EMAIL_RE.search(text) or any(pattern.search(text) for pattern in _VALUE_CREDENTIAL_PATTERNS):
+    if _EMAIL_RE.search(text) or _contains_value_credential(text):
         return True
+    # The keyed-value grammar cannot match without an assignment delimiter.
+    # Avoid starting its bounded-key regex at every character of large plain
+    # model/output strings.
+    if "=" not in text and ":" not in text:
+        return False
     return any(
         env_key_is_credential(match.group("key")) and _is_credential_material(match.group("value"))
         for match in _TEXT_KEY_VALUE_RE.finditer(text)

--- a/src/agent_bom/security.py
+++ b/src/agent_bom/security.py
@@ -533,6 +533,24 @@ def _is_credential_material(value: str) -> bool:
     return not (_CREDENTIAL_IDENTIFIER_VALUE_RE.match(value) and env_key_is_credential(value))
 
 
+def text_requires_redaction(value: object) -> bool:
+    """Return whether canonical free-text redaction would alter sensitive data.
+
+    Renderers use this exact predicate for their fast path. It intentionally
+    shares the central patterns and credential-key classifier so a duplicated
+    heuristic cannot drift into a redaction bypass.
+    """
+    text = str(value)
+    if "http://" in text.lower() or "https://" in text.lower():
+        return True
+    if _EMAIL_RE.search(text) or any(pattern.search(text) for pattern in _VALUE_CREDENTIAL_PATTERNS):
+        return True
+    return any(
+        env_key_is_credential(match.group("key")) and _is_credential_material(match.group("value"))
+        for match in _TEXT_KEY_VALUE_RE.finditer(text)
+    )
+
+
 def _looks_sensitive_value(value: str) -> bool:
     return sanitize_env_vars({"ARG": value}).get("ARG") == "***REDACTED***"
 
@@ -603,7 +621,17 @@ def _key_looks_sensitive(key: object) -> bool:
 # labels and set-dedups them, collapsing distinct credentials into one phantom
 # node and inventing cross-agent ``reaches_tool``/``exposes_cred`` edges.  Only
 # the VALUE of a credential is sensitive, and values are never carried here.
-_CREDENTIAL_IDENTIFIER_KEYS = frozenset({"credential_env_vars", "credential_env_var", "credential_names", "credential_refs"})
+_CREDENTIAL_IDENTIFIER_KEYS = frozenset(
+    {
+        "credential_env_vars",
+        "credential_env_var",
+        "credential_names",
+        "credential_refs",
+        "credentials_exposed",
+        "exposed_credentials",
+        "exposed_credential_names",
+    }
+)
 
 
 def _key_is_credential_identifier(key: object) -> bool:
@@ -704,6 +732,10 @@ def _sanitize_sensitive_string(value: str, *, key: object | None, max_str_len: i
         return sanitize_path_label(value)
     if _looks_like_path_value(value):
         return sanitize_path_label(value)
+    if not text_requires_redaction(value) and (
+        len(value.strip()) < _HIGH_ENTROPY_MIN_LEN or any(character.isspace() for character in value)
+    ):
+        return sanitize_log_label(value, max_len=max_str_len)
     if _looks_sensitive_value(value):
         return "***REDACTED***"
     return sanitize_text(value, max_len=max_str_len)

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -632,6 +632,9 @@ def test_get_scan_status_omits_large_result_payload():
 
     assert full.status_code == 200
     assert status.status_code == 200
+    full_body = full.json()
+    assert len(full_body["result"]["agents"][0]["payload"]) == 250_000
+    assert len(full_body["result"]["blast_radius"][0]["payload"]) == 250_000
     body = status.json()
     assert body["job_id"] == "job-large-result"
     assert body["status"] == "done"

--- a/tests/test_alert_dispatcher.py
+++ b/tests/test_alert_dispatcher.py
@@ -1,6 +1,8 @@
 """Tests for alert pipeline — dispatcher, channels, and scan alert generation."""
 
 import asyncio
+import json
+from types import SimpleNamespace
 from urllib.parse import urlsplit
 
 from agent_bom.alerts.dispatcher import (
@@ -102,6 +104,29 @@ def test_slack_payload_escapes_untrusted_mrkdwn():
     assert "agentone" in rendered
 
 
+def test_slack_payload_redacts_secret_pii_and_credential_urls():
+    secret = "ghp_" + "a" * 36
+    email = "alice.sentinel@example.invalid"
+    credential_url = "postgresql://admin:sentinel-password@db.internal/prod"
+    payload = _build_slack_payload(
+        {
+            "severity": "high",
+            "message": f"Exposed {secret} for {email}",
+            "detector": "sentinel",
+            "details": {
+                "affected_agents": [email],
+                "credentials_exposed": [secret],
+                "fixed_version": credential_url,
+            },
+        }
+    )
+
+    rendered = json.dumps(payload)
+    assert secret not in rendered
+    assert email not in rendered
+    assert credential_url not in rendered
+
+
 # ─── WebhookChannel ──────────────────────────────────────────────────────────
 
 
@@ -141,6 +166,47 @@ def test_webhook_channel_failure_does_not_log_secret_url(caplog, monkeypatch):
     assert urlsplit(redacted_urls[-1]).hostname == "hooks.slack.example.com"
 
 
+def test_webhook_channel_redacts_payload_before_delivery(monkeypatch):
+    import agent_bom.http_client as http_client
+    import agent_bom.security as security
+
+    secret = "ghp_" + "a" * 36
+    email = "alice.sentinel@example.invalid"
+    credential_url = "postgresql://admin:sentinel-password@db.internal/prod"
+    captured: dict = {}
+
+    class _ClientContext:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, *args):
+            return None
+
+    async def _request(*args, **kwargs):
+        captured.update(kwargs["json"])
+        return SimpleNamespace(status_code=204)
+
+    monkeypatch.setattr(security, "validate_url", lambda *a, **k: None)
+    monkeypatch.setattr(http_client, "create_client", lambda **kwargs: _ClientContext())
+    monkeypatch.setattr(http_client, "request_with_retry", _request)
+
+    channel = WebhookChannel("https://example.test/hook")
+    result = asyncio.run(
+        channel.send(
+            {
+                "message": f"Exposed {secret}",
+                "details": {"email": email, "connection_url": credential_url},
+            }
+        )
+    )
+
+    assert result is True
+    rendered = json.dumps(captured)
+    assert secret not in rendered
+    assert email not in rendered
+    assert credential_url not in rendered
+
+
 # ─── AlertDispatcher ─────────────────────────────────────────────────────────
 
 
@@ -156,6 +222,43 @@ def test_dispatcher_dispatch_stores_in_memory():
     assert count == 1
     assert d.alert_count() == 1
     assert d.list_alerts()[0]["message"] == "test"
+
+
+def test_dispatcher_redacts_alert_before_history_and_channels():
+    secret = "ghp_" + "a" * 36
+    email = "alice.sentinel@example.invalid"
+    credential_url = "postgresql://admin:sentinel-password@db.internal/prod"
+    dispatcher = AlertDispatcher()
+
+    asyncio.run(
+        dispatcher.dispatch(
+            {
+                "severity": "high",
+                "message": f"Exposed {secret}",
+                "details": {"email": email, "connection_url": credential_url},
+            }
+        )
+    )
+
+    rendered = json.dumps(dispatcher.list_alerts())
+    assert secret not in rendered
+    assert email not in rendered
+    assert credential_url not in rendered
+
+
+def test_dispatcher_channel_exception_does_not_leak_exception_text(caplog):
+    secret = "ghp_" + "a" * 36
+
+    class _FailingChannel:
+        async def send(self, alert: dict) -> bool:
+            raise RuntimeError(f"delivery failed with {secret}")
+
+    dispatcher = AlertDispatcher()
+    dispatcher.add_channel(_FailingChannel())
+    with caplog.at_level("ERROR"):
+        asyncio.run(dispatcher.dispatch({"severity": "high", "message": "test"}))
+
+    assert secret not in caplog.text
 
 
 def test_dispatcher_dispatch_adds_timestamp():

--- a/tests/test_cross_surface_scan_evidence.py
+++ b/tests/test_cross_surface_scan_evidence.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
-from agent_bom.api.routes.scan import _redact_scan_result_for_response
+from agent_bom.api.routes.scan import _job_summary_payload, _redact_scan_result_for_response
 from agent_bom.api.store import InMemoryJobStore
 from agent_bom.api.stores import _get_store, set_job_store
 from agent_bom.finding_scope import safe_finding_response_payload
@@ -74,6 +74,18 @@ def test_full_scan_job_and_findings_list_share_the_canonical_safe_projection() -
         {"framework": "soc2", "control": "CC6.1", "source": "scanner"},
     ]
     assert safe_finding_response_payload({**finding, "asset": {"stable_id": "asset-only"}})["asset"] == {"stable_id": "asset-only"}
+
+
+def test_full_scan_job_and_findings_list_redact_shaped_secret_text() -> None:
+    secret = "ghp_" + "a" * 36
+    finding = {**_finding(), "title": f"leaked token {secret}", "description": f"secret={secret}"}
+
+    list_projection = safe_finding_response_payload(finding)
+    result_projection = _redact_scan_result_for_response({"findings": [finding]})
+
+    assert result_projection is not None
+    assert secret not in json.dumps(list_projection)
+    assert secret not in json.dumps(result_projection)
 
 
 def test_unified_finding_drives_compliance_narrative_without_placeholder_entities() -> None:
@@ -149,6 +161,53 @@ def test_scan_job_model_keeps_the_same_result_summary_contract() -> None:
     assert projected is not job.result
     assert job.result["findings"][0]["asset"]["location"] == "/Users/example/.config/mcp.json"
     assert projected["summary"] == job.result["summary"]
+
+
+def test_full_scan_response_redacts_sensitive_top_level_side_blocks() -> None:
+    secret = "ghp_" + "a" * 36
+    email = "alice.sentinel@example.invalid"
+    credential_url = "postgresql://admin:sentinel-password@db.internal/prod"
+    durable = {
+        "scan_id": "scan-1",
+        "findings": [],
+        "executive_summary": f"Exposed {secret}",
+        "trust_assessment": {
+            "owner_email": email,
+            "connection_url": credential_url,
+        },
+    }
+
+    projected = _redact_scan_result_for_response(durable)
+
+    assert projected is not None
+    rendered = json.dumps(projected)
+    assert secret not in rendered
+    assert email not in rendered
+    assert credential_url not in rendered
+    assert secret in durable["executive_summary"]
+
+
+def test_scan_status_summary_redacts_warning_and_summary_payloads() -> None:
+    secret = "ghp_" + "a" * 36
+    email = "alice.sentinel@example.invalid"
+    job = ScanJob(
+        job_id="scan-1",
+        tenant_id="tenant-a",
+        status=JobStatus.DONE,
+        created_at="2026-08-17T12:00:00Z",
+        completed_at="2026-08-17T12:05:00Z",
+        request=ScanRequest(),
+        error=f"provider returned {secret}",
+        result={
+            "summary": {"detail": f"Contact {email}"},
+            "warnings": [f"Credential {secret}"],
+        },
+    )
+
+    rendered = json.dumps(_job_summary_payload(job))
+
+    assert secret not in rendered
+    assert email not in rendered
 
 
 def test_compliance_endpoint_reads_the_current_persisted_finding_queue() -> None:

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -204,6 +204,41 @@ def test_credential_to_tool_reaches_edges_export_with_evidence():
         os.unlink(path)
 
 
+def test_all_graph_serializers_redact_secret_pii_and_credential_urls():
+    secret = "ghp_" + "a" * 36
+    email = "alice.sentinel@example.invalid"
+    credential_url = "postgresql://admin:sentinel-password@db.internal/prod"
+    graph = DepGraph()
+    graph.add_node(
+        f"agent:{secret}",
+        f"{email} {secret}",
+        "agent",
+        attributes={"connection_url": credential_url, "owner": email},
+    )
+    graph.add_node("tool:safe", "safe tool", "tool")
+    graph.add_edge(
+        f"agent:{secret}",
+        "tool:safe",
+        "reaches_tool",
+        evidence={"secret_value": secret, "callback": credential_url},
+    )
+
+    rendered = (
+        json.dumps(to_json(graph)),
+        to_dot(graph),
+        to_mermaid(graph),
+        to_graphml(graph),
+        to_cypher(graph),
+    )
+    for output in rendered:
+        assert secret not in output
+        assert email not in output
+        assert credential_url not in output
+
+    # Outbound projection must not mutate the graph used for internal analysis.
+    assert secret in graph.nodes[0].id
+
+
 def test_same_env_var_name_stays_scoped_to_each_exported_server():
     data = _make_scan_json(
         [

--- a/tests/test_mcp_http_scan_contract.py
+++ b/tests/test_mcp_http_scan_contract.py
@@ -6,6 +6,7 @@ from agent_bom.api.models import ScanJob, ScanRequest
 from agent_bom.api.pipeline import _now, _run_scan_sync
 from agent_bom.api.stores import _COMPACTED_RESULT_MARKER
 from agent_bom.mcp_tools.scanning import scan_impl
+from agent_bom.models import Agent, AgentType
 
 _CONTRACT_KEYS = ("agents", "blast_radii", "blast_radius", "status", "vulnerabilities", "warnings")
 
@@ -86,3 +87,25 @@ async def test_mcp_scan_no_agent_shape_matches_http_scan(monkeypatch):
         assert result["vulnerabilities"] == []
         assert result["blast_radius"] == result["blast_radii"] == []
         assert result["warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_mcp_default_scan_redacts_secret_pii_and_credential_urls():
+    secret = "ghp_" + "a" * 36
+    email = "alice.sentinel@example.invalid"
+    credential_url = "postgresql://admin:sentinel-password@db.internal/prod"
+
+    async def _pipeline(*_args, **_kwargs):
+        agent = Agent(
+            name=secret,
+            agent_type=AgentType.CUSTOM,
+            config_path=credential_url,
+            source=email,
+        )
+        return [agent], [], [f"{email} {secret} {credential_url}"], []
+
+    rendered = await scan_impl(_run_scan_pipeline=_pipeline, _truncate_response=_truncate)
+
+    assert secret not in rendered
+    assert email not in rendered
+    assert credential_url not in rendered

--- a/tests/test_output_security_contract.py
+++ b/tests/test_output_security_contract.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import csv
 import io
+import json
 from datetime import datetime
 
 from agent_bom.finding import Asset, Finding, FindingSource, FindingType
-from agent_bom.models import AIBOMReport, BlastRadius, Package, Severity, Vulnerability
-from agent_bom.output import to_csv
+from agent_bom.models import Agent, AgentType, AIBOMReport, BlastRadius, MCPServer, Package, Severity, Vulnerability
+from agent_bom.output import to_csv, to_html, to_markdown
 from agent_bom.output.graph import export_graph_html
+from agent_bom.output.mermaid import to_mermaid_supply_chain
+from agent_bom.output.parquet_fmt import _row_dict
+from agent_bom.output.pdf import _build_report_lines
+from agent_bom.output.scan_document import to_text
+from agent_bom.output.svg import to_svg
 
 
 def _finding(
@@ -91,8 +97,264 @@ def test_graph_html_escapes_script_breakout_and_keeps_policy_findings_offline(tm
     assert "high" in offline_html.lower()
 
 
+def test_standard_html_escapes_script_breakout_from_embedded_graph_json():
+    payload = "</script><script>globalThis.PWNED=1</script>"
+    rendered = to_html(_report([_finding(title=payload, description=payload)]))
+
+    assert payload not in rendered
+    assert r"\u003c/script\u003e" in rendered
+
+
 def test_graph_policy_priority_points_to_finding_node():
     from agent_bom.output.graph import _graph_priority_summary
 
     finding = _finding(title="Policy title")
     assert _graph_priority_summary([finding])[0]["nodeId"] == f"finding:{finding.id}"
+
+
+def test_graph_element_redaction_preserves_distinct_nodes_and_edge_references():
+    from agent_bom.output.graph import sanitize_graph_elements
+
+    first = "ghp_" + "a" * 36
+    second = "ghp_" + "b" * 36
+    projected, _ = sanitize_graph_elements(
+        [
+            {"data": {"id": first, "label": first}},
+            {"data": {"id": second, "label": second}},
+            {"data": {"source": first, "target": second, "type": "reaches"}},
+        ]
+    )
+    node_ids = [element["data"]["id"] for element in projected[:2]]
+    edge = projected[2]["data"]
+
+    assert first not in str(projected)
+    assert second not in str(projected)
+    assert len(set(node_ids)) == 2
+    assert edge["source"] == node_ids[0]
+    assert edge["target"] == node_ids[1]
+
+
+def test_human_and_flat_exports_redact_secret_pii_and_credential_urls():
+    secret = "ghp_" + "a" * 36
+    email = "alice.sentinel@example.invalid"
+    credential_url = "postgresql://admin:sentinel-password@db.internal/prod"
+    finding = _finding(
+        title=f"Exposed {secret}",
+        description=f"Owner {email} configured {credential_url}",
+    )
+    finding.asset.location = credential_url
+    finding.evidence = {
+        "secret_value": secret,
+        "owner_email": email,
+        "connection_url": credential_url,
+    }
+    report = _report([finding])
+    report.trust_assessment_data = {
+        "verdict": "review",
+        "skill_name": secret,
+        "source_file": credential_url,
+        "overall_recommendation": email,
+    }
+
+    for rendered in (to_csv(report), to_markdown(report), to_html(report)):
+        assert secret not in rendered
+        assert email not in rendered
+        assert credential_url not in rendered
+
+    # Rendering must never mutate the finding used by internal correlation.
+    assert secret in finding.title
+
+
+def test_graph_html_redacts_secret_pii_and_credential_urls(tmp_path):
+    secret = "ghp_" + "a" * 36
+    email = "alice.sentinel@example.invalid"
+    credential_url = "postgresql://admin:sentinel-password@db.internal/prod"
+    finding = _finding(
+        title=f"Exposed {secret}",
+        description=f"Owner {email} configured {credential_url}",
+    )
+    report = _report([finding])
+    output = tmp_path / "graph.html"
+
+    export_graph_html(report, [], str(output))
+
+    rendered = output.read_text(encoding="utf-8")
+    assert secret not in rendered
+    assert email not in rendered
+    assert credential_url not in rendered
+
+
+def test_output_text_fast_path_matches_central_redaction_for_sensitive_shapes():
+    from agent_bom.output.finding_views import sanitize_output_text
+    from agent_bom.security import sanitize_text
+
+    samples = [
+        "ghp_" + "a" * 36,
+        "alice.sentinel@example.invalid",
+        "postgresql://admin:sentinel-password@db.internal/prod",
+        "api_key: abcdefghijklmnop",
+        "authorization_header: abcdefghijklmnopqrstuvwxyz",
+        "private_key_material = abcdefghijklmnopqrstuvwxyz",
+        "safe package label",
+    ]
+    assert [sanitize_output_text(value) for value in samples] == [sanitize_text(value, max_len=max(1_000, len(value))) for value in samples]
+
+
+def test_diagram_lake_pdf_and_text_outputs_redact_sensitive_inventory_fields():
+    secret = "ghp_" + "a" * 36
+    email = "alice.sentinel@example.invalid"
+    credential_url = "postgresql://admin:sentinel-password@db.internal/prod"
+    package = Package(name=secret, version="1.0.0", ecosystem="pypi")
+    server = MCPServer(name=email, command="python", args=[credential_url], packages=[package])
+    agent = Agent(
+        name=secret,
+        agent_type=AgentType.CUSTOM,
+        config_path=credential_url,
+        mcp_servers=[server],
+        source=email,
+    )
+    finding = _finding(
+        finding_type=FindingType.CVE,
+        title=f"CVE sentinel {secret}",
+        description=f"Owner {email} configured {credential_url}",
+        cve_id="CVE-SENTINEL-1",
+    )
+    finding.asset.name = secret
+    finding.asset.identifier = credential_url
+    finding.fixed_version = credential_url
+    finding.affected_agents = [email]
+    finding.affected_servers = [secret]
+    finding.exposed_credentials = [secret]
+    report = _report([finding])
+    report.agents = [agent]
+    report.scan_id = secret
+    report.executive_summary = f"Contact {email} about {credential_url} and {secret}"
+
+    rendered_outputs = (
+        to_mermaid_supply_chain(report),
+        to_svg(report, []),
+        "\n".join(_build_report_lines(report)),
+        to_text(report),
+        str(_row_dict(finding, report)),
+    )
+    for rendered in rendered_outputs:
+        assert secret not in rendered
+        assert email not in rendered
+        assert credential_url not in rendered
+
+
+def test_ocsf_events_redact_secret_pii_and_credential_urls():
+    from agent_bom.output.ocsf import alert_to_ocsf, finding_to_ocsf
+
+    secret = "ghp_" + "a" * 36
+    email = "alice.sentinel@example.invalid"
+    credential_url = "postgresql://admin:sentinel-password@db.internal/prod"
+    alert = {
+        "severity": "high",
+        "detector": secret,
+        "message": f"{secret} {email} {credential_url}",
+        "details": {"tool": secret, "connection_url": credential_url},
+    }
+    finding = _finding(title=f"{secret} {email}", description=credential_url)
+    finding.affected_agents = [email]
+    finding.exposed_credentials = [secret]
+
+    for event in (alert_to_ocsf(alert), finding_to_ocsf(finding)):
+        encoded = json.dumps(event)
+        assert secret not in encoded
+        assert email not in encoded
+        assert credential_url not in encoded
+
+
+def test_console_attack_flow_and_inventory_redact_sensitive_labels(monkeypatch):
+    from rich.console import Console
+
+    import agent_bom.output.console_render as console_render
+
+    secret = "ghp_" + "a" * 36
+    email = "alice.sentinel@example.invalid"
+    credential_url = "postgresql://admin:sentinel-password@db.internal/prod"
+    package = Package(name=secret, version="1.0.0", ecosystem="pypi")
+    server = MCPServer(name=secret, command="python", args=[credential_url], packages=[package])
+    agent = Agent(
+        name=email,
+        agent_type=AgentType.CUSTOM,
+        config_path=credential_url,
+        mcp_servers=[server],
+    )
+    finding = _finding(finding_type=FindingType.CVE, cve_id="CVE-SENTINEL-1")
+    finding.affected_agents = [email]
+    finding.affected_servers = [secret]
+    finding.exposed_credentials = [credential_url]
+    report = _report([finding])
+    report.agents = [agent]
+    output = io.StringIO()
+    monkeypatch.setattr(console_render, "console", Console(file=output, force_terminal=False, color_system=None))
+
+    console_render.print_agent_tree(report)
+    console_render.print_attack_flow_tree(report)
+
+    rendered = output.getvalue()
+    assert secret not in rendered
+    assert email not in rendered
+    assert credential_url not in rendered
+
+
+def test_linked_machine_exports_redact_sensitive_inventory_without_collapsing_ids():
+    from agent_bom.output import to_cyclonedx, to_sarif, to_spdx
+    from agent_bom.output.interop_security import sanitize_linked_document
+    from agent_bom.output.spdx2_fmt import to_spdx2, to_spdx2_tagvalue
+
+    secret = "ghp_" + "a" * 36
+    email = "alice.sentinel@example.invalid"
+    credential_url = "postgresql://admin:sentinel-password@db.internal/prod"
+    vulnerability = Vulnerability(
+        id="CVE-SENTINEL-1",
+        severity=Severity.HIGH,
+        summary=f"{secret} {email} {credential_url}",
+    )
+    package = Package(name=secret, version="1.0.0", ecosystem="pypi", vulnerabilities=[vulnerability])
+    server = MCPServer(name=email, command="python", args=[credential_url], packages=[package])
+    agent = Agent(
+        name=secret,
+        agent_type=AgentType.CUSTOM,
+        config_path=credential_url,
+        mcp_servers=[server],
+        source=email,
+    )
+    report = _report([])
+    report.agents = [agent]
+
+    rendered = (
+        json.dumps(to_cyclonedx(report)),
+        json.dumps(to_spdx(report)),
+        json.dumps(to_spdx2(report)),
+        to_spdx2_tagvalue(report),
+        json.dumps(to_sarif(report)),
+    )
+    for output in rendered:
+        assert secret not in output
+        assert email not in output
+        assert credential_url not in output
+
+    first = "ghp_" + "a" * 36
+    second = "ghp_" + "b" * 36
+    linked = sanitize_linked_document(
+        {
+            "components": [{"bom-ref": first}, {"bom-ref": second}],
+            "dependencies": [{"ref": first, "dependsOn": [second]}],
+        }
+    )
+    ids = [component["bom-ref"] for component in linked["components"]]
+    assert len(set(ids)) == 2
+    assert linked["dependencies"][0] == {"ref": ids[0], "dependsOn": [ids[1]]}
+
+    sarif_linked = sanitize_linked_document(
+        {
+            "rules": [{"id": first}, {"id": second}],
+            "results": [{"ruleId": first}, {"ruleId": second}],
+        }
+    )
+    rule_ids = [rule["id"] for rule in sarif_linked["rules"]]
+    assert len(set(rule_ids)) == 2
+    assert [result["ruleId"] for result in sarif_linked["results"]] == rule_ids

--- a/tests/test_proxy_webhook_retention.py
+++ b/tests/test_proxy_webhook_retention.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
 import agent_bom.proxy as proxy
 
@@ -33,3 +34,43 @@ def test_fire_webhook_retains_task_until_done_then_discards() -> None:
             proxy._send_webhook = original  # type: ignore[assignment]
 
     asyncio.run(scenario())
+
+
+def test_send_webhook_redacts_payload_before_delivery(monkeypatch) -> None:
+    import httpx
+
+    secret = "ghp_" + "a" * 36
+    email = "alice.sentinel@example.invalid"
+    credential_url = "postgresql://admin:sentinel-password@db.internal/prod"
+    captured: dict = {}
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url: str, *, json: dict):
+            captured.update(json)
+
+    monkeypatch.setattr("agent_bom.security.validate_url", lambda *a, **k: None)
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+
+    asyncio.run(
+        proxy._send_webhook(
+            "https://example.test/hook",
+            {
+                "message": f"Exposed {secret}",
+                "details": {"email": email, "connection_url": credential_url},
+            },
+        )
+    )
+
+    rendered = json.dumps(captured)
+    assert secret not in rendered
+    assert email not in rendered
+    assert credential_url not in rendered

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -460,6 +460,23 @@ def test_sanitize_sensitive_payload_preserves_safe_shape():
     assert result == {"package": "express", "version": "4.18.2", "count": 2}
 
 
+def test_sanitize_sensitive_payload_preserves_credential_identifiers_but_not_values():
+    from agent_bom.security import sanitize_sensitive_payload
+
+    secret = "ghp_" + "a" * 36
+    result = sanitize_sensitive_payload(
+        {
+            "credentials_exposed": ["OPENAI_API_KEY", secret],
+            "exposed_credentials": 1,
+        }
+    )
+
+    assert result == {
+        "credentials_exposed": ["OPENAI_API_KEY", "***REDACTED***"],
+        "exposed_credentials": 1,
+    }
+
+
 def test_sanitize_sensitive_payload_preserves_structured_graph_edge_ids():
     from agent_bom.security import sanitize_sensitive_payload
 


### PR DESCRIPTION
## Summary
- redact secret, PII, credential-URL, and hostile script content across API, MCP, webhook, console, graph, HTML, compliance, SIEM, and machine-export boundaries
- preserve linked graph/SBOM/SARIF/SPDX identifiers, edge references, and full-result evidence while sanitizing labels and content
- centralize tier-A string sanitization and use bounded render-local caches plus literal-prefixed credential URL detection to keep large-report overhead bounded

## Verification
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_output_security_contract.py tests/test_output_formats.py tests/test_output_cov.py tests/test_graph_export.py tests/test_alert_dispatcher.py tests/test_proxy_webhook_retention.py tests/test_cross_surface_scan_evidence.py tests/test_mcp_http_scan_contract.py tests/test_mcp_tool_impls.py tests/test_security.py tests/test_evidence_policy.py tests/test_finding_field_surfacing.py tests/test_owner_sla_export_parity.py tests/test_compliance_export.py tests/test_spdx2_and_checksums.py tests/test_sarif_schema_2_1_0.py tests/test_cyclonedx_vex_justification.py tests/test_parquet_export.py tests/test_pdf_output.py tests/test_mermaid.py tests/test_svg_output.py` (543 passed; one DNS-dependent case rerun separately)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_security.py tests/test_sanitize_text_secret_coverage.py tests/test_output_security_contract.py tests/api/test_api_endpoints.py -m 'not network and not slow'` (182 passed)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_alert_dispatcher.py::test_webhook_channel_init` (passed with DNS access)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/security.py src/agent_bom/api/routes/scan.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache make preflight`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check src/agent_bom tests/test_output_security_contract.py tests/test_graph_export.py tests/test_alert_dispatcher.py tests/test_proxy_webhook_retention.py tests/test_cross_surface_scan_evidence.py tests/test_mcp_http_scan_contract.py tests/test_security.py tests/api/test_api_endpoints.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff format --check src/agent_bom tests/test_output_security_contract.py tests/test_graph_export.py tests/test_alert_dispatcher.py tests/test_proxy_webhook_retention.py tests/test_cross_surface_scan_evidence.py tests/test_mcp_http_scan_contract.py tests/test_security.py tests/api/test_api_endpoints.py`

## Notes
- A CI regression probe found catastrophic backtracking in credential-URL detection and silent truncation of large full-result fields. The 500 KB API case now preserves both 250 KB fields and completes locally in about 2.9 seconds instead of approximately 10 minutes in CI.
- 2,000-row response/export probes remained sub-second; linked identifiers stayed unique under adversarial secret-shaped IDs.
- The work is based on main `1263afda9`, which contains the fixed CodeQL alert #1851 path.
