### PR TITLE
fix(ci): isolate measured output scale budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1120,13 +1120,44 @@ jobs:
           needs.changes.outputs.graph_performance == 'true'
         run: uv run pytest tests/graph/test_store_backed_build_wiring.py -q -m graph_performance
 
+  output-scale-performance:
+    name: Output scale performance
+    runs-on: ubuntu-latest
+    # Wall-clock assertions need an isolated, uninstrumented process. Running
+    # them inside the four-worker Python 3.11 coverage lane measures shared
+    # runner contention instead of exporter latency (issue #4968).
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    needs: changes
+    if: >-
+      !cancelled() && (
+        github.event_name != 'pull_request' ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.python == 'true'
+      )
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev --extra api --extra mcp-server
+
+      - name: Run measured output scale assertions
+        run: >-
+          uv run pytest tests/test_release_output_scale_contract.py -q
+          --tb=short --durations=10 -m output_performance -p no:randomly
+
   test:
     name: Test (Python 3.13)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
-    needs: [changes, test-smoke, test-pr-shard, test-main, graph-performance]
+    needs: [changes, test-smoke, test-pr-shard, test-main, graph-performance, output-scale-performance]
     if: ${{ !cancelled() }}
     steps:
       - name: Require every applicable correctness lane
@@ -1135,9 +1166,10 @@ jobs:
           PR_SHARDS_RESULT: ${{ needs.test-pr-shard.result }}
           MAIN_RESULT: ${{ needs.test-main.result }}
           GRAPH_RESULT: ${{ needs.graph-performance.result }}
+          OUTPUT_SCALE_RESULT: ${{ needs.output-scale-performance.result }}
         run: |
           set -euo pipefail
-          for result in "$SMOKE_RESULT" "$PR_SHARDS_RESULT" "$MAIN_RESULT" "$GRAPH_RESULT"; do
+          for result in "$SMOKE_RESULT" "$PR_SHARDS_RESULT" "$MAIN_RESULT" "$GRAPH_RESULT" "$OUTPUT_SCALE_RESULT"; do
             case "$result" in
               success|skipped) ;;
               *) echo "Required correctness lane ended with: $result" >&2; exit 1 ;;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -353,6 +353,7 @@ markers = [
     "network: tests that require network access (OSV API)",
     "slow: slow tests (e.g. large-scale perf benchmarks) — opt-in only",
     "graph_performance: measured graph scale assertions — graph changes, main, and scheduled evidence only",
+    "output_performance: measured export and API projection scale assertions — dedicated CI lane only",
     "live_cluster: tests that require a reachable local Kubernetes cluster (e.g. kind) — opt-in only",
     "real_vuln_db_sync: test drives sync_db itself; opts out of the autouse no-download patch",
 ]

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -229,6 +229,37 @@ def test_measured_graph_heap_assertion_has_dedicated_conditional_job() -> None:
     assert "-m graph_performance" in nightly
 
 
+def test_output_scale_budgets_run_in_a_dedicated_uninstrumented_lane() -> None:
+    """Wall-clock budgets must not share coverage/xdist CPU with the full suite."""
+
+    jobs = _ci()["jobs"]
+    scale_job = jobs["output-scale-performance"]
+    run = next(step["run"] for step in scale_job["steps"] if step.get("name") == "Run measured output scale assertions")
+    setup = next(step for step in scale_job["steps"] if step.get("uses") == "./.github/actions/setup-python")
+
+    assert setup["with"]["python-version"] == "3.11"
+    assert scale_job["needs"] == "changes"
+    assert "github.event_name != 'pull_request'" in scale_job["if"]
+    assert "needs.changes.outputs.python == 'true'" in scale_job["if"]
+    assert "tests/test_release_output_scale_contract.py" in run
+    assert "-m output_performance" in run
+    assert "--cov" not in run
+    assert " -n " not in run
+
+    main_run = next(step["run"] for step in jobs["test-main"]["steps"] if step.get("name") == "Run full correctness suite")
+    assert "not slow" in main_run
+
+    required = jobs["test"]
+    assert "output-scale-performance" in required["needs"]
+    required_run = next(step["run"] for step in required["steps"] if step.get("name") == "Require every applicable correctness lane")
+    assert "OUTPUT_SCALE_RESULT" in required_run
+    assert '"$OUTPUT_SCALE_RESULT"' in required_run
+
+    scale_test = (ROOT / "tests" / "test_release_output_scale_contract.py").read_text(encoding="utf-8")
+    assert "pytest.mark.slow" in scale_test
+    assert "pytest.mark.output_performance" in scale_test
+
+
 def test_security_reuses_typescript_install_for_build() -> None:
     text = CI_WORKFLOW.read_text(encoding="utf-8")
     security = text.split("  # 2. Linting + Type Checking", 1)[0]

--- a/tests/test_release_output_scale_contract.py
+++ b/tests/test_release_output_scale_contract.py
@@ -25,6 +25,8 @@ from agent_bom.models import Agent, AgentType, AIBOMReport, BlastRadius, MCPServ
 from agent_bom.output import to_csv, to_cyclonedx, to_html, to_markdown, to_spdx
 from agent_bom.output.spdx2_fmt import to_spdx2
 
+pytestmark = [pytest.mark.slow, pytest.mark.output_performance]
+
 _ITEM_COUNT = 2_000
 _SECRET = "ghp_" + "s" * 36
 _EMAIL = "scale.sentinel@example.invalid"


### PR DESCRIPTION
## Summary

- move the 2,000-item export/API wall-clock contracts out of the four-worker coverage suite into a required serial Python 3.11 lane
- retain the scale assertions as release gates while preventing shared-runner contention from being measured as exporter latency
- lock the dedicated lane, main/PR conditions, and required aggregator wiring with workflow-contract tests

## Verification

- red-first: the workflow contract failed because no dedicated output-scale lane existed
- clean Python 3.11 scale suite without coverage/xdist: 3 passed
- clean Python 3.11 scale suite under coverage/xdist: 3 passed, confirming the exporters themselves satisfy their per-export budgets when not competing with the full suite
- dedicated serial command: 3 passed in 11.78s
- `uv run pytest -q tests/test_ci_workflow_contract.py` (26 passed)
- `actionlint .github/workflows/ci.yml`
- Ruff check and format
- `make preflight`
- independent workflow review: no P0/P1 and no gate weakening

## Notes

- Main run 33040586348 completed 20,294 tests and failed only CSV/CycloneDX absolute timings in the Python 3.11 coverage lane; Python 3.13 and 3.14 passed.
- The required aggregator rejects a failed or canceled output-scale lane; docs/UI/deploy-only PRs may skip it, while every main run executes it.

Closes #4968.