### PR TITLE
fix(sources): require executable scan targets

### DIFF
--- a/src/agent_bom/api/routes/sources.py
+++ b/src/agent_bom/api/routes/sources.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 from typing import Annotated
+from urllib.parse import urlsplit
 
 import anyio.to_thread
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -20,11 +21,37 @@ from agent_bom.api.models import (
     SourceStatus,
     SourceUpdate,
 )
-from agent_bom.api.routes.scan import enqueue_scan_job
+from agent_bom.api.routes.scan import _sanitize_scan_request_paths, enqueue_scan_job
 from agent_bom.api.stores import _get_credential_ref_store, _get_source_store, _get_store
 from agent_bom.api.tenancy import require_body_tenant_match, require_request_tenant_id
 
 router = APIRouter()
+
+_RUNNABLE_SOURCE_KINDS = frozenset(
+    {
+        SourceKind.SCAN_REPO,
+        SourceKind.SCAN_IMAGE,
+        SourceKind.SCAN_IAC,
+        SourceKind.SCAN_CLOUD,
+        SourceKind.SCAN_MCP_CONFIG,
+        SourceKind.INGEST_ARTIFACT_IMPORT,
+        SourceKind.CONNECTOR_CLOUD_READ_ONLY,
+        SourceKind.CONNECTOR_REGISTRY,
+        SourceKind.CONNECTOR_WAREHOUSE,
+    }
+)
+
+
+def _safe_validation_errors(exc: ValidationError) -> list[dict[str, object]]:
+    """Return actionable validation metadata without echoing config values."""
+    return [
+        {
+            "type": error.get("type", "value_error"),
+            "loc": list(error.get("loc", ())),
+            "msg": error.get("msg", "Invalid scan request"),
+        }
+        for error in exc.errors()
+    ]
 
 
 def _now() -> str:
@@ -59,6 +86,9 @@ def _validate_credential_ref(request: Request, source: SourceRecord) -> None:
 
 
 def _apply_update(source: SourceRecord, body: SourceUpdate) -> SourceRecord:
