### PR TITLE
fix(security): close exception logging leaks

### DIFF
--- a/scripts/check_exception_sanitization.py
+++ b/scripts/check_exception_sanitization.py
@@ -21,7 +21,11 @@ Forbidden patterns (on the scanned trees):
   3. ``logger.<level>(f"...{exc}...")`` — raw exception interpolated into a log
      f-string. Use lazy ``%s`` formatting with a sanitized value:
      ``logger.warning("...: %s", sanitize_text(exc))``.
-  4. A caught exception object used anywhere in an API route's returned
+  4. A caught exception passed as a lazy logger argument, implicit traceback
+     capture via ``logger.exception(...)``, or explicit raw ``exc_info``.
+     Shared log sinks receive exception messages and tracebacks, so use a fixed
+     log message or ``sanitize_text(exc)`` without traceback capture.
+  5. A caught exception object used anywhere in an API route's returned
      response payload. Return a fixed external message instead. This
      intentionally avoids relying on custom sanitizer modeling in static
      analyzers such as CodeQL.
@@ -89,8 +93,10 @@ _DETAIL_FSTRING = re.compile(r"""detail\s*=\s*f["']""")
 # logger.<level>(f"...": flagged only if the f-string carries a bare exc field.
 # Matches log / logger / _log / _logger / self.logger and similar names.
 _LOGGER_FSTRING = re.compile(
-    r"""\b\w*log\w*\.(?:debug|info|warning|error|exception|critical)\(\s*f["']""",
+    r"""\b\w*log\w*\.(?:debug|info|warning|error|critical)\(\s*f["']""",
 )
+
+_LOG_METHODS = frozenset({"debug", "info", "warning", "error", "exception", "critical"})
 
 
 def _iter_files() -> list[Path]:
@@ -157,6 +163,100 @@ def _scan_returned_exception_flows(text: str, label: str) -> list[str]:
     return violations
 
 
