### PR TITLE
fix(gateway): align durable shadow profile counts

### DIFF
--- a/src/agent_bom/api/gateway_activity_store.py
+++ b/src/agent_bom/api/gateway_activity_store.py
@@ -26,6 +26,7 @@ from agent_bom.runtime.gateway_events import (
     GATEWAY_BLOCKED_EVENT_TYPES,
     GATEWAY_DATA_FILTER_EVENT_TYPES,
 )
+from agent_bom.runtime.profile_resolution import classify_profile_shadow_reason
 from agent_bom.storage.base import BackendKind, StorageSchema, TableSchema
 
 GATEWAY_ACTIVITY_SCHEMA_VERSION = 1
@@ -380,6 +381,9 @@ _SHADOW_REASON_MARKERS = (
 
 
 def _is_shadow_reason(reason_code: str) -> bool:
+    canonical = classify_profile_shadow_reason(reason_code)
+    if canonical is not None:
+        return canonical
     normalized = reason_code.lower()
     return any(marker in normalized for marker in _SHADOW_REASON_MARKERS)
 

--- a/src/agent_bom/api/routes/gateway_feed.py
+++ b/src/agent_bom/api/routes/gateway_feed.py
@@ -55,7 +55,7 @@ from agent_bom.runtime.gateway_events import (
     GATEWAY_BLOCKED_EVENT_TYPES,
     GATEWAY_DATA_FILTER_EVENT_TYPES,
 )
-from agent_bom.runtime.profile_resolution import ProfileResolutionCode as _ProfileCode
+from agent_bom.runtime.profile_resolution import classify_profile_shadow_reason
 
 router = APIRouter(dependencies=[Depends(demo_daily_evidence_dependency)])
 
@@ -185,38 +185,6 @@ _EVENT_TYPES = GATEWAY_ALLOWED_EVENT_TYPES | GATEWAY_BLOCKED_EVENT_TYPES | GATEW
 # refused to attribute this caller to a sanctioned profile".
 #
 # Codes are imported, never re-spelled here: one judgement, one implementation.
-_UNSANCTIONED_CLIENT_CODES = frozenset(
-    {
-        _ProfileCode.IDENTITY_INACTIVE.value,
-        _ProfileCode.TENANT_MISMATCH.value,
-        _ProfileCode.PROFILE_NOT_FOUND.value,
-        _ProfileCode.PROFILE_REVOKED.value,
-        _ProfileCode.PROFILE_DISABLED.value,
-        _ProfileCode.PROFILE_EXPIRED.value,
-        _ProfileCode.PROFILE_INCOMPLETE.value,
-        _ProfileCode.ISSUER_MISMATCH.value,
-        _ProfileCode.ENVIRONMENT_MISMATCH.value,
-        # Emitted by the gateway itself when no managed identity resolved at all.
-        "managed_identity_required",
-    }
-)
-
-# A block that is NOT a shadow-client verdict. Scope/constraint/blueprint denials
-# mean a *sanctioned* client exceeded its grant, and the ``*_unavailable`` codes
-# are operator-side outages — counting either as shadow AI would attribute our
-# own degradation, or an authorized caller, to an attacker.
-_SANCTIONED_OR_DEGRADED_CODES = frozenset(
-    {
-        _ProfileCode.RESOLVED.value,
-        _ProfileCode.INSUFFICIENT_SCOPE.value,
-        _ProfileCode.TOOL_CONSTRAINT_CONFLICT.value,
-        _ProfileCode.BLUEPRINT_UNKNOWN.value,
-        _ProfileCode.BLUEPRINT_MISMATCH.value,
-        "identity_store_unavailable",
-        "profile_store_unavailable",
-    }
-)
-
 _SHADOW_BLOCK_MARKERS = (
     "undeclared",
     "shadow",
@@ -390,11 +358,9 @@ def _is_shadow_block(alert: dict[str, Any]) -> bool:
     # Canonical profile enforcement wins outright when the gateway recorded it.
     # Only fall through to marker inference when no recognized code is present
     # (direct in-process alerts from a standalone proxy, and older records).
-    code = str(alert.get("reason_code") or "").strip().lower()
-    if code in _UNSANCTIONED_CLIENT_CODES:
-        return True
-    if code in _SANCTIONED_OR_DEGRADED_CODES:
-        return False
+    canonical = classify_profile_shadow_reason(str(alert.get("reason_code") or ""))
+    if canonical is not None:
+        return canonical
 
     details = alert.get("details")
     detail_reason = ""

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -92,6 +92,7 @@ from agent_bom.runtime.gateway_relay_contract import (
     relay_upstream_from_config,
 )
 from agent_bom.runtime.graph_reachability import ReachabilityMap, load_reachability_map
+from agent_bom.runtime.profile_resolution import ProfileResolutionCode
 from agent_bom.security import sanitize_error, sanitize_text
 
 logger = logging.getLogger(__name__)
@@ -1789,6 +1790,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         token_scopes: set[str] = set()
         scoped_identity: Any = None
         managed_identity_lookup_unavailable = False
+        identity_failure_code = ""
         if identity_token:
             try:
                 from agent_bom.api.agent_identity_store import get_agent_identity_store, identity_for_token
@@ -1812,12 +1814,14 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             identity_verified = True
             if scoped_identity.tenant_id != tenant_id:
                 identity_invalid_reason = "managed identity tenant mismatch"
+                identity_failure_code = ProfileResolutionCode.TENANT_MISMATCH.value
             elif (
                 not scoped_identity.blueprint_id
                 and settings.drift_enforcement_mode == "enforce"
                 and not _gateway_allows_anonymous_agents(settings)
             ):
                 identity_invalid_reason = "managed identity has no role blueprint binding"
+                identity_failure_code = ProfileResolutionCode.PROFILE_INCOMPLETE.value
         elif as_claims is not None:
             source_agent = str(as_claims.get("sub") or "").strip() or ANONYMOUS
             token_present = True
@@ -1826,6 +1830,8 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             token_scopes = scopes_from_claims(as_claims)
         else:
             source_agent, token_present, identity_invalid_reason = check_caller_identity(message, current_policy)
+            if identity_invalid_reason is not None:
+                identity_failure_code = ProfileResolutionCode.IDENTITY_INVALID.value
             source_agent = source_agent or ANONYMOUS
             # "Verified" for inline mutual-auth: a resolved, non-anonymous caller
             # whose token was cryptographically checked — JWKS/OIDC-signed JWT or
@@ -1852,15 +1858,18 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             )
             if agent_revoked:
                 identity_invalid_reason = "agent identity revoked"
+                identity_failure_code = ProfileResolutionCode.IDENTITY_INACTIVE.value
             elif revocation_lookup_incomplete:
                 # A knowingly partial answer is not a negative. Revocation is an
                 # emergency control, so this denies on every listener — the
                 # loopback anonymous-agent allowance does not govern it.
                 identity_invalid_reason = "agent identity revocation status unavailable"
+                identity_failure_code = ProfileResolutionCode.IDENTITY_STORE_UNAVAILABLE.value
             elif revocation_lookup_failed and (
                 current_policy.get("require_agent_identity") or not _gateway_allows_anonymous_agents(settings)
             ):
                 identity_invalid_reason = "agent identity revocation status unavailable"
+                identity_failure_code = ProfileResolutionCode.IDENTITY_STORE_UNAVAILABLE.value
 
         identity_block_reason: str | None = None
         if identity_invalid_reason is not None:
@@ -1868,11 +1877,13 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         elif not token_present:
             if current_policy.get("require_agent_identity"):
                 identity_block_reason = "Identity required: no agent_identity token in _meta"
+                identity_failure_code = ProfileResolutionCode.MANAGED_IDENTITY_REQUIRED.value
             elif not _gateway_allows_anonymous_agents(settings):
                 identity_block_reason = (
                     "Anonymous agent caller denied on non-loopback listener; supply an agent_identity "
                     "token or set AGENT_BOM_GATEWAY_ALLOW_ANONYMOUS_AGENTS for local development only"
                 )
+                identity_failure_code = ProfileResolutionCode.MANAGED_IDENTITY_REQUIRED.value
 
         # A role blueprint is not a client profile. Keep them distinct until a
         # canonical assignment resolves successfully.
@@ -1937,6 +1948,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                             GatewayRuntimeEventType.TOOL_CALL_BLOCKED,
                             decision="deny",
                             policy_source="identity",
+                            reason_code=identity_failure_code,
                         ),
                     }
                 )