+    # Stores may return a live object reference. Validate a detached candidate
+    # so a rejected update cannot mutate the persisted source in place.
+    source = source.model_copy(deep=True)
     for field in (
         "display_name",
         "description",
@@ -79,6 +109,59 @@ def _apply_update(source: SourceRecord, body: SourceUpdate) -> SourceRecord:
     elif source.status == SourceStatus.DISABLED:
         source.status = SourceStatus.CONFIGURED
     return source
+
+
+def _require_source_target(source: SourceRecord, request: ScanRequest) -> None:
+    """Reject a runnable source that would otherwise launch a default scan."""
+    has_target = True
+    required = ""
+    if source.kind == SourceKind.SCAN_REPO:
+        has_target = bool(
+            (request.repo_url or "").strip() or request.agent_projects or request.gha_path or request.sbom or request.filesystem_paths
+        )
+        required = "repo_url, agent_projects, gha_path, sbom, or filesystem_paths"
+    elif source.kind == SourceKind.SCAN_IMAGE:
+        has_target = bool(request.images)
+        required = "images"
+    elif source.kind == SourceKind.SCAN_IAC:
+        has_target = bool((request.repo_url or "").strip() or request.tf_dirs or request.k8s)
+        required = "repo_url, tf_dirs, or k8s"
+    elif source.kind == SourceKind.SCAN_CLOUD:
+        has_target = bool(request.connectors or request.inventory)
+        required = "connectors or inventory"
+    elif source.kind == SourceKind.SCAN_MCP_CONFIG:
+        has_target = bool((request.repo_url or "").strip() or request.inventory or request.agent_projects or request.discover_host)
+        required = "repo_url, inventory, agent_projects, or discover_host"
+    elif source.kind == SourceKind.INGEST_ARTIFACT_IMPORT:
+        has_target = bool(request.inventory or request.sbom or request.external_scan or request.vex)
+        required = "inventory, sbom, external_scan, or vex"
+
+    if not has_target:
+        raise HTTPException(
+            status_code=422,
+            detail=f"{source.kind.value} source requires {required} in config.scan_request",
+        )
+
+
+def _validate_source_repo_url(request: ScanRequest) -> ScanRequest:
+    """Reject unsafe stored repo targets without performing network I/O."""
+    if not request.repo_url:
+        return request
+    repo_url = request.repo_url.strip()
+    try:
+        parts = urlsplit(repo_url)
+        safe = (
+            parts.scheme in {"http", "https"}
+            and bool(parts.hostname)
+            and parts.username is None
+            and parts.password is None
+            and not any(ord(char) < 0x20 or char.isspace() for char in repo_url)
+        )
+    except ValueError:
+        safe = False
+    if not safe:
+        raise HTTPException(status_code=422, detail="repo_url must be an HTTP(S) URL without embedded credentials")
+    return request.model_copy(update={"repo_url": repo_url})
 
 
 def _request_for_source(source: SourceRecord) -> ScanRequest:
@@ -104,9 +187,15 @@ def _request_for_source(source: SourceRecord) -> ScanRequest:
         raise HTTPException(status_code=409, detail="Runtime sources are audited by proxy/gateway traffic, not by direct scan jobs")
 
     try:
-        return ScanRequest.model_validate(config)
+        request = ScanRequest.model_validate(config)
     except ValidationError as exc:
-        raise HTTPException(status_code=422, detail=exc.errors()) from exc
+        raise HTTPException(status_code=422, detail=_safe_validation_errors(exc)) from exc
+    request = _validate_source_repo_url(request)
+    _require_source_target(source, request)
+    # Source runs enqueue directly rather than entering POST /v1/scan. Apply
+    # the identical local-path jail before either Test or Run can accept the
+    # source configuration.
+    return _sanitize_scan_request_paths(request)
 
 
 @router.post("/sources", tags=["sources"], status_code=201)
@@ -132,6 +221,8 @@ async def create_source(request: Request, body: SourceCreate) -> dict:
         updated_at=now,
     )
     _validate_credential_ref(request, source)