+def _logger_receiver_name(node: ast.expr) -> str:
+    """Return a dotted best-effort name for a logger receiver expression."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _logger_receiver_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return ""
+
+
+def _is_logger_call(node: ast.Call) -> bool:
+    if not isinstance(node.func, ast.Attribute) or node.func.attr not in _LOG_METHODS:
+        return False
+    return "log" in _logger_receiver_name(node.func.value).lower()
+
+
+def _call_has_pragma(node: ast.Call, lines: list[str]) -> bool:
+    start = max(1, node.lineno)
+    end = min(len(lines), getattr(node, "end_lineno", node.lineno))
+    return any(PRAGMA in lines[index - 1] for index in range(start, end + 1))
+
+
+def _contains_raw_caught_exception(node: ast.AST, caught_name: str) -> bool:
+    """Return whether *node* carries the caught exception's raw value.
+
+    Access to a structured attribute such as ``exc.status.value`` remains
+    allowed, matching the response-flow contract. The central log sanitizer is
+    the only call allowed to consume the exception object directly.
+    """
+    if isinstance(node, ast.Name):
+        return node.id == caught_name
+    if isinstance(node, ast.Attribute):
+        return False
+    if isinstance(node, ast.Call):
+        name = ""
+        if isinstance(node.func, ast.Name):
+            name = node.func.id
+        elif isinstance(node.func, ast.Attribute):
+            name = node.func.attr
+        if name == "sanitize_text":
+            return False
+    return any(_contains_raw_caught_exception(child, caught_name) for child in ast.iter_child_nodes(node))
+
+
+def _raw_exc_info(keyword: ast.keyword, caught_name: str | None) -> bool:
+    if keyword.arg != "exc_info":
+        return False
+    value = keyword.value
+    if isinstance(value, ast.Constant) and value.value in (False, None):
+        return False
+    if caught_name and _contains_raw_caught_exception(value, caught_name):
+        return True
+    # True, sys.exc_info(), exception tuples, and other dynamic expressions all
+    # attach an unsanitized traceback to the shared log record.
+    return True
+
+
+def _scan_exception_logging_flows(text: str, label: str) -> list[str]:
+    """Flag caught exceptions and tracebacks crossing shared logger boundaries."""
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return []
+
+    lines = text.splitlines()
+    violations: dict[tuple[int, str], str] = {}
+    for call in (node for node in ast.walk(tree) if isinstance(node, ast.Call)):
+        if not _is_logger_call(call) or _call_has_pragma(call, lines):
+            continue
+        method = call.func.attr if isinstance(call.func, ast.Attribute) else ""
+        if method == "exception":
+            reason = "logger.exception captures a raw exception traceback — use logger.error with fixed or sanitized detail"
+        elif any(_raw_exc_info(keyword, None) for keyword in call.keywords):
+            reason = "raw exc_info attached to log record — remove traceback capture and sanitize any exception detail"
+        else:
+            continue
+        violations[(call.lineno, reason)] = f"{label}:{call.lineno}: {reason}"
+
+    for handler in (node for node in ast.walk(tree) if isinstance(node, ast.ExceptHandler)):
+        caught_name = handler.name
+        for call in (node for node in ast.walk(handler) if isinstance(node, ast.Call)):
+            if not _is_logger_call(call) or _call_has_pragma(call, lines):
+                continue
+            method = call.func.attr if isinstance(call.func, ast.Attribute) else ""
+            if method == "exception" or any(_raw_exc_info(keyword, caught_name) for keyword in call.keywords):
+                continue
+            if caught_name and any(_contains_raw_caught_exception(argument, caught_name) for argument in call.args[1:]):
+                reason = "caught exception passed as a lazy log argument — wrap it with sanitize_text(exc)"
+            else:
+                continue
+            violations[(call.lineno, reason)] = f"{label}:{call.lineno}: {reason}"
+    return list(violations.values())
+
+
 def scan_text(text: str, label: str) -> list[str]:
     """Scan a blob of source. Used by the test-suite to feed deliberate samples."""
     violations: list[str] = []
@@ -166,6 +266,7 @@ def scan_text(text: str, label: str) -> list[str]:
         reason = _scan_line(line)
         if reason:
             violations.append(f"{label}:{lineno}: {reason}")
+    violations.extend(_scan_exception_logging_flows(text, label))
     if label == "sample.py" or label.startswith("src/agent_bom/api/routes/"):
         violations.extend(_scan_returned_exception_flows(text, label))
     return violations

--- a/src/agent_bom/api/agent_identity_store.py
+++ b/src/agent_bom/api/agent_identity_store.py
@@ -1153,7 +1153,7 @@ def _export_audit_to_otlp(record: Any) -> None:
 
         export_governance_audit_record(record)
     except Exception:  # noqa: BLE001 — export must never abort cleanup
-        _lifecycle_logger.debug("governance audit OTLP export skipped", exc_info=True)
+        _lifecycle_logger.debug("governance audit OTLP export skipped", exc_info=False)
 
 
 def _emit_audit(record_kwargs: dict[str, Any], audit_log: Any) -> None:
@@ -1172,7 +1172,7 @@ def _emit_audit(record_kwargs: dict[str, Any], audit_log: Any) -> None:
             "check the governance_audit_log backend (SQLite path writable / disk space)",
             record_kwargs.get("action"),
             record_kwargs.get("target_id"),
-            exc_info=True,
+            exc_info=False,
         )
 
 
@@ -1200,7 +1200,7 @@ def cleanup_expired_grants(
         _lifecycle_logger.warning(
             "JIT-grant cleanup could not list grants; the identity store may be "
             "unreachable (check AGENT_BOM_POSTGRES_URL / DB connectivity). Skipping this tick.",
-            exc_info=True,
+            exc_info=False,
         )
         return {"expired": 0, "pruned": 0, "errors": 1}
 
@@ -1258,7 +1258,7 @@ def cleanup_expired_grants(
             _lifecycle_logger.warning("skipping JIT grant %s with unparseable timestamps", grant.grant_id)
         except Exception:  # noqa: BLE001 — one bad write must not abort the sweep
             errors += 1
-            _lifecycle_logger.warning("failed to clean up JIT grant %s; continuing", grant.grant_id, exc_info=True)
+            _lifecycle_logger.warning("failed to clean up JIT grant %s; continuing", grant.grant_id, exc_info=False)
 
     return {"expired": expired, "pruned": pruned, "errors": errors}
 
@@ -1292,7 +1292,7 @@ def deprovision_dormant_identities(
         _lifecycle_logger.warning(
             "dormant-identity sweep could not list identities; the identity store may be "
             "unreachable (check DB connectivity). Skipping this tick.",
-            exc_info=True,
+            exc_info=False,
         )
         return {"revoked": 0, "errors": 1, "disabled": 0}
 
@@ -1343,7 +1343,7 @@ def deprovision_dormant_identities(
             _lifecycle_logger.warning("skipping identity %s with unparseable last_used_at", identity.identity_id)
         except Exception:  # noqa: BLE001
             errors += 1
-            _lifecycle_logger.warning("failed to deprovision identity %s; continuing", identity.identity_id, exc_info=True)
+            _lifecycle_logger.warning("failed to deprovision identity %s; continuing", identity.identity_id, exc_info=False)
 
     return {"revoked": revoked, "errors": errors, "disabled": 0}
 
@@ -1373,7 +1373,7 @@ def flag_rotation_due_identities(
     except Exception:  # noqa: BLE001
         _lifecycle_logger.warning(
             "rotation-due sweep could not list identities; the identity store may be unreachable. Skipping this tick.",
-            exc_info=True,
+            exc_info=False,
         )
         return {"flagged": 0, "errors": 1}
 
@@ -1418,7 +1418,7 @@ def flag_rotation_due_identities(
             _lifecycle_logger.warning("skipping identity %s with unparseable issued_at", identity.identity_id)
         except Exception:  # noqa: BLE001
             errors += 1
-            _lifecycle_logger.warning("failed to flag identity %s for rotation; continuing", identity.identity_id, exc_info=True)
+            _lifecycle_logger.warning("failed to flag identity %s for rotation; continuing", identity.identity_id, exc_info=False)
 
     return {"flagged": flagged, "errors": errors}
 
@@ -1441,17 +1441,17 @@ def run_nhi_lifecycle_cleanup(
     try:
         result["grants"] = cleanup_expired_grants(store, now=now, audit_log=audit_log)
     except Exception:  # noqa: BLE001
-        _lifecycle_logger.warning("JIT-grant cleanup sweep failed wholesale; continuing", exc_info=True)
+        _lifecycle_logger.warning("JIT-grant cleanup sweep failed wholesale; continuing", exc_info=False)
         result["grants"] = {"expired": 0, "pruned": 0, "errors": 1}
     try:
         result["dormant"] = deprovision_dormant_identities(store, now=now, dormant_days=dormant_days, audit_log=audit_log)
     except Exception:  # noqa: BLE001
-        _lifecycle_logger.warning("dormant-identity sweep failed wholesale; continuing", exc_info=True)
+        _lifecycle_logger.warning("dormant-identity sweep failed wholesale; continuing", exc_info=False)
         result["dormant"] = {"revoked": 0, "errors": 1, "disabled": 0}
     try:
         result["rotation"] = flag_rotation_due_identities(store, now=now, rotation_days=rotation_days, audit_log=audit_log)
     except Exception:  # noqa: BLE001
-        _lifecycle_logger.warning("rotation-due sweep failed wholesale; continuing", exc_info=True)
+        _lifecycle_logger.warning("rotation-due sweep failed wholesale; continuing", exc_info=False)
         result["rotation"] = {"flagged": 0, "errors": 1}
     return result
 

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -851,7 +851,7 @@ def _default_tenant_id(details: dict[str, object]) -> str:
         if current:
             return str(current)
     except Exception:
-        logger.debug("Audit tenant fallback unavailable", exc_info=True)
+        logger.debug("Audit tenant fallback unavailable", exc_info=False)
     return "default"
 
 
@@ -979,4 +979,4 @@ def log_action(action: str, actor: str = "system", resource: str = "", **details
             }
         )
     except Exception:
-        logger.debug("Audit analytics sync skipped", exc_info=True)
+        logger.debug("Audit analytics sync skipped", exc_info=False)

--- a/src/agent_bom/api/clickhouse_store.py
+++ b/src/agent_bom/api/clickhouse_store.py
@@ -1163,5 +1163,5 @@ def ingest_scan_report_best_effort(
         ch_store.record_scan_metadata(metadata, tenant_id=tenant_id)
         return scan_id
     except Exception:
-        logger.debug("ClickHouse findings-ingest skipped (best-effort)", exc_info=True)
+        logger.debug("ClickHouse findings-ingest skipped (best-effort)", exc_info=False)
         return None

--- a/src/agent_bom/api/compliance_signing.py
+++ b/src/agent_bom/api/compliance_signing.py
@@ -38,6 +38,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Final
 
+from agent_bom.security import sanitize_text
+
 if TYPE_CHECKING:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
@@ -206,7 +208,7 @@ def _load_ed25519_signer() -> _Ed25519Signer | None:
         _signer_init_error = str(exc)
         logger.error(
             "AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM is set but could not be parsed: %s — falling back to HMAC",
-            exc,
+            sanitize_text(exc),
         )
         return None
 

--- a/src/agent_bom/api/connection_scheduler.py
+++ b/src/agent_bom/api/connection_scheduler.py
@@ -216,7 +216,7 @@ def _consume_continuous_events(
     try:
         consume(record, **kwargs)
     except Exception:  # noqa: BLE001 - one bad consume never sinks the tick
-        logger.exception(
+        logger.error(
             "Continuous event drain failed for connection %s (provider=%s)",
             record.id,
             record.provider,
@@ -234,7 +234,7 @@ def _select_continuous_drain_targets(store: ConnectionStore) -> list[CloudConnec
     try:
         candidates = store.list_continuous()
     except Exception:  # noqa: BLE001 - a store outage never sinks the tick
-        logger.exception("Listing continuous cloud connections failed")
+        logger.error("Listing continuous cloud connections failed")
         return []
 
     targets: list[CloudConnectionRecord] = []
@@ -247,7 +247,7 @@ def _select_continuous_drain_targets(store: ConnectionStore) -> list[CloudConnec
             if not enabled():
                 continue
         except Exception:  # noqa: BLE001 - defensive; never sink the tick
-            logger.exception(
+            logger.error(
                 "Continuous event-ingest enabled check failed for connection %s",
                 record.id,
             )
@@ -272,7 +272,7 @@ def describe_idle_scheduler(store: ConnectionStore) -> str | None:
         if store.list_schedulable():
             return None
     except Exception:  # noqa: BLE001 - the idle check never sinks the tick
-        logger.exception("Listing schedulable cloud connections for the scheduler idle check failed")
+        logger.error("Listing schedulable cloud connections for the scheduler idle check failed")
         return None
     if _select_continuous_drain_targets(store):
         return None
@@ -326,11 +326,11 @@ async def _gather_isolated(
             raise result
         if isinstance(result, BaseException):
             logger.error(
-                "Connection scheduler %s failed for connection %s (provider=%s)",
+                "Connection scheduler %s failed for connection %s (provider=%s): %s",
                 activity,
                 record.id,
                 record.provider,
-                exc_info=result,
+                sanitize_text(result),
             )
 
 
@@ -414,7 +414,7 @@ def _persist_scan_outcome(
             **details,
         )
     except Exception:  # noqa: BLE001 - persistence failure never sinks the tick
-        logger.exception("Persisting the scheduled scan outcome failed for connection %s", record.id)
+        logger.error("Persisting the scheduled scan outcome failed for connection %s", record.id)
         return False
     return outcome in {"success", "accepted"}
 
@@ -464,7 +464,7 @@ def execute_connection_scan(record: CloudConnectionRecord) -> bool:
             scan_id=job.job_id,
         )
     except Exception:  # noqa: BLE001 - contract: this function never raises
-        logger.exception(
+        logger.error(
             "Scheduled cloud connection scan bookkeeping failed for connection %s",
             record.id,
         )
@@ -542,7 +542,7 @@ async def connection_scheduler_loop(
         except Exception:
             consecutive_failures += 1
             backoff = min(interval * (2**consecutive_failures), max_backoff)
-            logger.exception(
+            logger.error(
                 "Connection scheduler loop error (attempt %d, next retry in %ds)",
                 consecutive_failures,
                 backoff,

--- a/src/agent_bom/api/demo_refresh.py
+++ b/src/agent_bom/api/demo_refresh.py
@@ -30,4 +30,4 @@ def demo_daily_evidence_dependency() -> None:
 
         refresh_demo_daily_evidence()
     except Exception:  # noqa: BLE001 - a demo refresh must never fail a request
-        _logger.warning("demo estate daily evidence refresh skipped", exc_info=True)
+        _logger.warning("demo estate daily evidence refresh skipped", exc_info=False)

--- a/src/agent_bom/api/export_scheduler.py
+++ b/src/agent_bom/api/export_scheduler.py
@@ -206,7 +206,7 @@ async def export_scheduler_loop(
         except Exception:
             consecutive_failures += 1
             backoff = min(interval * (2**consecutive_failures), max_backoff)
-            logger.exception("Export scheduler loop error (attempt %d, next retry in %ds)", consecutive_failures, backoff)
+            logger.error("Export scheduler loop error (attempt %d, next retry in %ds)", consecutive_failures, backoff)
             await asyncio.sleep(backoff)
             continue
         await asyncio.sleep(interval)

--- a/src/agent_bom/api/hub_observations_partition.py
+++ b/src/agent_bom/api/hub_observations_partition.py
@@ -546,7 +546,7 @@ def run_hub_observations_retention(*, retention_days: int | None = None) -> int:
                 if partitioned:
                     _alert_observation_partition_runway(runway_end, provisioning_failed=True)
                 else:
-                    logger.error("hub observations retention failed on a legacy unpartitioned table", exc_info=True)
+                    logger.error("hub observations retention failed on a legacy unpartitioned table", exc_info=False)
                 return 0
             if partitioned:
                 _alert_observation_partition_runway(observation_runway_end(conn), provisioning_failed=False)
@@ -556,7 +556,7 @@ def run_hub_observations_retention(*, retention_days: int | None = None) -> int:
             "hub observations partition maintenance could not open a maintenance connection; "
             "the %s partition runway cannot be checked or extended",
             OBSERVATIONS_TABLE,
-            exc_info=True,
+            exc_info=False,
         )
         return 0
 

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -2038,7 +2038,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 issuer=presented_issuer or None,
             )
         except Exception:  # pragma: no cover - audit side effects must not block auth
-            _logger.exception("Failed to record trusted proxy authentication audit event")
+            _logger.error("Failed to record trusted proxy authentication audit event")
         return await self._call_with_tenant_context(request, call_next)
 
     async def _call_with_tenant_context(self, request: StarletteRequest, call_next: RequestResponseEndpoint) -> Response:

--- a/src/agent_bom/api/oauth_as.py
+++ b/src/agent_bom/api/oauth_as.py
@@ -156,7 +156,7 @@ class OAuthSigningKey:
                     "to an ephemeral key. Issued access tokens will not survive a restart or be shared "
                     "across replicas. Check that the value contains real newlines — a literal '\\n' "
                     "sequence is the usual cause when the key is pasted into a hosting dashboard.",
-                    exc_info=True,
+                    exc_info=False,
                 )
                 self._private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
                 self._ephemeral = True

--- a/src/agent_bom/api/oidc.py
+++ b/src/agent_bom/api/oidc.py
@@ -46,6 +46,8 @@ from urllib.error import URLError
 from urllib.parse import urlparse
 from urllib.request import urlopen
 
+from agent_bom.security import sanitize_text
+
 logger = logging.getLogger(__name__)
 
 _JWKS_CACHE_TTL = 3600  # seconds — re-fetch public keys every hour
@@ -656,7 +658,7 @@ def describe_oidc_posture() -> dict[str, object]:
     except OIDCError as exc:
         from agent_bom.security import sanitize_error
 
-        logger.warning("OIDC posture config is invalid: %s", sanitize_error(exc))
+        logger.warning("OIDC posture config is invalid: %s", sanitize_text(sanitize_error(exc)))
         return {
             "supported": True,
             "configured": False,

--- a/src/agent_bom/api/partition_maintenance.py
+++ b/src/agent_bom/api/partition_maintenance.py
@@ -470,7 +470,7 @@ def run_partition_retention(
     try:
         from agent_bom.api.postgres_common import _maintenance_connection, bypass_tenant_rls
     except Exception:  # noqa: BLE001 — no Postgres driver available
-        logger.debug("partition retention skipped: postgres_common unavailable", exc_info=True)
+        logger.debug("partition retention skipped: postgres_common unavailable", exc_info=False)
         return {}
 
     for spec in active:
@@ -481,5 +481,5 @@ def run_partition_retention(
                 if created or dropped:
                     results[spec.table] = (created, dropped)
         except Exception:  # noqa: BLE001 — retention must stay fail-open
-            logger.debug("partition retention skipped for %s", spec.table, exc_info=True)
+            logger.debug("partition retention skipped for %s", spec.table, exc_info=False)
     return results

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -37,7 +37,7 @@ from agent_bom.api.stores import (
 )
 from agent_bom.api.tenant_worker import run_tenant_bound
 from agent_bom.config import API_SCAN_WORKER_RECYCLE_JOBS, API_SCAN_WORKERS
-from agent_bom.security import sanitize_error
+from agent_bom.security import sanitize_error, sanitize_text
 
 _logger = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ def request_scan_cancellation(job: ScanJob) -> JobStatus:
     try:
         _get_store().put(job)
     except Exception as persist_exc:  # noqa: BLE001
-        _logger.warning("Failed to persist cancel for job=%s: %s", job.job_id, sanitize_error(persist_exc))
+        _logger.warning("Failed to persist cancel for job=%s: %s", job.job_id, sanitize_text(sanitize_error(persist_exc)))
     _jobs_put(job.job_id, job, compact_terminal=False)
     return status
 
@@ -132,9 +132,9 @@ def _observe_scan_future(done_future: Future | Any) -> None:
     try:
         exc = done_future.exception()
         if exc is not None:
-            _logger.error("Unhandled API scan worker failure", exc_info=(type(exc), exc, exc.__traceback__))
+            _logger.error("Unhandled API scan worker failure: %s", sanitize_text(exc))
     except Exception:  # noqa: BLE001
-        _logger.exception("Failed to observe API scan worker completion")
+        _logger.error("Failed to observe API scan worker completion")
     finally:
         with _executor_lock:
             _executor_active_jobs = max(0, _executor_active_jobs - 1)
@@ -232,7 +232,7 @@ def submit_claimed_scan_job(job: ScanJob, on_complete: Any) -> None:
             try:
                 on_complete(job.job_id)
             except Exception:  # noqa: BLE001
-                _logger.exception("claimed scan on_complete callback failed job=%s", job.job_id)
+                _logger.error("claimed scan on_complete callback failed job=%s", job.job_id)
 
     future.add_done_callback(_done)
 
@@ -573,7 +573,7 @@ def _persist_graph_snapshot(
         if cost_records:
             graph_input = {**report_json, "llm_cost_records": cost_records}
     except Exception as exc:  # noqa: BLE001
-        _logger.debug("graph cost rollup skipped: %s", exc)
+        _logger.debug("graph cost rollup skipped: %s", sanitize_text(exc))
 
     # Store-backed producer (#4055/#4075): auto-on above the entity threshold
     # (or forced via AGENT_BOM_GRAPH_STORE_BACKED_BUILD). Builds into a per-build
@@ -601,7 +601,7 @@ def _persist_graph_snapshot(
 
             link_report_findings_to_graph(report_json, graph)
         except Exception as link_exc:  # noqa: BLE001 — never fail persist on FK stamping
-            _logger.debug("finding↔node persist linking skipped: %s", link_exc)
+            _logger.debug("finding↔node persist linking skipped: %s", sanitize_text(link_exc))
 
         # Annotate CWPP workload nodes with tenant-scoped runtime evidence before
         # persist so investigation loads see it without a second enrich pass.
@@ -616,7 +616,7 @@ def _persist_graph_snapshot(
             wl_index = RuntimeWorkloadEvidenceIndex.from_store(get_runtime_workload_evidence_store(), tenant_id)
             enrich_graph_workload_runtime_evidence(graph, wl_index)
         except Exception as runtime_exc:  # noqa: BLE001 — never fail persist on enrich
-            _logger.debug("workload runtime evidence graph enrich skipped: %s", runtime_exc)
+            _logger.debug("workload runtime evidence graph enrich skipped: %s", sanitize_text(runtime_exc))
 
         from agent_bom.api.postgres_store import reset_current_tenant, set_current_tenant
 
@@ -897,12 +897,12 @@ def _ast_result_for_symbol_reach(paths: Iterable[str]) -> Any | None:
             if not project_has_analyzable_sources(project):
                 continue
         except OSError as path_exc:
-            _logger.debug("AST symbol-reach path skipped for %s: %s", raw, sanitize_error(path_exc))
+            _logger.debug("AST symbol-reach path skipped for %s: %s", raw, sanitize_text(sanitize_error(path_exc)))
             continue
         try:
             result = analyze_project(project)
         except Exception as ast_exc:  # noqa: BLE001
-            _logger.debug("AST symbol-reach analysis skipped for %s: %s", raw, sanitize_error(ast_exc))
+            _logger.debug("AST symbol-reach analysis skipped for %s: %s", raw, sanitize_text(sanitize_error(ast_exc)))
             continue
         if merged is None:
             merged = result
@@ -936,7 +936,7 @@ def _apply_tenant_workflow_metadata(report: Any, *, tenant_id: str) -> None:
     try:
         owner_index = build_tenant_triage_owner_index(tenant_id)
     except Exception as exc:  # noqa: BLE001 - workflow metadata must not fail the scan artifact
-        _logger.warning("Finding owner enrichment unavailable: %s", sanitize_error(exc, generic=True))
+        _logger.warning("Finding owner enrichment unavailable: %s", sanitize_text(sanitize_error(exc, generic=True)))
         owner_index = {}
     observed_at = getattr(report, "generated_at", None)
     observed_text = observed_at.isoformat() if isinstance(observed_at, datetime) else str(observed_at or "")
@@ -979,7 +979,7 @@ def _rendered_result_document(job: ScanJob, report: Any, blast_radii: list | Non
 
         return render_scan_document(report, requested, blast_radii=blast_radii), None
     except Exception as exc:  # noqa: BLE001 — a formatting failure never fails the scan
-        _logger.warning("Rendering scan result as %s failed: %s", requested, sanitize_error(exc, generic=True))
+        _logger.warning("Rendering scan result as %s failed: %s", requested, sanitize_text(sanitize_error(exc, generic=True)))
         return None, f"Requested {requested} output could not be rendered; result carries AI-BOM JSON only"
 
 
@@ -1144,7 +1144,7 @@ def _run_scan_sync(job: ScanJob) -> None:
                 if freshness is None or freshness >= 1 or source_list:
                     sync_db(sources=source_list)
             except Exception as db_exc:  # noqa: BLE001
-                _logger.warning("API auto DB refresh failed: %s", sanitize_error(db_exc))
+                _logger.warning("API auto DB refresh failed: %s", sanitize_text(sanitize_error(db_exc)))
                 warnings_all.append(f"Auto DB refresh skipped: {sanitize_error(db_exc)}")
 
         # ── Discovery phase ──
@@ -1476,7 +1476,7 @@ def _run_scan_sync(job: ScanJob) -> None:
                         pipeline.update_step("output", "Persisting unified graph...")
                         _persist_graph_snapshot(job, report_json, lock=lock)
                     except Exception as graph_exc:  # noqa: BLE001
-                        _logger.warning("Unified graph persistence failed: %s", sanitize_error(graph_exc, generic=True))
+                        _logger.warning("Unified graph persistence failed: %s", sanitize_text(sanitize_error(graph_exc, generic=True)))
                         _record_graph_persistence(job, status="failed", lock=lock)
                         with lock:
                             job.progress.append("Graph persistence failed; scan evidence remains available")
@@ -1587,7 +1587,7 @@ def _run_scan_sync(job: ScanJob) -> None:
                     try:
                         blast_radii = scan_agents_sync(agents, enable_enrichment=False, offline=False, compliance_enabled=True)
                     except Exception as retry_exc:  # noqa: BLE001
-                        _logger.error("Scan retry also failed: %s", sanitize_error(retry_exc))
+                        _logger.error("Scan retry also failed: %s", sanitize_text(sanitize_error(retry_exc)))
                         from agent_bom.scanners.executor import ScannerDriverError, apply_registered_failure_mode
 
                         # Registry marks sca-vulnerability FAIL_CLOSED; honor that after retries.
@@ -1645,7 +1645,7 @@ def _run_scan_sync(job: ScanJob) -> None:
             if suppression["suppressed"]:
                 warnings_all.append(f"{suppression['suppressed']} finding(s) suppressed by tenant feedback/rules")
         except Exception as exc:  # noqa: BLE001
-            _logger.warning("Tenant suppression-rule evaluation skipped: %s", sanitize_error(exc))
+            _logger.warning("Tenant suppression-rule evaluation skipped: %s", sanitize_text(sanitize_error(exc)))
             warnings_all.append("Tenant suppression-rule evaluation skipped")
 
         # ── Analysis phase ──
@@ -1676,7 +1676,7 @@ def _run_scan_sync(job: ScanJob) -> None:
                     with lock:
                         job.progress.append(f"Symbol reachability: stamped {sym_stamped} blast-radius row(s) with function-level evidence")
         except Exception as reach_exc:  # noqa: BLE001
-            _logger.warning("Reachability surfacing skipped: %s", sanitize_error(reach_exc))
+            _logger.warning("Reachability surfacing skipped: %s", sanitize_text(sanitize_error(reach_exc)))
         pipeline.complete_step("analysis", f"Computed {len(blast_radii)} blast radius entries", {"blast_radius": len(blast_radii)})
 
         # ── Output phase ──
@@ -1693,11 +1693,11 @@ def _run_scan_sync(job: ScanJob) -> None:
         try:
             report_findings.extend(evaluate_a2a_auth_posture(agents))
         except Exception as a2a_exc:  # noqa: BLE001
-            _logger.warning("A2A auth posture evaluation skipped: %s", sanitize_error(a2a_exc))
+            _logger.warning("A2A auth posture evaluation skipped: %s", sanitize_text(sanitize_error(a2a_exc)))
         try:
             report_findings.extend(evaluate_mcp_auth_posture(agents))
         except Exception as mcp_auth_exc:  # noqa: BLE001
-            _logger.warning("MCP auth posture evaluation skipped: %s", sanitize_error(mcp_auth_exc))
+            _logger.warning("MCP auth posture evaluation skipped: %s", sanitize_text(sanitize_error(mcp_auth_exc)))
         report = AIBOMReport(
             agents=agents,
             blast_radii=blast_radii,
@@ -1743,7 +1743,7 @@ def _run_scan_sync(job: ScanJob) -> None:
             if _coverage_warnings:
                 report.coverage_warnings = _coverage_warnings
         except Exception as cov_exc:  # noqa: BLE001
-            _logger.debug("coverage-warning attach skipped: %s", sanitize_error(cov_exc))
+            _logger.debug("coverage-warning attach skipped: %s", sanitize_text(sanitize_error(cov_exc)))
 
         # Opt-in estate enrichment (cloud inventory + NHI discovery). Default
         # OFF: no-op and no network I/O unless the per-provider env flags are
@@ -1753,7 +1753,7 @@ def _run_scan_sync(job: ScanJob) -> None:
 
             enrich_report_with_estate_discovery(report)
         except Exception as enrich_exc:  # noqa: BLE001
-            _logger.warning("Estate enrichment skipped: %s", sanitize_error(enrich_exc))
+            _logger.warning("Estate enrichment skipped: %s", sanitize_text(sanitize_error(enrich_exc)))
 
         if req.ai_enrich:
             try:
@@ -1765,7 +1765,7 @@ def _run_scan_sync(job: ScanJob) -> None:
                     deterministic=req.ai_deterministic,
                 )
             except Exception as ai_exc:  # noqa: BLE001
-                _logger.warning("Advisory AI enrichment skipped: %s", sanitize_error(ai_exc, generic=True))
+                _logger.warning("Advisory AI enrichment skipped: %s", sanitize_text(sanitize_error(ai_exc, generic=True)))
                 with lock:
                     job.progress.append("Advisory AI enrichment skipped")
 
@@ -1787,7 +1787,7 @@ def _run_scan_sync(job: ScanJob) -> None:
                 tenant_id=job.tenant_id or "",
             )
         except Exception as gderiv_exc:  # noqa: BLE001
-            _logger.warning("Graph-derived findings surfacing skipped: %s", sanitize_error(gderiv_exc))
+            _logger.warning("Graph-derived findings surfacing skipped: %s", sanitize_text(sanitize_error(gderiv_exc)))
 
         _apply_tenant_workflow_metadata(report, tenant_id=job.tenant_id or "default")
         report_json = to_json(report)
@@ -1820,7 +1820,7 @@ def _run_scan_sync(job: ScanJob) -> None:
                 pipeline.update_step("output", "Persisting unified graph...")
                 _persist_graph_snapshot(job, report_json, lock=lock)
             except Exception as graph_exc:  # noqa: BLE001
-                _logger.warning("Unified graph persistence failed: %s", sanitize_error(graph_exc, generic=True))
+                _logger.warning("Unified graph persistence failed: %s", sanitize_text(sanitize_error(graph_exc, generic=True)))
                 _record_graph_persistence(job, status="failed", lock=lock)
                 with lock:
                     job.progress.append("Graph persistence failed; scan evidence remains available")
@@ -1838,7 +1838,7 @@ def _run_scan_sync(job: ScanJob) -> None:
                         f"open={asset_diff['summary']['total_open']})"
                     )
             except Exception as asset_exc:  # noqa: BLE001
-                _logger.warning("Asset tracker persistence failed: %s", asset_exc)
+                _logger.warning("Asset tracker persistence failed: %s", sanitize_text(asset_exc))
                 with lock:
                     job.progress.append(f"Asset tracker skipped: {sanitize_error(asset_exc)}")
 
@@ -1854,7 +1854,7 @@ def _run_scan_sync(job: ScanJob) -> None:
                     with lock:
                         job.progress.append(f"Local analytics synced scan {recorded_scan_id}")
             except Exception as local_analytics_exc:  # noqa: BLE001
-                _logger.debug("Local analytics persistence skipped: %s", local_analytics_exc)
+                _logger.debug("Local analytics persistence skipped: %s", sanitize_text(local_analytics_exc))
         else:
             with lock:
                 job.progress.append("Result side-effect persistence skipped by request")
@@ -1898,7 +1898,7 @@ def _run_scan_sync(job: ScanJob) -> None:
                     analytics_store.record_compliance_control(control, tenant_id=tenant_id)
                 analytics_store.record_cis_benchmark_checks(analytics.cis_benchmark_checks, tenant_id=tenant_id)
             except Exception as analytics_exc:  # noqa: BLE001
-                _logger.warning("API ClickHouse analytics persistence failed: %s", analytics_exc)
+                _logger.warning("API ClickHouse analytics persistence failed: %s", sanitize_text(analytics_exc))
                 with lock:
                     job.progress.append(f"Analytics sync skipped: {sanitize_error(analytics_exc)}")
 
@@ -1964,7 +1964,7 @@ def _run_scan_sync(job: ScanJob) -> None:
             # compliance/graph reads that load from the store. Reporting it as a
             # clean success would be a lie, so surface the failure on the job
             # the caller polls rather than swallowing it in a finally block.
-            _logger.error("Scan result persistence failed job=%s: %s", job.job_id, persist_exc)
+            _logger.error("Scan result persistence failed job=%s: %s", job.job_id, sanitize_text(persist_exc))
             with lock:
                 job.status = JobStatus.FAILED
                 job.error = f"result not persisted: {sanitize_error(persist_exc)}"
@@ -1985,7 +1985,7 @@ def _run_scan_sync(job: ScanJob) -> None:
 
                 refresh_batch_parent(job.parent_job_id, tenant_id=job.tenant_id or "default")
             except Exception:  # noqa: BLE001
-                _logger.exception("Failed to refresh scan batch parent job=%s child=%s", job.parent_job_id, job.job_id)
+                _logger.error("Failed to refresh scan batch parent job=%s child=%s", job.parent_job_id, job.job_id)
         _release_scan_memory()
         # Update operator-visible scan metrics. The active gauge feeds
         # the KEDA scaler in deploy/helm/agent-bom; the completion

--- a/src/agent_bom/api/postgres_audit.py
+++ b/src/agent_bom/api/postgres_audit.py
@@ -177,7 +177,7 @@ class PostgresAuditLog:
                 "(pre-existing chain forks?); appends will retry but forks cannot "
                 "be rejected at the DB until the existing rows are reconciled",
                 _AUDIT_FORK_GUARD_INDEX,
-                exc_info=True,
+                exc_info=False,
             )
 
     def _hydrate_checkpoints(self) -> None:

--- a/src/agent_bom/api/postgres_common.py
+++ b/src/agent_bom/api/postgres_common.py
@@ -90,7 +90,7 @@ def _audit_rls_bypass_activation(*, caller: str) -> None:
             source_field=caller,
         )
     except Exception:
-        logger.debug("Postgres tenant RLS bypass audit log write failed", exc_info=True)
+        logger.debug("Postgres tenant RLS bypass audit log write failed", exc_info=False)
 
 
 @contextmanager
@@ -491,7 +491,7 @@ def _guard_rls_capable_role(pool: ConnectionPool) -> None:
         # Best-effort probe: a transient connect error or a store mock without a
         # real role table must not mask the primary failure. A genuinely
         # RLS-bypassing role is still caught on the next successful pool use.
-        logger.debug("Postgres RLS role guard could not inspect role attributes", exc_info=True)
+        logger.debug("Postgres RLS role guard could not inspect role attributes", exc_info=False)
         return
 
     _rls_role_checked = True
@@ -542,7 +542,7 @@ def reset_pool() -> None:
             try:
                 close()
             except Exception:
-                logger.debug("Postgres pool close skipped during reset", exc_info=True)
+                logger.debug("Postgres pool close skipped during reset", exc_info=False)
     _pool = None
     _maintenance_pool = None
     _rls_role_checked = False

--- a/src/agent_bom/api/routes/assets.py
+++ b/src/agent_bom/api/routes/assets.py
@@ -52,7 +52,7 @@ async def list_assets(
             "mttr_days": mttr,
         }
     except Exception:
-        _logger.exception("Failed to list assets")
+        _logger.error("Failed to list assets")
         return {
             "schema_version": "vulnerability-assets.v1",
             "scope": _ASSET_SCOPE,
@@ -82,7 +82,7 @@ async def get_asset_stats(request: Request) -> dict:
             "mttr_days": mttr,
         }
     except Exception:
-        _logger.exception("Failed to get asset stats")
+        _logger.error("Failed to get asset stats")
         return {
             "schema_version": "vulnerability-assets.stats.v1",
             "scope": _ASSET_SCOPE,

--- a/src/agent_bom/api/routes/blueprints.py
+++ b/src/agent_bom/api/routes/blueprints.py
@@ -308,4 +308,4 @@ def _emit_decision_event(tenant_id: str, event_type: str, version: dict[str, Any
             },
         )
     except Exception:  # noqa: BLE001
-        logger.warning("blueprint decision event emit failed", exc_info=True)
+        logger.warning("blueprint decision event emit failed", exc_info=False)

--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -51,7 +51,7 @@ from agent_bom.cloud.runtime_workload_evidence import (
 from agent_bom.cloud.runtime_workload_evidence_store import get_runtime_workload_evidence_store
 from agent_bom.config import CLOUD_CIS_TIMEOUT_SECONDS
 from agent_bom.rbac import require_authenticated_permission
-from agent_bom.security import sanitize_log_label
+from agent_bom.security import sanitize_log_label, sanitize_text
 
 router = APIRouter(tags=["cloud"])
 _logger = logging.getLogger(__name__)
@@ -360,7 +360,7 @@ async def cloud_inventory(
     except Exception as exc:  # noqa: BLE001
         # Full diagnostics go to the server log only; the client gets a generic
         # message so no exception/stack detail is exposed over REST.
-        _logger.exception("Cloud inventory failed")
+        _logger.error("Cloud inventory failed")
         raise HTTPException(status_code=500, detail="Cloud inventory failed; see server logs.") from exc
 
 
@@ -541,7 +541,7 @@ async def cloud_cis_benchmark(
         raise
     except Exception as exc:  # noqa: BLE001
         # Full diagnostics to the server log only; client gets a generic message.
-        _logger.exception("Cloud CIS benchmark failed")
+        _logger.error("Cloud CIS benchmark failed")
         raise HTTPException(status_code=500, detail="Cloud CIS benchmark failed; see server logs.") from exc
 
 
@@ -908,7 +908,7 @@ async def cloud_runtime_evidence_ingest(
     except HTTPException:
         raise
     except Exception as exc:  # noqa: BLE001
-        _logger.exception("Runtime evidence ingest failed")
+        _logger.error("Runtime evidence ingest failed")
         raise HTTPException(status_code=500, detail="Runtime evidence ingest failed; see server logs.") from exc
 
 
@@ -1029,7 +1029,7 @@ async def cloud_side_scan_trigger(
         # The specific cause is logged server-side; the external response stays
         # generic so no exception detail reaches the caller (CodeQL:
         # information-exposure-through-an-exception).
-        _logger.info("cloud_side_scan disabled for tenant %s: %s", sanitize_log_label(tenant_id), sanitize_log_label(exc))
+        _logger.info("cloud_side_scan disabled for tenant %s: %s", sanitize_log_label(tenant_id), sanitize_text(sanitize_log_label(exc)))
         return {
             "status": "disabled",
             "execution_id": execution_id,
@@ -1048,7 +1048,7 @@ async def cloud_side_scan_trigger(
             "cloud_side_scan unavailable for %s tenant %s: %s",
             sanitize_log_label(provider),
             sanitize_log_label(tenant_id),
-            sanitize_log_label(exc),
+            sanitize_text(sanitize_log_label(exc)),
         )
         return {
             "status": "unavailable",
@@ -1067,7 +1067,7 @@ async def cloud_side_scan_trigger(
         raise
     except Exception as exc:  # noqa: BLE001
         # The executor still ran guaranteed teardown; do not leak internals.
-        _logger.exception("Cloud side-scan execution failed")
+        _logger.error("Cloud side-scan execution failed")
         raise HTTPException(
             status_code=500, detail="Cloud side-scan failed; see server logs. Temporary resource teardown still ran."
         ) from exc

--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -67,7 +67,7 @@ from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpress
 from agent_bom.cloud.event_ingest import CloudChangeEvent, dispatch_change_event
 from agent_bom.config import CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES
 from agent_bom.rbac import require_authenticated_permission
-from agent_bom.security import sanitize_error
+from agent_bom.security import sanitize_error, sanitize_text
 
 if TYPE_CHECKING:
     from agent_bom.api.models import ScanJob
@@ -385,7 +385,7 @@ async def create_connection(request: Request, body: CloudConnectionCreate, _role
             _logger.error(
                 "Cloud connection scan-on-create enqueue failed connection=%s: %s",
                 record.id,
-                sanitize_error(exc, generic=True),
+                sanitize_text(sanitize_error(exc, generic=True)),
             )
 
     return record.to_public_dict()
@@ -509,7 +509,7 @@ async def ingest_connection_events(
                 _logger.warning(
                     "Connection event ingest dispatch failed for connection %s: %s",
                     record.id,
-                    sanitize_error(exc, generic=True),
+                    sanitize_text(sanitize_error(exc, generic=True)),
                 )
                 results.append(
                     {
@@ -556,7 +556,7 @@ async def ingest_connection_events(
     except HTTPException:
         raise
     except Exception as exc:  # noqa: BLE001
-        _logger.exception("Connection events ingest failed")
+        _logger.error("Connection events ingest failed")
         raise HTTPException(
             status_code=500,
             detail=sanitize_error(exc, generic=True),
@@ -1188,7 +1188,7 @@ def _run_snowflake_connection_scan(
             _logger.warning(
                 "Snowflake estate sweep failed for connection %s; returning agent discovery + CIS only",
                 record.id,
-                exc_info=True,
+                exc_info=False,
             )
     finally:
         # The broker connection is this function's to close (discover / CIS /
@@ -1425,7 +1425,7 @@ def execute_queued_connection_scan(job: ScanJob) -> dict[str, Any]:
             "Cloud connection scan job failed connection=%s job=%s: %s",
             record.id,
             job.job_id,
-            sanitize_error(exc, generic=True),
+            sanitize_text(sanitize_error(exc, generic=True)),
         )
         log_action(
             "cloud_connection.scan",
@@ -1557,7 +1557,7 @@ async def test_connection(request: Request, connection_id: str, _role: Any = _SC
     except Exception as exc:  # noqa: BLE001 - broker failure
         detail = _safe_connection_detail(exc)
         _mark_connection(record, status=STATUS_ERROR, status_detail=detail)
-        _logger.exception("Cloud connection test failed for connection %s", record.id)
+        _logger.error("Cloud connection test failed for connection %s", record.id)
         log_action(
             "cloud_connection.test",
             actor=actor,
@@ -1696,7 +1696,7 @@ async def scan_connection(
             _logger.error(
                 "Cloud connection scan reservation failed connection=%s: %s",
                 record.id,
-                sanitize_error(exc, generic=True),
+                sanitize_text(sanitize_error(exc, generic=True)),
             )
             raise HTTPException(status_code=503, detail="Cloud connection scan could not be queued.") from None
 
@@ -1716,7 +1716,7 @@ async def scan_connection(
             "Cloud connection scan dispatch failed connection=%s job=%s: %s",
             record.id,
             job.job_id,
-            sanitize_error(exc, generic=True),
+            sanitize_text(sanitize_error(exc, generic=True)),
         )
         raise HTTPException(status_code=503, detail="Cloud connection scan could not be queued.") from None
     log_action(

--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -515,7 +515,7 @@ async def list_agents(
             headers={"Retry-After": str(exc.retry_after_seconds)},
         ) from exc
     except Exception as exc:  # noqa: BLE001
-        _logger.warning("Agent discovery failed: %s", sanitize_error(exc, generic=True))
+        _logger.warning("Agent discovery failed: %s", sanitize_text(sanitize_error(exc, generic=True)))
         raise HTTPException(status_code=500, detail=sanitize_error(exc, generic=True)) from exc
 
 
@@ -543,7 +543,7 @@ async def get_agent_mesh(request: Request) -> dict:
     try:
         return await anyio.to_thread.run_sync(_get_agent_mesh_impl, request)
     except Exception as exc:  # noqa: BLE001
-        _logger.exception("Request failed")
+        _logger.error("Request failed")
         raise HTTPException(status_code=500, detail=sanitize_error(exc)) from exc
 
 
@@ -602,7 +602,7 @@ async def get_agent_detail(request: Request, agent_name: str) -> dict:
     except HTTPException:
         raise
     except Exception as exc:  # noqa: BLE001
-        _logger.exception("Agent detail failed")
+        _logger.error("Agent detail failed")
         raise HTTPException(status_code=500, detail=sanitize_error(exc)) from exc
 
 

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -2559,12 +2559,12 @@ async def test_siem_connection(
         )
         return {"siem_type": siem_type, "healthy": healthy}
     except ValueError as exc:
-        _logger.info("Invalid SIEM test request: %s", sanitize_error(exc))
+        _logger.info("Invalid SIEM test request: %s", sanitize_text(sanitize_error(exc)))
         raise HTTPException(status_code=400, detail="Invalid SIEM connector request") from exc
     except Exception as exc:
-        _logger.exception(
+        _logger.error(
             "Unexpected error while testing SIEM connection: %s",
-            sanitize_error(exc),
+            sanitize_text(sanitize_error(exc)),
         )
         log_action(
             "siem.test",

--- a/src/agent_bom/api/routes/entitlements.py
+++ b/src/agent_bom/api/routes/entitlements.py
@@ -27,7 +27,7 @@ def _audit_entitlement_read(request: Request, *, resource: str, details: dict[st
             )
         )
     except Exception:
-        _logger.exception("Failed to append entitlement audit entry")
+        _logger.error("Failed to append entitlement audit entry")
 
 
 @router.get("/entitlements", tags=["enterprise"])

--- a/src/agent_bom/api/routes/governance.py
+++ b/src/agent_bom/api/routes/governance.py
@@ -27,7 +27,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
-from agent_bom.security import sanitize_error
+from agent_bom.security import sanitize_error, sanitize_text
 
 router = APIRouter()
 _logger = logging.getLogger(__name__)
@@ -93,7 +93,7 @@ async def governance_report(days: int = 30) -> dict[str, Any]:
     except HTTPException:
         raise
     except Exception as exc:
-        _logger.exception("Request failed")
+        _logger.error("Request failed")
         raise HTTPException(status_code=500, detail=sanitize_error(exc))
 
 
@@ -158,7 +158,7 @@ async def governance_findings(
     except HTTPException:
         raise
     except Exception as exc:
-        _logger.exception("Request failed")
+        _logger.error("Request failed")
         raise HTTPException(status_code=500, detail=sanitize_error(exc))
 
 
@@ -176,7 +176,7 @@ def _runtime_activity_events(tenant_id: str, *, days: int, sources: list[dict[st
     try:
         records = get_runtime_event_store().list_observations(tenant_id, limit=_ACTIVITY_EVENT_LIMIT)
     except Exception as exc:  # a runtime-store outage must not sink the whole timeline
-        _logger.warning("Runtime activity source unavailable: %s", exc)
+        _logger.warning("Runtime activity source unavailable: %s", sanitize_text(exc))
         sources.append({"source": "runtime", "status": "unavailable", "event_count": 0, "detail": sanitize_error(exc)})
         return []
 
@@ -227,7 +227,7 @@ def _snowflake_activity_events(*, days: int, sources: list[dict[str, Any]]) -> l
     try:
         timeline = cast(dict[str, Any], discover_activity(provider="snowflake", days=days).to_dict())
     except Exception as exc:  # one provider failing must not fail the request
-        _logger.warning("Snowflake activity source unavailable: %s", exc)
+        _logger.warning("Snowflake activity source unavailable: %s", sanitize_text(exc))
         sources.append({"source": "snowflake", "status": "unavailable", "event_count": 0, "detail": sanitize_error(exc)})
         return []
 
@@ -300,7 +300,7 @@ async def activity_timeline(request: Request, days: int = 30) -> dict[str, Any]:
     except HTTPException:
         raise
     except Exception as exc:
-        _logger.exception("Request failed")
+        _logger.error("Request failed")
         raise HTTPException(status_code=500, detail=sanitize_error(exc))
 
 
@@ -339,7 +339,7 @@ async def cortex_telemetry(hours: int = 24) -> dict[str, Any]:
     except HTTPException:
         raise
     except Exception as exc:
-        _logger.exception("Request failed")
+        _logger.error("Request failed")
         raise HTTPException(status_code=500, detail=sanitize_error(exc))
 
 
@@ -369,7 +369,7 @@ async def cortex_agent_telemetry(name: str, hours: int = 24) -> dict[str, Any]:
     except HTTPException:
         raise
     except Exception as exc:
-        _logger.exception("Request failed")
+        _logger.error("Request failed")
         raise HTTPException(status_code=500, detail=sanitize_error(exc))
 
 
@@ -417,7 +417,7 @@ async def cortex_health() -> dict[str, Any]:
     except HTTPException:
         raise
     except Exception as exc:
-        _logger.exception("Request failed")
+        _logger.error("Request failed")
         raise HTTPException(status_code=500, detail=sanitize_error(exc))
 
 

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1810,7 +1810,7 @@ def _enrich_loaded_graph_runtime_evidence(graph: Any, tenant_id: str) -> Any:
         index = RuntimeWorkloadEvidenceIndex.from_store(get_runtime_workload_evidence_store(), tenant_id)
         enrich_graph_workload_runtime_evidence(graph, index)
     except Exception:  # noqa: BLE001 — investigation reads must not fail closed on enrich
-        logger.debug("workload runtime evidence load enrich skipped", exc_info=True)
+        logger.debug("workload runtime evidence load enrich skipped", exc_info=False)
     return graph
 
 
@@ -1887,7 +1887,7 @@ def _ensure_attack_campaigns(graph: UnifiedGraph, paths: list[AttackPath] | None
             result = compute_partitioned_campaigns(graph)
             graph.attack_campaigns = list(result.campaigns)
     except Exception:  # noqa: BLE001 — campaigns are additive; never break investigation reads
-        logger.debug("attack campaign serve-path materialisation skipped", exc_info=True)
+        logger.debug("attack campaign serve-path materialisation skipped", exc_info=False)
 
 
 def _filtered_graph_response(graph: UnifiedGraph, *, offset: int, limit: int) -> dict[str, Any]:
@@ -1967,7 +1967,7 @@ def _overlay_filter_and_respond(
 
             apply_governance_overlay(graph, tenant_id=tenant)
         except Exception:  # noqa: BLE001
-            logger.warning("governance overlay failed", exc_info=True)
+            logger.warning("governance overlay failed", exc_info=False)
     filtered = graph.filtered_view(filters)
     return _filtered_graph_response(filtered, offset=offset, limit=limit)
 
@@ -4401,5 +4401,5 @@ async def get_graph_rollup(
         raise
     except Exception as exc:  # noqa: BLE001
         # Never leak internal exception detail in the response (CodeQL lesson).
-        logger.warning("graph rollup failed", exc_info=True)
+        logger.warning("graph rollup failed", exc_info=False)
         raise HTTPException(status_code=500, detail="Failed to compute graph roll-up") from exc

--- a/src/agent_bom/api/routes/kspm.py
+++ b/src/agent_bom/api/routes/kspm.py
@@ -148,7 +148,7 @@ async def run_cluster_posture(
             headers={"Retry-After": str(exc.retry_after_seconds)},
         ) from exc
     except Exception as exc:  # noqa: BLE001
-        _logger.exception("KSPM cluster posture failed")
+        _logger.error("KSPM cluster posture failed")
         raise HTTPException(status_code=500, detail="KSPM cluster posture failed; see server logs.") from exc
 
     cluster_ref = f"{result.transport or 'unknown'}:{'all' if scope.all_namespaces else scope.namespace}"

--- a/src/agent_bom/api/routes/mitre.py
+++ b/src/agent_bom/api/routes/mitre.py
@@ -81,7 +81,7 @@ def _build_coverage(tenant_id: str, jobs: list[Any]) -> dict[str, Any]:
     try:
         hub_findings = store.list(tenant_id)
     except Exception:  # pragma: no cover - defensive: never fail coverage on a store hiccup
-        _logger.warning("hub store list failed for tenant coverage", exc_info=True)
+        _logger.warning("hub store list failed for tenant coverage", exc_info=False)
         hub_findings = []
     findings.extend(f for f in hub_findings if isinstance(f, dict))
     findings.extend(_native_coverage_findings(jobs))

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -480,7 +480,7 @@ def _persist_llm_costs(body: dict, *, tenant_id: str) -> dict[str, Any]:
 
         calls = parse_ml_api_spans(body)
     except Exception:  # noqa: BLE001
-        _logger.warning("LLM cost ingest skipped", exc_info=True)
+        _logger.warning("LLM cost ingest skipped", exc_info=False)
         return {"calls": 0, "cost_usd": 0.0}
 
     allocation = _allocation_for_spans(body)
@@ -538,7 +538,7 @@ def _screen_trace_content_events(body: dict, *, tenant_id: str) -> list[dict[str
     try:
         findings = screen_trace_content(body)
     except Exception:  # noqa: BLE001 — screening never blocks metadata ingest
-        _logger.warning("Trace content screening skipped", exc_info=True)
+        _logger.warning("Trace content screening skipped", exc_info=False)
         return []
     events: list[dict[str, Any]] = []
     for finding in findings:
@@ -561,7 +561,7 @@ def _screen_trace_content_events(body: dict, *, tenant_id: str) -> list[dict[str
         try:
             _get_analytics_store().record_events(events, tenant_id=tenant_id)
         except Exception:  # noqa: BLE001
-            _logger.warning("Trace content analytics sync skipped", exc_info=True)
+            _logger.warning("Trace content analytics sync skipped", exc_info=False)
         _persist_runtime_observations(events, tenant_id=tenant_id, source="otel_content")
     return events
 
@@ -589,7 +589,7 @@ async def ingest_traces(request: Request, body: dict, screen_content: bool | Non
         # parser exception text back to the client.
         raise HTTPException(status_code=422, detail=sanitize_error(exc)) from exc
     except Exception as exc:  # noqa: BLE001
-        _logger.exception("Request failed")
+        _logger.error("Request failed")
         raise HTTPException(status_code=500, detail=sanitize_error(exc)) from exc
 
 
@@ -665,7 +665,7 @@ def _ingest_traces_sync(body: dict, tenant_id: str, screen: bool) -> dict:
         try:
             _get_analytics_store().record_events(analytics_events, tenant_id=tenant_id)
         except Exception:  # noqa: BLE001
-            _logger.warning("Trace analytics sync skipped", exc_info=True)
+            _logger.warning("Trace analytics sync skipped", exc_info=False)
         _persist_runtime_observations(analytics_events, tenant_id=tenant_id, source="otel")
 
     return {
@@ -773,7 +773,7 @@ def _nhi_by_credential_for_tenant(tenant_id: str) -> dict[str, list[dict[str, An
                             next_frontier.append(edge.target)
                 frontier = next_frontier
     except Exception:  # noqa: BLE001
-        _logger.warning("NHI credential resolution skipped", exc_info=True)
+        _logger.warning("NHI credential resolution skipped", exc_info=False)
         return out
     return out
 

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -661,7 +661,7 @@ def _runtime_snapshot(request: Request, jobs: list[Any]) -> dict[str, Any]:
 
         ctx = _derive_deployment_context(request, jobs)
     except Exception:  # pragma: no cover - defensive; degrade to empty signals
-        _logger.debug("deployment-context derivation failed", exc_info=True)
+        _logger.debug("deployment-context derivation failed", exc_info=False)
         ctx = {}
     active = sum(1 for key in ("has_gateway", "has_proxy", "has_traces", "has_mesh") if ctx.get(key))
     return {
@@ -690,7 +690,7 @@ def _cost_snapshot(request: Request) -> dict[str, Any]:
             "budget_configured": budget is not None,
         }
     except Exception:  # pragma: no cover - cost store optional
-        _logger.debug("cost snapshot failed", exc_info=True)
+        _logger.debug("cost snapshot failed", exc_info=False)
         return {"total_cost_usd": 0.0, "total_calls": 0, "agents": 0, "budget_configured": False}
 
 
@@ -703,7 +703,7 @@ def _identity_snapshot(request: Request) -> dict[str, Any]:
 
         identities = len(get_agent_identity_store().list(tenant_id, limit=1000))
     except Exception:  # pragma: no cover - identity store optional
-        _logger.debug("identity snapshot failed", exc_info=True)
+        _logger.debug("identity snapshot failed", exc_info=False)
 
     fleet_total = 0
     low_trust = 0
@@ -712,7 +712,7 @@ def _identity_snapshot(request: Request) -> dict[str, Any]:
         fleet_total = len(agents)
         low_trust = sum(1 for a in agents if float(getattr(a, "trust_score", 0.0) or 0.0) < 50)
     except Exception:  # pragma: no cover - fleet store optional
-        _logger.debug("fleet snapshot failed", exc_info=True)
+        _logger.debug("fleet snapshot failed", exc_info=False)
 
     return {
         "managed_identities": identities,
@@ -769,7 +769,7 @@ def _hub_severity_snapshot(request: Request) -> dict[str, int]:
                 return empty
             counts = breakdown(tenant_id) or {}
     except Exception:  # pragma: no cover - hub store optional
-        _logger.debug("hub severity snapshot failed", exc_info=True)
+        _logger.debug("hub severity snapshot failed", exc_info=False)
         return empty
     for key, value in counts.items():
         empty[str(key).lower()] = empty.get(str(key).lower(), 0) + int(value or 0)
@@ -805,7 +805,7 @@ def _hub_kev_snapshot(request: Request) -> int:
         since = time_window.window_since_iso(time_window.normalize_window_days(None))
         count = int(counter(tenant_id, origin="bulk_ingest", since=since) or 0)
     except Exception:  # pragma: no cover - hub store optional
-        _logger.debug("hub kev snapshot failed", exc_info=True)
+        _logger.debug("hub kev snapshot failed", exc_info=False)
         return 0
     hub_overview_cache.set_cached_kev(tenant_id, count)
     return count
@@ -848,7 +848,7 @@ def _hub_top_risks(request: Request, *, limit: int = _HUB_TOP_RISK_LIMIT) -> lis
             include_total=False,
         )
     except Exception:  # pragma: no cover - hub store optional
-        _logger.debug("hub top risks failed", exc_info=True)
+        _logger.debug("hub top risks failed", exc_info=False)
         return []
     rows = page[0] if isinstance(page, tuple) else page
     return [_finding_top_risk(row) for row in rows or [] if isinstance(row, dict)]
@@ -1007,7 +1007,7 @@ def _cloud_account_count(request: Request) -> int:
 
         return len(get_connection_store().list_for_tenant(_tenant_id(request)))
     except Exception:  # pragma: no cover - connection store optional
-        _logger.debug("cloud account snapshot failed", exc_info=True)
+        _logger.debug("cloud account snapshot failed", exc_info=False)
         return 0
 
 

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -1038,7 +1038,7 @@ def _ws_auth_required() -> bool:
 
         return get_auth_posture().auth_required
     except Exception:
-        _logger.warning("websocket auth posture unavailable; requiring authentication", exc_info=True)
+        _logger.warning("websocket auth posture unavailable; requiring authentication", exc_info=False)
         return True
 
 

--- a/src/agent_bom/api/routes/runtime_blueprints.py
+++ b/src/agent_bom/api/routes/runtime_blueprints.py
@@ -86,7 +86,7 @@ async def get_runtime_blueprint_drift(request: Request, blueprint_id: str) -> di
                 },
             )
     except Exception:  # noqa: BLE001
-        logger.warning("drift incident persistence failed", exc_info=True)
+        logger.warning("drift incident persistence failed", exc_info=False)
     return result
 
 
@@ -189,5 +189,5 @@ def _promote_accepted_drift(tenant_id: str, incident: Any, blueprint_id_override
             "version_id": version.version_id,
         }
     except Exception:  # noqa: BLE001
-        logger.warning("drift-accept blueprint promotion failed", exc_info=True)
+        logger.warning("drift-accept blueprint promotion failed", exc_info=False)
         return None

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -91,7 +91,7 @@ from agent_bom.finding_scope import (
     FindingClass,
     canonical_finding_severity_filter,
 )
-from agent_bom.security import sanitize_error
+from agent_bom.security import sanitize_error, sanitize_text
 
 router = APIRouter()
 _logger = logging.getLogger(__name__)
@@ -1430,7 +1430,7 @@ def enqueue_scan_job(
             _logger.error(
                 "Failed to persist scan dispatch failure job=%s: %s",
                 job.job_id,
-                sanitize_error(persist_exc, generic=True),
+                sanitize_text(sanitize_error(persist_exc, generic=True)),
             )
         _jobs_put(job.job_id, job, compact_terminal=True)
         try:
@@ -1440,7 +1440,7 @@ def enqueue_scan_job(
         _logger.error(
             "Scan dispatch failed job=%s: %s",
             job.job_id,
-            sanitize_error(exc, generic=True),
+            sanitize_text(sanitize_error(exc, generic=True)),
         )
         raise RuntimeError("Scan dispatch failed before execution.") from None
     return job
@@ -2773,7 +2773,7 @@ def _project_findings_reachability(
             )
         return projection.rows, warnings
     except Exception as exc:  # noqa: BLE001 — optional evidence must not fail the findings list
-        _logger.warning("Finding graph reachability projection skipped: %s", sanitize_error(exc))
+        _logger.warning("Finding graph reachability projection skipped: %s", sanitize_text(sanitize_error(exc)))
         warnings.append("Graph reachability evidence is unavailable for this page; unmatched findings remain unassessed.")
         return rows, warnings
 

--- a/src/agent_bom/api/scan_queue.py
+++ b/src/agent_bom/api/scan_queue.py
@@ -117,7 +117,7 @@ class DistributedScanWorker:
             try:
                 await asyncio.to_thread(self._tick)
             except Exception:  # noqa: BLE001
-                _logger.exception("Distributed scan worker tick failed id=%s", self._worker_id)
+                _logger.error("Distributed scan worker tick failed id=%s", self._worker_id)
             try:
                 await asyncio.wait_for(self._stop.wait(), timeout=self._poll)
             except asyncio.TimeoutError:
@@ -147,7 +147,7 @@ class DistributedScanWorker:
                 # Could not hand off locally (e.g. executor draining): drop the
                 # claim so another tick/replica can reclaim it after lease expiry.
                 self._inflight.discard(job.job_id)
-                _logger.exception("Failed to submit claimed job=%s; will be reclaimed", job.job_id)
+                _logger.error("Failed to submit claimed job=%s; will be reclaimed", job.job_id)
                 break
 
     def _on_complete(self, job_id: str) -> None:
@@ -155,4 +155,4 @@ class DistributedScanWorker:
         try:
             self._store.complete_dispatch(job_id)
         except Exception:  # noqa: BLE001
-            _logger.exception("Failed to clear dispatch row job=%s", job_id)
+            _logger.error("Failed to clear dispatch row job=%s", job_id)

--- a/src/agent_bom/api/scheduler.py
+++ b/src/agent_bom/api/scheduler.py
@@ -152,7 +152,7 @@ async def scheduler_loop(
                 return conn
             pool.putconn(conn)
         except Exception:
-            logger.exception("Failed to acquire scheduler leader lock")
+            logger.error("Failed to acquire scheduler leader lock")
         return None
 
     try:
@@ -196,14 +196,14 @@ async def scheduler_loop(
                             finally:
                                 reset_current_tenant(tenant_token)
                     except Exception:
-                        logger.exception("Failed to trigger scheduled scan: %s", schedule.name)
+                        logger.error("Failed to trigger scheduled scan: %s", schedule.name)
 
                 # Success — reset backoff counter
                 consecutive_failures = 0
             except Exception:
                 consecutive_failures += 1
                 backoff = min(interval_seconds * (2**consecutive_failures), max_backoff)
-                logger.exception(
+                logger.error(
                     "Scheduler loop error (attempt %d, next retry in %ds)",
                     consecutive_failures,
                     backoff,
@@ -220,4 +220,4 @@ async def scheduler_loop(
                 leader_conn.execute("SELECT pg_advisory_unlock(%s)", (_SCHEDULER_LEADER_LOCK_ID,))
                 _get_pool().putconn(leader_conn)
             except Exception:
-                logger.exception("Failed to release scheduler leader lock")
+                logger.error("Failed to release scheduler leader lock")

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -480,7 +480,7 @@ async def _lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
                 set_analytics_store(base_store)
                 _logger.info("ClickHouse analytics store enabled without buffering")
         except Exception:
-            _logger.warning("ClickHouse analytics unavailable, using NullAnalyticsStore", exc_info=True)
+            _logger.warning("ClickHouse analytics unavailable, using NullAnalyticsStore", exc_info=False)
 
     # ── Rate-limit key rotation status ──
     try:
@@ -508,7 +508,7 @@ async def _lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
                 _rl_status["age_days"],
             )
     except Exception:
-        _logger.debug("rate_limit_key_rotation status check skipped", exc_info=True)
+        _logger.debug("rate_limit_key_rotation status check skipped", exc_info=False)
 
     global _cleanup_task
     from agent_bom.api.scan_job_reconciliation import fail_orphaned_active_scan_jobs, reconcile_scan_jobs_active
@@ -518,7 +518,7 @@ async def _lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
         fail_orphaned_active_scan_jobs(store)
         reconcile_scan_jobs_active(store)
     except Exception:  # noqa: BLE001
-        _logger.debug("scan job metric startup reconciliation skipped", exc_info=True)
+        _logger.debug("scan job metric startup reconciliation skipped", exc_info=False)
 
     _cleanup_task = asyncio.create_task(_cleanup_loop())
 
@@ -627,7 +627,7 @@ async def _lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
             _scan_worker = DistributedScanWorker(_scan_store)
             await _scan_worker.start()
     except Exception:  # noqa: BLE001
-        _logger.exception("Distributed scan worker failed to start; continuing single-node")
+        _logger.error("Distributed scan worker failed to start; continuing single-node")
         _scan_worker = None
 
     if os.environ.get("AGENT_BOM_DEMO_ESTATE", "").strip().lower() in {"1", "true", "yes", "on"}:
@@ -636,7 +636,7 @@ async def _lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
 
             await asyncio.to_thread(maybe_bootstrap_demo_estate)
         except Exception:  # noqa: BLE001
-            _logger.warning("demo estate bootstrap skipped", exc_info=True)
+            _logger.warning("demo estate bootstrap skipped", exc_info=False)
 
     yield
 
@@ -651,7 +651,7 @@ async def _lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
         try:
             await _scan_worker.stop()
         except Exception:  # noqa: BLE001
-            _logger.debug("scan worker stop skipped", exc_info=True)
+            _logger.debug("scan worker stop skipped", exc_info=False)
     if _scheduler_task:
         _scheduler_task.cancel()
     if _connection_scheduler_task:
@@ -689,7 +689,7 @@ async def _lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
         if _stores._analytics_store is not None and hasattr(_stores._analytics_store, "close"):
             _stores._analytics_store.close()
     except Exception:
-        _logger.debug("Analytics store close skipped", exc_info=True)
+        _logger.debug("Analytics store close skipped", exc_info=False)
 
 
 app = FastAPI(
@@ -1145,7 +1145,7 @@ async def _cleanup_tick() -> None:
         if demo_estate_enabled():
             await asyncio.to_thread(maybe_bootstrap_demo_estate)
     except Exception:  # noqa: BLE001
-        _logger.warning("demo estate cleanup-loop reseed skipped", exc_info=True)
+        _logger.warning("demo estate cleanup-loop reseed skipped", exc_info=False)
     # Tier-B replay-log TTL purge (#2261). Wrapped so a backend hiccup
     # never takes down the whole cleanup loop.
     try:
@@ -1155,7 +1155,7 @@ async def _cleanup_tick() -> None:
         if removed:
             _logger.info("proxy_replay_log cleanup removed %d expired rows", removed)
     except Exception:  # noqa: BLE001
-        _logger.debug("proxy_replay_log cleanup skipped", exc_info=True)
+        _logger.debug("proxy_replay_log cleanup skipped", exc_info=False)
     # Hub observations partition retention (#3463). Postgres-only; no-op on
     # SQLite and legacy unpartitioned tables. Fail-open like other cleanup
     # hooks so a backend hiccup never stops the loop.
@@ -1169,7 +1169,7 @@ async def _cleanup_tick() -> None:
                 dropped_partitions,
             )
     except Exception:  # noqa: BLE001
-        _logger.debug("hub observations retention skipped", exc_info=True)
+        _logger.debug("hub observations retention skipped", exc_info=False)
     # Generic partition maintenance for the other append-only tables (#3463):
     # ensure next partitions exist and roll over expired ones. Postgres-only;
     # a strict no-op on SQLite and on any table an operator has not converted
@@ -1186,7 +1186,7 @@ async def _cleanup_tick() -> None:
                 partitions_dropped,
             )
     except Exception:  # noqa: BLE001
-        _logger.debug("partition maintenance skipped", exc_info=True)
+        _logger.debug("partition maintenance skipped", exc_info=False)
     # NHI lifecycle enforcement (#nhi): expire lingering JIT grants, opt-in
     # dormant-identity deprovision, advisory token rotation-due flagging.
     # Backend-agnostic and fail-open — a store error logs and is skipped so
@@ -1222,7 +1222,7 @@ async def _cleanup_tick() -> None:
     except Exception:  # noqa: BLE001 — cleanup must never crash the loop
         _logger.warning(
             "nhi lifecycle cleanup skipped this tick; check the agent-identity store and governance audit-log backend connectivity",
-            exc_info=True,
+            exc_info=False,
         )
     # Managed-trial lifecycle: access is revoked at expiry, while data is
     # deleted only after the configured grace period. This hook is opt-in
@@ -1243,7 +1243,7 @@ async def _cleanup_tick() -> None:
     except Exception:  # noqa: BLE001 — lifecycle cleanup remains retryable
         _logger.warning(
             "managed-trial lifecycle cleanup skipped this tick; check the lifecycle and tenant stores",
-            exc_info=True,
+            exc_info=False,
         )
     # Unstick jobs that have been RUNNING for too long
     try:

--- a/src/agent_bom/api/side_scan_scheduler.py
+++ b/src/agent_bom/api/side_scan_scheduler.py
@@ -243,7 +243,7 @@ def run_scheduled_side_scan_once(
         logger.warning("Scheduled side-scan unavailable for %s target %s", target.provider, target.target_id)
         return {**base, "status": "unavailable"}
     except Exception:  # noqa: BLE001 - one bad target never raises to the loop
-        logger.exception("Scheduled side-scan failed for %s target %s", target.provider, target.target_id)
+        logger.error("Scheduled side-scan failed for %s target %s", target.provider, target.target_id)
         return {**base, "status": "failed"}
 
     record = get_side_scan_state_store(state_db_path=state_db_path).get(
@@ -288,7 +288,7 @@ async def schedule_provider_side_scans(
             try:
                 return await asyncio.to_thread(runner, target)
             except Exception:  # noqa: BLE001 - isolate a raising runner (e.g. injected fake)
-                logger.exception("Scheduled side-scan runner raised for target %s", target.target_id)
+                logger.error("Scheduled side-scan runner raised for target %s", target.target_id)
                 return {
                     "provider": target.provider,
                     "target_id": target.target_id,
@@ -325,7 +325,7 @@ async def side_scan_scheduler_loop(
         except Exception:
             consecutive_failures += 1
             backoff = min(interval * (2**consecutive_failures), max_backoff)
-            logger.exception(
+            logger.error(
                 "Side-scan scheduler loop error (attempt %d, next retry in %ds)",
                 consecutive_failures,
                 backoff,

--- a/src/agent_bom/api/tenant_quota.py
+++ b/src/agent_bom/api/tenant_quota.py
@@ -116,7 +116,7 @@ def _maybe_postgres_advisory_lock(tenant_id: str) -> Iterator[None]:
                 "tenant_quota_guard could not acquire Postgres advisory lock for tenant=%s in clustered mode: %s. "
                 "Refusing the request to avoid cross-replica quota overshoot.",
                 tenant_id,
-                exc,
+                sanitize_text(exc),
             )
             raise HTTPException(
                 status_code=503,
@@ -129,7 +129,7 @@ def _maybe_postgres_advisory_lock(tenant_id: str) -> Iterator[None]:
         _logger.warning(
             "tenant_quota_guard could not acquire Postgres advisory lock for tenant=%s: %s. Falling back to per-process serialisation.",
             tenant_id,
-            exc,
+            sanitize_text(exc),
         )
         yield
         return

--- a/src/agent_bom/api/trend_recording.py
+++ b/src/agent_bom/api/trend_recording.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from agent_bom.baseline import TrendPoint
-from agent_bom.security import sanitize_error
+from agent_bom.security import sanitize_error, sanitize_text
 
 _logger = logging.getLogger(__name__)
 _SEVERITIES = ("critical", "high", "medium", "low")
@@ -97,6 +97,6 @@ def record_scan_trend_best_effort(
 
         _get_trend_store().record(point)
     except Exception as exc:  # noqa: BLE001 - trend history must not fail a completed scan
-        _logger.warning("Posture trend persistence skipped: %s", sanitize_error(exc, generic=True))
+        _logger.warning("Posture trend persistence skipped: %s", sanitize_text(sanitize_error(exc, generic=True)))
         return False
     return True

--- a/src/agent_bom/api/webhook_store.py
+++ b/src/agent_bom/api/webhook_store.py
@@ -290,10 +290,10 @@ def emit_governance_event(
                 target_outbox.enqueue(event, destination)
                 enqueued += 1
             except Exception:  # noqa: BLE001
-                logger.warning("webhook enqueue failed for subscription %s", sub.subscription_id, exc_info=True)
+                logger.warning("webhook enqueue failed for subscription %s", sub.subscription_id, exc_info=False)
         return enqueued
     except Exception:  # noqa: BLE001
-        logger.warning("governance webhook emit failed for %s", event_type, exc_info=True)
+        logger.warning("governance webhook emit failed for %s", event_type, exc_info=False)
         return 0
 
 

--- a/src/agent_bom/cloud/aisvs_benchmark.py
+++ b/src/agent_bom/cloud/aisvs_benchmark.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from agent_bom.cloud.aws_cis_benchmark import CheckStatus, CISCheckResult
+from agent_bom.security import sanitize_text
 
 logger = logging.getLogger(__name__)
 
@@ -519,7 +520,7 @@ def _check_ai_7_2() -> CISCheckResult:
                 if not digest:
                     unverifiable.append(f"{tag_path.parent.name}:{tag_path.name}")
             except Exception as exc:  # noqa: BLE001
-                logger.debug("Could not parse model manifest %s: %s", tag_path, exc)
+                logger.debug("Could not parse model manifest %s: %s", tag_path, sanitize_text(exc))
                 unverifiable.append(str(tag_path.name))
 
         if total == 0:
@@ -636,7 +637,7 @@ def run_benchmark(
             else:
                 result = check_fn()
         except Exception as exc:
-            logger.warning("AISVS check %s failed with exception: %s", check_id, exc)
+            logger.warning("AISVS check %s failed with exception: %s", check_id, sanitize_text(exc))
             result = CISCheckResult(
                 check_id=check_id,
                 title=f"Check {check_id}",

--- a/src/agent_bom/cloud/aws.py
+++ b/src/agent_bom/cloud/aws.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from agent_bom.discovery_envelope import DiscoveryEnvelope, RedactionStatus, ScanMode
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
+from agent_bom.security import sanitize_text
 
 from .base import CloudDiscoveryError
 from .normalization import (
@@ -408,7 +409,7 @@ def _resolve_account_id(session: Any) -> str | None:
     try:
         identity = session.client("sts").get_caller_identity()
     except Exception as exc:
-        logger.debug("Could not resolve AWS account ID via STS: %s", exc)
+        logger.debug("Could not resolve AWS account ID via STS: %s", sanitize_text(exc))
         return None
     account_id = str(identity.get("Account", "")).strip()
     return account_id or None
@@ -852,7 +853,7 @@ def _extract_tools_from_schema(action_group_detail: dict) -> list[MCPTool]:
                         )
                     )
     except (json.JSONDecodeError, TypeError) as exc:
-        logger.warning("Failed to parse OpenAPI spec for Lambda tool extraction: %s", exc)
+        logger.warning("Failed to parse OpenAPI spec for Lambda tool extraction: %s", sanitize_text(exc))
 
     return tools
 

--- a/src/agent_bom/cloud/aws_cis_benchmark.py
+++ b/src/agent_bom/cloud/aws_cis_benchmark.py
@@ -61,6 +61,8 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Callable
 
+from agent_bom.security import sanitize_text
+
 from .aws_inventory import is_access_denied_error
 from .base import CloudDiscoveryError
 
@@ -1067,7 +1069,7 @@ def _check_2_1_2(s3_client: Any) -> CISCheckResult:
                 denied.append(name)
             else:
                 # Skip buckets we can't access (cross-region, deleted, etc.)
-                logger.debug("Could not check encryption for bucket %s: %s", name, exc)
+                logger.debug("Could not check encryption for bucket %s: %s", name, sanitize_text(exc))
 
     if unencrypted:
         result.status = CheckStatus.FAIL
@@ -1111,7 +1113,7 @@ def _check_2_1_3(s3_client: Any) -> CISCheckResult:
         except Exception as exc:
             if is_access_denied_error(exc):
                 denied.append(name)
-            logger.debug("Could not check MFA Delete for bucket %s: %s", name, exc)
+            logger.debug("Could not check MFA Delete for bucket %s: %s", name, sanitize_text(exc))
 
     if no_mfa_delete:
         result.status = CheckStatus.FAIL
@@ -1156,7 +1158,7 @@ def _check_2_1_4(s3_client: Any) -> CISCheckResult:
             # Skip inaccessible buckets (permissions, deleted, etc.)
             if is_access_denied_error(exc):
                 denied.append(name)
-            logger.debug("Could not check versioning for bucket %s: %s", name, exc)
+            logger.debug("Could not check versioning for bucket %s: %s", name, sanitize_text(exc))
 
     if unversioned:
         result.status = CheckStatus.FAIL
@@ -1195,7 +1197,7 @@ def _check_2_2_1(ec2_client: Any) -> CISCheckResult:
             result.evidence = "EBS volume encryption is enabled by default."
     except Exception as exc:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
-        logger.debug("Could not check EBS default encryption: %s (%s)", exc, error_code)
+        logger.debug("Could not check EBS default encryption: %s (%s)", sanitize_text(exc), error_code)
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not check EBS encryption default: {error_code or exc}"
     return result
@@ -1296,7 +1298,7 @@ def _check_2_4_1(kms_client: Any) -> CISCheckResult:
                 if is_access_denied_error(exc):
                     denied.append(key_id)
                     continue
-                logger.debug("Could not check rotation for key %s: %s", key_id, exc)
+                logger.debug("Could not check rotation for key %s: %s", key_id, sanitize_text(exc))
 
     if no_rotation:
         result.status = CheckStatus.FAIL
@@ -1489,7 +1491,7 @@ def _check_3_6(s3_client: Any, cloudtrail_client: Any) -> CISCheckResult:
             # Skip inaccessible buckets
             if is_access_denied_error(exc):
                 denied.append(bucket_name)
-            logger.debug("Could not check logging for bucket %s: %s", bucket_name, exc)
+            logger.debug("Could not check logging for bucket %s: %s", bucket_name, sanitize_text(exc))
 
     if no_logging:
         result.status = CheckStatus.FAIL
@@ -1552,7 +1554,7 @@ def _check_3_3(s3_client: Any, cloudtrail_client: Any) -> CISCheckResult:
             if is_access_denied_error(exc):
                 denied.append(bucket_name)
                 continue
-            logger.debug("Could not check bucket policy for %s: %s", bucket_name, exc)
+            logger.debug("Could not check bucket policy for %s: %s", bucket_name, sanitize_text(exc))
 
     if public_buckets:
         result.status = CheckStatus.FAIL
@@ -1851,7 +1853,7 @@ def _check_4_3(logs_client: Any, cloudwatch_client: Any) -> CISCheckResult:
                 result.evidence = "A root account usage metric filter exists, but no CloudWatch alarm targets its metric."
     except Exception as exc:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
-        logger.debug("Could not check metric filters: %s (%s)", exc, error_code)
+        logger.debug("Could not check metric filters: %s (%s)", sanitize_text(exc), error_code)
         result.status = CheckStatus.ERROR
         result.evidence = _safe_error_evidence("Could not query metric filters and alarms.", error_code)
     return result
@@ -1905,7 +1907,7 @@ def _check_4_4(logs_client: Any, cloudwatch_client: Any = None) -> CISCheckResul
             result.evidence = "Metric filter for IAM policy changes exists."
     except Exception as exc:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
-        logger.debug("Could not check metric filters: %s (%s)", exc, error_code)
+        logger.debug("Could not check metric filters: %s (%s)", sanitize_text(exc), error_code)
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not query metric filters: {error_code or exc}"
     if result.status is CheckStatus.PASS:
@@ -1965,7 +1967,7 @@ def _check_4_5(logs_client: Any, cloudtrail_client: Any, cloudwatch_client: Any 
             result.evidence = "Metric filter for CloudTrail configuration changes exists."
     except Exception as exc:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
-        logger.debug("Could not check metric filters: %s (%s)", exc, error_code)
+        logger.debug("Could not check metric filters: %s (%s)", sanitize_text(exc), error_code)
         result.status = CheckStatus.ERROR
         result.evidence = _safe_error_evidence("Could not query metric filters.", error_code)
     if result.status is CheckStatus.PASS:
@@ -2799,7 +2801,7 @@ def _check_5_1(ec2_client: Any) -> CISCheckResult:
                         break
     except Exception as exc:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
-        logger.debug("Could not check NACLs: %s (%s)", exc, error_code)
+        logger.debug("Could not check NACLs: %s (%s)", sanitize_text(exc), error_code)
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not query Network ACLs: {error_code or exc}"
         return result
@@ -2853,7 +2855,7 @@ def _check_5_4(ec2_client: Any) -> CISCheckResult:
             result.evidence = "All VPC peering routes use specific CIDR ranges."
     except Exception as exc:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
-        logger.debug("Could not check route tables: %s (%s)", exc, error_code)
+        logger.debug("Could not check route tables: %s (%s)", sanitize_text(exc), error_code)
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not query route tables: {error_code or exc}"
     return result
@@ -2998,7 +3000,7 @@ def run_benchmark(
         account_id = sts.get_caller_identity()["Account"]
     except Exception as exc:
         # Account ID lookup is non-fatal; continue with empty value
-        logger.debug("Could not get AWS account ID: %s", exc)
+        logger.debug("Could not get AWS account ID: %s", sanitize_text(exc))
 
     report = CISBenchmarkReport(
         region=resolved_region,
@@ -3045,7 +3047,7 @@ def run_benchmark(
                 )
             )
         except Exception as exc:
-            logger.warning("CIS check %s failed: %s", check_id, exc)
+            logger.warning("CIS check %s failed: %s", check_id, sanitize_text(exc))
             report.checks.append(
                 CISCheckResult(
                     check_id=check_id,
@@ -3390,7 +3392,7 @@ def run_all_account_benchmarks(
     try:
         account_ids = aws_organizations.list_member_account_ids(profile, force=True, session=session)
     except Exception as exc:  # noqa: BLE001 — org enumeration failure must degrade, not crash
-        logger.warning("AWS org account enumeration failed: %s", sanitize_discovery_warning(exc))
+        logger.warning("AWS org account enumeration failed: %s", sanitize_text(sanitize_discovery_warning(exc)))
         account_ids = []
 
     if not account_ids:

--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -42,6 +42,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 from agent_bom.discovery_envelope import DiscoveryEnvelope, RedactionStatus, ScanMode
+from agent_bom.security import sanitize_text
 
 from .aws import (
     _account_id_from_arn,
@@ -781,7 +782,7 @@ def discover_all_account_inventories(
     try:
         account_ids = aws_organizations.list_member_account_ids(profile, force=True, session=session)
     except Exception as exc:  # noqa: BLE001 — org enumeration failure must degrade, not crash
-        logger.warning("AWS org account enumeration failed: %s", sanitize_discovery_warning(exc))
+        logger.warning("AWS org account enumeration failed: %s", sanitize_text(sanitize_discovery_warning(exc)))
         account_ids = []
 
     if not account_ids:
@@ -824,7 +825,7 @@ def discover_all_account_inventories(
             try:
                 payloads.append(future.result())
             except Exception as exc:  # noqa: BLE001 — one account's failure must not sink the rest
-                logger.warning("AWS inventory failed for account %s: %s", account_id, sanitize_discovery_warning(exc))
+                logger.warning("AWS inventory failed for account %s: %s", account_id, sanitize_text(sanitize_discovery_warning(exc)))
                 payloads.append(
                     {
                         **_empty_payload(region=""),

--- a/src/agent_bom/cloud/azure.py
+++ b/src/agent_bom/cloud/azure.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
+from agent_bom.security import sanitize_text
 
 from .base import CloudDiscoveryError
 from .normalization import build_cloud_origin, build_cloud_principal, build_cloud_scope, build_cloud_timestamps, build_package_purl
@@ -554,7 +555,7 @@ def _discover_azure_functions(
                         )
                 except Exception as exc:
                     # Site config read is best-effort
-                    logger.debug("Could not read site config for function app %s: %s", app_name, exc)
+                    logger.debug("Could not read site config for function app %s: %s", app_name, sanitize_text(exc))
 
             from agent_bom.cloud.serverless_zip import extract_azure_function_packages
 
@@ -773,7 +774,7 @@ def _discover_ml_endpoints(
                             )
                     except Exception as exc:
                         # Deployment listing is best-effort
-                        logger.debug("Could not list deployments for endpoint %s: %s", ep_name, exc)
+                        logger.debug("Could not list deployments for endpoint %s: %s", ep_name, sanitize_text(exc))
 
                     server = MCPServer(
                         name=f"ml-endpoint:{ep_name}",

--- a/src/agent_bom/cloud/azure_cis_benchmark.py
+++ b/src/agent_bom/cloud/azure_cis_benchmark.py
@@ -50,7 +50,7 @@ import os
 from dataclasses import dataclass, field
 from typing import Any
 
-from agent_bom.security import sanitize_error
+from agent_bom.security import sanitize_error, sanitize_text
 
 from .aws_cis_benchmark import CheckStatus, CISCheckResult, finalize_read_coverage
 from .aws_inventory import is_access_denied_error
@@ -1357,7 +1357,7 @@ def _check_3_10(storage_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(acct_name)
-                logger.debug("Could not check soft delete for %s: %s", acct_name, exc)
+                logger.debug("Could not check soft delete for %s: %s", acct_name, sanitize_text(exc))
 
         if failing:
             result.status = CheckStatus.FAIL
@@ -1654,7 +1654,7 @@ def _check_4_1_1(sql_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(server_name)
-                logger.debug("Could not check auditing for SQL server %s: %s", server_name, exc)
+                logger.debug("Could not check auditing for SQL server %s: %s", server_name, sanitize_text(exc))
 
         if failing:
             result.status = CheckStatus.FAIL
@@ -1745,7 +1745,7 @@ def _check_4_1_2(sql_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(server_name)
-                logger.debug("Could not check TDE for SQL server %s: %s", server_name, exc)
+                logger.debug("Could not check TDE for SQL server %s: %s", server_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"SQL servers without TDE configured: {', '.join(failing)}"
@@ -1797,7 +1797,7 @@ def _check_4_1_3(sql_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(server_name)
-                logger.debug("Could not check AD admin for SQL server %s: %s", server_name, exc)
+                logger.debug("Could not check AD admin for SQL server %s: %s", server_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"SQL servers without Azure AD admin: {', '.join(failing)}"
@@ -1850,7 +1850,7 @@ def _check_4_1_4(sql_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(server_name)
-                logger.debug("Could not check ATP for SQL server %s: %s", server_name, exc)
+                logger.debug("Could not check ATP for SQL server %s: %s", server_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"SQL servers without Advanced Threat Protection: {', '.join(failing)}"
@@ -2007,7 +2007,7 @@ def _check_4_2_3(mysql_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(server_name)
-                logger.debug("Could not check log_checkpoints for MySQL server %s: %s", server_name, exc)
+                logger.debug("Could not check log_checkpoints for MySQL server %s: %s", server_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"MySQL servers with log_checkpoints disabled: {', '.join(failing)}"
@@ -2091,7 +2091,7 @@ def _check_4_3_2(postgresql_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(server_name)
-                logger.debug("Could not check log_checkpoints for PostgreSQL server %s: %s", server_name, exc)
+                logger.debug("Could not check log_checkpoints for PostgreSQL server %s: %s", server_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"PostgreSQL servers with log_checkpoints disabled: {', '.join(failing)}"
@@ -2144,7 +2144,7 @@ def _check_4_3_3(postgresql_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(server_name)
-                logger.debug("Could not check log_connections for PostgreSQL server %s: %s", server_name, exc)
+                logger.debug("Could not check log_connections for PostgreSQL server %s: %s", server_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"PostgreSQL servers with log_connections disabled: {', '.join(failing)}"
@@ -2197,7 +2197,7 @@ def _check_4_3_4(postgresql_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(server_name)
-                logger.debug("Could not check log_disconnections for PostgreSQL server %s: %s", server_name, exc)
+                logger.debug("Could not check log_disconnections for PostgreSQL server %s: %s", server_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"PostgreSQL servers with log_disconnections disabled: {', '.join(failing)}"
@@ -2250,7 +2250,7 @@ def _check_4_3_5(postgresql_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(server_name)
-                logger.debug("Could not check connection_throttling for PostgreSQL server %s: %s", server_name, exc)
+                logger.debug("Could not check connection_throttling for PostgreSQL server %s: %s", server_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"PostgreSQL servers with connection_throttling disabled: {', '.join(failing)}"
@@ -2458,7 +2458,7 @@ def _check_5_2_1(postgresql_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(server_name)
-                logger.debug("Could not check log_connections for PostgreSQL server %s: %s", server_name, exc)
+                logger.debug("Could not check log_connections for PostgreSQL server %s: %s", server_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"PostgreSQL servers with log_connections off: {', '.join(failing)}"
@@ -2511,7 +2511,7 @@ def _check_5_2_2(postgresql_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(server_name)
-                logger.debug("Could not check log_disconnections for PostgreSQL server %s: %s", server_name, exc)
+                logger.debug("Could not check log_disconnections for PostgreSQL server %s: %s", server_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"PostgreSQL servers with log_disconnections off: {', '.join(failing)}"
@@ -2564,7 +2564,7 @@ def _check_5_2_3(postgresql_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(server_name)
-                logger.debug("Could not check connection_throttling for PostgreSQL server %s: %s", server_name, exc)
+                logger.debug("Could not check connection_throttling for PostgreSQL server %s: %s", server_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"PostgreSQL servers with connection_throttling off: {', '.join(failing)}"
@@ -3048,7 +3048,7 @@ def _check_8_1(kv_client: Any, subscription_id: str) -> CISCheckResult:
                 # vault is UNREADABLE, not compliant. Never let it fall through
                 # to PASS: a denied vault must not read as "keys have expiration".
                 denied.append(vault_name)
-                logger.debug("Could not enumerate keys in vault %s: %s", vault_name, exc)
+                logger.debug("Could not enumerate keys in vault %s: %s", vault_name, sanitize_text(exc))
 
         if failing_keys:
             result.status = CheckStatus.FAIL
@@ -3102,7 +3102,7 @@ def _check_8_2(kv_client: Any, subscription_id: str) -> CISCheckResult:
             except Exception as exc:
                 # Denied vault is UNREADABLE, not compliant — never fall through to PASS.
                 denied.append(vault_name)
-                logger.debug("Could not enumerate secrets in vault %s: %s", vault_name, exc)
+                logger.debug("Could not enumerate secrets in vault %s: %s", vault_name, sanitize_text(exc))
 
         if failing_secrets:
             result.status = CheckStatus.FAIL
@@ -3165,7 +3165,7 @@ def _check_8_3(kv_client: Any, subscription_id: str) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(vault_name)
-                logger.debug("Could not check recoverability for vault %s: %s", vault_name, exc)
+                logger.debug("Could not check recoverability for vault %s: %s", vault_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"Key Vaults without full recoverability: {', '.join(failing[:10])}"
@@ -3232,7 +3232,7 @@ def _check_8_4(kv_client: Any, subscription_id: str) -> CISCheckResult:
             except Exception as exc:
                 # Denied RBAC vault is UNREADABLE, not compliant — never PASS.
                 denied.append(vault_name)
-                logger.debug("Could not enumerate keys in RBAC vault %s: %s", vault_name, exc)
+                logger.debug("Could not enumerate keys in RBAC vault %s: %s", vault_name, sanitize_text(exc))
         if failing_keys:
             result.status = CheckStatus.FAIL
             result.evidence = f"Keys without expiration in RBAC vaults: {', '.join(failing_keys[:10])}"
@@ -3301,7 +3301,7 @@ def _check_8_5(kv_client: Any, subscription_id: str) -> CISCheckResult:
             except Exception as exc:
                 # Denied RBAC vault is UNREADABLE, not compliant — never PASS.
                 denied.append(vault_name)
-                logger.debug("Could not enumerate secrets in RBAC vault %s: %s", vault_name, exc)
+                logger.debug("Could not enumerate secrets in RBAC vault %s: %s", vault_name, sanitize_text(exc))
         if failing_secrets:
             result.status = CheckStatus.FAIL
             result.evidence = f"Secrets without expiration in RBAC vaults: {', '.join(failing_secrets[:10])}"
@@ -3354,7 +3354,7 @@ def _check_8_6(kv_client: Any, subscription_id: str) -> CISCheckResult:
             except Exception as exc:
                 # Denied vault is UNREADABLE, not compliant — never PASS.
                 denied.append(vault_name)
-                logger.debug("Could not enumerate secrets in vault %s: %s", vault_name, exc)
+                logger.debug("Could not enumerate secrets in vault %s: %s", vault_name, sanitize_text(exc))
         if failing_secrets:
             result.status = CheckStatus.FAIL
             result.evidence = f"Secrets without content type: {', '.join(failing_secrets[:10])}"
@@ -3411,7 +3411,7 @@ def _check_8_7(kv_client: Any, subscription_id: str) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(vault_name)
-                logger.debug("Could not check private endpoints for vault %s: %s", vault_name, exc)
+                logger.debug("Could not check private endpoints for vault %s: %s", vault_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"Key Vaults without private endpoints: {', '.join(failing)}"
@@ -3469,7 +3469,7 @@ def _check_9_1(webapp_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(app_name)
-                logger.debug("Could not check auth settings for app %s: %s", app_name, exc)
+                logger.debug("Could not check auth settings for app %s: %s", app_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"Web apps without authentication enabled: {', '.join(failing[:10])}"
@@ -3557,7 +3557,7 @@ def _check_9_3(webapp_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(app_name)
-                logger.debug("Could not check TLS for app %s: %s", app_name, exc)
+                logger.debug("Could not check TLS for app %s: %s", app_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"Web apps not using TLS 1.2+: {', '.join(failing[:10])}"
@@ -3676,7 +3676,7 @@ def _check_9_6(webapp_client: Any) -> CISCheckResult:
             except Exception as exc:
                 if is_access_denied_error(exc):
                     denied.append(app_name)
-                logger.debug("Could not check FTP state for app %s: %s", app_name, exc)
+                logger.debug("Could not check FTP state for app %s: %s", app_name, sanitize_text(exc))
         if failing:
             result.status = CheckStatus.FAIL
             result.evidence = f"Web apps with FTP enabled: {', '.join(failing[:10])}"
@@ -3923,7 +3923,7 @@ def run_benchmark(
         try:
             report.checks.append(check_fn())
         except Exception as exc:
-            logger.warning("Azure CIS check %s failed with exception: %s", check_id, exc)
+            logger.warning("Azure CIS check %s failed with exception: %s", check_id, sanitize_text(exc))
             report.checks.append(
                 CISCheckResult(
                     check_id=check_id,

--- a/src/agent_bom/cloud/clickhouse.py
+++ b/src/agent_bom/cloud/clickhouse.py
@@ -12,6 +12,8 @@ import logging
 import os
 from typing import Any
 
+from agent_bom.security import sanitize_text
+
 logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 30  # seconds
@@ -121,7 +123,7 @@ class ClickHouseClient:
                 # modern ClickHouse. Older clusters may return a transient
                 # error on repeat runs; log and continue so ensure_tables
                 # stays safe to call on every process start.
-                logger.debug("ClickHouse migration skipped (%s): %s", exc, migration.split("\n", 1)[0])
+                logger.debug("ClickHouse migration skipped (%s): %s", sanitize_text(exc), migration.split("\n", 1)[0])
         self.execute("INSERT INTO control_plane_schema_versions (component, version) VALUES ('analytics', 1)")
         logger.info("ClickHouse analytics tables ensured in database '%s'", self.database)
 

--- a/src/agent_bom/cloud/databricks_security.py
+++ b/src/agent_bom/cloud/databricks_security.py
@@ -28,6 +28,8 @@ import os
 from dataclasses import dataclass, field
 from typing import Any
 
+from agent_bom.security import sanitize_text
+
 from .aws_cis_benchmark import CheckStatus, CISCheckResult
 from .base import CloudDiscoveryError
 
@@ -99,7 +101,7 @@ def _safe(func: Any, *args: Any, **kwargs: Any) -> Any:
     try:
         return func(*args, **kwargs)
     except Exception as exc:
-        logger.debug("Databricks API call failed: %s", exc)
+        logger.debug("Databricks API call failed: %s", sanitize_text(exc))
         return None
 
 

--- a/src/agent_bom/cloud/gcp_cis_benchmark.py
+++ b/src/agent_bom/cloud/gcp_cis_benchmark.py
@@ -40,6 +40,8 @@ import threading
 from dataclasses import dataclass, field
 from typing import Any
 
+from agent_bom.security import sanitize_text
+
 from .aws_cis_benchmark import CheckStatus, CISCheckResult, finalize_read_coverage
 from .aws_inventory import is_access_denied_error
 from .base import CloudDiscoveryError
@@ -2222,7 +2224,7 @@ def _check_5_1(project_id: str) -> CISCheckResult:
                 # IAM check is best-effort per bucket
                 if is_access_denied_error(exc):
                     denied.append(bucket.name)
-                logger.debug("Could not check IAM policy for bucket %s: %s", bucket.name, exc)
+                logger.debug("Could not check IAM policy for bucket %s: %s", bucket.name, sanitize_text(exc))
 
         if public_buckets:
             result.status = CheckStatus.FAIL
@@ -2833,7 +2835,7 @@ def run_benchmark(
             try:
                 report.checks.append(check_fn())
             except Exception as exc:
-                logger.warning("GCP CIS check %s failed with exception: %s", check_id, exc)
+                logger.warning("GCP CIS check %s failed with exception: %s", check_id, sanitize_text(exc))
                 report.checks.append(
                     CISCheckResult(
                         check_id=check_id,
@@ -2893,7 +2895,7 @@ def run_all_project_benchmarks(
     try:
         project_ids = gcp_organizations.list_project_ids(resolved, force=True)
     except Exception as exc:  # noqa: BLE001 — org enumeration failure must degrade, not crash
-        logger.warning("GCP org project enumeration failed: %s", sanitize_discovery_warning(exc))
+        logger.warning("GCP org project enumeration failed: %s", sanitize_text(sanitize_discovery_warning(exc)))
         warnings.append(sanitize_discovery_warning(exc))
         project_ids = []
 

--- a/src/agent_bom/cloud/gcp_inventory.py
+++ b/src/agent_bom/cloud/gcp_inventory.py
@@ -42,6 +42,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 from agent_bom.discovery_envelope import DiscoveryEnvelope, RedactionStatus, ScanMode
+from agent_bom.security import sanitize_text
 
 from .aws_inventory import dedupe_missing_permissions, record_discovery_failure
 from .gcp_authorization_collector import collect_gcp_authorization
@@ -201,7 +202,7 @@ def discover_all_project_inventories(credentials: Any = None, *, force: bool = F
 
         project_ids = gcp_organizations.list_project_ids(resolved, force=force)
     except Exception as exc:  # noqa: BLE001 — org enumeration failure must degrade
-        logger.warning("GCP org project enumeration failed: %s", sanitize_discovery_warning(exc))
+        logger.warning("GCP org project enumeration failed: %s", sanitize_text(sanitize_discovery_warning(exc)))
         project_ids = []
 
     if not project_ids:
@@ -228,7 +229,7 @@ def discover_all_project_inventories(credentials: Any = None, *, force: bool = F
                 logger.warning(
                     "GCP inventory failed for project %s: %s",
                     futures[future],
-                    sanitize_discovery_warning(exc),
+                    sanitize_text(sanitize_discovery_warning(exc)),
                 )
     return payloads
 

--- a/src/agent_bom/cloud/gpu_infra.py
+++ b/src/agent_bom/cloud/gpu_infra.py
@@ -34,6 +34,7 @@ from agent_bom.cloud.normalization import build_package_purl
 from agent_bom.http_client import create_client, request_with_retry
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 from agent_bom.scanners.firmware_advisory import check_firmware_advisories
+from agent_bom.security import sanitize_text
 
 logger = logging.getLogger(__name__)
 
@@ -390,7 +391,7 @@ def discover_docker_gpu_containers() -> tuple[list[GpuContainer], list[str]]:
                     )
                 )
         except Exception as exc:  # noqa: BLE001
-            logger.debug("Error parsing container info: %s", exc)
+            logger.debug("Error parsing container info: %s", sanitize_text(exc))
             continue
 
     return containers, warnings
@@ -698,7 +699,7 @@ def discover_k8s_gpu_nodes(
                 )
             )
         except Exception as exc:  # noqa: BLE001
-            logger.debug("Error parsing K8s node: %s", exc)
+            logger.debug("Error parsing K8s node: %s", sanitize_text(exc))
             continue
 
     return nodes, warnings
@@ -809,7 +810,7 @@ async def scan_gpu_infra(
         try:
             dcgm_endpoints = await probe_dcgm_from_containers(docker_containers)
         except Exception as exc:  # noqa: BLE001
-            logger.debug("DCGM probe error: %s", exc)
+            logger.debug("DCGM probe error: %s", sanitize_text(exc))
             all_warnings.append(f"DCGM probe skipped: {exc}")
 
     # Driver CVE checks — runs against every K8s GPU node by vendor

--- a/src/agent_bom/cloud/mlflow_provider.py
+++ b/src/agent_bom/cloud/mlflow_provider.py
@@ -14,6 +14,7 @@ import os
 
 from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
+from agent_bom.security import sanitize_text
 
 from .base import CloudDiscoveryError
 from .normalization import build_cloud_origin, build_package_purl
@@ -139,7 +140,7 @@ def _discover_registered_models(
                         run_packages = _extract_run_packages(client, run_id)
                         packages.extend(run_packages)
                     except (OSError, ValueError, KeyError) as exc:
-                        logger.debug("Failed to extract packages from MLflow run %s: %s", run_id, exc)
+                        logger.debug("Failed to extract packages from MLflow run %s: %s", run_id, sanitize_text(exc))
 
                 # Extract flavor from source path
                 flavor_packages = _extract_flavor_packages(source)
@@ -234,7 +235,7 @@ def _discover_experiments(
                     if run_id:
                         packages = _extract_run_packages(client, run_id)
             except (OSError, ValueError, KeyError) as exc:
-                logger.debug("Failed to extract packages from MLflow experiment %s: %s", exp_id, exc)
+                logger.debug("Failed to extract packages from MLflow experiment %s: %s", exp_id, sanitize_text(exc))
 
             server = MCPServer(
                 name=f"mlflow-exp:{exp_name}",
@@ -286,7 +287,7 @@ def _extract_run_packages(client, run_id: str) -> list[Package]:
                         packages.extend(_parse_requirements_txt(str(req_data)))
                 except (OSError, ValueError) as exc:
                     # requirements.txt may not exist for this artifact
-                    logger.debug("Could not read requirements.txt for run %s: %s", run_id, exc)
+                    logger.debug("Could not read requirements.txt for run %s: %s", run_id, sanitize_text(exc))
 
                 try:
                     conda_path = f"{path}/conda.yaml"
@@ -295,9 +296,9 @@ def _extract_run_packages(client, run_id: str) -> list[Package]:
                         packages.extend(_parse_conda_yaml(str(conda_data)))
                 except (OSError, ValueError) as exc:
                     # conda.yaml may not exist for this artifact
-                    logger.debug("Could not read conda.yaml for run %s: %s", run_id, exc)
+                    logger.debug("Could not read conda.yaml for run %s: %s", run_id, sanitize_text(exc))
     except (OSError, ValueError, KeyError) as exc:
-        logger.debug("Could not list artifacts for run %s: %s", run_id, exc)
+        logger.debug("Could not list artifacts for run %s: %s", run_id, sanitize_text(exc))
 
     return packages
 
@@ -395,6 +396,6 @@ def _parse_conda_yaml(content: str) -> list[Package]:
                         if name and not name.startswith("-"):
                             packages.append(Package(name=name, version="unknown", ecosystem="pypi"))
     except (ImportError, ValueError, KeyError) as exc:
-        logger.debug("Could not parse conda.yaml: %s", exc)
+        logger.debug("Could not parse conda.yaml: %s", sanitize_text(exc))
 
     return packages

--- a/src/agent_bom/cloud/model_provenance.py
+++ b/src/agent_bom/cloud/model_provenance.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from agent_bom.security import sanitize_text
+
 logger = logging.getLogger(__name__)
 
 # Ollama manifest directory — module-level so tests can patch it
@@ -355,7 +357,7 @@ def _get_ollama_manifest_api(host: str, model_name: str) -> dict | None:
             return data
     except (OSError, json.JSONDecodeError) as exc:
         _safe_name = model_name.replace("\n", "").replace("\r", "") if model_name else ""
-        logger.debug("Could not fetch Ollama model info for %s: %s", _safe_name, exc)
+        logger.debug("Could not fetch Ollama model info for %s: %s", _safe_name, sanitize_text(exc))
     return None
 
 

--- a/src/agent_bom/cloud/ollama.py
+++ b/src/agent_bom/cloud/ollama.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package
+from agent_bom.security import sanitize_text
 
 logger = logging.getLogger(__name__)
 
@@ -157,7 +158,7 @@ def _discover_via_api(host: str) -> list[dict] | None:
             data = resp.json()
             return data.get("models", [])
     except (ImportError, OSError) as exc:
-        logger.debug("Ollama httpx API probe failed: %s", exc)
+        logger.debug("Ollama httpx API probe failed: %s", sanitize_text(exc))
 
     # Fallback: try with sync httpx client (retry-capable)
     try:
@@ -171,7 +172,7 @@ def _discover_via_api(host: str) -> list[dict] | None:
             data = fallback_resp.json()
             return data.get("models", [])
     except (OSError, ValueError) as exc:
-        logger.debug("Ollama sync API probe failed: %s", exc)
+        logger.debug("Ollama sync API probe failed: %s", sanitize_text(exc))
 
     return None
 

--- a/src/agent_bom/cloud/runpod.py
+++ b/src/agent_bom/cloud/runpod.py
@@ -14,6 +14,7 @@ import os
 from agent_bom import http_client
 from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
+from agent_bom.security import sanitize_text
 
 from .base import CloudDiscoveryError
 from .normalization import build_cloud_origin, build_package_purl
@@ -136,7 +137,7 @@ def discover(
 
                     container_sbom = scan_container_image(image).to_dict()
                 except Exception as exc:  # noqa: BLE001
-                    logger.debug("Container SBOM scan skipped for %s: %s", image, exc)
+                    logger.debug("Container SBOM scan skipped for %s: %s", image, sanitize_text(exc))
 
             server = MCPServer(
                 name=f"runpod:{pod_name}",

--- a/src/agent_bom/cloud/serverless_zip.py
+++ b/src/agent_bom/cloud/serverless_zip.py
@@ -8,6 +8,7 @@ import zipfile
 from typing import Any
 
 from agent_bom.models import Package
+from agent_bom.security import sanitize_text
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ def packages_from_zip_bytes(data: bytes, *, ecosystem: str) -> list[Package]:
 
                 return _parse_node_packages_from_zip(zf)
     except Exception as exc:  # noqa: BLE001 — malformed archives degrade to empty
-        logger.debug("Could not parse serverless zip (%s): %s", ecosystem, exc)
+        logger.debug("Could not parse serverless zip (%s): %s", ecosystem, sanitize_text(exc))
     return []
 
 

--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -56,7 +56,7 @@ from agent_bom.governance import (
     QueryHistoryRecord,
 )
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
-from agent_bom.security import sanitize_error
+from agent_bom.security import sanitize_error, sanitize_text
 
 from .aws_inventory import record_discovery_failure
 from .base import CloudDiscoveryError
@@ -114,7 +114,7 @@ def _record_snowflake_inventory_failure(
             ).to_dict()
         )
     except Exception:  # noqa: BLE001 — coverage evidence is supplementary; never fail discovery
-        logger.debug("Could not record Snowflake inventory coverage warning", exc_info=True)
+        logger.debug("Could not record Snowflake inventory coverage warning", exc_info=False)
 
 
 # Backwards-compatible aliases for the shared cloud helpers. Call sites and
@@ -1080,7 +1080,7 @@ def _describe_mcp_server_tools(
 
                             tools.append(MCPTool(name=tool_name, description=description))
                 except (ImportError, ValueError, KeyError, TypeError) as exc:
-                    logger.debug("Could not parse tool spec for MCP server: %s", exc)
+                    logger.debug("Could not parse tool spec for MCP server: %s", sanitize_text(exc))
 
     except Exception as exc:
         warnings.append(f"Could not describe MCP Server {server_name}: {sanitize_error(exc)}")

--- a/src/agent_bom/cloud/snowflake_cis_benchmark.py
+++ b/src/agent_bom/cloud/snowflake_cis_benchmark.py
@@ -26,6 +26,8 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
+from agent_bom.security import sanitize_text
+
 from .aws_cis_benchmark import CheckStatus, CISCheckResult
 from .base import CloudDiscoveryError
 from .normalization import coerce_truthy as _sf_truthy
@@ -861,7 +863,7 @@ def run_benchmark(
                 check_result = check_fn(cursor)
                 report.checks.append(check_result)
             except Exception as exc:
-                logger.warning("CIS Snowflake check %s failed: %s", check_id, exc)
+                logger.warning("CIS Snowflake check %s failed: %s", check_id, sanitize_text(exc))
                 # Own-worded catalog title only — never docstring-derived text,
                 # which would reproduce the copyrighted CIS house-style title.
                 error_metadata = _CHECK_ERROR_METADATA.get(check_id)

--- a/src/agent_bom/cloud/vastai.py
+++ b/src/agent_bom/cloud/vastai.py
@@ -14,6 +14,7 @@ import os
 from agent_bom import http_client
 from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
+from agent_bom.security import sanitize_text
 
 from .base import CloudDiscoveryError
 from .normalization import build_cloud_origin, build_package_purl
@@ -96,7 +97,7 @@ def discover(
 
                     container_sbom = scan_container_image(image).to_dict()
                 except Exception as exc:  # noqa: BLE001
-                    logger.debug("Container SBOM scan skipped for %s: %s", image, exc)
+                    logger.debug("Container SBOM scan skipped for %s: %s", image, sanitize_text(exc))
 
             server = MCPServer(
                 name=f"vastai:{label}",

--- a/src/agent_bom/cloud/vector_db.py
+++ b/src/agent_bom/cloud/vector_db.py
@@ -465,7 +465,7 @@ def _record_pinecone_coverage_gap(reason: str, detail: str) -> None:
             ).to_dict()
         )
     except Exception:  # noqa: BLE001 — coverage evidence is supplementary; never fail discovery
-        logger.debug("Could not record Pinecone coverage warning", exc_info=True)
+        logger.debug("Could not record Pinecone coverage warning", exc_info=False)
 
 
 def check_pinecone(api_key: str, timeout: int = _DEFAULT_TIMEOUT) -> list[PineconeIndexResult]:

--- a/src/agent_bom/cloud/wandb_provider.py
+++ b/src/agent_bom/cloud/wandb_provider.py
@@ -14,6 +14,7 @@ import os
 
 from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
+from agent_bom.security import sanitize_text
 
 from .base import CloudDiscoveryError
 from .normalization import build_cloud_origin, build_package_purl
@@ -234,7 +235,7 @@ def _discover_artifacts(
                     agents.append(agent)
             except (ValueError, KeyError, AttributeError) as exc:
                 # Artifact type may not exist in this project
-                logger.debug("Could not list W&B artifacts of type %s: %s", art_type, exc)
+                logger.debug("Could not list W&B artifacts of type %s: %s", art_type, sanitize_text(exc))
 
     except Exception as exc:
         warnings.append(f"Could not list W&B artifacts: {exc}")

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -329,7 +329,7 @@ def _agent_cost_anomaly(tenant_id: str, source_agent: str) -> tuple[bool, str]:
 
         flagged = cost_anomalous_agents(tenant_id)
     except Exception as exc:  # noqa: BLE001
-        logger.warning("gateway anomaly check failed: %s", _sanitize_for_log(exc))
+        logger.warning("gateway anomaly check failed: %s", sanitize_text(_sanitize_for_log(exc)))
         return False, ""
     info = flagged.get(source_agent)
     if info:
@@ -369,7 +369,7 @@ def _agent_is_quarantined(tenant_id: str, source_agent: str) -> bool:
 
         agent = find_fleet_agent(_get_fleet_store(), tenant_id, source_agent)
     except Exception as exc:  # noqa: BLE001
-        logger.warning("gateway fleet check failed: %s", _sanitize_for_log(exc))
+        logger.warning("gateway fleet check failed: %s", sanitize_text(_sanitize_for_log(exc)))
         return False
     if agent is None:
         return False
@@ -403,7 +403,7 @@ def _agent_identity_revoked(tenant_id: str, source_agent: str) -> tuple[bool, bo
         revoked, lookup_incomplete = agent_identity_revoked(get_agent_identity_store(), tenant_id, source_agent)
         return revoked, lookup_incomplete, False
     except Exception as exc:  # noqa: BLE001
-        logger.warning("gateway agent identity revocation check failed: %s", _sanitize_for_log(exc))
+        logger.warning("gateway agent identity revocation check failed: %s", sanitize_text(_sanitize_for_log(exc)))
         return False, False, True
 
 
@@ -437,7 +437,7 @@ def _open_drift_violates_tool(tenant_id: str, blueprint_id: str, tool_name: str)
 
         incidents = get_drift_incident_store().list(tenant_id, include_resolved=False, limit=_DRIFT_INCIDENT_LOOKUP_CAP)
     except Exception as exc:  # noqa: BLE001
-        logger.warning("gateway drift check failed: %s", _sanitize_for_log(exc))
+        logger.warning("gateway drift check failed: %s", sanitize_text(_sanitize_for_log(exc)))
         return _DriftLookup(unavailable=True, reason="drift incident store unavailable")
     blueprint_key = blueprint_id.strip().lower().replace("-", "_")
     for incident in incidents:
@@ -543,7 +543,7 @@ def _evaluate_control_plane_bundle(
         return evaluate_gateway_policy_bundle(policies, source_agent, tool_name, arguments)
     except Exception as exc:  # noqa: BLE001
         # Fail closed: a bundle that cannot be evaluated must not silently pass.
-        logger.warning("gateway control-plane bundle evaluation failed: %s", _sanitize_for_log(exc))
+        logger.warning("gateway control-plane bundle evaluation failed: %s", sanitize_text(_sanitize_for_log(exc)))
         return False, "control-plane policy evaluation error"
 
 
@@ -714,7 +714,7 @@ def _emit_gateway_governance_event(event_type: str, *, tenant_id: str, subject_i
 
         emit_governance_event(event_type=event_type, tenant_id=tenant_id, source="gateway", subject_id=subject_id, payload=payload)
     except Exception:  # noqa: BLE001
-        logger.debug("gateway governance webhook emit failed for %s", event_type, exc_info=True)
+        logger.debug("gateway governance webhook emit failed for %s", event_type, exc_info=False)
 
 
 async def _emit_policy_interop_event(
@@ -748,7 +748,7 @@ async def _emit_policy_interop_event(
     try:
         event = build_policy_ocsf_event(decision=decision, reason=reason, ctx=ctx, policy_source=policy_source)
     except Exception as exc:  # noqa: BLE001
-        logger.warning("gateway OCSF event build failed: %s", _sanitize_for_log(exc))
+        logger.warning("gateway OCSF event build failed: %s", sanitize_text(_sanitize_for_log(exc)))
         return
     try:
         await asyncio.to_thread(
@@ -758,7 +758,7 @@ async def _emit_policy_interop_event(
             token=settings.policy_webhook_token,
         )
     except Exception as exc:  # noqa: BLE001 — webhook must never break the relay
-        logger.warning("gateway policy webhook dispatch error (event dropped, relay unaffected): %s", _sanitize_for_log(exc))
+        logger.warning("gateway policy webhook dispatch error (event dropped, relay unaffected): %s", sanitize_text(_sanitize_for_log(exc)))
 
 
 class GatewayCircuitOpenError(RuntimeError):
@@ -972,7 +972,7 @@ def _gateway_requires_auth(settings: GatewaySettings) -> bool:
     try:
         return get_key_store().has_keys()
     except Exception as exc:
-        logger.warning("Gateway key store status unavailable: %s", _sanitize_for_log(exc))
+        logger.warning("Gateway key store status unavailable: %s", sanitize_text(_sanitize_for_log(exc)))
         return True
 
 
@@ -1091,14 +1091,14 @@ def _authenticate_gateway_request(request: Request, settings: GatewaySettings) -
         store = get_key_store()
         has_keys = store.has_keys()
     except Exception as exc:
-        logger.warning("Gateway key store unavailable: %s", _sanitize_for_log(exc))
+        logger.warning("Gateway key store unavailable: %s", sanitize_text(_sanitize_for_log(exc)))
         raise HTTPException(status_code=503, detail="gateway authentication unavailable") from exc
 
     if has_keys:
         try:
             api_key = store.verify(raw_token) if raw_token else None
         except Exception as exc:
-            logger.warning("Gateway key verification unavailable: %s", _sanitize_for_log(exc))
+            logger.warning("Gateway key verification unavailable: %s", sanitize_text(_sanitize_for_log(exc)))
             raise HTTPException(status_code=503, detail="gateway authentication unavailable") from exc
         if api_key is None:
             raise HTTPException(status_code=401, detail="gateway authentication required")
@@ -1249,7 +1249,7 @@ def build_control_plane_audit_sink(
                 response = await client.post(audit_url, json=payload, headers=headers)
                 response.raise_for_status()
         except Exception as exc:  # noqa: BLE001
-            logger.warning("Gateway audit push failed: %s", _sanitize_for_log(exc))
+            logger.warning("Gateway audit push failed: %s", sanitize_text(_sanitize_for_log(exc)))
 
     return _sink
 
@@ -1342,11 +1342,11 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 next_policy = _load_policy_file(settings.policy_path)
             except FileNotFoundError as exc:
                 policy_state["last_error"] = sanitize_error(exc)
-                logger.warning("gateway policy reload failed for %s: %s", settings.policy_path, _sanitize_for_log(exc))
+                logger.warning("gateway policy reload failed for %s: %s", settings.policy_path, sanitize_text(_sanitize_for_log(exc)))
                 return False
             except Exception as exc:  # noqa: BLE001
                 policy_state["last_error"] = sanitize_error(exc)
-                logger.warning("gateway policy reload failed for %s: %s", settings.policy_path, _sanitize_for_log(exc))
+                logger.warning("gateway policy reload failed for %s: %s", settings.policy_path, sanitize_text(_sanitize_for_log(exc)))
                 return False
 
             policy_state["policy"] = next_policy
@@ -1409,7 +1409,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 logger.warning(
                     "gateway firewall policy reload failed for %s: %s",
                     settings.firewall_policy_path,
-                    _sanitize_for_log(exc),
+                    sanitize_text(_sanitize_for_log(exc)),
                 )
                 return False
             except Exception as exc:  # noqa: BLE001
@@ -1418,7 +1418,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 logger.warning(
                     "gateway firewall policy reload failed for %s: %s",
                     settings.firewall_policy_path,
-                    _sanitize_for_log(exc),
+                    sanitize_text(_sanitize_for_log(exc)),
                 )
                 return False
 
@@ -1796,7 +1796,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 scoped_identity = identity_for_token(get_agent_identity_store(), identity_token)
             except Exception as exc:  # noqa: BLE001
                 managed_identity_lookup_unavailable = True
-                logger.warning("gateway managed identity lookup failed: %s", _sanitize_for_log(exc))
+                logger.warning("gateway managed identity lookup failed: %s", sanitize_text(_sanitize_for_log(exc)))
         if settings.oauth_as is not None:
             for candidate in (identity_token, _extract_request_token(request)):
                 if candidate:
@@ -1980,7 +1980,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     )
                 except Exception as exc:  # noqa: BLE001
                     profile_failure_code = "profile_store_unavailable"
-                    logger.warning("gateway runtime profile lookup unavailable: %s", _public_gateway_error(exc))
+                    logger.warning("gateway runtime profile lookup unavailable: %s", sanitize_text(_public_gateway_error(exc)))
                 else:
                     if not resolution.resolved or resolution.profile is None:
                         profile_failure_code = resolution.code.value
@@ -2268,7 +2268,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
 
             budget_blocked, budget, budget_spend = check_budget_enforcement(get_cost_store(), tenant_id, source_agent)
         except Exception as exc:  # noqa: BLE001
-            logger.warning("gateway budget check failed: %s", _sanitize_for_log(exc))
+            logger.warning("gateway budget check failed: %s", sanitize_text(_sanitize_for_log(exc)))
             budget_blocked, budget, budget_spend = False, None, 0.0
         if budget_blocked and budget is not None:
             record_gateway_relay(upstream.name, "blocked")
@@ -2322,7 +2322,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
 
                 cc_blocked, cc_budget, cc_spend = check_cost_center_budget_enforcement(get_cost_store(), tenant_id, cost_center)
             except Exception as exc:  # noqa: BLE001
-                logger.warning("gateway cost-center budget check failed: %s", _sanitize_for_log(exc))
+                logger.warning("gateway cost-center budget check failed: %s", sanitize_text(_sanitize_for_log(exc)))
                 cc_blocked, cc_budget, cc_spend = False, None, 0.0
             if cc_blocked and cc_budget is not None:
                 record_gateway_relay(upstream.name, "blocked")
@@ -2384,7 +2384,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 get_cost_store(), tenant_id, source_agent
             )
         except Exception as exc:  # noqa: BLE001
-            logger.warning("gateway owner budget check failed: %s", _sanitize_for_log(exc))
+            logger.warning("gateway owner budget check failed: %s", sanitize_text(_sanitize_for_log(exc)))
             owner_blocked, owner_budget, owner_spend_usd, budget_owner, budget_workflow = False, None, 0.0, "", ""
         if owner_blocked and owner_budget is not None:
             record_gateway_relay(upstream.name, "blocked")
@@ -2729,7 +2729,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 try:
                     reach_hit = reachability_map.reaches_privileged(source_agent, tool_name)
                 except Exception as exc:  # noqa: BLE001 — fail-open, never break the relay
-                    logger.warning("gateway graph-reachability check failed: %s", _sanitize_for_log(exc))
+                    logger.warning("gateway graph-reachability check failed: %s", sanitize_text(_sanitize_for_log(exc)))
                     reach_hit = None
                 if reach_hit is not None:
                     reach_reason = (
@@ -2807,7 +2807,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 try:
                     cond_decision, cond_reason, _cond_rule = evaluate_conditional_rules(current_policy, decision_ctx)
                 except Exception as exc:  # noqa: BLE001
-                    logger.warning("gateway conditional-rules evaluation error: %s", _sanitize_for_log(exc))
+                    logger.warning("gateway conditional-rules evaluation error: %s", sanitize_text(_sanitize_for_log(exc)))
                     cond_decision, cond_reason = GatewayDecision.DENY, "conditional rules evaluation error"
                 # Policy plugins follow the gateway fail-mode knob (fail-open
                 # forwards on a plugin engine error, fail-closed denies).
@@ -2819,7 +2819,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     )
                     plugin_eval_error = False
                 except Exception as exc:  # noqa: BLE001
-                    logger.warning("gateway plugin evaluation error: %s", _sanitize_for_log(exc))
+                    logger.warning("gateway plugin evaluation error: %s", sanitize_text(_sanitize_for_log(exc)))
                     plugin_decision, plugin_reason = GatewayDecision.ALLOW, ""
                     plugin_eval_error = True
                 # Compose: DENY outranks QUARANTINE outranks ALLOW. Conditional
@@ -3113,7 +3113,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 )
             raise HTTPException(status_code=502, detail="upstream error: timeout") from exc
         except Exception as exc:  # noqa: BLE001
-            logger.exception("gateway upstream call failed for %s", upstream.name)
+            logger.error("gateway upstream call failed for %s", upstream.name)
             record_gateway_relay(upstream.name, "upstream_error")
             if settings.audit_sink is not None:
                 await settings.audit_sink(

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -347,7 +347,7 @@ async def _maybe_block_on_firewall(
             "firewall evaluator raised; allowing call (source=%s, target=%s): %s",
             source_agent,
             target_agent,
-            exc,
+            sanitize_text(exc),
         )
         return None
 
@@ -1374,7 +1374,7 @@ async def run_proxy(
                         "Gateway policy fetch failed from %s; using cached bundle from %s: %s",
                         control_plane_url,
                         control_plane_policy_cache_path,
-                        exc,
+                        sanitize_text(exc),
                     )
                 else:
                     logger.error("Failed to load enabled gateway policies from %s: %s", control_plane_url, sanitize_text(exc))

--- a/src/agent_bom/runtime/incident_feedback.py
+++ b/src/agent_bom/runtime/incident_feedback.py
@@ -189,7 +189,7 @@ class RuntimeIncidentSink:
                 handle.write(line + "\n")
             return True
         except (OSError, TypeError, ValueError):
-            logger.debug("Could not emit runtime incident feedback (non-fatal)", exc_info=True)
+            logger.debug("Could not emit runtime incident feedback (non-fatal)", exc_info=False)
             return False
 
 
@@ -207,7 +207,7 @@ def load_incident_records(path: str | os.PathLike[str] | None) -> list[RuntimeIn
     try:
         text = resolved.read_text(encoding="utf-8")
     except OSError:
-        logger.debug("Could not read runtime incident feedback file (non-fatal)", exc_info=True)
+        logger.debug("Could not read runtime incident feedback file (non-fatal)", exc_info=False)
         return []
     for line in text.splitlines():
         stripped = line.strip()

--- a/src/agent_bom/runtime/protection.py
+++ b/src/agent_bom/runtime/protection.py
@@ -571,7 +571,7 @@ class ProtectionEngine:
             )
             self._feedback_sink.emit(record)
         except Exception:  # pragma: no cover - belt-and-suspenders fail-safe
-            logger.debug("Runtime feedback emission failed (non-fatal)", exc_info=True)
+            logger.debug("Runtime feedback emission failed (non-fatal)", exc_info=False)
 
     # ── Deep defense internals ───────────────────────────────────────────
 

--- a/tests/test_exception_sanitization_guard.py
+++ b/tests/test_exception_sanitization_guard.py
@@ -70,6 +70,54 @@ def test_flags_logger_fstring_exc() -> None:
         assert "log f-string" in out[0]
 
 
+def test_flags_caught_exception_passed_to_lazy_logger_formatting() -> None:
+    source = """
+try:
+    connect()
+except RuntimeError as exc:
+    logger.warning("connection failed: %s", exc)
+"""
+    out = GUARD.scan_text(source, "sample.py")
+    assert len(out) == 1
+    assert "lazy log argument" in out[0]
+
+
+def test_flags_logger_exception_implicit_traceback() -> None:
+    source = """
+try:
+    connect()
+except RuntimeError:
+    logger.exception("connection failed")
+"""
+    out = GUARD.scan_text(source, "sample.py")
+    assert len(out) == 1
+    assert "logger.exception" in out[0]
+
+    outside_handler = GUARD.scan_text('logger.exception("connection failed")\n', "sample.py")
+    assert len(outside_handler) == 1
+    assert "logger.exception" in outside_handler[0]
+
+
+def test_flags_explicit_raw_exc_info() -> None:
+    for statement in (
+        'logger.error("connection failed", exc_info=True)',
+        'logger.error("connection failed", exc_info=exc)',
+    ):
+        source = f"""
+try:
+    connect()
+except RuntimeError as exc:
+    {statement}
+"""
+        out = GUARD.scan_text(source, "sample.py")
+        assert len(out) == 1, statement
+        assert "exc_info" in out[0]
+
+    outside_handler = GUARD.scan_text('logger.error("worker failed", exc_info=(kind, failure, traceback))\n', "sample.py")
+    assert len(outside_handler) == 1
+    assert "exc_info" in outside_handler[0]
+
+
 def test_flags_exception_flow_into_returned_payload_even_through_custom_sanitizer() -> None:
     source = """
 try:
@@ -94,15 +142,37 @@ def test_allows_sanitized_and_structured_forms() -> None:
     raise HTTPException(status_code=400, detail=f"bad: {sanitize_error(exc)}") from exc
     raise HTTPException(status_code=503, detail=sanitize_error(exc, generic=True)) from exc
     logger.warning("failed: %s", sanitize_text(exc))
+    logger.error("failed without exception detail")
+    logger.error("failed without traceback", exc_info=False)
     raise HTTPException(status_code=409, detail=f"Cannot approve exception in {exc.status.value} state")
     return JSONResponse(status_code=429, content=exc.to_dict())
     """
     assert GUARD.scan_text(safe, "sample.py") == []
 
 
+def test_allows_sanitized_logging_inside_exception_handler() -> None:
+    source = """
+try:
+    connect()
+except RuntimeError as exc:
+    logger.warning("failed: %s", sanitize_text(exc))
+    logger.warning("failed in state: %s", exc.status.value)
+    logger.error("failed without traceback", exc_info=False)
+"""
+    assert GUARD.scan_text(source, "sample.py") == []
+
+
 def test_pragma_silences_a_vetted_line() -> None:
     line = "    raise HTTPException(status_code=422, detail=str(exc))  # exc-safe: value is a fixed enum\n"
     assert GUARD.scan_text(line, "sample.py") == []
+
+    source = """
+try:
+    connect()
+except FixedMessageError:
+    logger.exception("fixed library exception")  # exc-safe: exception type has constant text and no sensitive state
+"""
+    assert GUARD.scan_text(source, "sample.py") == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- close 253 raw-exception logging paths across API, cloud, gateway, proxy, and runtime code
- sanitize caught exceptions before interpolation and disable implicit traceback emission where raw exception state is not safe to persist
- expand the AST guard to reject lazy logger exception arguments, `logger.exception`, and unsafe `exc_info` use while retaining documented safe exceptions

## Verification

- `python scripts/check_exception_sanitization.py`
- `ruff check scripts/check_exception_sanitization.py src/agent_bom/api src/agent_bom/cloud src/agent_bom/gateway_server.py src/agent_bom/proxy.py src/agent_bom/runtime/incident_feedback.py src/agent_bom/runtime/protection.py tests/test_exception_sanitization_guard.py`
- `pytest -q tests/test_exception_sanitization_guard.py tests/test_connection_scheduler.py tests/test_export_scheduler.py tests/test_side_scan_scheduler.py tests/test_gateway_server.py tests/api/test_api_pipeline_events.py` (167 passed)
- `git diff --check origin/main...HEAD`

## Notes

- Logging remains operational, but raw exception messages and tracebacks no longer cross persistent log boundaries by default.
- The branch is rebased on `5f99d70d08e082e6ef58e436e870a3f9c518e1b2` and the commit signature is verified.