@@ -1961,9 +1973,9 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         if runtime_profile_mode != "off":
             profile_failure_code = ""
             if managed_identity_lookup_unavailable:
-                profile_failure_code = "identity_store_unavailable"
+                profile_failure_code = ProfileResolutionCode.IDENTITY_STORE_UNAVAILABLE.value
             elif scoped_identity is None:
-                profile_failure_code = "managed_identity_required"
+                profile_failure_code = ProfileResolutionCode.MANAGED_IDENTITY_REQUIRED.value
             else:
                 profile_identity_id = str(getattr(scoped_identity, "identity_id", "") or "")
                 try:
@@ -1979,7 +1991,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                         granted_scopes=token_scopes,
                     )
                 except Exception as exc:  # noqa: BLE001
-                    profile_failure_code = "profile_store_unavailable"
+                    profile_failure_code = ProfileResolutionCode.PROFILE_STORE_UNAVAILABLE.value
                     logger.warning("gateway runtime profile lookup unavailable: %s", sanitize_text(_public_gateway_error(exc)))
                 else:
                     if not resolution.resolved or resolution.profile is None:

--- a/src/agent_bom/runtime/profile_resolution.py
+++ b/src/agent_bom/runtime/profile_resolution.py
@@ -21,7 +21,10 @@ PROFILE_SCHEMA_VERSION = "runtime.client.profile.v1"
 
 class ProfileResolutionCode(str, Enum):
     RESOLVED = "resolved"