+    if source.kind in _RUNNABLE_SOURCE_KINDS:
+        _request_for_source(source)
     _get_source_store().put(source)
     log_action(
         "source.create",
@@ -176,6 +267,8 @@ async def get_source(request: Request, source_id: str) -> dict:
 async def update_source(request: Request, source_id: str, body: SourceUpdate) -> dict:
     source = _apply_update(_source_for_request(request, source_id), body)
     _validate_credential_ref(request, source)
+    if source.kind in _RUNNABLE_SOURCE_KINDS:
+        _request_for_source(source)
     _get_source_store().put(source)
     log_action(
         "source.update",

--- a/tests/api/test_api_sources.py
+++ b/tests/api/test_api_sources.py
@@ -9,6 +9,7 @@ from starlette.testclient import TestClient
 
 from agent_bom.api import stores as _stores
 from agent_bom.api.credential_store import InMemoryCredentialRefStore
+from agent_bom.api.models import SourceKind, SourceRecord
 from agent_bom.api.server import app, configure_api
 from agent_bom.api.source_store import InMemorySourceStore
 from agent_bom.api.store import InMemoryJobStore
@@ -117,6 +118,96 @@ def test_source_create_rejects_mismatched_tenant(source_client: TestClient) -> N
     )
     assert resp.status_code == 403
     assert "tenant_id in the request body must match the authenticated tenant" in resp.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected_target"),
+    [
+        ("scan.repo", "repo_url, agent_projects, gha_path, sbom, or filesystem_paths"),
+        ("scan.image", "images"),
+        ("scan.iac", "repo_url, tf_dirs, or k8s"),
+        ("scan.cloud", "connectors or inventory"),
+        ("scan.mcp_config", "repo_url, inventory, agent_projects, or discover_host"),
+        ("ingest.artifact_import", "inventory, sbom, external_scan, or vex"),
+    ],
+)
+def test_runnable_source_create_rejects_empty_scan_target(
+    source_client: TestClient,
+    kind: str,
+    expected_target: str,
+) -> None:
+    response = source_client.post(
+        "/v1/sources",
+        headers=ANALYST_HEADERS,
+        json={"display_name": f"Empty {kind}", "kind": kind},
+    )
+
+    assert response.status_code == 422
+    assert f"{kind} source requires {expected_target}" in response.json()["detail"]
+
+
+def test_legacy_empty_runnable_source_cannot_test_or_enqueue(
+    source_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = SourceRecord(
+        source_id="legacy-empty-repo",
+        tenant_id="tenant-alpha",
+        display_name="Legacy empty repo",
+        kind=SourceKind.SCAN_REPO,
+    )
+    _stores._source_store.put(source)
+
+    def _must_not_enqueue(**kwargs):
+        raise AssertionError("an empty source must not enqueue an all-default scan")
+
+    monkeypatch.setattr("agent_bom.api.routes.sources.enqueue_scan_job", _must_not_enqueue)
+
+    tested = source_client.post(f"/v1/sources/{source.source_id}/test", headers=ANALYST_HEADERS)
+    run = source_client.post(f"/v1/sources/{source.source_id}/run", headers=ANALYST_HEADERS)
+
+    assert tested.status_code == 422
+    assert run.status_code == 422
+    assert "scan.repo source requires repo_url, agent_projects, gha_path, sbom, or filesystem_paths" in tested.json()["detail"]
+    assert "scan.repo source requires repo_url, agent_projects, gha_path, sbom, or filesystem_paths" in run.json()["detail"]
+
+
+def test_source_config_uses_the_api_local_path_jail(
+    source_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_BOM_API_LOCAL_PATH_SCANS", "disabled")
+
+    response = source_client.post(
+        "/v1/sources",
+        headers=ANALYST_HEADERS,
+        json={
+            "display_name": "Unsafe local IaC source",
+            "kind": "scan.iac",
+            "config": {"scan_request": {"tf_dirs": ["/private/tenant-secret"]}},
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Local filesystem scans are disabled"
+    assert "/private/tenant-secret" not in response.text
+
+
+def test_source_repo_target_rejects_embedded_credentials_without_persisting(source_client: TestClient) -> None:
+    response = source_client.post(
+        "/v1/sources",
+        headers=ANALYST_HEADERS,
+        json={
+            "display_name": "Unsafe repository",
+            "kind": "scan.repo",
+            "config": {"scan_request": {"repo_url": "https://operator:secret-value@example.com/repo"}},
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "repo_url must be an HTTP(S) URL without embedded credentials"
+    assert "secret-value" not in response.text
+    assert source_client.get("/v1/sources", headers=VIEWER_HEADERS).json()["count"] == 0
 
 
 def test_credential_reference_crud_and_tenant_isolation(source_client: TestClient) -> None:
@@ -285,7 +376,7 @@ def test_source_with_credential_reference_requires_same_tenant_ref(source_client
             "kind": "scan.cloud",
             "credential_mode": "reference",
             "credential_ref": credential_ref_id,
-            "config": {"scan_request": {"inventory": "agents.json", "format": "json"}},
+            "config": {"scan_request": {"connectors": ["jira"], "format": "json"}},
         },
     )
     assert create.status_code == 201
@@ -344,7 +435,7 @@ def test_viewer_cannot_test_or_run_sources(source_client: TestClient, monkeypatc
         json={
             "display_name": "Repo scan source",
             "kind": "scan.repo",
-            "config": {"scan_request": {"inventory": "agents.json", "format": "json"}},
+            "config": {"scan_request": {"repo_url": "https://github.com/example/repo", "format": "json"}},
         },
     )
     source_id = created.json()["source_id"]
@@ -381,7 +472,7 @@ def test_running_source_queues_source_linked_job(source_client: TestClient, monk
         json={
             "display_name": "Repo scan source",
             "kind": "scan.repo",
-            "config": {"scan_request": {"inventory": "agents.json", "format": "json"}},
+            "config": {"scan_request": {"repo_url": "https://github.com/example/repo", "format": "json"}},
         },
     )
     source_id = created.json()["source_id"]
@@ -391,6 +482,10 @@ def test_running_source_queues_source_linked_job(source_client: TestClient, monk
     run_body = run.json()
     assert run_body["source_id"] == source_id
     assert run_body["status"] == "pending"
+
+    job = _stores._store.get(run_body["job_id"], tenant_id="tenant-alpha")
+    assert job is not None
+    assert job.request.repo_url == "https://github.com/example/repo"
 
     source = source_client.get(f"/v1/sources/{source_id}", headers=VIEWER_HEADERS).json()
     assert source["last_job_id"] == run_body["job_id"]
@@ -405,7 +500,7 @@ def test_running_source_queues_source_linked_job(source_client: TestClient, monk
 
 
 def test_source_run_rejects_unknown_scan_request_fields(source_client: TestClient) -> None:
-    created = source_client.post(
+    response = source_client.post(
         "/v1/sources",
         headers=ANALYST_HEADERS,
         json={
@@ -414,12 +509,8 @@ def test_source_run_rejects_unknown_scan_request_fields(source_client: TestClien
             "config": {"scan_request": {"project_path": "."}},
         },
     )
-    source_id = created.json()["source_id"]
-
-    resp = source_client.post(f"/v1/sources/{source_id}/run", headers=ANALYST_HEADERS)
-
-    assert resp.status_code == 422
-    body = resp.json()
+    assert response.status_code == 422
+    body = response.json()
     assert "project_path" in str(body)
     assert "extra_forbidden" in str(body)
 

--- a/tests/api/test_no_auth_role_enforcement.py
+++ b/tests/api/test_no_auth_role_enforcement.py
@@ -95,7 +95,11 @@ def test_pure_no_auth_analyst_uses_the_route_role_matrix(
 
     created = pure_no_auth_client.post(
         "/v1/sources",
-        json={"display_name": "repo", "kind": "scan.repo"},
+        json={
+            "display_name": "repo",
+            "kind": "scan.repo",
+            "config": {"scan_request": {"repo_url": "https://github.com/example/repo"}},
+        },
     )
     assert created.status_code == 201
     source_id = created.json()["source_id"]
@@ -123,7 +127,11 @@ def test_pure_no_auth_admin_can_use_protected_source_mutations(
     assert session["role"] == "admin"
     created = pure_no_auth_client.post(
         "/v1/sources",
-        json={"display_name": "repo", "kind": "scan.repo"},
+        json={
+            "display_name": "repo",
+            "kind": "scan.repo",
+            "config": {"scan_request": {"repo_url": "https://github.com/example/repo"}},
+        },
     )
     assert created.status_code == 201
     assert pure_no_auth_client.delete(f"/v1/sources/{created.json()['source_id']}").status_code == 204

--- a/tests/test_write_path_contract.py
+++ b/tests/test_write_path_contract.py
@@ -156,7 +156,16 @@ def test_unknown_field_on_a_write_is_rejected_and_named(method: str, path: str, 
 BODY_TENANT_WRITES = [
     pytest.param("POST", "/v1/credentials", {"display_name": "c", "provider": "aws", "external_ref": "env:X"}, id="credentials"),
     pytest.param("POST", "/v1/schedules", {"name": "s", "cron_expression": "0 0 * * *"}, id="schedules"),
-    pytest.param("POST", "/v1/sources", {"display_name": "s", "kind": "scan.repo"}, id="sources"),
+    pytest.param(
+        "POST",
+        "/v1/sources",
+        {
+            "display_name": "s",
+            "kind": "scan.repo",
+            "config": {"scan_request": {"repo_url": "https://github.com/example/repo"}},
+        },
+        id="sources",
+    ),
     pytest.param("POST", "/v1/exceptions", {"vuln_id": "CVE-2024-1", "package_name": "p"}, id="exceptions"),
     pytest.param(
         "POST",

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -407,6 +407,7 @@ function kindOption(kind: SourceKind | string): KindOption | undefined {
 const DEFAULT_FORM_STATE: FormState = {
   display_name: "",
   kind: "scan.repo",
+  target: "",
   description: "",
   owner: "",
   connector_name: "",
@@ -415,9 +416,57 @@ const DEFAULT_FORM_STATE: FormState = {
 interface FormState {
   display_name: string;
   kind: SourceKind;
+  target: string;
   description: string;
   owner: string;
   connector_name: string;
+}
+
+interface SourceTargetSpec {
+  label: string;
+  placeholder: string;
+  requiredMessage: string;
+  help: string;
+}
+
+function sourceTargetSpec(kind: SourceKind): SourceTargetSpec | null {
+  switch (kind) {
+    case "scan.repo":
+      return {
+        label: "Repository URL",
+        placeholder: "https://github.com/org/repository",
+        requiredMessage: "Repository URL is required for a repo scan source.",
+        help: "Agent-Bom shallow-clones this public HTTP(S) repository and statically scans the returned tree.",
+      };
+    case "scan.image":
+      return {
+        label: "Container image",
+        placeholder: "ghcr.io/org/app:v1",
+        requiredMessage: "Container image is required for an image scan source.",
+        help: "Use an immutable tag or digest when repeatable snapshot comparison matters.",
+      };
+    case "scan.iac":
+      return {
+        label: "IaC repository URL",
+        placeholder: "https://github.com/org/infrastructure",
+        requiredMessage: "Repository URL is required for an IaC scan source.",
+        help: "The queued job scans Terraform and Kubernetes files in this repository without executing repository code.",
+      };
+    case "scan.mcp_config":
+      return {
+        label: "Configuration repository URL",
+        placeholder: "https://github.com/org/agent-configs",
+        requiredMessage: "Repository URL is required for an MCP configuration source.",
+        help: "Use a repository containing the MCP and agent configuration that the control plane should inspect.",
+      };
+    default:
+      return null;
+  }
+}
+
+function scanRequestForSourceTarget(kind: SourceKind, target: string): Record<string, unknown> {
+  if (kind === "scan.image") return { images: [target] };
+  return { repo_url: target };
 }
 
 const SCHEDULABLE_KINDS = new Set<SourceKind>([
@@ -536,7 +585,7 @@ const CONNECTOR_CATALOG: CatalogConnector[] = [
     id: "mcp",
     category: "ai",
     label: "MCP configs",
-    tagline: "Local MCP configuration scan",
+    tagline: "Repository MCP configuration scan",
     icon: Plug,
     keywords: "model context protocol mcp servers tools aispm",
     action: { type: "source", sourceKind: "scan.mcp_config" },
@@ -989,7 +1038,7 @@ function ConnectionsHub() {
   const handleRegisterSource = useCallback(
     (kind: SourceKind) => {
       if (!canManageSources) return;
-      setFormState((current) => ({ ...current, kind }));
+      setFormState((current) => ({ ...current, kind, target: "" }));
       setCreateNonce((n) => n + 1);
       setTab("sources");
     },
@@ -1119,7 +1168,11 @@ function ConnectionsHub() {
   }
 
   function updateForm<K extends keyof FormState>(field: K, value: FormState[K]) {
-    setFormState((current) => ({ ...current, [field]: value }));
+    setFormState((current) => ({
+      ...current,
+      [field]: value,
+      ...(field === "kind" ? { target: "" } : {}),
+    }));
   }
 
   async function handleCreateSource(event: React.FormEvent<HTMLFormElement>) {
@@ -1139,6 +1192,21 @@ function ConnectionsHub() {
 
     if (!payload.display_name) {
       setFormMessage("Display name is required.");
+      return;
+    }
+    const targetSpec = sourceTargetSpec(formState.kind);
+    if (targetSpec) {
+      const target = formState.target.trim();
+      if (!target) {
+        setFormMessage(targetSpec.requiredMessage);
+        return;
+      }
+      payload.config = { scan_request: scanRequestForSourceTarget(formState.kind, target) };
+    } else if (formState.kind === "scan.cloud") {
+      setFormMessage("Cloud accounts use the read-only cloud account connection workflow.");
+      return;
+    } else if (formState.kind === "ingest.artifact_import") {
+      setFormMessage("Artifact sources require an API-side inventory, SBOM, external_scan, or VEX path.");
       return;
     }
     if (selected.mode === "Read-only connector") {
@@ -1794,6 +1862,7 @@ function SourcesSegment(props: SourcesSegmentProps) {
   } = props;
 
   const selectedKind = kindOption(formState.kind) ?? SOURCE_KIND_OPTIONS[0]!;
+  const targetSpec = sourceTargetSpec(formState.kind);
 
   return (
     <div className="space-y-5">
@@ -1988,6 +2057,25 @@ function SourcesSegment(props: SourcesSegmentProps) {
                       </option>
                     ))}
                   </select>
+                </label>
+              ) : null}
+
+              {targetSpec ? (
+                <label className="block">
+                  <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                    {targetSpec.label}
+                  </span>
+                  <input
+                    value={formState.target}
+                    onChange={(event) => onUpdateForm("target", event.target.value)}
+                    aria-label={targetSpec.label}
+                    className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[color:var(--foreground)] outline-none transition focus:border-[color:var(--accent-border)]"
+                    placeholder={targetSpec.placeholder}
+                    autoComplete="off"
+                  />
+                  <span className="mt-1.5 block text-xs leading-5 text-[color:var(--text-secondary)]">
+                    {targetSpec.help}
+                  </span>
                 </label>
               ) : null}
 

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -815,6 +815,37 @@ describe("ConnectionsPage — Connect segment", () => {
     expect(replaceMock).toHaveBeenCalledWith("/connections?tab=sources");
   });
 
+  it("requires and persists the repository target when registering a runnable source", async () => {
+    navState.search = "?tab=sources";
+    apiMock.createSource.mockResolvedValue({
+      ...SOURCE_RECORD,
+      config: { scan_request: { repo_url: "https://github.com/acme/payments" } },
+    });
+    render(<ConnectionsPage />);
+    fireEvent.change(await screen.findByPlaceholderText("Payments monorepo"), {
+      target: { value: "Payments monorepo" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Register source" }));
+
+    expect(await screen.findByText("Repository URL is required for a repo scan source.")).toBeInTheDocument();
+    expect(apiMock.createSource).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Repository URL" }), {
+      target: { value: "https://github.com/acme/payments" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Register source" }));
+
+    await waitFor(() =>
+      expect(apiMock.createSource).toHaveBeenCalledWith(
+        expect.objectContaining({
+          display_name: "Payments monorepo",
+          kind: "scan.repo",
+          config: { scan_request: { repo_url: "https://github.com/acme/payments" } },
+        }),
+      ),
+    );
+  });
+
   it("filters the gallery by category and free-text search", async () => {
     render(<ConnectionsPage />);
     await waitForConnectTab();


### PR DESCRIPTION
## Summary

- require provider-compatible executable targets before connected sources can be created, updated, tested, or run
- reuse the existing local-path boundary and reject embedded repository credentials before persistence
- keep cloud and artifact providers on their truthful execution paths and surface target requirements in the Connections UI

## Verification

- `pytest -q tests/api/test_api_sources.py` — 21 passed
- `npm test -- --run tests/connections-page.test.tsx` — 47 passed
- `npm run typecheck`
- `ruff check src/agent_bom/api/routes/sources.py tests/api/test_api_sources.py`
- `make preflight`
- `git diff --check`

## Notes

Credential references remain validation-only in this slice; resolving them into execution authentication requires the existing broker boundary and is not represented as shipped here.