+    IDENTITY_INVALID = "identity_invalid"
     IDENTITY_INACTIVE = "identity_inactive"
+    IDENTITY_STORE_UNAVAILABLE = "identity_store_unavailable"
+    MANAGED_IDENTITY_REQUIRED = "managed_identity_required"
     TENANT_MISMATCH = "tenant_mismatch"
     PROFILE_NOT_FOUND = "profile_not_found"
     PROFILE_REVOKED = "profile_revoked"
@@ -34,6 +37,53 @@ class ProfileResolutionCode(str, Enum):
     ENVIRONMENT_MISMATCH = "environment_mismatch"
     INSUFFICIENT_SCOPE = "insufficient_scope"
     TOOL_CONSTRAINT_CONFLICT = "tool_constraint_conflict"
+    PROFILE_STORE_UNAVAILABLE = "profile_store_unavailable"
+
+
+_UNSANCTIONED_PROFILE_REASON_CODES = frozenset(
+    {
+        ProfileResolutionCode.IDENTITY_INACTIVE.value,
+        ProfileResolutionCode.IDENTITY_INVALID.value,
+        ProfileResolutionCode.MANAGED_IDENTITY_REQUIRED.value,
+        ProfileResolutionCode.TENANT_MISMATCH.value,
+        ProfileResolutionCode.PROFILE_NOT_FOUND.value,
+        ProfileResolutionCode.PROFILE_REVOKED.value,
+        ProfileResolutionCode.PROFILE_DISABLED.value,
+        ProfileResolutionCode.PROFILE_EXPIRED.value,
+        ProfileResolutionCode.PROFILE_INCOMPLETE.value,
+        ProfileResolutionCode.ISSUER_MISMATCH.value,
+        ProfileResolutionCode.ENVIRONMENT_MISMATCH.value,
+    }
+)
+
+_NON_SHADOW_PROFILE_REASON_CODES = frozenset(
+    {
+        ProfileResolutionCode.RESOLVED.value,
+        ProfileResolutionCode.INSUFFICIENT_SCOPE.value,
+        ProfileResolutionCode.TOOL_CONSTRAINT_CONFLICT.value,
+        ProfileResolutionCode.BLUEPRINT_UNKNOWN.value,
+        ProfileResolutionCode.BLUEPRINT_MISMATCH.value,
+        # Operator-side lookup failures are degraded evidence, not shadow AI.
+        ProfileResolutionCode.IDENTITY_STORE_UNAVAILABLE.value,
+        ProfileResolutionCode.PROFILE_STORE_UNAVAILABLE.value,
+    }
+)
+
+
+def classify_profile_shadow_reason(reason_code: str) -> bool | None:
+    """Classify canonical profile reasons without inferring from free text.
+
+    ``None`` preserves the legacy compatibility boundary: callers may apply
+    marker inference only to old proxy-shaped events whose reason is not part
+    of the canonical profile contract.
+    """
+
+    normalized = str(reason_code or "").strip().lower()
+    if normalized in _UNSANCTIONED_PROFILE_REASON_CODES:
+        return True
+    if normalized in _NON_SHADOW_PROFILE_REASON_CODES:
+        return False
+    return None
 
 
 @dataclass(frozen=True)
@@ -223,5 +273,6 @@ __all__ = [
     "ProfileResolution",
     "ProfileResolutionCode",
     "ResolvedRuntimeProfile",
+    "classify_profile_shadow_reason",
     "resolve_runtime_profile",
 ]

--- a/tests/test_gateway_activity_ledger.py
+++ b/tests/test_gateway_activity_ledger.py
@@ -406,6 +406,38 @@ def test_window_summary_counts_canonical_events_without_materializing_payloads(s
 
 
 @pytest.mark.parametrize("store_kind", ["memory", "sqlite"])
+@pytest.mark.parametrize(
+    "reason_code",
+    ["identity_invalid", "managed_identity_required", "tenant_mismatch", "profile_revoked"],
+)
+def test_window_summary_counts_canonical_unsanctioned_profile_block_as_shadow(store_kind: str, reason_code: str, tmp_path) -> None:
+    store = (
+        InMemoryGatewayActivityStore(max_events_per_tenant=20)
+        if store_kind == "memory"
+        else SQLiteGatewayActivityStore(str(tmp_path / "activity.db"), max_events_per_tenant=20)
+    )
+    store.append_batch(
+        [
+            _record(
+                "revoked-profile",
+                event_type="gateway.tool_call.blocked",
+                decision="deny",
+                reason_code=reason_code,
+            )
+        ]
+    )
+
+    summary = store.summarize_window(
+        "tenant-a",
+        start="2026-07-28T00:00:00+00:00",
+        end="2026-07-28T23:59:59+00:00",
+    )
+
+    assert summary.blocked == 1
+    assert summary.shadow_blocked == 1
+
+
+@pytest.mark.parametrize("store_kind", ["memory", "sqlite"])
 def test_cursor_ordinal_beyond_the_storage_range_is_a_bad_cursor_not_an_outage(store_kind: str, tmp_path) -> None:
     """A read client must not be able to make the ledger report itself down.
 

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -18,6 +18,7 @@ import json
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -27,6 +28,8 @@ from starlette.testclient import TestClient
 
 import agent_bom.gateway_server as gateway_server
 from agent_bom.api.auth import Role
+from agent_bom.api.gateway_activity_store import InMemoryGatewayActivityStore, SQLiteGatewayActivityStore
+from agent_bom.api.routes.proxy import _gateway_activity_record_from_alert
 from agent_bom.api.tracing import parse_traceparent
 from agent_bom.gateway_server import GatewaySettings, GatewayUpstreamRelay, create_gateway_app
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
@@ -1668,7 +1671,8 @@ def test_relay_loopback_allows_anonymous_caller() -> None:
     assert resp.json()["result"] == {"ok": True}
 
 
-def test_relay_non_loopback_denies_anonymous_by_default(monkeypatch) -> None:
+@pytest.mark.parametrize("store_kind", ["memory", "sqlite"])
+def test_relay_non_loopback_denies_anonymous_by_default(monkeypatch, tmp_path, store_kind: str) -> None:
     _no_key_store(monkeypatch)
     audit_events: list[dict[str, Any]] = []
 
@@ -1692,6 +1696,31 @@ def test_relay_non_loopback_denies_anonymous_by_default(monkeypatch) -> None:
     assert audit_events[0]["event_type"] == "gateway.tool_call.blocked"
     assert audit_events[0]["decision"] == "deny"
     assert audit_events[0]["policy_source"] == "identity"
+    assert audit_events[0]["reason_code"] == "managed_identity_required"
+
+    received_at = datetime.now(timezone.utc)
+    record = _gateway_activity_record_from_alert(
+        audit_events[0],
+        tenant_id="default",
+        source_id="gateway-e2e",
+        session_id="session-e2e",
+        received_at=received_at,
+        request_trace_id="trace-e2e",
+    )
+    assert record is not None
+    store = (
+        InMemoryGatewayActivityStore(max_events_per_tenant=20)
+        if store_kind == "memory"
+        else SQLiteGatewayActivityStore(str(tmp_path / "activity.db"), max_events_per_tenant=20)
+    )
+    store.append_batch([record])
+    summary = store.summarize_window(
+        "default",
+        start=(received_at - timedelta(minutes=1)).isoformat(),
+        end=(received_at + timedelta(minutes=1)).isoformat(),
+    )
+    assert summary.blocked == 1
+    assert summary.shadow_blocked == 1
 
 
 def test_relay_non_loopback_allows_anonymous_with_opt_out_flag(monkeypatch) -> None:
@@ -1740,10 +1769,16 @@ def test_relay_invalid_token_always_fails_closed_on_loopback(monkeypatch) -> Non
     async def fake_caller(upstream, message, extra_headers):
         raise AssertionError("invalid-token caller must not relay upstream")
 
+    audit_events: list[dict[str, Any]] = []
+
+    async def audit_sink(event):
+        audit_events.append(event)
+
     settings = GatewaySettings(
         registry=_simple_registry(),
         policy={"agent_tokens": {"good-token": "agent-a"}},
         upstream_caller=fake_caller,
+        audit_sink=audit_sink,
         allow_anonymous_agents=True,  # opt-out only governs MISSING identity, not invalid
     )
     client = TestClient(create_gateway_app(settings))
@@ -1752,6 +1787,7 @@ def test_relay_invalid_token_always_fails_closed_on_loopback(monkeypatch) -> Non
         json=_json_rpc("tools/call", name="read_file", arguments={}, _meta={"agent_identity": "forged-token"}),
     )
     _assert_identity_blocked(resp)
+    assert audit_events[0]["reason_code"] == "identity_invalid"
 
 
 def test_relay_valid_token_relays_on_non_loopback(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- emit stable identity and managed-profile failure codes on canonical gateway decisions
- use one profile-reason classifier for live-feed and durable memory, SQLite, and Postgres KPI aggregation
- count missing, invalid, tenant-mismatched, inactive, and revoked profile blocks without treating operator-store outages as Shadow AI

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-shadow-kpi-uv uv run pytest -q tests/test_gateway_server.py tests/test_gateway_activity_ledger.py tests/api/test_api_gateway_feed.py tests/api/test_gateway_feed_durable.py tests/api/test_gateway_feed_health.py tests/test_runtime_profile_resolution.py` (149 passed)
- targeted Ruff check and format checks
- targeted MyPy (4 source files)
- `uv run python scripts/check_exception_sanitization.py`
- `make preflight`
- independent gateway-to-ledger revalidation (10 passed)

## Notes

- Gateway identity authorization remains fail-closed; this change makes the retained decision evidence and KPIs match that enforcement.
- Progresses #4152.