### PR TITLE
fix(runtime): require durable gateway audit delivery

### DIFF
--- a/deploy/helm/agent-bom/examples/README.md
+++ b/deploy/helm/agent-bom/examples/README.md
@@ -14,13 +14,13 @@ product split.
 | `enterprise-demo` | `eks-mcp-pilot-values.yaml` + `eks-enterprise-demo-overlay.yaml` | Focused pilot plus scheduled AWS estate inventory (IRSA, `AGENT_BOM_AWS_INVENTORY=1`) |
 | `byo-postgres` | `byo-postgres-values.yaml` | Overlay for operator-owned Postgres-compatible databases, including Snowflake Postgres candidates |
 | `production` | `eks-production-values.yaml` | Postgres-backed production EKS rollout with autoscaling, backup, and ExternalSecrets |
-| `keda-autoscaling` | `eks-production-values.yaml` + `eks-keda-values.yaml` + `gateway-upstreams.example.yaml` | Production overlay with KEDA-backed API and gateway autoscaling |
+| `keda-autoscaling` | `eks-production-values.yaml` + `eks-keda-values.yaml` | Production overlay with KEDA-backed control-plane API autoscaling |
 | `eks-vanilla` | `eks-vanilla-values.yaml` | Postgres-backed production EKS rollout with ALB, IRSA, Kubernetes Secrets, and no service mesh / ESO / cert-manager requirement |
 | `mesh-hardening` | `eks-istio-kyverno-values.yaml` | Overlay for Istio mTLS/authz and Kyverno policy-controller packaging |
 | `collector-mtls` | `collector-mtls-values.yaml` | Scanner fleet-sync push with client TLS + delegated control-plane mTLS posture env |
 | `oidc-discovery-shim` | `eks-mcp-pilot-values.yaml` + `gateway-upstreams.example.yaml` + `oidc-discovery-shim-values.yaml` | Gateway-hosted `/.well-known/openid-configuration` for legacy IdPs (MCP OAuth interop) |
 | `snowflake-backend` | `eks-snowflake-values.yaml` | Overlay for Snowflake governance and selected store parity, not a claim of full control-plane replacement |
-| `gateway-runtime` | `eks-mcp-pilot-values.yaml` + `gateway-upstreams.example.yaml` | Focused pilot plus central gateway rendering for shared MCP relay/policy |
+| `gateway-runtime` | `eks-mcp-pilot-values.yaml` + `gateway-upstreams.example.yaml` | Focused pilot plus one PVC-backed gateway writer for shared MCP relay/policy; pre-create the `agent-bom-gateway-audit` claim |
 | `control-plane-identity` | `control-plane-identity-values.yaml` | Keyless control-plane cloud identity (EKS IRSA / EC2-ECS instance role / AKS + GKE workload identity) that assumes read-only connect roles — zero static keys. See `docs/DEPLOY_PLATFORM.md` "Connect your cloud (zero keys)" |
 
 ## Validate the shipped profiles

--- a/deploy/helm/agent-bom/examples/eks-keda-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-keda-values.yaml
@@ -80,39 +80,3 @@ controlPlane:
                     value: 4
                     periodSeconds: 30
                 selectPolicy: Max
-
-gateway:
-  autoscaling:
-    enabled: true
-    minReplicas: 3
-    maxReplicas: 12
-    keda:
-      enabled: true
-      pollingIntervalSeconds: 30
-      cooldownSeconds: 300
-      prometheus:
-        serverAddress: http://prometheus.monitoring.svc:9090
-        relayRateThreshold: "25"
-        pressureRateThreshold: "1"
-      fallback:
-        failureThreshold: 3
-        replicas: 3
-      advanced:
-        horizontalPodAutoscalerConfig:
-          behavior:
-            scaleDown:
-              stabilizationWindowSeconds: 300
-              policies:
-                - type: Percent
-                  value: 25
-                  periodSeconds: 60
-            scaleUp:
-              stabilizationWindowSeconds: 30
-              policies:
-                - type: Percent
-                  value: 100
-                  periodSeconds: 30
-                - type: Pods
-                  value: 4
-                  periodSeconds: 30
-              selectPolicy: Max

--- a/deploy/helm/agent-bom/examples/oidc-discovery-shim-values.yaml
+++ b/deploy/helm/agent-bom/examples/oidc-discovery-shim-values.yaml
@@ -15,6 +15,12 @@
 
 gateway:
   enabled: true
+  replicas: 1
+  persistence:
+    enabled: true
+    # Provision this PVC before installing the example. It retains mandatory
+    # gateway audit outcomes across control-plane outages and pod reschedules.
+    existingClaim: agent-bom-gateway-audit
   env:
     - name: AGENT_BOM_OIDC_DISCOVERY_SHIM_JSON
       value: |

--- a/deploy/helm/agent-bom/templates/gateway-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/gateway-deployment.yaml
@@ -1,14 +1,14 @@
 {{- $profileEnforcement := .Values.gateway.profileEnforcement | default "off" -}}
 {{- $gatewayEnvFrom := .Values.gateway.envFrom -}}
 {{- $gatewayPersistence := .Values.gateway.persistence | default dict -}}
-{{- $gatewayRuntimeReplicas := int (.Values.gateway.replicas | default 2) -}}
+{{- $gatewayRuntimeReplicas := int (.Values.gateway.replicas | default 1) -}}
 {{- if or (.Values.gateway.autoscaling.enabled | default false) (.Values.gateway.autoscaling.keda.enabled | default false) -}}
 {{- $gatewayRuntimeReplicas = int (.Values.gateway.autoscaling.maxReplicas | default 2) -}}
 {{- end -}}
-{{- if and .Values.gateway.enabled (not (.Values.gateway.controlPlaneDiscovery.url | default "")) (not ($gatewayPersistence.enabled | default false)) -}}
-{{- fail "local-only gateway audit requires gateway.persistence.enabled=true and a restart-stable PVC" -}}
+{{- if and .Values.gateway.enabled (not ($gatewayPersistence.enabled | default false)) -}}
+{{- fail "gateway audit requires gateway.persistence.enabled=true and a restart-stable PVC, including control-plane-connected deployments" -}}
 {{- end -}}
-{{- if and .Values.gateway.enabled ($gatewayPersistence.enabled | default false) (ne (int (.Values.gateway.replicas | default 2)) 1) -}}
+{{- if and .Values.gateway.enabled ($gatewayPersistence.enabled | default false) (ne (int (.Values.gateway.replicas | default 1)) 1) -}}
 {{- fail "gateway persistence requires gateway.replicas=1 because durable delivery claims are process-owned" -}}
 {{- end -}}
 {{- if and .Values.gateway.enabled ($gatewayPersistence.enabled | default false) (or (.Values.gateway.autoscaling.enabled | default false) (.Values.gateway.autoscaling.keda.enabled | default false)) -}}
@@ -30,7 +30,7 @@ metadata:
     {{- include "agent-bom.labels" . | nindent 4 }}
     app.kubernetes.io/component: gateway
 spec:
-  replicas: {{ .Values.gateway.replicas | default 2 }}
+  replicas: {{ .Values.gateway.replicas | default 1 }}
   {{- if ($gatewayPersistence.enabled | default false) }}
   strategy:
     type: Recreate

--- a/deploy/helm/agent-bom/templates/gateway-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/gateway-deployment.yaml
@@ -105,8 +105,10 @@ spec:
               port: http
             initialDelaySeconds: 2
             periodSeconds: 5
-          {{- with .Values.gateway.env }}
           env:
+            - name: AGENT_BOM_STATE_DIR
+              value: {{ .Values.gateway.stateDir | default "/tmp/agent-bom" | quote }}
+          {{- with .Values.gateway.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with $gatewayEnvFrom }}

--- a/deploy/helm/agent-bom/templates/gateway-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/gateway-deployment.yaml
@@ -5,6 +5,9 @@
 {{- if or (.Values.gateway.autoscaling.enabled | default false) (.Values.gateway.autoscaling.keda.enabled | default false) -}}
 {{- $gatewayRuntimeReplicas = int (.Values.gateway.autoscaling.maxReplicas | default 2) -}}
 {{- end -}}
+{{- if and .Values.gateway.enabled (not (.Values.gateway.controlPlaneDiscovery.url | default "")) (not ($gatewayPersistence.enabled | default false)) -}}
+{{- fail "local-only gateway audit requires gateway.persistence.enabled=true and a restart-stable PVC" -}}
+{{- end -}}
 {{- if and .Values.gateway.enabled ($gatewayPersistence.enabled | default false) (ne (int (.Values.gateway.replicas | default 2)) 1) -}}
 {{- fail "gateway persistence requires gateway.replicas=1 because durable delivery claims are process-owned" -}}
 {{- end -}}

--- a/deploy/helm/agent-bom/templates/gateway-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/gateway-deployment.yaml
@@ -1,6 +1,10 @@
 {{- $profileEnforcement := .Values.gateway.profileEnforcement | default "off" -}}
 {{- $gatewayEnvFrom := .Values.gateway.envFrom -}}
 {{- $gatewayPersistence := .Values.gateway.persistence | default dict -}}
+{{- $gatewayRuntimeReplicas := int (.Values.gateway.replicas | default 2) -}}
+{{- if or (.Values.gateway.autoscaling.enabled | default false) (.Values.gateway.autoscaling.keda.enabled | default false) -}}
+{{- $gatewayRuntimeReplicas = int (.Values.gateway.autoscaling.maxReplicas | default 2) -}}
+{{- end -}}
 {{- if and .Values.gateway.enabled ($gatewayPersistence.enabled | default false) (ne (int (.Values.gateway.replicas | default 2)) 1) -}}
 {{- fail "gateway persistence requires gateway.replicas=1 because durable delivery claims are process-owned" -}}
 {{- end -}}
@@ -24,6 +28,10 @@ metadata:
     app.kubernetes.io/component: gateway
 spec:
   replicas: {{ .Values.gateway.replicas | default 2 }}
+  {{- if ($gatewayPersistence.enabled | default false) }}
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "agent-bom.name" . }}
@@ -116,6 +124,8 @@ spec:
             initialDelaySeconds: 2
             periodSeconds: 5
           env:
+            - name: AGENT_BOM_GATEWAY_REPLICAS
+              value: {{ $gatewayRuntimeReplicas | quote }}
             - name: AGENT_BOM_STATE_DIR
               {{- if ($gatewayPersistence.enabled | default false) }}
               value: {{ $gatewayPersistence.mountPath | default "/var/lib/agent-bom" | quote }}

--- a/deploy/helm/agent-bom/templates/gateway-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/gateway-deployment.yaml
@@ -1,5 +1,15 @@
 {{- $profileEnforcement := .Values.gateway.profileEnforcement | default "off" -}}
 {{- $gatewayEnvFrom := .Values.gateway.envFrom -}}
+{{- $gatewayPersistence := .Values.gateway.persistence | default dict -}}
+{{- if and .Values.gateway.enabled ($gatewayPersistence.enabled | default false) (ne (int (.Values.gateway.replicas | default 2)) 1) -}}
+{{- fail "gateway persistence requires gateway.replicas=1 because durable delivery claims are process-owned" -}}
+{{- end -}}
+{{- if and .Values.gateway.enabled ($gatewayPersistence.enabled | default false) (or (.Values.gateway.autoscaling.enabled | default false) (.Values.gateway.autoscaling.keda.enabled | default false)) -}}
+{{- fail "gateway persistence is incompatible with gateway autoscaling until cross-pod delivery leases are implemented" -}}
+{{- end -}}
+{{- if and .Values.gateway.enabled ($gatewayPersistence.enabled | default false) (not ($gatewayPersistence.existingClaim | default "")) -}}
+{{- fail "gateway.persistence.existingClaim is required when gateway persistence is enabled" -}}
+{{- end -}}
 {{- if and .Values.gateway.enabled (ne $profileEnforcement "off") (not $gatewayEnvFrom) -}}
 {{- fail "gateway profile enforcement requires gateway.envFrom with a gateway-scoped Secret containing the shared AGENT_BOM_POSTGRES_URL" -}}
 {{- end -}}
@@ -101,13 +111,17 @@ spec:
             periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: http
             initialDelaySeconds: 2
             periodSeconds: 5
           env:
             - name: AGENT_BOM_STATE_DIR
+              {{- if ($gatewayPersistence.enabled | default false) }}
+              value: {{ $gatewayPersistence.mountPath | default "/var/lib/agent-bom" | quote }}
+              {{- else }}
               value: {{ .Values.gateway.stateDir | default "/tmp/agent-bom" | quote }}
+              {{- end }}
           {{- with .Values.gateway.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -129,6 +143,10 @@ spec:
               readOnly: true
             - name: tmp
               mountPath: /tmp
+            {{- if ($gatewayPersistence.enabled | default false) }}
+            - name: audit-state
+              mountPath: {{ $gatewayPersistence.mountPath | default "/var/lib/agent-bom" | quote }}
+            {{- end }}
             {{- with .Values.gateway.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -138,6 +156,11 @@ spec:
             name: {{ include "agent-bom.name" . }}-gateway-upstreams
         - name: tmp
           emptyDir: {}
+        {{- if ($gatewayPersistence.enabled | default false) }}
+        - name: audit-state
+          persistentVolumeClaim:
+            claimName: {{ required "gateway.persistence.existingClaim is required" $gatewayPersistence.existingClaim | quote }}
+        {{- end }}
         {{- with .Values.gateway.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -312,6 +312,11 @@ gateway:
     # Optional URL for --from-control-plane discovery.
     # Example: https://agent-bom.internal.example.com
     url: ""
+  # Writable local state for the bounded gateway audit backlog. The default
+  # uses the pod's /tmp emptyDir and survives container restarts in that pod.
+  # For pod rescheduling durability, mount a PVC with extraVolumes /
+  # extraVolumeMounts and point stateDir at that mount.
+  stateDir: /tmp/agent-bom
   # Optional runtime policy JSON path (mounted via extraVolumes + extraVolumeMounts).
   policyPath: ""
   # In-process policy file reload interval; requires policyPath when > 0.

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -316,8 +316,9 @@ gateway:
   # uses the pod's /tmp emptyDir and survives container restarts in that pod.
   stateDir: /tmp/agent-bom
   # Opt-in pod-rescheduling durability. Claims are process-owned, so the chart
-  # deliberately requires one replica and disables both HPA modes when a PVC
-  # is used. Scale-out needs a shared lease implementation that is not shipped.
+  # deliberately requires one replica, disables both HPA modes, and uses a
+  # Recreate rollout when a PVC is used. Scale-out needs a shared lease
+  # implementation that is not shipped.
   persistence:
     enabled: false
     existingClaim: ""

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -312,13 +312,15 @@ gateway:
     # Optional URL for --from-control-plane discovery.
     # Example: https://agent-bom.internal.example.com
     url: ""
-  # Writable local state for the bounded gateway audit backlog. The default
-  # uses the pod's /tmp emptyDir and survives container restarts in that pod.
+  # Writable local retry state. With control-plane discovery, tools/call is
+  # forwarded only after the control plane durably acknowledges admission, so
+  # this pod-local cache never substitutes for canonical evidence. A gateway
+  # without a control-plane URL must enable the PVC-backed mode below.
   stateDir: /tmp/agent-bom
-  # Opt-in pod-rescheduling durability. Claims are process-owned, so the chart
-  # deliberately requires one replica, disables both HPA modes, and uses a
-  # Recreate rollout when a PVC is used. Scale-out needs a shared lease
-  # implementation that is not shipped.
+  # Pod-rescheduling durability for a local-only gateway. Claims and the local
+  # HMAC chain are process-owned, so the chart requires one replica, disables
+  # both HPA modes, and uses a Recreate rollout when a PVC is used. Scale-out
+  # needs a shared lease implementation that is not shipped.
   persistence:
     enabled: false
     existingClaim: ""

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -314,9 +314,14 @@ gateway:
     url: ""
   # Writable local state for the bounded gateway audit backlog. The default
   # uses the pod's /tmp emptyDir and survives container restarts in that pod.
-  # For pod rescheduling durability, mount a PVC with extraVolumes /
-  # extraVolumeMounts and point stateDir at that mount.
   stateDir: /tmp/agent-bom
+  # Opt-in pod-rescheduling durability. Claims are process-owned, so the chart
+  # deliberately requires one replica and disables both HPA modes when a PVC
+  # is used. Scale-out needs a shared lease implementation that is not shipped.
+  persistence:
+    enabled: false
+    existingClaim: ""
+    mountPath: /var/lib/agent-bom
   # Optional runtime policy JSON path (mounted via extraVolumes + extraVolumeMounts).
   policyPath: ""
   # In-process policy file reload interval; requires policyPath when > 0.

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -273,8 +273,13 @@ monitor:
 # ─────────────────────────────────────────────────────────────────────────────
 gateway:
   enabled: false
-  replicas: 2
+  # Durable delivery claims are process-owned; the shipped topology is one
+  # replica with a restart-stable PVC. Scale-out requires shared leases.
+  replicas: 1
   autoscaling:
+    # Reserved for a future shared-lease delivery backend. Enabling either HPA
+    # mode currently fails rendering because persistent audit delivery is
+    # required and supports one writer.
     enabled: false
     minReplicas: 2
     maxReplicas: 6
@@ -312,12 +317,11 @@ gateway:
     # Optional URL for --from-control-plane discovery.
     # Example: https://agent-bom.internal.example.com
     url: ""
-  # Writable local retry state. With control-plane discovery, tools/call is
-  # forwarded only after the control plane durably acknowledges admission, so
-  # this pod-local cache never substitutes for canonical evidence. A gateway
-  # without a control-plane URL must enable the PVC-backed mode below.
+  # Writable local retry state. Every Helm gateway requires the PVC-backed mode
+  # below: even with control-plane discovery, post-forward outcomes and errors
+  # must survive a control-plane outage and pod reschedule without loss.
   stateDir: /tmp/agent-bom
-  # Pod-rescheduling durability for a local-only gateway. Claims and the local
+  # Pod-rescheduling durability for every gateway. Claims and the local
   # HMAC chain are process-owned, so the chart requires one replica, disables
   # both HPA modes, and uses a Recreate rollout when a PVC is used. Scale-out
   # needs a shared lease implementation that is not shipped.

--- a/docs/AGENT_FIREWALL.md
+++ b/docs/AGENT_FIREWALL.md
@@ -174,6 +174,12 @@ through the configured audit sink. In a normal cluster install that sink fans
 out to `/v1/proxy/audit`, so denies and warns flow into the same HMAC-chained
 audit table the proxy already writes to.
 
+The standalone gateway binds both the response and audit event to the
+authenticated request tenant. When a policy declares `tenant_id`, a request
+authenticated for a different tenant is rejected with `403`; the gateway never
+relabels that request as the policy tenant. Static bearer and OAuth gateway
+credentials use the operator-controlled `AGENT_BOM_TENANT_ID` binding.
+
 The control-plane API route records every decision directly into
 `/v1/firewall/stats`, including allow decisions, so the runtime dashboard has a
 denominator for allow/warn/deny trends.

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-26",
+  "generated_on": "2026-08-27",
   "version": "0.102.0",
   "metrics": [
     {
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 874,
+      "value": 875,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-26`
+- Generated on: `2026-08-27`
 - Version: `0.102.0`
 
 | Metric | Value | Source | Notes |
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 49 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 874 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 875 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -9,6 +9,14 @@ single canonical version.
 For policy-layer ordering inside a single tool-call see
 `docs/POLICY_PRECEDENCE.md`. This page is the higher-level surface map.
 
+The standalone gateway exposes separate liveness and admission signals.
+`/healthz` reports delivery degradation and bounded backlog details. `/readyz`
+continues returning 200 while the local audit spool is durable, observable, and
+accepting events, even if the remote control plane is temporarily unavailable;
+it returns 503 when persistence cannot be observed, the bounded backlog cannot
+accept another event, or shutdown has begun. This keeps degraded delivery
+truthful without removing a safely spooling gateway from service.
+
 ### Runtime doc set
 
 This page is the canonical runtime surface map. The detail docs:

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -14,9 +14,11 @@ The standalone gateway exposes separate liveness and admission signals.
 returns 200 only while the configured audit path can admit tool execution. A
 control-plane gateway therefore becomes unready when the remote durable
 acknowledgement is unavailable, even though its bounded local spool retains the
-event for retry. A local-only gateway remains ready while its restart-stable
-SQLite audit store is writable. Persistence failure, a full bounded backlog, or
-shutdown returns 503.
+event for retry. The Helm chart requires that spool on a restart-stable PVC for
+both remote-connected and local-only gateways, runs one writer replica, and
+rejects autoscaling until shared delivery leases exist. A local-only gateway
+remains ready while its SQLite audit store is writable. Persistence failure, a
+full bounded backlog, or shutdown returns 503.
 
 ### Runtime doc set
 

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -11,11 +11,12 @@ For policy-layer ordering inside a single tool-call see
 
 The standalone gateway exposes separate liveness and admission signals.
 `/healthz` reports delivery degradation and bounded backlog details. `/readyz`
-continues returning 200 while the local audit spool is durable, observable, and
-accepting events, even if the remote control plane is temporarily unavailable;
-it returns 503 when persistence cannot be observed, the bounded backlog cannot
-accept another event, or shutdown has begun. This keeps degraded delivery
-truthful without removing a safely spooling gateway from service.
+returns 200 only while the configured audit path can admit tool execution. A
+control-plane gateway therefore becomes unready when the remote durable
+acknowledgement is unavailable, even though its bounded local spool retains the
+event for retry. A local-only gateway remains ready while its restart-stable
+SQLite audit store is writable. Persistence failure, a full bounded backlog, or
+shutdown returns 503.
 
 ### Runtime doc set
 

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -207,8 +207,7 @@ else:
 def _hmac_sha256_hex(signing_key: bytes, payload: bytes) -> str:
     """Authenticate an audit payload with HMAC; this is not password hashing."""
 
-    # codeql[py/weak-sensitive-data-hashing]
-    return hmac.digest(signing_key, payload, "sha256").hex()
+    return hmac.digest(signing_key, payload, "sha256").hex()  # lgtm[py/weak-sensitive-data-hashing]
 
 
 @dataclass

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -208,8 +208,7 @@ else:
 def _hmac_sha256_hex(signing_key: bytes, payload: bytes) -> str:
     """Authenticate an audit payload; this is a MAC, not password hashing."""
 
-    # lgtm[py/weak-sensitive-data-hashing] HMAC-SHA256 is a message
-    # authentication code over audit records, not a password derivation hash.
+    # lgtm[py/weak-sensitive-data-hashing]
     return hmac.new(signing_key, payload, hashlib.sha256).hexdigest()
 
 

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -205,6 +205,12 @@ else:
     )
 
 
+def _hmac_sha256_hex(signing_key: bytes, payload: bytes) -> str:
+    """Authenticate an audit payload; this is a MAC, not password hashing."""
+
+    return hmac.new(signing_key, payload, hashlib.sha256).hexdigest()  # lgtm[py/weak-sensitive-data-hashing]
+
+
 @dataclass
 class AuditEntry:
     """Single audit log entry."""
@@ -229,7 +235,7 @@ class AuditEntry:
 
     def _legacy_hmac(self, hmac_key: bytes | None = None) -> str:
         payload = f"{self.prev_signature}|{self.entry_id}|{self.timestamp}|{self.action}|{self.actor}|{self.resource}"
-        return hmac.new(hmac_key or _HMAC_KEY, payload.encode(), hashlib.sha256).hexdigest()
+        return _hmac_sha256_hex(hmac_key or _HMAC_KEY, payload.encode())
 
     def compute_hmac(self, hmac_key: bytes | None = None) -> str:
         """Compute HMAC-SHA256 signature for tamper detection (chain-hashed)."""
@@ -237,9 +243,7 @@ class AuditEntry:
             f"{self.prev_signature}|{self.entry_id}|{self.timestamp}|"
             f"{self.action}|{self.actor}|{self.resource}|{self._canonical_details_json()}"
         )
-        # lgtm[py/weak-sensitive-data-hashing] HMAC-SHA256 authenticates an
-        # already-sanitized audit record; it does not derive or store passwords.
-        return hmac.new(hmac_key or _HMAC_KEY, payload.encode(), hashlib.sha256).hexdigest()
+        return _hmac_sha256_hex(hmac_key or _HMAC_KEY, payload.encode())
 
     def sign(self, hmac_key: bytes | None = None) -> None:
         """Sign this entry."""
@@ -266,7 +270,7 @@ class AuditEntry:
 
 def sign_export_payload(payload: bytes) -> str:
     """Sign an exported audit payload so downstream consumers can verify it."""
-    return hmac.new(_HMAC_KEY, payload, hashlib.sha256).hexdigest()
+    return _hmac_sha256_hex(_HMAC_KEY, payload)
 
 
 def verify_export_payload(payload: bytes, signature: str) -> bool:

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -208,7 +208,9 @@ else:
 def _hmac_sha256_hex(signing_key: bytes, payload: bytes) -> str:
     """Authenticate an audit payload; this is a MAC, not password hashing."""
 
-    return hmac.new(signing_key, payload, hashlib.sha256).hexdigest()  # lgtm[py/weak-sensitive-data-hashing]
+    # lgtm[py/weak-sensitive-data-hashing] HMAC-SHA256 is a message
+    # authentication code over audit records, not a password derivation hash.
+    return hmac.new(signing_key, payload, hashlib.sha256).hexdigest()
 
 
 @dataclass

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -227,11 +227,11 @@ class AuditEntry:
     def _canonical_details_json(self) -> str:
         return json.dumps(self.details or {}, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
 
-    def _legacy_hmac(self) -> str:
+    def _legacy_hmac(self, hmac_key: bytes | None = None) -> str:
         payload = f"{self.prev_signature}|{self.entry_id}|{self.timestamp}|{self.action}|{self.actor}|{self.resource}"
-        return hmac.new(_HMAC_KEY, payload.encode(), hashlib.sha256).hexdigest()
+        return hmac.new(hmac_key or _HMAC_KEY, payload.encode(), hashlib.sha256).hexdigest()
 
-    def compute_hmac(self) -> str:
+    def compute_hmac(self, hmac_key: bytes | None = None) -> str:
         """Compute HMAC-SHA256 signature for tamper detection (chain-hashed)."""
         payload = (
             f"{self.prev_signature}|{self.entry_id}|{self.timestamp}|"
@@ -239,16 +239,16 @@ class AuditEntry:
         )
         # lgtm[py/weak-sensitive-data-hashing] HMAC-SHA256 authenticates an
         # already-sanitized audit record; it does not derive or store passwords.
-        return hmac.new(_HMAC_KEY, payload.encode(), hashlib.sha256).hexdigest()
+        return hmac.new(hmac_key or _HMAC_KEY, payload.encode(), hashlib.sha256).hexdigest()
 
-    def sign(self) -> None:
+    def sign(self, hmac_key: bytes | None = None) -> None:
         """Sign this entry."""
-        self.hmac_signature = self.compute_hmac()
+        self.hmac_signature = self.compute_hmac(hmac_key)
 
-    def verify(self) -> bool:
+    def verify(self, hmac_key: bytes | None = None) -> bool:
         """Verify HMAC signature."""
-        return hmac.compare_digest(self.hmac_signature, self.compute_hmac()) or hmac.compare_digest(
-            self.hmac_signature, self._legacy_hmac()
+        return hmac.compare_digest(self.hmac_signature, self.compute_hmac(hmac_key)) or hmac.compare_digest(
+            self.hmac_signature, self._legacy_hmac(hmac_key)
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -351,13 +351,13 @@ def _entry_tenant(entry: AuditEntry) -> str:
     return str((entry.details or {}).get("tenant_id") or "default")
 
 
-def _verify_audit_chain(entries: list[AuditEntry]) -> tuple[int, int]:
+def _verify_audit_chain(entries: list[AuditEntry], hmac_key: bytes | None = None) -> tuple[int, int]:
     """Verify HMAC chain from genesis (``prev_signature`` must start at ``""``)."""
     verified = 0
     tampered = 0
     prev_sig = ""
     for entry in entries:
-        if entry.prev_signature != prev_sig or not entry.verify():
+        if entry.prev_signature != prev_sig or not entry.verify(hmac_key):
             tampered += 1
         else:
             verified += 1
@@ -374,9 +374,10 @@ class _AuditChainCheckpoint:
 def _verify_audit_chain_with_checkpoint(
     entries: list[AuditEntry],
     checkpoint: _AuditChainCheckpoint | None,
+    hmac_key: bytes | None = None,
 ) -> tuple[int, int]:
     """Verify chain integrity and detect tail truncation via signed checkpoint."""
-    verified, tampered = _verify_audit_chain(entries)
+    verified, tampered = _verify_audit_chain(entries, hmac_key)
     if checkpoint is None:
         return verified, tampered
     if not entries:
@@ -467,8 +468,9 @@ class InMemoryAuditLog:
 class SQLiteAuditLog:
     """SQLite-backed append-only audit log."""
 
-    def __init__(self, db_path: str = "agent_bom_audit.db") -> None:
+    def __init__(self, db_path: str = "agent_bom_audit.db", *, hmac_key: bytes | None = None) -> None:
         self._db_path = db_path
+        self._hmac_key = hmac_key
         self._local = threading.local()
         self._last_sig_by_tenant: dict[str, str] = defaultdict(str)
         self._append_lock = threading.Lock()
@@ -680,7 +682,7 @@ class SQLiteAuditLog:
                 if prev_sig is None or prev_sig == "":
                     prev_sig = self._latest_signature_for_tenant(tenant_id)
                 entry.prev_signature = prev_sig
-                entry.sign()
+                entry.sign(self._hmac_key)
                 try:
                     self._conn.execute(
                         "INSERT INTO audit_log"
@@ -813,7 +815,7 @@ class SQLiteAuditLog:
         fetch_limit = total if total else limit
         entries = self._list_entries_chronological(limit=fetch_limit, tenant_id=tenant_id)
         checkpoint = self._get_checkpoint(tenant_key)
-        return _verify_audit_chain_with_checkpoint(entries, checkpoint)
+        return _verify_audit_chain_with_checkpoint(entries, checkpoint, self._hmac_key)
 
 
 # ── Module-level singleton ──

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -205,8 +205,9 @@ else:
 
 
 def _hmac_sha256_hex(signing_key: bytes, payload: bytes) -> str:
-    """Authenticate an audit payload; this is a MAC, not password hashing."""
+    """Authenticate an audit payload with HMAC; this is not password hashing."""
 
+    # codeql[py/weak-sensitive-data-hashing]
     return hmac.digest(signing_key, payload, "sha256").hex()
 
 

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -13,7 +13,6 @@ in-memory (dev) and SQLite (production) backends.
 
 from __future__ import annotations
 
-import hashlib
 import hmac
 import json
 import logging
@@ -208,8 +207,7 @@ else:
 def _hmac_sha256_hex(signing_key: bytes, payload: bytes) -> str:
     """Authenticate an audit payload; this is a MAC, not password hashing."""
 
-    # lgtm[py/weak-sensitive-data-hashing]
-    return hmac.new(signing_key, payload, hashlib.sha256).hexdigest()
+    return hmac.digest(signing_key, payload, "sha256").hex()
 
 
 @dataclass

--- a/src/agent_bom/api/gateway_activity_store.py
+++ b/src/agent_bom/api/gateway_activity_store.py
@@ -24,6 +24,7 @@ from agent_bom.api.storage_schema import ensure_sqlite_schema_version
 from agent_bom.runtime.gateway_events import (
     GATEWAY_ALLOWED_EVENT_TYPES,
     GATEWAY_BLOCKED_EVENT_TYPES,
+    GATEWAY_CANONICAL_EVENT_TYPES,
     GATEWAY_DATA_FILTER_EVENT_TYPES,
 )
 from agent_bom.runtime.profile_resolution import classify_profile_shadow_reason
@@ -140,7 +141,7 @@ def ensure_sqlite_gateway_activity_schema(conn: sqlite3.Connection) -> None:
     ensure_sqlite_schema_version(conn, "runtime_events", version=GATEWAY_ACTIVITY_STORAGE_VERSION)
 
 
-_EVENT_TYPES = GATEWAY_ALLOWED_EVENT_TYPES | GATEWAY_BLOCKED_EVENT_TYPES | GATEWAY_DATA_FILTER_EVENT_TYPES
+_EVENT_TYPES = GATEWAY_CANONICAL_EVENT_TYPES
 _EXPECTED_DECISIONS = {
     "gateway.tool_call.allowed": "allow",
     "gateway.tool_call.blocked": "deny",
@@ -148,6 +149,9 @@ _EXPECTED_DECISIONS = {
     "gateway.dlp.result_redacted": "allow",
     "gateway.dlp.result_blocked": "deny",
     "gateway.visual.redacted": "allow",
+    "gateway.runtime_profile.warned": "allow",
+    "gateway.runtime_profile.dev_bypass": "allow",
+    "gateway.runtime_profile.blocked": "deny",
 }
 _ALLOWED_EVENT_FIELDS = frozenset(
     {

--- a/src/agent_bom/api/gateway_activity_store.py
+++ b/src/agent_bom/api/gateway_activity_store.py
@@ -152,6 +152,9 @@ _EXPECTED_DECISIONS = {
     "gateway.runtime_profile.warned": "allow",
     "gateway.runtime_profile.dev_bypass": "allow",
     "gateway.runtime_profile.blocked": "deny",
+    "gateway.enforcement.warned": "allow",
+    "gateway.enforcement.observed": "allow",
+    "gateway.enforcement.blocked": "deny",
 }
 _ALLOWED_EVENT_FIELDS = frozenset(
     {

--- a/src/agent_bom/api/routes/gateway_feed.py
+++ b/src/agent_bom/api/routes/gateway_feed.py
@@ -53,7 +53,9 @@ from agent_bom.rbac import require_authenticated_permission
 from agent_bom.runtime.gateway_events import (
     GATEWAY_ALLOWED_EVENT_TYPES,
     GATEWAY_BLOCKED_EVENT_TYPES,
+    GATEWAY_CANONICAL_EVENT_TYPES,
     GATEWAY_DATA_FILTER_EVENT_TYPES,
+    GATEWAY_PROFILE_EVENT_TYPES,
 )
 from agent_bom.runtime.profile_resolution import classify_profile_shadow_reason
 
@@ -171,7 +173,7 @@ ACTION_TOOL_CALL_AUTHORIZED = "tool_call_authorized"
 ACTION_TOOL_CALL_BLOCKED = "tool_call_blocked"
 ACTION_DATA_FILTER_APPLIED = "data_filter_applied"
 ACTION_LLM_CALL = "llm_call"
-_EVENT_TYPES = GATEWAY_ALLOWED_EVENT_TYPES | GATEWAY_BLOCKED_EVENT_TYPES | GATEWAY_DATA_FILTER_EVENT_TYPES
+_EVENT_TYPES = GATEWAY_CANONICAL_EVENT_TYPES
 
 # Block reasons that indicate a shadow / undeclared agent or shadow MCP server
 # rather than an ordinary policy block. ``undeclared`` is emitted by the proxy
@@ -446,6 +448,11 @@ def _classify_alert_action(alert: dict[str, Any]) -> str | None:
     feed stays consistent with ``/v1/runtime/production-index``.
     """
     event_type = str(alert.get("event_type") or "").lower()
+    if event_type in GATEWAY_PROFILE_EVENT_TYPES:
+        # Profile posture is durable evidence but is not itself a tool call.
+        # A later surface slice can render it as a dedicated activity class;
+        # never inflate authorized/blocked call counts in the compatibility UI.
+        return None
     if event_type in GATEWAY_DATA_FILTER_EVENT_TYPES or event_type == "gateway.visual_leak_blocked":
         return ACTION_DATA_FILTER_APPLIED
     if event_type in GATEWAY_BLOCKED_EVENT_TYPES:

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -42,9 +42,8 @@ from agent_bom.api.models import ProxyAuditIngestRequest
 from agent_bom.api.stores import _get_idempotency_store
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.runtime.gateway_events import (
-    GATEWAY_ALLOWED_EVENT_TYPES,
-    GATEWAY_BLOCKED_EVENT_TYPES,
-    GATEWAY_DATA_FILTER_EVENT_TYPES,
+    GATEWAY_CANONICAL_EVENT_TYPES,
+    GATEWAY_DENIED_EVENT_TYPES,
 )
 from agent_bom.security import sanitize_error, sanitize_sensitive_payload
 
@@ -165,7 +164,7 @@ def _alert_visible_to_tenant(alert: dict, tenant_id: str) -> bool:
     return alert_tenant == tenant_id
 
 
-_CANONICAL_GATEWAY_EVENT_TYPES = GATEWAY_ALLOWED_EVENT_TYPES | GATEWAY_BLOCKED_EVENT_TYPES | GATEWAY_DATA_FILTER_EVENT_TYPES
+_CANONICAL_GATEWAY_EVENT_TYPES = GATEWAY_CANONICAL_EVENT_TYPES
 
 
 def _gateway_activity_record_from_alert(
@@ -211,7 +210,7 @@ def _gateway_activity_record_from_alert(
             raise ValueError("canonical gateway event requires a representable event_timestamp") from exc
     if not isinstance(event_timestamp, str) or not event_timestamp.strip():
         raise ValueError("canonical gateway event requires event_timestamp")
-    expected_decision = "deny" if event_type in GATEWAY_BLOCKED_EVENT_TYPES else "allow"
+    expected_decision = "deny" if event_type in GATEWAY_DENIED_EVENT_TYPES else "allow"
     agent_id = str(alert.get("agent_id") or alert.get("agent_name") or alert.get("source_agent") or source_id or "unknown")
     canonical: dict[str, Any] = {
         "schema_version": "gateway.runtime.event.v1",

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import cast
@@ -543,7 +544,16 @@ def serve_cmd(
         except RuntimeError as exc:
             raise click.ClickException(str(exc)) from exc
 
-    audit_sink = build_control_plane_audit_sink(control_plane_url, control_plane_token, source_id="gateway") if control_plane_url else None
+    audit_sink = (
+        build_control_plane_audit_sink(
+            control_plane_url,
+            control_plane_token,
+            tenant_id=os.environ.get("AGENT_BOM_TENANT_ID", "default"),
+            source_id="gateway",
+        )
+        if control_plane_url
+        else None
+    )
 
     control_plane_policies: list[dict] = []
     if policy_bundle_path is not None:

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import sys
 from pathlib import Path
 from typing import cast
@@ -22,6 +21,7 @@ from agent_bom.cli._common import read_json_file_for_cli
 from agent_bom.cli._grouped_help import SuggestingGroup
 from agent_bom.cli._runtime_status import emit_runtime_status_strip
 from agent_bom.cli._server import _is_loopback_host
+from agent_bom.cli._tenant import resolve_cli_tenant_id_strict
 
 logger = logging.getLogger(__name__)
 
@@ -548,7 +548,7 @@ def serve_cmd(
         build_control_plane_audit_sink(
             control_plane_url,
             control_plane_token,
-            tenant_id=os.environ.get("AGENT_BOM_TENANT_ID", "default"),
+            tenant_id=resolve_cli_tenant_id_strict(),
             source_id="gateway",
         )
         if control_plane_url

--- a/src/agent_bom/deploy_profiles.py
+++ b/src/agent_bom/deploy_profiles.py
@@ -131,13 +131,11 @@ def helm_validation_profiles(repo_root: Path) -> list[HelmValidationProfile]:
         ),
         HelmValidationProfile(
             name="keda-autoscaling",
-            description="Production EKS defaults with KEDA-backed API and gateway autoscaling.",
+            description="Production EKS defaults with KEDA-backed control-plane API autoscaling.",
             values_files=(
                 examples / "eks-production-values.yaml",
                 examples / "eks-keda-values.yaml",
             ),
-            set_arguments=("gateway.enabled=true",),
-            set_file_arguments=(("gateway.upstreamsYaml", examples / "gateway-upstreams.example.yaml"),),
         ),
         HelmValidationProfile(
             name="eks-vanilla",
@@ -156,9 +154,14 @@ def helm_validation_profiles(repo_root: Path) -> list[HelmValidationProfile]:
         ),
         HelmValidationProfile(
             name="gateway-runtime",
-            description="Focused pilot plus central gateway rendering with shipped upstream example.",
+            description="Focused pilot plus single-writer PVC-backed gateway with shipped upstream example.",
             values_files=(examples / "eks-mcp-pilot-values.yaml",),
-            set_arguments=("gateway.enabled=true",),
+            set_arguments=(
+                "gateway.enabled=true",
+                "gateway.replicas=1",
+                "gateway.persistence.enabled=true",
+                "gateway.persistence.existingClaim=agent-bom-gateway-audit",
+            ),
             set_file_arguments=(("gateway.upstreamsYaml", examples / "gateway-upstreams.example.yaml"),),
         ),
         HelmValidationProfile(

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -3603,48 +3603,53 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             logger.warning("gateway upstream circuit open for %s", upstream.name)
             record_gateway_relay(upstream.name, "circuit_open")
             retry_after_header = str(int(exc.retry_after_seconds))
-            if settings.audit_sink is not None:
-                await settings.audit_sink(
-                    {
-                        "action": "gateway.upstream_circuit_open",
-                        "upstream": upstream.name,
-                        "tenant_id": tenant_id,
-                        "reason": "circuit_open",
-                        "retry_after_seconds": int(exc.retry_after_seconds),
-                    }
-                )
+            await _audit_after_forward(
+                {
+                    "action": "gateway.upstream_circuit_open",
+                    "upstream": upstream.name,
+                    "tenant_id": tenant_id,
+                    "reason": "circuit_open",
+                    "retry_after_seconds": int(exc.retry_after_seconds),
+                }
+            )
             raise HTTPException(
                 status_code=503,
                 detail="upstream circuit open",
-                headers={"Retry-After": retry_after_header},
+                headers=_post_forward_headers({"Retry-After": retry_after_header}),
             ) from exc
         except asyncio.TimeoutError as exc:
             logger.warning("gateway upstream call timed out for %s", upstream.name)
             record_gateway_relay(upstream.name, "upstream_timeout")
-            if settings.audit_sink is not None:
-                await settings.audit_sink(
-                    {
-                        "action": "gateway.upstream_error",
-                        "upstream": upstream.name,
-                        "tenant_id": tenant_id,
-                        "error": "timeout",
-                        "reason": "timeout",
-                    }
-                )
-            raise HTTPException(status_code=502, detail="upstream error: timeout") from exc
+            await _audit_after_forward(
+                {
+                    "action": "gateway.upstream_error",
+                    "upstream": upstream.name,
+                    "tenant_id": tenant_id,
+                    "error": "timeout",
+                    "reason": "timeout",
+                }
+            )
+            raise HTTPException(
+                status_code=502,
+                detail="upstream error: timeout",
+                headers=_post_forward_headers({}),
+            ) from exc
         except Exception as exc:  # noqa: BLE001
             logger.error("gateway upstream call failed for %s", upstream.name)
             record_gateway_relay(upstream.name, "upstream_error")
-            if settings.audit_sink is not None:
-                await settings.audit_sink(
-                    {
-                        "action": "gateway.upstream_error",
-                        "upstream": upstream.name,
-                        "tenant_id": tenant_id,
-                        "error": _public_gateway_error(exc),
-                    }
-                )
-            raise HTTPException(status_code=502, detail=f"upstream error: {_public_gateway_error(exc)}") from exc
+            await _audit_after_forward(
+                {
+                    "action": "gateway.upstream_error",
+                    "upstream": upstream.name,
+                    "tenant_id": tenant_id,
+                    "error": _public_gateway_error(exc),
+                }
+            )
+            raise HTTPException(
+                status_code=502,
+                detail=f"upstream error: {_public_gateway_error(exc)}",
+                headers=_post_forward_headers({}),
+            ) from exc
 
         record_gateway_relay(upstream.name, "forwarded")
 

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -89,6 +89,7 @@ from agent_bom.runtime.audit_delivery import (
     AuditSpilloverClaim,
     AuditSpilloverStore,
     audit_delivery_paths,
+    canonical_runtime_state_path,
 )
 from agent_bom.runtime.fail_mode import gateway_fail_mode_matrix
 from agent_bom.runtime.gateway_events import (
@@ -122,6 +123,7 @@ _GATEWAY_AUDIT_DLQ_BYTES = 64 * 1024 * 1024
 
 class GatewayAuditDeliveryUnavailableError(RuntimeError):
     """The gateway could not durably retain a runtime audit event."""
+
 
 # Lazy singleton so disabled deploys don't pay the import cost of the
 # visual detector (Pillow/pytesseract). Built on first use when
@@ -1293,15 +1295,14 @@ class ControlPlaneAuditSink:
         self._worker: asyncio.Task[None] | None = None
         self._closed = False
         self._persistence_available = True
+        self._remote_ack_available = True
 
     @staticmethod
     def _batch_idempotency_key(session_id: str, events: list[dict[str, Any]]) -> str:
         event_identities = [
             str(event.get("event_id"))
             if event.get("event_id")
-            else hashlib.sha256(
-                json.dumps(event, separators=(",", ":"), sort_keys=True, ensure_ascii=True).encode("utf-8")
-            ).hexdigest()
+            else hashlib.sha256(json.dumps(event, separators=(",", ":"), sort_keys=True, ensure_ascii=True).encode("utf-8")).hexdigest()
             for event in events
         ]
         material = json.dumps([session_id, event_identities], separators=(",", ":"), ensure_ascii=True)
@@ -1334,7 +1335,7 @@ class ControlPlaneAuditSink:
             headers["Authorization"] = f"Bearer {self._token}"
         return headers
 
-    async def __call__(self, event: dict[str, Any]) -> None:
+    async def _persist_and_flush(self, event: dict[str, Any], *, require_remote_ack: bool) -> None:
         async with self._lock:
             try:
                 if not self._persistence_available:
@@ -1357,10 +1358,21 @@ class ControlPlaneAuditSink:
                 self._persistence_available = False
                 raise GatewayAuditDeliveryUnavailableError("durable audit backlog is full")
             self._persistence_available = True
+            flushed = False
             if not self._delivery_state.controller.is_circuit_open():
                 flushed = await self._flush_locked()
-                if not flushed and not self._persistence_available:
-                    raise GatewayAuditDeliveryUnavailableError("durable audit backlog is unavailable")
+            if not flushed and not self._persistence_available:
+                raise GatewayAuditDeliveryUnavailableError("durable audit backlog is unavailable")
+            if require_remote_ack and not flushed:
+                raise GatewayAuditDeliveryUnavailableError("control-plane durable acknowledgement is unavailable")
+
+    async def __call__(self, event: dict[str, Any]) -> None:
+        await self._persist_and_flush(event, require_remote_ack=False)
+
+    async def admit_before_tool_execution(self, event: dict[str, Any]) -> None:
+        """Require the control plane to durably acknowledge before execution."""
+
+        await self._persist_and_flush(event, require_remote_ack=True)
 
     async def _flush_locked(self) -> bool:
         try:
@@ -1394,9 +1406,11 @@ class ControlPlaneAuditSink:
                 self._persistence_available = False
                 logger.error("Gateway audit persistence unavailable while retaining a failed delivery")
             self._delivery_state.controller.record_failure()
+            self._remote_ack_available = False
             logger.warning("Gateway audit push failed; retained for retry (error_type=%s)", type(exc).__name__)
             return False
         self._persistence_available = True
+        self._remote_ack_available = True
         self._delivery_state.controller.record_success()
         return True
 
@@ -1452,7 +1466,12 @@ class ControlPlaneAuditSink:
                 "dropped_events": self._delivery_state.store.dropped_events,
             }
             backlog_observable = False
-        accepting_events = self._persistence_available and not bool(health["dlq_bytes"]) and not bool(health["dropped_events"])
+        accepting_events = (
+            self._persistence_available
+            and self._remote_ack_available
+            and not bool(health["dlq_bytes"])
+            and not bool(health["dropped_events"])
+        )
         if not accepting_events:
             health["status"] = "degraded"
         return {
@@ -1460,6 +1479,7 @@ class ControlPlaneAuditSink:
             "durable": self._persistence_available and backlog_observable,
             "accepting_events": accepting_events,
             "backlog_observable": backlog_observable,
+            "remote_acknowledgement_available": self._remote_ack_available,
             "retry_worker_running": self._worker is not None and not self._worker.done() and not self._closed,
             **health,
         }
@@ -1471,12 +1491,21 @@ class LocalGatewayAuditSink:
     def __init__(self, db_path: Path) -> None:
         from agent_bom.api.audit_log import SQLiteAuditLog
 
+        db_path = canonical_runtime_state_path(db_path)
         parent_fd = AuditSpilloverStore._safe_parent_fd(db_path)
         os.close(parent_fd)
         AuditSpilloverStore._validate_existing_path(db_path)
-        self._store = SQLiteAuditLog(str(db_path))
+        self._hmac_key = self.load_key(db_path, create=not db_path.exists())
+        self._store = SQLiteAuditLog(str(db_path), hmac_key=self._hmac_key)
         self._available = True
         self.db_path = db_path
+
+    @staticmethod
+    def load_key(db_path: Path, *, create: bool = False) -> bytes:
+        return AuditSpilloverStore.load_or_create_private_key(
+            canonical_runtime_state_path(db_path).with_suffix(".hmac.key"),
+            create=create,
+        )
 
     async def __call__(self, event: dict[str, Any]) -> None:
         from agent_bom.api.audit_log import AuditEntry, sanitize_audit_details
@@ -1503,6 +1532,9 @@ class LocalGatewayAuditSink:
             logger.error("Gateway local audit persistence unavailable (error_type=%s)", type(exc).__name__)
             raise GatewayAuditDeliveryUnavailableError("local durable audit store is unavailable") from None
 
+    async def admit_before_tool_execution(self, event: dict[str, Any]) -> None:
+        await self(event)
+
     def health(self) -> dict[str, str | int | bool]:
         return {
             "configured": True,
@@ -1511,6 +1543,30 @@ class LocalGatewayAuditSink:
             "durable": self._available,
             "accepting_events": self._available,
             "backlog_observable": True,
+            "retry_worker_running": False,
+            "backlog_bytes": 0,
+            "dropped_events": 0,
+        }
+
+
+class UnavailableGatewayAuditSink:
+    """Fail-closed health surface retained when local audit setup fails."""
+
+    async def __call__(self, _event: dict[str, Any]) -> None:
+        raise GatewayAuditDeliveryUnavailableError("local durable audit store is unavailable")
+
+    async def admit_before_tool_execution(self, event: dict[str, Any]) -> None:
+        await self(event)
+
+    @staticmethod
+    def health() -> dict[str, str | int | bool]:
+        return {
+            "configured": True,
+            "mode": "unavailable",
+            "status": "degraded",
+            "durable": False,
+            "accepting_events": False,
+            "backlog_observable": False,
             "retry_worker_running": False,
             "backlog_bytes": 0,
             "dropped_events": 0,
@@ -1625,6 +1681,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             settings.audit_sink = build_local_gateway_audit_sink()
         except Exception as exc:  # noqa: BLE001 - relay remains fail-closed below
             logger.error("Gateway local audit initialization failed (error_type=%s)", type(exc).__name__)
+            settings.audit_sink = UnavailableGatewayAuditSink()
     if settings.enable_visual_leak_detection and settings.require_visual_leak_detection_ready:
         from agent_bom.runtime.visual_leak_detector import require_visual_leak_runtime
 
@@ -3441,7 +3498,8 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             )
         if _forward_is_tool_call and settings.audit_sink is not None:
             try:
-                await settings.audit_sink(
+                admission = getattr(settings.audit_sink, "admit_before_tool_execution", settings.audit_sink)
+                await admission(
                     {
                         "action": "gateway.tool_call",
                         "upstream": upstream.name,
@@ -3475,6 +3533,29 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     status_code=503,
                     headers=rate_limit_headers or None,
                 )
+
+        post_forward_audit_degraded = False
+
+        async def _audit_after_forward(event: dict[str, Any]) -> None:
+            """Never turn a completed upstream side effect into an ambiguous 500."""
+
+            nonlocal post_forward_audit_degraded
+            if settings.audit_sink is None:
+                return
+            try:
+                await settings.audit_sink(event)
+            except Exception as exc:  # noqa: BLE001 - outcome is already produced
+                post_forward_audit_degraded = True
+                record_gateway_relay(upstream.name, "audit_unavailable")
+                logger.error(
+                    "Gateway post-forward audit degraded (error_type=%s)",
+                    type(exc).__name__,
+                )
+
+        def _post_forward_headers(headers: dict[str, str]) -> dict[str, str]:
+            if post_forward_audit_degraded:
+                headers["X-Agent-BOM-Audit-Delivery"] = "degraded"
+            return headers
 
         # Forward to the upstream with bounded W3C trace headers and JSON-RPC
         # `_meta` so both HTTP-aware and JSON-RPC-aware upstreams can stitch
@@ -3592,7 +3673,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     if alerts:
                         record_gateway_relay(upstream.name, "visual_leak_redacted")
                         if settings.audit_sink is not None:
-                            await settings.audit_sink(
+                            await _audit_after_forward(
                                 {
                                     "action": "gateway.visual_leak_blocked",
                                     "upstream": upstream.name,
@@ -3652,7 +3733,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                         tool=str(tool_name_for_dlp),
                         data_action="pii_redacted",
                     )
-                await settings.audit_sink(
+                await _audit_after_forward(
                     {
                         "action": "gateway.dlp_result",
                         "upstream": upstream.name,
@@ -3682,7 +3763,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                         },
                     },
                     status_code=200,
-                    headers=rate_limit_headers or None,
+                    headers=_post_forward_headers(dict(rate_limit_headers)) or None,
                 )
             if result_redacted:
                 upstream_response["result"] = _redact_obj_pii(upstream_response.get("result"))
@@ -3695,13 +3776,14 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 "method": message.get("method"),
                 "tool": None,
             }
-            await settings.audit_sink(forward_audit_event)
+            await _audit_after_forward(forward_audit_event)
         response_headers = dict(rate_limit_headers)
         response_headers["traceparent"] = str(trace_meta["traceparent"])
         if trace_meta["tracestate"]:
             response_headers["tracestate"] = str(trace_meta["tracestate"])
         if trace_meta["baggage"]:
             response_headers["baggage"] = str(trace_meta["baggage"])
+        _post_forward_headers(response_headers)
         return JSONResponse(upstream_response, headers=response_headers or None)
 
     return app

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -3347,6 +3347,48 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     }
                 )
 
+        # Durably admit an authorized tool call before any upstream side effect.
+        # Readiness can remove an unhealthy pod from service, but it cannot
+        # protect an in-flight/direct request. Persisting the authorization here
+        # makes a full/unavailable audit backlog fail closed before execution.
+        _forward_is_tool_call = is_tools_call(message)
+        if _forward_is_tool_call and settings.audit_sink is not None:
+            try:
+                await settings.audit_sink(
+                    {
+                        "action": "gateway.tool_call",
+                        "upstream": upstream.name,
+                        "tenant_id": tenant_id,
+                        "method": message.get("method"),
+                        "tool": extract_tool_name(message),
+                        "source_agent": source_agent,
+                        **_typed_runtime_event(
+                            GatewayRuntimeEventType.TOOL_CALL_ALLOWED,
+                            decision="allow",
+                            policy_source=resolved_policy_source,
+                            tool=extract_tool_name(message) or "",
+                        ),
+                    }
+                )
+            except GatewayAuditDeliveryUnavailableError:
+                record_gateway_relay(upstream.name, "audit_unavailable")
+                return JSONResponse(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": message.get("id"),
+                        "error": {
+                            "code": -32003,
+                            "message": "Gateway audit persistence unavailable",
+                            "data": {
+                                "reason": "Tool call was not executed because durable audit admission failed",
+                                "policy_source": "audit_delivery",
+                            },
+                        },
+                    },
+                    status_code=503,
+                    headers=rate_limit_headers or None,
+                )
+
         # Forward to the upstream with bounded W3C trace headers and JSON-RPC
         # `_meta` so both HTTP-aware and JSON-RPC-aware upstreams can stitch
         # the same end-to-end trace.
@@ -3558,29 +3600,14 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             if result_redacted:
                 upstream_response["result"] = _redact_obj_pii(upstream_response.get("result"))
 
-        if settings.audit_sink is not None:
-            _forward_is_tool_call = is_tools_call(message)
+        if settings.audit_sink is not None and not _forward_is_tool_call:
             forward_audit_event: dict[str, Any] = {
-                "action": "gateway.tool_call" if _forward_is_tool_call else "gateway.message",
+                "action": "gateway.message",
                 "upstream": upstream.name,
                 "tenant_id": tenant_id,
                 "method": message.get("method"),
-                "tool": extract_tool_name(message) if _forward_is_tool_call else None,
+                "tool": None,
             }
-            # Only an actual tools/call is an authorized tool invocation. JSON-RPC
-            # handshake / discovery traffic (initialize, tools/list, notifications)
-            # is forwarded too but must not be tagged TOOL_CALL_ALLOWED, or the live
-            # feed would inflate calls_today / tool_calls_authorized with
-            # non-invocation messages.
-            if _forward_is_tool_call:
-                forward_audit_event.update(
-                    _typed_runtime_event(
-                        GatewayRuntimeEventType.TOOL_CALL_ALLOWED,
-                        decision="allow",
-                        policy_source=resolved_policy_source,
-                        tool=extract_tool_name(message) or "",
-                    )
-                )
             await settings.audit_sink(forward_audit_event)
         response_headers = dict(rate_limit_headers)
         response_headers["traceparent"] = str(trace_meta["traceparent"])

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -105,7 +105,7 @@ from agent_bom.runtime.gateway_relay_contract import (
 )
 from agent_bom.runtime.graph_reachability import ReachabilityMap, load_reachability_map
 from agent_bom.runtime.profile_resolution import ProfileResolutionCode
-from agent_bom.security import sanitize_error, sanitize_text
+from agent_bom.security import sanitize_error, sanitize_sensitive_payload, sanitize_text
 
 logger = logging.getLogger(__name__)
 _GATEWAY_TRACER = get_tracer("agent_bom.gateway")
@@ -1337,6 +1337,8 @@ class ControlPlaneAuditSink:
     async def __call__(self, event: dict[str, Any]) -> None:
         async with self._lock:
             try:
+                if not self._persistence_available:
+                    raise GatewayAuditDeliveryUnavailableError("durable audit backlog is unavailable")
                 event = canonicalize_gateway_enforcement_event(ensure_gateway_event_identity(event))
                 event_tenant = str(event.get("tenant_id") or "")
                 if event_tenant != self._tenant_id:
@@ -1356,7 +1358,9 @@ class ControlPlaneAuditSink:
                 raise GatewayAuditDeliveryUnavailableError("durable audit backlog is full")
             self._persistence_available = True
             if not self._delivery_state.controller.is_circuit_open():
-                await self._flush_locked()
+                flushed = await self._flush_locked()
+                if not flushed and not self._persistence_available:
+                    raise GatewayAuditDeliveryUnavailableError("durable audit backlog is unavailable")
 
     async def _flush_locked(self) -> bool:
         try:
@@ -1461,6 +1465,65 @@ class ControlPlaneAuditSink:
         }
 
 
+class LocalGatewayAuditSink:
+    """HMAC-chained local durability for gateways without a control plane."""
+
+    def __init__(self, db_path: Path) -> None:
+        from agent_bom.api.audit_log import SQLiteAuditLog
+
+        parent_fd = AuditSpilloverStore._safe_parent_fd(db_path)
+        os.close(parent_fd)
+        AuditSpilloverStore._validate_existing_path(db_path)
+        self._store = SQLiteAuditLog(str(db_path))
+        self._available = True
+        self.db_path = db_path
+
+    async def __call__(self, event: dict[str, Any]) -> None:
+        from agent_bom.api.audit_log import AuditEntry, sanitize_audit_details
+
+        if not self._available:
+            raise GatewayAuditDeliveryUnavailableError("local durable audit store is unavailable")
+        identified = canonicalize_gateway_enforcement_event(ensure_gateway_event_identity(event))
+        sanitized = sanitize_sensitive_payload(identified)
+        if not isinstance(sanitized, dict):
+            self._available = False
+            raise GatewayAuditDeliveryUnavailableError("local durable audit event is invalid")
+        action = str(sanitized.get("action") or sanitized.get("event_type") or "gateway.runtime")[:256]
+        upstream = str(sanitized.get("upstream") or "gateway")[:200]
+        entry = AuditEntry(
+            action=action,
+            actor="gateway",
+            resource=f"upstream/{upstream}",
+            details=sanitize_audit_details(sanitized),
+        )
+        try:
+            await asyncio.to_thread(self._store.append, entry)
+        except Exception as exc:  # noqa: BLE001 - local audit failure is fail-closed
+            self._available = False
+            logger.error("Gateway local audit persistence unavailable (error_type=%s)", type(exc).__name__)
+            raise GatewayAuditDeliveryUnavailableError("local durable audit store is unavailable") from None
+
+    def health(self) -> dict[str, str | int | bool]:
+        return {
+            "configured": True,
+            "mode": "local_hmac_sqlite",
+            "status": "healthy" if self._available else "degraded",
+            "durable": self._available,
+            "accepting_events": self._available,
+            "backlog_observable": True,
+            "retry_worker_running": False,
+            "backlog_bytes": 0,
+            "dropped_events": 0,
+        }
+
+
+def build_local_gateway_audit_sink(*, state_dir: Path | None = None) -> LocalGatewayAuditSink:
+    """Build the default durable audit path for a standalone local gateway."""
+
+    root = state_dir or Path(os.environ.get("AGENT_BOM_STATE_DIR", Path.home() / ".agent-bom")).expanduser()
+    return LocalGatewayAuditSink(root / "runtime-audit" / "gateway-local-audit.db")
+
+
 def build_control_plane_audit_sink(
     base_url: str,
     token: str | None,
@@ -1557,6 +1620,11 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
     Separating app construction from CLI entry point keeps the server
     testable end-to-end via ``TestClient(create_gateway_app(settings))``.
     """
+    if settings.audit_sink is None:
+        try:
+            settings.audit_sink = build_local_gateway_audit_sink()
+        except Exception as exc:  # noqa: BLE001 - relay remains fail-closed below
+            logger.error("Gateway local audit initialization failed (error_type=%s)", type(exc).__name__)
     if settings.enable_visual_leak_detection and settings.require_visual_leak_detection_ready:
         from agent_bom.runtime.visual_leak_detector import require_visual_leak_runtime
 
@@ -1811,8 +1879,9 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 **visual_leak_runtime_health(),
                 "required": settings.require_visual_leak_detection_ready,
             }
-        if isinstance(settings.audit_sink, ControlPlaneAuditSink):
-            audit_delivery_health = settings.audit_sink.health()
+        audit_health = getattr(settings.audit_sink, "health", None)
+        if callable(audit_health):
+            audit_delivery_health = audit_health()
             health["audit_delivery"] = audit_delivery_health
             if audit_delivery_health["status"] != "healthy":
                 health["status"] = "degraded"
@@ -3352,6 +3421,24 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         # protect an in-flight/direct request. Persisting the authorization here
         # makes a full/unavailable audit backlog fail closed before execution.
         _forward_is_tool_call = is_tools_call(message)
+        if _forward_is_tool_call and settings.audit_sink is None:
+            record_gateway_relay(upstream.name, "audit_unavailable")
+            return JSONResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "id": message.get("id"),
+                    "error": {
+                        "code": -32003,
+                        "message": "Gateway audit persistence unavailable",
+                        "data": {
+                            "reason": "Tool call was not executed because no durable audit sink is configured",
+                            "policy_source": "audit_delivery",
+                        },
+                    },
+                },
+                status_code=503,
+                headers=rate_limit_headers or None,
+            )
         if _forward_is_tool_call and settings.audit_sink is not None:
             try:
                 await settings.audit_sink(

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -95,6 +95,7 @@ from agent_bom.runtime.gateway_events import (
     GatewayRuntimeEventType,
     build_gateway_runtime_event,
     canonicalize_gateway_enforcement_event,
+    ensure_gateway_event_identity,
 )
 from agent_bom.runtime.gateway_relay_contract import (
     MAX_GATEWAY_RELAY_MESSAGE_BYTES,
@@ -1091,12 +1092,16 @@ def _api_key_allows_gateway_relay(api_key: Any) -> tuple[bool, str]:
     return True, ""
 
 
+def _configured_gateway_tenant_id() -> str:
+    return os.environ.get("AGENT_BOM_TENANT_ID", "default").strip() or "default"
+
+
 def _authenticate_gateway_request(request: Request, settings: GatewaySettings) -> tuple[str, str]:
     raw_token = _extract_request_token(request)
     if settings.bearer_token:
         if not raw_token or not _request_has_expected_token(request, settings.bearer_token):
             raise HTTPException(status_code=401, detail="gateway authentication required")
-        return "default", "static_gateway_token"
+        return _configured_gateway_tenant_id(), "static_gateway_token"
 
     # OAuth 2.1 broker: a standard MCP client presenting an AS-issued access
     # token in the Authorization header satisfies transport auth (the AS already
@@ -1105,7 +1110,7 @@ def _authenticate_gateway_request(request: Request, settings: GatewaySettings) -
     if settings.oauth_as is not None and raw_token:
         claims = settings.oauth_as.validate_token(raw_token)
         if claims is not None:
-            return "default", "oauth_as"
+            return _configured_gateway_tenant_id(), "oauth_as"
 
     try:
         store = get_key_store()
@@ -1127,7 +1132,7 @@ def _authenticate_gateway_request(request: Request, settings: GatewaySettings) -
             raise HTTPException(status_code=403, detail=reason)
         return api_key.tenant_id or "default", "api_key"
 
-    return "default", "none"
+    return _configured_gateway_tenant_id(), "none"
 
 
 def _inject_jsonrpc_trace_meta(
@@ -1332,7 +1337,7 @@ class ControlPlaneAuditSink:
     async def __call__(self, event: dict[str, Any]) -> None:
         async with self._lock:
             try:
-                event = canonicalize_gateway_enforcement_event(event)
+                event = canonicalize_gateway_enforcement_event(ensure_gateway_event_identity(event))
                 event_tenant = str(event.get("tenant_id") or "")
                 if event_tenant != self._tenant_id:
                     raise GatewayAuditDeliveryUnavailableError("audit credential is not bound to the event tenant")
@@ -1820,9 +1825,9 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         health = await healthz()
         audit_delivery = health.get("audit_delivery")
         ready = not isinstance(audit_delivery, dict) or (
-            audit_delivery.get("status") == "healthy"
-            and bool(audit_delivery.get("durable"))
+            bool(audit_delivery.get("durable"))
             and bool(audit_delivery.get("accepting_events"))
+            and bool(audit_delivery.get("backlog_observable"))
         )
         return JSONResponse(status_code=200 if ready else 503, content={"ready": ready, **health})
 
@@ -1847,6 +1852,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         # gate the firewall-check endpoint, not just /mcp/{server}. Otherwise
         # the policy evaluator is reachable unauthenticated on shared
         # deployments and leaks every rule via the matched_rule field.
+        tenant_id = _configured_gateway_tenant_id()
         if _gateway_requires_auth(settings):
             tenant_id, auth_method = _authenticate_gateway_request(request, settings)
             request.state.tenant_id = tenant_id
@@ -1877,6 +1883,8 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             policy_source = firewall_state["source"]
             policy_loaded_at = firewall_state["last_loaded_at"]
             policy_load_failed = bool(firewall_state.get("load_failed"))
+        if policy.tenant_id is not None and policy.tenant_id != tenant_id:
+            raise HTTPException(status_code=403, detail="firewall policy is not bound to the authenticated tenant")
         if fail_closed and policy_load_failed and settings.firewall_policy_path is not None:
             result = FirewallEvaluation(
                 decision=FirewallDecision.DENY,
@@ -1914,7 +1922,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 "loaded_at": policy_loaded_at,
                 "default_decision": policy.default_decision.value,
                 "enforcement_mode": policy.enforcement_mode.value,
-                "tenant_id": policy.tenant_id,
+                "tenant_id": tenant_id,
             },
         }
 
@@ -1931,7 +1939,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     "source_roles": list(raw_source_roles),
                     "target_roles": list(raw_target_roles),
                     "matched_rule": response_payload["matched_rule"],
-                    "tenant_id": policy.tenant_id,
+                    "tenant_id": tenant_id,
                     "enforcement_mode": policy.enforcement_mode.value,
                     "timestamp": time.time(),
                 }
@@ -1962,7 +1970,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
     async def relay(server_name: str, request: Request) -> JSONResponse:
         """Route an MCP JSON-RPC request to the named upstream after policy + audit."""
         trace_meta = make_request_trace(dict(request.headers))
-        tenant_id = "default"
+        tenant_id = _configured_gateway_tenant_id()
         auth_method = "none"
         if _gateway_requires_auth(settings):
             tenant_id, auth_method = _authenticate_gateway_request(request, settings)

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -86,11 +86,16 @@ from agent_bom.proxy_scanner import ScanConfig, redact_pii, scan_tool_call, scan
 from agent_bom.runtime.audit_delivery import (
     AuditDeliveryController,
     AuditDeliveryState,
+    AuditSpilloverClaim,
     AuditSpilloverStore,
     audit_delivery_paths,
 )
 from agent_bom.runtime.fail_mode import gateway_fail_mode_matrix
-from agent_bom.runtime.gateway_events import GatewayRuntimeEventType, build_gateway_runtime_event
+from agent_bom.runtime.gateway_events import (
+    GatewayRuntimeEventType,
+    build_gateway_runtime_event,
+    canonicalize_gateway_enforcement_event,
+)
 from agent_bom.runtime.gateway_relay_contract import (
     MAX_GATEWAY_RELAY_MESSAGE_BYTES,
     RelayForwardRequest,
@@ -1266,15 +1271,15 @@ class ControlPlaneAuditSink:
     def __init__(
         self,
         *,
-        audit_url: str,
         token: str | None,
+        tenant_id: str,
         source_id: str,
         session_id: str,
         delivery_state: AuditDeliveryState,
         sender: GatewayAuditSender,
     ) -> None:
-        self._audit_url = audit_url
         self._token = token
+        self._tenant_id = tenant_id
         self._source_id = source_id
         self._session_id = session_id
         self._delivery_state = delivery_state
@@ -1286,8 +1291,15 @@ class ControlPlaneAuditSink:
 
     @staticmethod
     def _batch_idempotency_key(session_id: str, events: list[dict[str, Any]]) -> str:
-        event_ids = [str(event.get("event_id") or "") for event in events]
-        material = json.dumps([session_id, event_ids], separators=(",", ":"), ensure_ascii=True)
+        event_identities = [
+            str(event.get("event_id"))
+            if event.get("event_id")
+            else hashlib.sha256(
+                json.dumps(event, separators=(",", ":"), sort_keys=True, ensure_ascii=True).encode("utf-8")
+            ).hexdigest()
+            for event in events
+        ]
+        material = json.dumps([session_id, event_identities], separators=(",", ":"), ensure_ascii=True)
         return "gateway-audit-" + hashlib.sha256(material.encode("utf-8")).hexdigest()
 
     @staticmethod
@@ -1320,7 +1332,16 @@ class ControlPlaneAuditSink:
     async def __call__(self, event: dict[str, Any]) -> None:
         async with self._lock:
             try:
+                event = canonicalize_gateway_enforcement_event(event)
+                event_tenant = str(event.get("tenant_id") or "")
+                if event_tenant != self._tenant_id:
+                    raise GatewayAuditDeliveryUnavailableError("audit credential is not bound to the event tenant")
+                if self._delivery_state.store.dlq_size_bytes() or self._delivery_state.store.dropped_events:
+                    self._persistence_available = False
+                    raise GatewayAuditDeliveryUnavailableError("durable audit backlog is full")
                 destination = self._delivery_state.store.append_events([event])
+            except GatewayAuditDeliveryUnavailableError:
+                raise
             except Exception as exc:  # noqa: BLE001 - local durability failure is fail-closed
                 self._persistence_available = False
                 logger.error("Gateway audit persistence unavailable (error_type=%s)", type(exc).__name__)
@@ -1342,26 +1363,30 @@ class ControlPlaneAuditSink:
         if claim is None:
             self._persistence_available = True
             return True
-        events = claim.events
-        if not events:
+        if not claim.events:
             self._delivery_state.store.acknowledge_claim(claim)
             return True
+        active_claim: AuditSpilloverClaim | None = claim
         try:
-            response = await self._sender(self._payload(events), self._headers())
-            self._validate_acknowledgement(events, response)
+            while active_claim is not None:
+                events = active_claim.events[:500]
+                response = await self._sender(self._payload(events), self._headers())
+                self._validate_acknowledgement(events, response)
+                active_claim = self._delivery_state.store.acknowledge_claim_prefix(active_claim, len(events))
         except asyncio.CancelledError:
-            self._delivery_state.store.restore_claim(claim)
+            if active_claim is not None:
+                self._delivery_state.store.restore_claim(active_claim)
             raise
         except Exception as exc:  # noqa: BLE001 - retained backlog is retried
             try:
-                self._delivery_state.store.restore_claim(claim)
+                if active_claim is not None:
+                    self._delivery_state.store.restore_claim(active_claim)
             except Exception:  # noqa: BLE001 - do not leak persistence exception details
                 self._persistence_available = False
                 logger.error("Gateway audit persistence unavailable while retaining a failed delivery")
             self._delivery_state.controller.record_failure()
             logger.warning("Gateway audit push failed; retained for retry (error_type=%s)", type(exc).__name__)
             return False
-        self._delivery_state.store.acknowledge_claim(claim)
         self._persistence_available = True
         self._delivery_state.controller.record_success()
         return True
@@ -1423,7 +1448,7 @@ class ControlPlaneAuditSink:
             health["status"] = "degraded"
         return {
             "configured": True,
-            "durable": True,
+            "durable": self._persistence_available and backlog_observable,
             "accepting_events": accepting_events,
             "backlog_observable": backlog_observable,
             "retry_worker_running": self._worker is not None and not self._worker.done() and not self._closed,
@@ -1435,6 +1460,7 @@ def build_control_plane_audit_sink(
     base_url: str,
     token: str | None,
     *,
+    tenant_id: str = "default",
     source_id: str = "gateway",
     session_id: str | None = None,
     spill_path: Path | None = None,
@@ -1446,7 +1472,10 @@ def build_control_plane_audit_sink(
     """Build the gateway's shared bounded control-plane audit delivery sink."""
 
     audit_url = base_url.rstrip("/") + "/v1/proxy/audit"
-    delivery_identity = f"{source_id}\0{audit_url}"
+    normalized_tenant_id = tenant_id.strip()
+    if not normalized_tenant_id:
+        raise ValueError("gateway audit tenant_id must not be empty")
+    delivery_identity = f"{source_id}\0{audit_url}\0{normalized_tenant_id}"
     active_session_id = session_id or "gateway-" + hashlib.sha256(delivery_identity.encode("utf-8")).hexdigest()[:20]
     state_dir = Path(os.environ.get("AGENT_BOM_STATE_DIR", Path.home() / ".agent-bom")).expanduser()
     stable_paths = audit_delivery_paths(
@@ -1474,8 +1503,8 @@ def build_control_plane_audit_sink(
     else:
         active_sender = sender
     return ControlPlaneAuditSink(
-        audit_url=audit_url,
         token=token,
+        tenant_id=normalized_tenant_id,
         source_id=source_id,
         session_id=active_session_id,
         delivery_state=AuditDeliveryState(controller=controller, store=store),
@@ -1783,6 +1812,19 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             if audit_delivery_health["status"] != "healthy":
                 health["status"] = "degraded"
         return health
+
+    @app.get("/readyz")
+    async def readyz() -> JSONResponse:
+        """Report whether configured durable audit delivery can accept work."""
+
+        health = await healthz()
+        audit_delivery = health.get("audit_delivery")
+        ready = not isinstance(audit_delivery, dict) or (
+            audit_delivery.get("status") == "healthy"
+            and bool(audit_delivery.get("durable"))
+            and bool(audit_delivery.get("accepting_events"))
+        )
+        return JSONResponse(status_code=200 if ready else 503, content={"ready": ready, **health})
 
     @app.post("/v1/firewall/check")
     async def firewall_check(request: Request) -> JSONResponse:

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -28,13 +28,13 @@ Non-goals for MVP (see design doc):
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import ipaddress
 import json
 import logging
 import os
 import threading
 import time
-import uuid
 from contextlib import asynccontextmanager, nullcontext
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -83,6 +83,12 @@ from agent_bom.proxy_policy import (
     summarize_policy_bundle,
 )
 from agent_bom.proxy_scanner import ScanConfig, redact_pii, scan_tool_call, scan_tool_response
+from agent_bom.runtime.audit_delivery import (
+    AuditDeliveryController,
+    AuditDeliveryState,
+    AuditSpilloverStore,
+    audit_delivery_paths,
+)
 from agent_bom.runtime.fail_mode import gateway_fail_mode_matrix
 from agent_bom.runtime.gateway_events import GatewayRuntimeEventType, build_gateway_runtime_event
 from agent_bom.runtime.gateway_relay_contract import (
@@ -101,7 +107,15 @@ _MAX_GATEWAY_MESSAGE_BYTES = MAX_GATEWAY_RELAY_MESSAGE_BYTES
 _GATEWAY_RELAY_SCOPE = "gateway:relay"
 
 AuditSink = Callable[[dict[str, Any]], Awaitable[None]]
+GatewayAuditSender = Callable[[dict[str, Any], dict[str, str]], Awaitable[dict[str, Any]]]
 UpstreamCaller = Callable[[UpstreamConfig, dict[str, Any], dict[str, str]], Awaitable[dict[str, Any]]]
+
+_GATEWAY_AUDIT_SPILLOVER_BYTES = 8 * 1024 * 1024
+_GATEWAY_AUDIT_DLQ_BYTES = 64 * 1024 * 1024
+
+
+class GatewayAuditDeliveryUnavailableError(RuntimeError):
+    """The gateway could not durably retain a runtime audit event."""
 
 # Lazy singleton so disabled deploys don't pay the import cost of the
 # visual detector (Pillow/pytesseract). Built on first use when
@@ -1222,37 +1236,251 @@ async def _read_bounded_gateway_body(request: Any) -> bytes:
     return bytes(body)
 
 
+async def _send_gateway_audit_batch(
+    audit_url: str,
+    payload: dict[str, Any],
+    headers: dict[str, str],
+) -> dict[str, Any]:
+    """POST one already-redacted backlog batch to the control plane."""
+
+    import httpx
+
+    async with httpx.AsyncClient(timeout=httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=5.0)) as client:
+        response = await client.post(audit_url, json=payload, headers=headers)
+        response.raise_for_status()
+        body = response.json()
+    if not isinstance(body, dict):
+        raise RuntimeError("control-plane audit acknowledgement is not an object")
+    return body
+
+
+class ControlPlaneAuditSink:
+    """Durably queue and retry standalone-gateway audit delivery.
+
+    A remote outage is fail-safe while the bounded local backlog accepts the
+    event: the relay may continue and health reports degraded. If neither the
+    spill file nor its finite DLQ can retain the event, ``__call__`` raises and
+    the gateway fails closed instead of acknowledging an unaudited decision.
+    """
+
+    def __init__(
+        self,
+        *,
+        audit_url: str,
+        token: str | None,
+        source_id: str,
+        session_id: str,
+        delivery_state: AuditDeliveryState,
+        sender: GatewayAuditSender,
+    ) -> None:
+        self._audit_url = audit_url
+        self._token = token
+        self._source_id = source_id
+        self._session_id = session_id
+        self._delivery_state = delivery_state
+        self._sender = sender
+        self._lock = asyncio.Lock()
+        self._worker: asyncio.Task[None] | None = None
+        self._closed = False
+        self._persistence_available = True
+
+    @staticmethod
+    def _batch_idempotency_key(session_id: str, events: list[dict[str, Any]]) -> str:
+        event_ids = [str(event.get("event_id") or "") for event in events]
+        material = json.dumps([session_id, event_ids], separators=(",", ":"), ensure_ascii=True)
+        return "gateway-audit-" + hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _validate_acknowledgement(events: list[dict[str, Any]], response: dict[str, Any]) -> None:
+        from agent_bom.runtime.gateway_events import GATEWAY_CANONICAL_EVENT_TYPES
+
+        canonical_count = sum(str(event.get("event_type") or "") in GATEWAY_CANONICAL_EVENT_TYPES for event in events)
+        durable_count = int(response.get("durable_accepted_count") or 0) + int(response.get("durable_duplicate_count") or 0)
+        conflict_count = int(response.get("durable_conflict_count") or 0)
+        accepted_count = int(response.get("accepted_alert_count") or 0) + int(response.get("duplicate_alert_count") or 0)
+        if conflict_count or durable_count < canonical_count:
+            raise RuntimeError("control plane did not durably acknowledge canonical gateway activity")
+        if accepted_count < len(events):
+            raise RuntimeError("control plane did not acknowledge the complete gateway audit batch")
+
+    def _payload(self, events: list[dict[str, Any]]) -> dict[str, Any]:
+        return {
+            "source_id": self._source_id,
+            "session_id": self._session_id,
+            "idempotency_key": self._batch_idempotency_key(self._session_id, events),
+            "alerts": events,
+        }
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+        return headers
+
+    async def __call__(self, event: dict[str, Any]) -> None:
+        async with self._lock:
+            try:
+                destination = self._delivery_state.store.append_events([event])
+            except Exception as exc:  # noqa: BLE001 - local durability failure is fail-closed
+                self._persistence_available = False
+                logger.error("Gateway audit persistence unavailable (error_type=%s)", type(exc).__name__)
+                raise GatewayAuditDeliveryUnavailableError("durable audit backlog is unavailable") from None
+            if destination in {"dlq", "dropped"}:
+                self._persistence_available = False
+                raise GatewayAuditDeliveryUnavailableError("durable audit backlog is full")
+            self._persistence_available = True
+            if not self._delivery_state.controller.is_circuit_open():
+                await self._flush_locked()
+
+    async def _flush_locked(self) -> bool:
+        try:
+            claim = self._delivery_state.store.claim_spillover()
+        except Exception as exc:  # noqa: BLE001 - health must report local durability failure
+            self._persistence_available = False
+            logger.error("Gateway audit persistence unavailable during retry (error_type=%s)", type(exc).__name__)
+            return False
+        if claim is None:
+            self._persistence_available = True
+            return True
+        events = claim.events
+        if not events:
+            self._delivery_state.store.acknowledge_claim(claim)
+            return True
+        try:
+            response = await self._sender(self._payload(events), self._headers())
+            self._validate_acknowledgement(events, response)
+        except asyncio.CancelledError:
+            self._delivery_state.store.restore_claim(claim)
+            raise
+        except Exception as exc:  # noqa: BLE001 - retained backlog is retried
+            try:
+                self._delivery_state.store.restore_claim(claim)
+            except Exception:  # noqa: BLE001 - do not leak persistence exception details
+                self._persistence_available = False
+                logger.error("Gateway audit persistence unavailable while retaining a failed delivery")
+            self._delivery_state.controller.record_failure()
+            logger.warning("Gateway audit push failed; retained for retry (error_type=%s)", type(exc).__name__)
+            return False
+        self._delivery_state.store.acknowledge_claim(claim)
+        self._persistence_available = True
+        self._delivery_state.controller.record_success()
+        return True
+
+    async def flush_once(self) -> bool:
+        """Attempt one serialized backlog delivery, primarily for startup/tests."""
+
+        async with self._lock:
+            if self._delivery_state.controller.is_circuit_open():
+                return False
+            return await self._flush_locked()
+
+    async def _retry_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._delivery_state.controller.current_backoff_seconds())
+            await self.flush_once()
+
+    async def start(self) -> None:
+        """Recover a prior spill immediately, then maintain bounded retries."""
+
+        if self._worker is not None:
+            return
+        self._closed = False
+        await self.flush_once()
+        self._worker = asyncio.create_task(self._retry_loop(), name="gateway-audit-delivery")
+
+    async def aclose(self) -> None:
+        self._closed = True
+        if self._worker is None:
+            return
+        self._worker.cancel()
+        try:
+            await self._worker
+        except asyncio.CancelledError:
+            pass
+        self._worker = None
+
+    def health(self) -> dict[str, str | int | bool]:
+        try:
+            health = self._delivery_state.health(buffer_bytes=0)
+            backlog_observable = True
+        except Exception:  # noqa: BLE001 - health remains secret-free and available
+            self._persistence_available = False
+            controller = self._delivery_state.controller
+            health = {
+                "status": "degraded",
+                "buffer_bytes": 0,
+                "spillover_bytes": 0,
+                "dlq_bytes": 0,
+                "backlog_bytes": 0,
+                "consecutive_failures": controller.consecutive_failures,
+                "backoff_seconds": controller.current_backoff_seconds(),
+                "circuit_open": controller.is_circuit_open(),
+                "dropped_events": self._delivery_state.store.dropped_events,
+            }
+            backlog_observable = False
+        accepting_events = self._persistence_available and not bool(health["dlq_bytes"]) and not bool(health["dropped_events"])
+        if not accepting_events:
+            health["status"] = "degraded"
+        return {
+            "configured": True,
+            "durable": True,
+            "accepting_events": accepting_events,
+            "backlog_observable": backlog_observable,
+            "retry_worker_running": self._worker is not None and not self._worker.done() and not self._closed,
+            **health,
+        }
+
+
 def build_control_plane_audit_sink(
     base_url: str,
     token: str | None,
     *,
     source_id: str = "gateway",
     session_id: str | None = None,
-) -> AuditSink:
-    """Build an audit sink that forwards gateway runtime events to the API."""
+    spill_path: Path | None = None,
+    dlq_path: Path | None = None,
+    max_spillover_bytes: int = _GATEWAY_AUDIT_SPILLOVER_BYTES,
+    max_dlq_bytes: int = _GATEWAY_AUDIT_DLQ_BYTES,
+    sender: GatewayAuditSender | None = None,
+) -> ControlPlaneAuditSink:
+    """Build the gateway's shared bounded control-plane audit delivery sink."""
+
     audit_url = base_url.rstrip("/") + "/v1/proxy/audit"
-    active_session_id = session_id or str(uuid.uuid4())
+    delivery_identity = f"{source_id}\0{audit_url}"
+    active_session_id = session_id or "gateway-" + hashlib.sha256(delivery_identity.encode("utf-8")).hexdigest()[:20]
+    state_dir = Path(os.environ.get("AGENT_BOM_STATE_DIR", Path.home() / ".agent-bom")).expanduser()
+    stable_paths = audit_delivery_paths(
+        state_dir,
+        surface="gateway",
+        identity=delivery_identity,
+    )
+    active_spill_path = spill_path or stable_paths.spill_path
+    active_dlq_path = dlq_path or stable_paths.dlq_path
+    controller = AuditDeliveryController()
+    store = AuditSpilloverStore(
+        spill_path=active_spill_path,
+        dlq_path=active_dlq_path,
+        max_spillover_bytes=max_spillover_bytes,
+        max_dlq_bytes=max_dlq_bytes,
+    )
 
-    async def _sink(event: dict[str, Any]) -> None:
-        import httpx
+    active_sender: GatewayAuditSender
+    if sender is None:
 
-        headers: dict[str, str] = {"Content-Type": "application/json"}
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
-        payload = {
-            "source_id": source_id,
-            "session_id": active_session_id,
-            "idempotency_key": event.get("event_id") or str(uuid.uuid4()),
-            "alerts": [event],
-        }
-        try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=5.0)) as client:
-                response = await client.post(audit_url, json=payload, headers=headers)
-                response.raise_for_status()
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("Gateway audit push failed: %s", sanitize_text(_sanitize_for_log(exc)))
+        async def _sender(payload: dict[str, Any], headers: dict[str, str]) -> dict[str, Any]:
+            return await _send_gateway_audit_batch(audit_url, payload, headers)
 
-    return _sink
+        active_sender = _sender
+    else:
+        active_sender = sender
+    return ControlPlaneAuditSink(
+        audit_url=audit_url,
+        token=token,
+        source_id=source_id,
+        session_id=active_session_id,
+        delivery_state=AuditDeliveryState(controller=controller, store=store),
+        sender=active_sender,
+    )
 
 
 def _warn_on_quarantined_agents(settings: GatewaySettings) -> None:
@@ -1441,6 +1669,8 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         nonlocal reload_task
         nonlocal firewall_reload_task
         try:
+            if isinstance(settings.audit_sink, ControlPlaneAuditSink):
+                await settings.audit_sink.start()
             if settings.policy_path is not None:
                 await _reload_policy_if_changed(force=True)
                 if settings.policy_reload_interval_seconds > 0:
@@ -1462,6 +1692,8 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                         pass
             reload_task = None
             firewall_reload_task = None
+            if isinstance(settings.audit_sink, ControlPlaneAuditSink):
+                await settings.audit_sink.aclose()
 
     app = FastAPI(title="agent-bom gateway", version="1", lifespan=_lifespan)
 
@@ -1545,6 +1777,11 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 **visual_leak_runtime_health(),
                 "required": settings.require_visual_leak_detection_ready,
             }
+        if isinstance(settings.audit_sink, ControlPlaneAuditSink):
+            audit_delivery_health = settings.audit_sink.health()
+            health["audit_delivery"] = audit_delivery_health
+            if audit_delivery_health["status"] != "healthy":
+                health["status"] = "degraded"
         return health
 
     @app.post("/v1/firewall/check")
@@ -2040,18 +2277,29 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                         "development_mode": bool(explicit_dev_bypass),
                         "trace_id": str(trace_meta["trace_id"]),
                     }
-                    if runtime_profile_mode == "enforce" and not explicit_dev_bypass and is_tools_call(message):
+                    if runtime_profile_mode == "enforce" and not explicit_dev_bypass:
                         profile_audit.update(
                             _typed_runtime_event(
-                                GatewayRuntimeEventType.TOOL_CALL_BLOCKED,
+                                GatewayRuntimeEventType.TOOL_CALL_BLOCKED
+                                if is_tools_call(message)
+                                else GatewayRuntimeEventType.RUNTIME_PROFILE_BLOCKED,
                                 decision="deny",
                                 policy_source="runtime_profile",
                                 reason_code=profile_failure_code,
                             )
                         )
                     else:
-                        profile_event_id = f"gw_{uuid.uuid4().hex}"
-                        profile_audit.update({"event_id": profile_event_id, "decision_id": profile_event_id})
+                        profile_audit.update(
+                            _typed_runtime_event(
+                                GatewayRuntimeEventType.RUNTIME_PROFILE_DEV_BYPASS
+                                if explicit_dev_bypass
+                                else GatewayRuntimeEventType.RUNTIME_PROFILE_WARNED,
+                                decision="allow",
+                                policy_source="runtime_profile",
+                                reason_code=profile_failure_code,
+                            )
+                        )
+                        profile_audit["development_mode"] = bool(explicit_dev_bypass)
                     await settings.audit_sink(profile_audit)
 
                 if runtime_profile_mode == "enforce" and not explicit_dev_bypass:
@@ -3297,6 +3545,8 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
 
 # Re-export the parser for easier test authoring / CLI glue.
 __all__ = [
+    "ControlPlaneAuditSink",
+    "GatewayAuditDeliveryUnavailableError",
     "GatewaySettings",
     "build_control_plane_audit_sink",
     "create_gateway_app",

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -64,8 +64,10 @@ ProxyMetricsServer = _proxy_audit.ProxyMetricsServer
 ReplayDetector = _proxy_audit.ReplayDetector
 RotatingAuditLog = _proxy_audit.RotatingAuditLog
 AuditDeliveryController = _proxy_audit.AuditDeliveryController
+AuditDeliveryPaths = _proxy_audit.AuditDeliveryPaths
 AuditDeliveryState = _proxy_audit.AuditDeliveryState
 AuditSpilloverStore = _proxy_audit.AuditSpilloverStore
+audit_delivery_paths = _proxy_audit.audit_delivery_paths
 _truncate_args = _proxy_audit._truncate_args
 compute_payload_hash = _proxy_audit.compute_payload_hash
 compute_response_hmac = _proxy_audit.compute_response_hmac
@@ -406,6 +408,18 @@ def _sanitize_for_log(value: object) -> str:
 def _generate_proxy_source_id() -> str:
     hostname = platform.node() or "unknown"
     return hashlib.sha256(hostname.encode()).hexdigest()[:12]
+
+
+def _proxy_audit_delivery_paths(
+    control_plane_url: str,
+    tenant_id: str,
+    source_id: str,
+) -> AuditDeliveryPaths:
+    """Resolve restart-stable, secret-free proxy audit backlog paths."""
+
+    state_dir = Path(os.environ.get("AGENT_BOM_STATE_DIR", Path.home() / ".agent-bom")).expanduser()
+    identity = "\x00".join((control_plane_url.rstrip("/"), tenant_id, source_id))
+    return audit_delivery_paths(state_dir, surface="proxy", identity=identity)
 
 
 def _control_plane_headers(token: str | None, etag: str | None = None) -> dict[str, str]:
@@ -1285,16 +1299,21 @@ async def run_proxy(
         max_audit_buffer_bytes,
         int(os.environ.get("AGENT_BOM_PROXY_AUDIT_SPILLOVER_MAX_BYTES", str(max_audit_buffer_bytes * 8))),
     )
+    stable_audit_paths = _proxy_audit_delivery_paths(
+        control_plane_url or "local",
+        control_plane_tenant_id,
+        control_plane_source_id,
+    )
     audit_spill_path = Path(
         os.environ.get(
             "AGENT_BOM_PROXY_AUDIT_SPILLOVER_PATH",
-            str(Path(tempfile.gettempdir()) / f"agent-bom-proxy-audit-{control_plane_session_id}.jsonl"),
+            str(stable_audit_paths.spill_path),
         )
     )
     audit_dlq_path = Path(
         os.environ.get(
             "AGENT_BOM_PROXY_AUDIT_DLQ_PATH",
-            str(Path(tempfile.gettempdir()) / f"agent-bom-proxy-audit-{control_plane_session_id}.dlq.jsonl"),
+            str(stable_audit_paths.dlq_path),
         )
     )
     audit_delivery = AuditDeliveryController(
@@ -1407,15 +1426,14 @@ async def run_proxy(
             return True
         async with audit_lock:
             alerts = list(audit_buffer)
-            in_memory_bytes = audit_buffer_bytes
-            spillover_alerts = audit_spillover.read_spillover()
+            spillover_claim = audit_spillover.claim_spillover()
             audit_buffer.clear()
             audit_buffer_bytes = 0
             _sync_audit_metrics()
+        spillover_alerts = spillover_claim.events if spillover_claim else []
         combined_alerts = spillover_alerts + alerts
         if not combined_alerts and summary is None:
             return True
-        spillover_had_data = bool(spillover_alerts)
         try:
             await _push_proxy_audit_batch(
                 control_plane_url,
@@ -1429,13 +1447,19 @@ async def run_proxy(
             metrics.record_audit_push_failure()
             logger.warning("Proxy audit push failed: %s", sanitize_text(exc))
             async with audit_lock:
-                audit_buffer[:0] = alerts
-                audit_buffer_bytes += in_memory_bytes
+                if spillover_claim is not None:
+                    destination = audit_spillover.restore_claim(spillover_claim, alerts)
+                else:
+                    destination = audit_spillover.append_events(alerts)
+                if destination == "dlq":
+                    logger.error("Proxy audit retry backlog exceeded the spill limit; persisted the batch to the bounded DLQ")
+                elif destination == "dropped":
+                    logger.error("Proxy audit spillover and DLQ are full; a failed delivery batch was dropped")
                 _sync_audit_metrics()
             return False
         else:
-            if spillover_had_data:
-                audit_spillover.clear_spillover()
+            if spillover_claim is not None:
+                audit_spillover.acknowledge_claim(spillover_claim)
             _sync_audit_metrics()
             return True
 

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -64,6 +64,7 @@ ProxyMetricsServer = _proxy_audit.ProxyMetricsServer
 ReplayDetector = _proxy_audit.ReplayDetector
 RotatingAuditLog = _proxy_audit.RotatingAuditLog
 AuditDeliveryController = _proxy_audit.AuditDeliveryController
+AuditDeliveryState = _proxy_audit.AuditDeliveryState
 AuditSpilloverStore = _proxy_audit.AuditSpilloverStore
 _truncate_args = _proxy_audit._truncate_args
 compute_payload_hash = _proxy_audit.compute_payload_hash
@@ -1316,16 +1317,18 @@ async def run_proxy(
         dlq_path=audit_dlq_path,
         max_spillover_bytes=max_audit_spillover_bytes,
     )
+    audit_delivery_state = AuditDeliveryState(controller=audit_delivery, store=audit_spillover)
 
     def _event_size_bytes(payload: dict) -> int:
         return len(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
 
     def _sync_audit_metrics() -> None:
-        metrics.set_audit_buffer_bytes(audit_buffer_bytes)
-        metrics.set_audit_spillover_bytes(audit_spillover.spillover_size_bytes())
-        metrics.set_audit_dlq_bytes(audit_spillover.dlq_size_bytes())
-        metrics.set_audit_push_backoff_seconds(audit_delivery.current_backoff_seconds())
-        metrics.set_audit_circuit_open(audit_delivery.is_circuit_open())
+        health = audit_delivery_state.health(buffer_bytes=audit_buffer_bytes)
+        metrics.set_audit_buffer_bytes(int(health["buffer_bytes"]))
+        metrics.set_audit_spillover_bytes(int(health["spillover_bytes"]))
+        metrics.set_audit_dlq_bytes(int(health["dlq_bytes"]))
+        metrics.set_audit_push_backoff_seconds(int(health["backoff_seconds"]))
+        metrics.set_audit_circuit_open(bool(health["circuit_open"]))
 
     async def _queue_control_plane_alert(alert_payload: dict) -> None:
         nonlocal audit_buffer_bytes
@@ -1341,6 +1344,10 @@ async def run_proxy(
                         "Proxy audit spillover exceeded %s bytes; diverting alert backlog to DLQ %s",
                         max_audit_spillover_bytes,
                         audit_dlq_path,
+                    )
+                elif destination == "dropped":
+                    logger.error(
+                        "Proxy audit spillover and DLQ are full; dropping one sanitized audit event",
                     )
                 else:
                     logger.warning(

--- a/src/agent_bom/proxy_audit.py
+++ b/src/agent_bom/proxy_audit.py
@@ -27,8 +27,10 @@ from agent_bom.event_normalization import build_agentic_identity_graph_projectio
 from agent_bom.runtime import audit_delivery as _audit_delivery
 
 AuditDeliveryController = _audit_delivery.AuditDeliveryController
+AuditDeliveryPaths = _audit_delivery.AuditDeliveryPaths
 AuditDeliveryState = _audit_delivery.AuditDeliveryState
 AuditSpilloverStore = _audit_delivery.AuditSpilloverStore
+audit_delivery_paths = _audit_delivery.audit_delivery_paths
 
 logger = logging.getLogger(__name__)
 

--- a/src/agent_bom/proxy_audit.py
+++ b/src/agent_bom/proxy_audit.py
@@ -24,6 +24,11 @@ from agent_bom.audit_integrity import (
     persist_ephemeral_chain_key,
 )
 from agent_bom.event_normalization import build_agentic_identity_graph_projection, build_proxy_event_relationships
+from agent_bom.runtime import audit_delivery as _audit_delivery
+
+AuditDeliveryController = _audit_delivery.AuditDeliveryController
+AuditDeliveryState = _audit_delivery.AuditDeliveryState
+AuditSpilloverStore = _audit_delivery.AuditSpilloverStore
 
 logger = logging.getLogger(__name__)
 
@@ -232,104 +237,6 @@ class ProxyMetrics:
             "audit_push_backoff_seconds": self.audit_push_backoff_seconds,
             "audit_circuit_open": 1 if self.audit_circuit_open else 0,
         }
-
-
-@dataclass
-class AuditDeliveryController:
-    """Backoff and circuit-breaker state for proxy audit push delivery."""
-
-    base_interval_seconds: int = 10
-    max_backoff_seconds: int = 300
-    breaker_failure_threshold: int = 3
-    breaker_cooldown_seconds: int = 60
-    consecutive_failures: int = 0
-    _next_delay_seconds: int = 10
-    _circuit_open_until: float = 0.0
-
-    def is_circuit_open(self, now: float | None = None) -> bool:
-        now = time.monotonic() if now is None else now
-        return now < self._circuit_open_until
-
-    def current_backoff_seconds(self, now: float | None = None) -> int:
-        now = time.monotonic() if now is None else now
-        if self.is_circuit_open(now):
-            return max(int(self._circuit_open_until - now), 1)
-        return self._next_delay_seconds
-
-    def record_success(self) -> None:
-        self.consecutive_failures = 0
-        self._next_delay_seconds = self.base_interval_seconds
-        self._circuit_open_until = 0.0
-
-    def record_failure(self, now: float | None = None) -> None:
-        now = time.monotonic() if now is None else now
-        self.consecutive_failures += 1
-        if self._next_delay_seconds <= self.base_interval_seconds:
-            self._next_delay_seconds = min(self.base_interval_seconds * 2, self.max_backoff_seconds)
-        else:
-            self._next_delay_seconds = min(self._next_delay_seconds * 2, self.max_backoff_seconds)
-        if self.consecutive_failures >= self.breaker_failure_threshold:
-            self._circuit_open_until = now + self.breaker_cooldown_seconds
-
-
-@dataclass
-class AuditSpilloverStore:
-    """Persist bounded proxy audit overflow to spillover and DLQ files."""
-
-    spill_path: Path
-    dlq_path: Path
-    max_spillover_bytes: int
-
-    def spillover_size_bytes(self) -> int:
-        try:
-            return self.spill_path.stat().st_size
-        except FileNotFoundError:
-            return 0
-
-    def dlq_size_bytes(self) -> int:
-        try:
-            return self.dlq_path.stat().st_size
-        except FileNotFoundError:
-            return 0
-
-    def append_events(self, events: list[dict]) -> str:
-        if not events:
-            return "noop"
-        encoded = [json.dumps(event) for event in events]
-        total_bytes = sum(len((line + "\n").encode("utf-8")) for line in encoded)
-        if self.spillover_size_bytes() + total_bytes <= self.max_spillover_bytes:
-            self._append_lines(self.spill_path, encoded)
-            return "spillover"
-        self._append_lines(self.dlq_path, encoded)
-        return "dlq"
-
-    def read_spillover(self) -> list[dict]:
-        if not self.spill_path.exists():
-            return []
-        events: list[dict] = []
-        with self.spill_path.open("r", encoding="utf-8") as handle:
-            for line in handle:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    payload = json.loads(line)
-                except json.JSONDecodeError:
-                    logger.warning("Skipping malformed proxy audit spillover line from %s", self.spill_path)
-                    continue
-                if isinstance(payload, dict):
-                    events.append(payload)
-        return events
-
-    def clear_spillover(self) -> None:
-        if self.spill_path.exists():
-            self.spill_path.unlink()
-
-    def _append_lines(self, path: Path, lines: list[str]) -> None:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("a", encoding="utf-8") as handle:
-            for line in lines:
-                handle.write(line + "\n")
 
 
 @dataclass(frozen=True)

--- a/src/agent_bom/runtime/audit_delivery.py
+++ b/src/agent_bom/runtime/audit_delivery.py
@@ -264,6 +264,31 @@ class AuditSpilloverStore:
                 claim.path.unlink()
             _ACTIVE_CLAIMS.discard(os.path.abspath(claim.path))
 
+    def acknowledge_claim_prefix(
+        self,
+        claim: AuditSpilloverClaim,
+        event_count: int,
+    ) -> AuditSpilloverClaim | None:
+        """Durably acknowledge an ordered prefix and retain the unsent tail."""
+
+        if event_count < 1 or event_count > len(claim.events):
+            raise ValueError("acknowledged event count is outside the claimed batch")
+        with self._exclusive():
+            self._validate_claim_path(claim.path)
+            self._reject_symlink(claim.path)
+            if not claim.path.exists():
+                _ACTIVE_CLAIMS.discard(os.path.abspath(claim.path))
+                return None
+            remaining = claim.events[event_count:]
+            if not remaining:
+                claim.path.unlink()
+                _ACTIVE_CLAIMS.discard(os.path.abspath(claim.path))
+                return None
+            encoded = self._encode_events(remaining)
+            payload = b"".join((line + "\n").encode("utf-8") for line in encoded)
+            self._atomic_write_locked(claim.path, payload)
+            return AuditSpilloverClaim(path=claim.path, events=[dict(event) for event in remaining])
+
     def restore_claim(
         self,
         claim: AuditSpilloverClaim,
@@ -301,12 +326,6 @@ class AuditSpilloverStore:
             claim.path.unlink()
             _ACTIVE_CLAIMS.discard(os.path.abspath(claim.path))
             return destination
-
-    def clear_spillover(self) -> None:
-        with self._exclusive():
-            self._reject_symlink(self.spill_path)
-            if self.spill_path.exists():
-                self.spill_path.unlink()
 
     @staticmethod
     def _reject_symlink(path: Path) -> None:

--- a/src/agent_bom/runtime/audit_delivery.py
+++ b/src/agent_bom/runtime/audit_delivery.py
@@ -1,0 +1,231 @@
+"""Shared bounded delivery state for runtime audit events.
+
+This module owns the retry controller and disk backlog used by the stdio proxy
+and the HTTP gateway.  Transport-specific code remains responsible for the
+actual network call; persistence, restart loading, circuit state, and health
+reporting must not drift between runtime entry points.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Mapping
+
+from agent_bom.security import sanitize_sensitive_payload, sanitize_text
+
+logger = logging.getLogger(__name__)
+
+AuditBacklogDestination = Literal["noop", "spillover", "dlq", "dropped"]
+_DEFAULT_MIN_DLQ_BYTES = 1024 * 1024
+
+
+@dataclass
+class AuditDeliveryController:
+    """Backoff and circuit-breaker state for runtime audit delivery."""
+
+    base_interval_seconds: int = 10
+    max_backoff_seconds: int = 300
+    breaker_failure_threshold: int = 3
+    breaker_cooldown_seconds: int = 60
+    consecutive_failures: int = 0
+    _next_delay_seconds: int = 10
+    _circuit_open_until: float = 0.0
+
+    def is_circuit_open(self, now: float | None = None) -> bool:
+        now = time.monotonic() if now is None else now
+        return now < self._circuit_open_until
+
+    def current_backoff_seconds(self, now: float | None = None) -> int:
+        now = time.monotonic() if now is None else now
+        if self.is_circuit_open(now):
+            return max(int(self._circuit_open_until - now), 1)
+        return self._next_delay_seconds
+
+    def record_success(self) -> None:
+        self.consecutive_failures = 0
+        self._next_delay_seconds = self.base_interval_seconds
+        self._circuit_open_until = 0.0
+
+    def record_failure(self, now: float | None = None) -> None:
+        now = time.monotonic() if now is None else now
+        self.consecutive_failures += 1
+        if self._next_delay_seconds <= self.base_interval_seconds:
+            self._next_delay_seconds = min(self.base_interval_seconds * 2, self.max_backoff_seconds)
+        else:
+            self._next_delay_seconds = min(self._next_delay_seconds * 2, self.max_backoff_seconds)
+        if self.consecutive_failures >= self.breaker_failure_threshold:
+            self._circuit_open_until = now + self.breaker_cooldown_seconds
+
+
+@dataclass
+class AuditSpilloverStore:
+    """Persist a bounded, secret-safe runtime audit backlog and DLQ."""
+
+    spill_path: Path
+    dlq_path: Path
+    max_spillover_bytes: int
+    max_dlq_bytes: int | None = None
+    dropped_events: int = field(default=0, init=False)
+    _lock: threading.RLock = field(default_factory=threading.RLock, init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        self.spill_path = Path(self.spill_path)
+        self.dlq_path = Path(self.dlq_path)
+        if self.max_spillover_bytes < 1:
+            raise ValueError("max_spillover_bytes must be greater than zero")
+        if self.max_dlq_bytes is None:
+            # Keep the proxy's historical spill-to-DLQ behavior even for tiny
+            # test/operator spill limits, while replacing its unbounded DLQ
+            # with a finite ceiling.
+            self.max_dlq_bytes = max(self.max_spillover_bytes * 8, _DEFAULT_MIN_DLQ_BYTES)
+        if self.max_dlq_bytes < 1:
+            raise ValueError("max_dlq_bytes must be greater than zero")
+
+    @staticmethod
+    def _size_bytes(path: Path) -> int:
+        try:
+            return path.stat().st_size
+        except FileNotFoundError:
+            return 0
+
+    def spillover_size_bytes(self) -> int:
+        return self._size_bytes(self.spill_path)
+
+    def dlq_size_bytes(self) -> int:
+        return self._size_bytes(self.dlq_path)
+
+    @property
+    def dlq_limit_bytes(self) -> int:
+        """Return the normalized finite DLQ ceiling."""
+
+        if self.max_dlq_bytes is None:  # pragma: no cover - normalized in __post_init__
+            raise RuntimeError("max_dlq_bytes was not initialized")
+        return self.max_dlq_bytes
+
+    @staticmethod
+    def _encode_events(events: list[Mapping[str, Any]]) -> list[str]:
+        encoded: list[str] = []
+        for event in events:
+            sanitized = sanitize_sensitive_payload(dict(event))
+            if not isinstance(sanitized, dict):  # pragma: no cover - defensive contract guard
+                continue
+            encoded.append(json.dumps(sanitized, separators=(",", ":"), sort_keys=True))
+        return encoded
+
+    def append_events(self, events: list[Mapping[str, Any]]) -> AuditBacklogDestination:
+        if not events:
+            return "noop"
+        encoded = self._encode_events(events)
+        if not encoded:
+            return "noop"
+        total_bytes = sum(len((line + "\n").encode("utf-8")) for line in encoded)
+        with self._lock:
+            if self.spillover_size_bytes() + total_bytes <= self.max_spillover_bytes:
+                self._append_lines(self.spill_path, encoded)
+                return "spillover"
+            if self.dlq_size_bytes() + total_bytes <= self.dlq_limit_bytes:
+                self._append_lines(self.dlq_path, encoded)
+                return "dlq"
+            self.dropped_events += len(encoded)
+            return "dropped"
+
+    def read_spillover(self) -> list[dict[str, Any]]:
+        with self._lock:
+            if not self.spill_path.exists():
+                return []
+            self._reject_symlink(self.spill_path)
+            events: list[dict[str, Any]] = []
+            with self.spill_path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        payload = json.loads(line)
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            "Skipping malformed runtime audit spillover line from %s",
+                            sanitize_text(self.spill_path),
+                        )
+                        continue
+                    if isinstance(payload, dict):
+                        events.append(payload)
+            return events
+
+    def clear_spillover(self) -> None:
+        with self._lock:
+            if self.spill_path.exists():
+                self._reject_symlink(self.spill_path)
+                self.spill_path.unlink()
+
+    @staticmethod
+    def _reject_symlink(path: Path) -> None:
+        if path.is_symlink():
+            raise ValueError("runtime audit backlog path must not be a symlink")
+
+    def _append_lines(self, path: Path, lines: list[str]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self._reject_symlink(path)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags, 0o600)
+        try:
+            os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+            with os.fdopen(fd, "a", encoding="utf-8") as handle:
+                fd = -1
+                for line in lines:
+                    handle.write(line + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+        finally:
+            if fd >= 0:
+                os.close(fd)
+
+
+@dataclass(frozen=True)
+class AuditDeliveryState:
+    """One shared controller/backlog with a secret-free health contract."""
+
+    controller: AuditDeliveryController
+    store: AuditSpilloverStore
+
+    def health(self, *, buffer_bytes: int = 0, now: float | None = None) -> dict[str, str | int | bool]:
+        memory_bytes = max(0, int(buffer_bytes))
+        spillover_bytes = self.store.spillover_size_bytes()
+        dlq_bytes = self.store.dlq_size_bytes()
+        circuit_open = self.controller.is_circuit_open(now)
+        degraded = bool(
+            memory_bytes
+            or spillover_bytes
+            or dlq_bytes
+            or self.controller.consecutive_failures
+            or circuit_open
+            or self.store.dropped_events
+        )
+        return {
+            "status": "degraded" if degraded else "healthy",
+            "buffer_bytes": memory_bytes,
+            "spillover_bytes": spillover_bytes,
+            "dlq_bytes": dlq_bytes,
+            "backlog_bytes": memory_bytes + spillover_bytes,
+            "consecutive_failures": self.controller.consecutive_failures,
+            "backoff_seconds": self.controller.current_backoff_seconds(now),
+            "circuit_open": circuit_open,
+            "dropped_events": self.store.dropped_events,
+        }
+
+
+__all__ = [
+    "AuditBacklogDestination",
+    "AuditDeliveryController",
+    "AuditDeliveryState",
+    "AuditSpilloverStore",
+]

--- a/src/agent_bom/runtime/audit_delivery.py
+++ b/src/agent_bom/runtime/audit_delivery.py
@@ -8,22 +8,64 @@ reporting must not drift between runtime entry points.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
 import stat
 import threading
 import time
+import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, Mapping
+from typing import Any, Iterator, Literal, Mapping, Sequence
 
-from agent_bom.security import sanitize_sensitive_payload, sanitize_text
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows falls back to process locking
+    fcntl = None  # type: ignore[assignment]
+
+from agent_bom.security import sanitize_sensitive_payload
 
 logger = logging.getLogger(__name__)
 
 AuditBacklogDestination = Literal["noop", "spillover", "dlq", "dropped"]
 _DEFAULT_MIN_DLQ_BYTES = 1024 * 1024
+_STORE_LOCKS: dict[tuple[str, str], threading.RLock] = {}
+_STORE_LOCKS_GUARD = threading.Lock()
+_ACTIVE_CLAIMS: set[str] = set()
+
+
+@dataclass(frozen=True)
+class AuditDeliveryPaths:
+    """Stable, secret-free paths for one runtime-delivery identity."""
+
+    spill_path: Path
+    dlq_path: Path
+
+
+def audit_delivery_paths(state_dir: Path, *, surface: str, identity: str) -> AuditDeliveryPaths:
+    """Derive restart-stable backlog paths without embedding credentials."""
+
+    safe_surface = "".join(character for character in surface.lower() if character.isalnum() or character in {"-", "_"})
+    if not safe_surface:
+        raise ValueError("audit delivery surface must contain a safe character")
+    identity_digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:20]
+    root = Path(state_dir) / "runtime-audit"
+    stem = f"{safe_surface}-{identity_digest}"
+    return AuditDeliveryPaths(
+        spill_path=root / f"{stem}.spill.jsonl",
+        dlq_path=root / f"{stem}.dlq.jsonl",
+    )
+
+
+@dataclass(frozen=True)
+class AuditSpilloverClaim:
+    """An atomically detached spill segment being delivered."""
+
+    path: Path
+    events: list[dict[str, Any]]
 
 
 @dataclass
@@ -88,18 +130,63 @@ class AuditSpilloverStore:
         if self.max_dlq_bytes < 1:
             raise ValueError("max_dlq_bytes must be greater than zero")
 
+    def _shared_lock(self) -> threading.RLock:
+        key = (os.path.abspath(self.spill_path), os.path.abspath(self.dlq_path))
+        with _STORE_LOCKS_GUARD:
+            return _STORE_LOCKS.setdefault(key, threading.RLock())
+
+    @staticmethod
+    def _safe_parent_fd(path: Path) -> int:
+        parent = path.parent
+        parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if parent.is_symlink():
+            raise ValueError("runtime audit backlog parent directory must not be a symlink")
+        flags = os.O_RDONLY
+        if hasattr(os, "O_DIRECTORY"):
+            flags |= os.O_DIRECTORY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        return os.open(parent, flags)
+
+    @contextmanager
+    def _exclusive(self) -> Iterator[None]:
+        """Serialize bounds/rotation across store objects and processes."""
+
+        with self._shared_lock(), self._lock:
+            parent_fd = self._safe_parent_fd(self.spill_path)
+            lock_name = f".{self.spill_path.name}.lock"
+            lock_flags = os.O_RDWR | os.O_CREAT
+            if hasattr(os, "O_NOFOLLOW"):
+                lock_flags |= os.O_NOFOLLOW
+            lock_fd = os.open(lock_name, lock_flags, 0o600, dir_fd=parent_fd)
+            try:
+                os.fchmod(lock_fd, stat.S_IRUSR | stat.S_IWUSR)
+                if fcntl is not None:
+                    fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                yield
+            finally:
+                if fcntl is not None:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                os.close(lock_fd)
+                os.close(parent_fd)
+
     @staticmethod
     def _size_bytes(path: Path) -> int:
         try:
-            return path.stat().st_size
+            stat_result = path.lstat()
         except FileNotFoundError:
             return 0
+        if stat.S_ISLNK(stat_result.st_mode):
+            raise ValueError("runtime audit backlog path must not be a symlink")
+        return stat_result.st_size
 
     def spillover_size_bytes(self) -> int:
-        return self._size_bytes(self.spill_path)
+        with self._exclusive():
+            return self._spill_backlog_size_locked()
 
     def dlq_size_bytes(self) -> int:
-        return self._size_bytes(self.dlq_path)
+        with self._exclusive():
+            return self._size_bytes(self.dlq_path)
 
     @property
     def dlq_limit_bytes(self) -> int:
@@ -110,7 +197,7 @@ class AuditSpilloverStore:
         return self.max_dlq_bytes
 
     @staticmethod
-    def _encode_events(events: list[Mapping[str, Any]]) -> list[str]:
+    def _encode_events(events: Sequence[Mapping[str, Any]]) -> list[str]:
         encoded: list[str] = []
         for event in events:
             sanitized = sanitize_sensitive_payload(dict(event))
@@ -119,50 +206,106 @@ class AuditSpilloverStore:
             encoded.append(json.dumps(sanitized, separators=(",", ":"), sort_keys=True))
         return encoded
 
-    def append_events(self, events: list[Mapping[str, Any]]) -> AuditBacklogDestination:
+    def append_events(self, events: Sequence[Mapping[str, Any]]) -> AuditBacklogDestination:
         if not events:
             return "noop"
         encoded = self._encode_events(events)
         if not encoded:
             return "noop"
         total_bytes = sum(len((line + "\n").encode("utf-8")) for line in encoded)
-        with self._lock:
-            if self.spillover_size_bytes() + total_bytes <= self.max_spillover_bytes:
-                self._append_lines(self.spill_path, encoded)
+        with self._exclusive():
+            if self._spill_backlog_size_locked() + total_bytes <= self.max_spillover_bytes:
+                self._append_lines_locked(self.spill_path, encoded)
                 return "spillover"
-            if self.dlq_size_bytes() + total_bytes <= self.dlq_limit_bytes:
-                self._append_lines(self.dlq_path, encoded)
+            if self._size_bytes(self.dlq_path) + total_bytes <= self.dlq_limit_bytes:
+                self._append_lines_locked(self.dlq_path, encoded)
                 return "dlq"
             self.dropped_events += len(encoded)
             return "dropped"
 
     def read_spillover(self) -> list[dict[str, Any]]:
-        with self._lock:
+        with self._exclusive():
+            self._recover_orphan_claims_locked()
             if not self.spill_path.exists():
                 return []
-            self._reject_symlink(self.spill_path)
-            events: list[dict[str, Any]] = []
-            with self.spill_path.open("r", encoding="utf-8") as handle:
-                for line in handle:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        payload = json.loads(line)
-                    except json.JSONDecodeError:
-                        logger.warning(
-                            "Skipping malformed runtime audit spillover line from %s",
-                            sanitize_text(self.spill_path),
-                        )
-                        continue
-                    if isinstance(payload, dict):
-                        events.append(payload)
-            return events
+            return self._read_events_locked(self.spill_path)
+
+    def claim_spillover(self) -> AuditSpilloverClaim | None:
+        """Atomically detach the active spill so concurrent appends stay live."""
+
+        with self._exclusive():
+            self._recover_orphan_claims_locked()
+            if self._size_bytes(self.spill_path) == 0:
+                return None
+            parent_fd = self._safe_parent_fd(self.spill_path)
+            claim_path = self.spill_path.with_name(
+                f"{self.spill_path.name}.claim-{time.time_ns():020d}-{os.getpid()}-{uuid.uuid4().hex}"
+            )
+            try:
+                os.rename(
+                    self.spill_path.name,
+                    claim_path.name,
+                    src_dir_fd=parent_fd,
+                    dst_dir_fd=parent_fd,
+                )
+                os.fsync(parent_fd)
+                _ACTIVE_CLAIMS.add(os.path.abspath(claim_path))
+            finally:
+                os.close(parent_fd)
+            return AuditSpilloverClaim(path=claim_path, events=self._read_events_locked(claim_path))
+
+    def acknowledge_claim(self, claim: AuditSpilloverClaim) -> None:
+        """Delete only the segment a successful send actually delivered."""
+
+        with self._exclusive():
+            self._validate_claim_path(claim.path)
+            self._reject_symlink(claim.path)
+            if claim.path.exists():
+                claim.path.unlink()
+            _ACTIVE_CLAIMS.discard(os.path.abspath(claim.path))
+
+    def restore_claim(
+        self,
+        claim: AuditSpilloverClaim,
+        pending_events: Sequence[Mapping[str, Any]] | None = None,
+    ) -> AuditBacklogDestination:
+        """Restore a failed segment and persist the paired in-memory batch.
+
+        Events appended while the transport awaits remain in the active spill.
+        When the combined segment fits, the failed in-memory snapshot is placed
+        before those newer events. If it does not fit, the claimed and active
+        spill remains intact and the snapshot is diverted to the bounded DLQ.
+        """
+
+        with self._exclusive():
+            self._validate_claim_path(claim.path)
+            self._reject_symlink(claim.path)
+            if not claim.path.exists():
+                _ACTIVE_CLAIMS.discard(os.path.abspath(claim.path))
+                return "noop"
+            claimed = self._read_bytes_locked(claim.path)
+            active = self._read_bytes_locked(self.spill_path)
+            encoded = self._encode_events(pending_events or [])
+            pending = b"".join((line + "\n").encode("utf-8") for line in encoded)
+            if len(claimed) + len(pending) + len(active) <= self.max_spillover_bytes:
+                self._atomic_write_locked(self.spill_path, claimed + pending + active)
+                destination: AuditBacklogDestination = "spillover" if pending else "noop"
+            else:
+                self._atomic_write_locked(self.spill_path, claimed + active)
+                if self._size_bytes(self.dlq_path) + len(pending) <= self.dlq_limit_bytes:
+                    self._append_lines_locked(self.dlq_path, encoded)
+                    destination = "dlq"
+                else:
+                    self.dropped_events += len(encoded)
+                    destination = "dropped"
+            claim.path.unlink()
+            _ACTIVE_CLAIMS.discard(os.path.abspath(claim.path))
+            return destination
 
     def clear_spillover(self) -> None:
-        with self._lock:
+        with self._exclusive():
+            self._reject_symlink(self.spill_path)
             if self.spill_path.exists():
-                self._reject_symlink(self.spill_path)
                 self.spill_path.unlink()
 
     @staticmethod
@@ -170,13 +313,78 @@ class AuditSpilloverStore:
         if path.is_symlink():
             raise ValueError("runtime audit backlog path must not be a symlink")
 
-    def _append_lines(self, path: Path, lines: list[str]) -> None:
-        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    def _claim_paths_locked(self) -> list[Path]:
+        parent_fd = self._safe_parent_fd(self.spill_path)
+        os.close(parent_fd)
+        return sorted(self.spill_path.parent.glob(f"{self.spill_path.name}.claim-*"))
+
+    def _spill_backlog_size_locked(self) -> int:
+        return self._size_bytes(self.spill_path) + sum(self._size_bytes(path) for path in self._claim_paths_locked())
+
+    def _validate_claim_path(self, path: Path) -> None:
+        expected_prefix = f"{self.spill_path.name}.claim-"
+        if path.parent != self.spill_path.parent or not path.name.startswith(expected_prefix):
+            raise ValueError("runtime audit spillover claim does not belong to this store")
+
+    def _read_events_locked(self, path: Path) -> list[dict[str, Any]]:
         self._reject_symlink(path)
+        events: list[dict[str, Any]] = []
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Skipping malformed runtime audit spillover record",
+                    )
+                    continue
+                if isinstance(payload, dict):
+                    events.append(payload)
+        return events
+
+    def _read_bytes_locked(self, path: Path) -> bytes:
+        self._reject_symlink(path)
+        if not path.exists():
+            return b""
+        return path.read_bytes()
+
+    def _recover_orphan_claims_locked(self) -> None:
+        claims = [path for path in self._claim_paths_locked() if self._claim_is_orphaned(path)]
+        if not claims:
+            return
+        recovered = b"".join(self._read_bytes_locked(path) for path in claims)
+        active = self._read_bytes_locked(self.spill_path)
+        self._atomic_write_locked(self.spill_path, recovered + active)
+        for path in claims:
+            path.unlink()
+
+    @staticmethod
+    def _claim_is_orphaned(path: Path) -> bool:
+        if os.path.abspath(path) in _ACTIVE_CLAIMS:
+            return False
+        try:
+            owner_pid = int(path.name.rsplit("-", 2)[1])
+        except (IndexError, ValueError):
+            return True
+        if owner_pid == os.getpid():
+            return True
+        try:
+            os.kill(owner_pid, 0)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            return False
+        return False
+
+    def _append_lines_locked(self, path: Path, lines: list[str]) -> None:
+        parent_fd = self._safe_parent_fd(path)
         flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
-        fd = os.open(path, flags, 0o600)
+        fd = os.open(path.name, flags, 0o600, dir_fd=parent_fd)
         try:
             os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
             with os.fdopen(fd, "a", encoding="utf-8") as handle:
@@ -188,6 +396,32 @@ class AuditSpilloverStore:
         finally:
             if fd >= 0:
                 os.close(fd)
+            os.close(parent_fd)
+
+    def _atomic_write_locked(self, path: Path, content: bytes) -> None:
+        parent_fd = self._safe_parent_fd(path)
+        temp_name = f".{path.name}.tmp-{uuid.uuid4().hex}"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(temp_name, flags, 0o600, dir_fd=parent_fd)
+        try:
+            os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+            with os.fdopen(fd, "wb") as handle:
+                fd = -1
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_name, path.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            os.fsync(parent_fd)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            try:
+                os.unlink(temp_name, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+            os.close(parent_fd)
 
 
 @dataclass(frozen=True)
@@ -226,6 +460,9 @@ class AuditDeliveryState:
 __all__ = [
     "AuditBacklogDestination",
     "AuditDeliveryController",
+    "AuditDeliveryPaths",
     "AuditDeliveryState",
+    "AuditSpilloverClaim",
     "AuditSpilloverStore",
+    "audit_delivery_paths",
 ]

--- a/src/agent_bom/runtime/audit_delivery.py
+++ b/src/agent_bom/runtime/audit_delivery.py
@@ -148,6 +148,21 @@ class AuditSpilloverStore:
             flags |= os.O_NOFOLLOW
         return os.open(parent, flags)
 
+    @staticmethod
+    def _validate_single_link_regular(stat_result: os.stat_result) -> None:
+        """Reject special files and aliases to files outside the backlog."""
+
+        if not stat.S_ISREG(stat_result.st_mode) or stat_result.st_nlink != 1:
+            raise ValueError("runtime audit backlog path must be a single-link regular file")
+
+    @classmethod
+    def _validate_existing_path(cls, path: Path) -> None:
+        try:
+            stat_result = path.lstat()
+        except FileNotFoundError:
+            return
+        cls._validate_single_link_regular(stat_result)
+
     @contextmanager
     def _exclusive(self) -> Iterator[None]:
         """Serialize bounds/rotation across store objects and processes."""
@@ -158,26 +173,27 @@ class AuditSpilloverStore:
             lock_flags = os.O_RDWR | os.O_CREAT
             if hasattr(os, "O_NOFOLLOW"):
                 lock_flags |= os.O_NOFOLLOW
-            lock_fd = os.open(lock_name, lock_flags, 0o600, dir_fd=parent_fd)
             try:
-                os.fchmod(lock_fd, stat.S_IRUSR | stat.S_IWUSR)
-                if fcntl is not None:
-                    fcntl.flock(lock_fd, fcntl.LOCK_EX)
-                yield
+                lock_fd = os.open(lock_name, lock_flags, 0o600, dir_fd=parent_fd)
+                try:
+                    self._validate_single_link_regular(os.fstat(lock_fd))
+                    if fcntl is not None:
+                        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                    yield
+                finally:
+                    if fcntl is not None:
+                        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                    os.close(lock_fd)
             finally:
-                if fcntl is not None:
-                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
-                os.close(lock_fd)
                 os.close(parent_fd)
 
-    @staticmethod
-    def _size_bytes(path: Path) -> int:
+    @classmethod
+    def _size_bytes(cls, path: Path) -> int:
         try:
             stat_result = path.lstat()
         except FileNotFoundError:
             return 0
-        if stat.S_ISLNK(stat_result.st_mode):
-            raise ValueError("runtime audit backlog path must not be a symlink")
+        cls._validate_single_link_regular(stat_result)
         return stat_result.st_size
 
     def spillover_size_bytes(self) -> int:
@@ -327,10 +343,11 @@ class AuditSpilloverStore:
             _ACTIVE_CLAIMS.discard(os.path.abspath(claim.path))
             return destination
 
-    @staticmethod
-    def _reject_symlink(path: Path) -> None:
-        if path.is_symlink():
-            raise ValueError("runtime audit backlog path must not be a symlink")
+    @classmethod
+    def _reject_symlink(cls, path: Path) -> None:
+        """Compatibility name for validating any existing backlog path."""
+
+        cls._validate_existing_path(path)
 
     def _claim_paths_locked(self) -> list[Path]:
         parent_fd = self._safe_parent_fd(self.spill_path)
@@ -346,29 +363,42 @@ class AuditSpilloverStore:
             raise ValueError("runtime audit spillover claim does not belong to this store")
 
     def _read_events_locked(self, path: Path) -> list[dict[str, Any]]:
-        self._reject_symlink(path)
         events: list[dict[str, Any]] = []
-        with path.open("r", encoding="utf-8") as handle:
-            for line in handle:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    payload = json.loads(line)
-                except json.JSONDecodeError:
-                    logger.warning(
-                        "Skipping malformed runtime audit spillover record",
-                    )
-                    continue
-                if isinstance(payload, dict):
-                    events.append(payload)
+        for line in self._read_bytes_locked(path).decode("utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Skipping malformed runtime audit spillover record",
+                )
+                continue
+            if isinstance(payload, dict):
+                events.append(payload)
         return events
 
     def _read_bytes_locked(self, path: Path) -> bytes:
-        self._reject_symlink(path)
-        if not path.exists():
-            return b""
-        return path.read_bytes()
+        parent_fd = self._safe_parent_fd(path)
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            try:
+                fd = os.open(path.name, flags, dir_fd=parent_fd)
+            except FileNotFoundError:
+                return b""
+            try:
+                self._validate_single_link_regular(os.fstat(fd))
+                with os.fdopen(fd, "rb") as handle:
+                    fd = -1
+                    return handle.read()
+            finally:
+                if fd >= 0:
+                    os.close(fd)
+        finally:
+            os.close(parent_fd)
 
     def _recover_orphan_claims_locked(self) -> None:
         claims = [path for path in self._claim_paths_locked() if self._claim_is_orphaned(path)]
@@ -399,25 +429,15 @@ class AuditSpilloverStore:
         return False
 
     def _append_lines_locked(self, path: Path, lines: list[str]) -> None:
-        parent_fd = self._safe_parent_fd(path)
-        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
-        if hasattr(os, "O_NOFOLLOW"):
-            flags |= os.O_NOFOLLOW
-        fd = os.open(path.name, flags, 0o600, dir_fd=parent_fd)
-        try:
-            os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
-            with os.fdopen(fd, "a", encoding="utf-8") as handle:
-                fd = -1
-                for line in lines:
-                    handle.write(line + "\n")
-                handle.flush()
-                os.fsync(handle.fileno())
-        finally:
-            if fd >= 0:
-                os.close(fd)
-            os.close(parent_fd)
+        existing = self._read_bytes_locked(path)
+        appended = b"".join((line + "\n").encode("utf-8") for line in lines)
+        # Replace a private temporary inode instead of writing into an existing
+        # inode. Even if a hostile same-user process races a new hardlink after
+        # validation, the external inode is never mutated.
+        self._atomic_write_locked(path, existing + appended)
 
     def _atomic_write_locked(self, path: Path, content: bytes) -> None:
+        self._validate_existing_path(path)
         parent_fd = self._safe_parent_fd(path)
         temp_name = f".{path.name}.tmp-{uuid.uuid4().hex}"
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL

--- a/src/agent_bom/runtime/audit_delivery.py
+++ b/src/agent_bom/runtime/audit_delivery.py
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 
 AuditBacklogDestination = Literal["noop", "spillover", "dlq", "dropped"]
 _DEFAULT_MIN_DLQ_BYTES = 1024 * 1024
+_MACOS_TMP_ALIAS = Path(os.sep) / "tmp"
+_MACOS_CANONICAL_TMP = Path(os.sep) / "private" / "tmp"
 _STORE_LOCKS: dict[tuple[str, str], threading.RLock] = {}
 _STORE_LOCKS_GUARD = threading.Lock()
 _ACTIVE_CLAIMS: set[str] = set()
@@ -44,11 +46,11 @@ def canonical_runtime_state_path(path: Path) -> Path:
     expanded = Path(path).expanduser()
     if sys.platform == "darwin" and expanded.is_absolute():
         try:
-            relative = expanded.relative_to("/tmp")
+            relative = expanded.relative_to(_MACOS_TMP_ALIAS)
         except ValueError:
             pass
         else:
-            return Path("/private/tmp") / relative
+            return _MACOS_CANONICAL_TMP / relative
     return expanded
 
 

--- a/src/agent_bom/runtime/audit_delivery.py
+++ b/src/agent_bom/runtime/audit_delivery.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import stat
+import sys
 import threading
 import time
 import uuid
@@ -35,6 +36,20 @@ _DEFAULT_MIN_DLQ_BYTES = 1024 * 1024
 _STORE_LOCKS: dict[tuple[str, str], threading.RLock] = {}
 _STORE_LOCKS_GUARD = threading.Lock()
 _ACTIVE_CLAIMS: set[str] = set()
+
+
+def canonical_runtime_state_path(path: Path) -> Path:
+    """Resolve only macOS's fixed ``/tmp`` alias without following arbitrary links."""
+
+    expanded = Path(path).expanduser()
+    if sys.platform == "darwin" and expanded.is_absolute():
+        try:
+            relative = expanded.relative_to("/tmp")
+        except ValueError:
+            pass
+        else:
+            return Path("/private/tmp") / relative
+    return expanded
 
 
 @dataclass(frozen=True)
@@ -118,8 +133,8 @@ class AuditSpilloverStore:
     _lock: threading.RLock = field(default_factory=threading.RLock, init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
-        self.spill_path = Path(self.spill_path)
-        self.dlq_path = Path(self.dlq_path)
+        self.spill_path = canonical_runtime_state_path(Path(self.spill_path))
+        self.dlq_path = canonical_runtime_state_path(Path(self.dlq_path))
         if self.max_spillover_bytes < 1:
             raise ValueError("max_spillover_bytes must be greater than zero")
         if self.max_dlq_bytes is None:
@@ -189,6 +204,63 @@ class AuditSpilloverStore:
         except FileNotFoundError:
             return
         cls._validate_single_link_regular(stat_result)
+
+    @classmethod
+    def load_or_create_private_key(cls, path: Path, *, size: int = 32, create: bool = True) -> bytes:
+        """Atomically load or create a private fixed-size key beside durable state."""
+
+        key_path = canonical_runtime_state_path(path)
+        parent_fd = cls._safe_parent_fd(key_path)
+        read_flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            read_flags |= os.O_NOFOLLOW
+        if hasattr(os, "O_CLOEXEC"):
+            read_flags |= os.O_CLOEXEC
+        try:
+            try:
+                fd = os.open(key_path.name, read_flags, dir_fd=parent_fd)
+            except FileNotFoundError:
+                if not create:
+                    raise ValueError("runtime audit key is missing for existing durable state") from None
+                create_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                if hasattr(os, "O_NOFOLLOW"):
+                    create_flags |= os.O_NOFOLLOW
+                if hasattr(os, "O_CLOEXEC"):
+                    create_flags |= os.O_CLOEXEC
+                key = os.urandom(size)
+                try:
+                    fd = os.open(key_path.name, create_flags, 0o600, dir_fd=parent_fd)
+                except FileExistsError:
+                    fd = os.open(key_path.name, read_flags, dir_fd=parent_fd)
+                else:
+                    try:
+                        os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+                        with os.fdopen(fd, "wb") as handle:
+                            fd = -1
+                            handle.write(key)
+                            handle.flush()
+                            os.fsync(handle.fileno())
+                        os.fsync(parent_fd)
+                        return key
+                    finally:
+                        if fd >= 0:
+                            os.close(fd)
+            try:
+                file_stat = os.fstat(fd)
+                cls._validate_single_link_regular(file_stat)
+                if stat.S_IMODE(file_stat.st_mode) & 0o077:
+                    raise ValueError("runtime audit key permissions must be owner-only")
+                with os.fdopen(fd, "rb") as handle:
+                    fd = -1
+                    key = handle.read(size + 1)
+            finally:
+                if fd >= 0:
+                    os.close(fd)
+            if len(key) != size:
+                raise ValueError("runtime audit key has an invalid length")
+            return key
+        finally:
+            os.close(parent_fd)
 
     @contextmanager
     def _exclusive(self) -> Iterator[None]:
@@ -281,9 +353,7 @@ class AuditSpilloverStore:
             if self._size_bytes(self.spill_path) == 0:
                 return None
             parent_fd = self._safe_parent_fd(self.spill_path)
-            claim_path = self.spill_path.with_name(
-                f"{self.spill_path.name}.claim-{time.time_ns():020d}-{os.getpid()}-{uuid.uuid4().hex}"
-            )
+            claim_path = self.spill_path.with_name(f"{self.spill_path.name}.claim-{time.time_ns():020d}-{os.getpid()}-{uuid.uuid4().hex}")
             try:
                 os.rename(
                     self.spill_path.name,
@@ -537,4 +607,5 @@ __all__ = [
     "AuditSpilloverClaim",
     "AuditSpilloverStore",
     "audit_delivery_paths",
+    "canonical_runtime_state_path",
 ]

--- a/src/agent_bom/runtime/audit_delivery.py
+++ b/src/agent_bom/runtime/audit_delivery.py
@@ -137,16 +137,43 @@ class AuditSpilloverStore:
 
     @staticmethod
     def _safe_parent_fd(path: Path) -> int:
+        """Open/create every parent component without following symlinks."""
+
         parent = path.parent
-        parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        if parent.is_symlink():
-            raise ValueError("runtime audit backlog parent directory must not be a symlink")
         flags = os.O_RDONLY
         if hasattr(os, "O_DIRECTORY"):
             flags |= os.O_DIRECTORY
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
-        return os.open(parent, flags)
+        if hasattr(os, "O_CLOEXEC"):
+            flags |= os.O_CLOEXEC
+
+        parts = parent.parts
+        if ".." in parts:
+            raise ValueError("runtime audit backlog parent must not contain parent traversal")
+        current_fd = os.open(os.sep if parent.is_absolute() else ".", flags)
+        components = parts[1:] if parent.is_absolute() else parts
+        try:
+            for component in components:
+                if component in {"", "."}:
+                    continue
+                try:
+                    os.mkdir(component, mode=0o700, dir_fd=current_fd)
+                except FileExistsError:
+                    pass
+                try:
+                    next_fd = os.open(component, flags, dir_fd=current_fd)
+                except OSError as exc:
+                    raise ValueError("runtime audit backlog parent must not contain symlink ancestors") from exc
+                if not stat.S_ISDIR(os.fstat(next_fd).st_mode):
+                    os.close(next_fd)
+                    raise ValueError("runtime audit backlog parent must contain directories only")
+                os.close(current_fd)
+                current_fd = next_fd
+            return current_fd
+        except Exception:
+            os.close(current_fd)
+            raise
 
     @staticmethod
     def _validate_single_link_regular(stat_result: os.stat_result) -> None:
@@ -268,7 +295,15 @@ class AuditSpilloverStore:
                 _ACTIVE_CLAIMS.add(os.path.abspath(claim_path))
             finally:
                 os.close(parent_fd)
-            return AuditSpilloverClaim(path=claim_path, events=self._read_events_locked(claim_path))
+            try:
+                events = self._read_events_locked(claim_path)
+            except Exception:
+                # Keep the poisoned segment on disk for operator recovery, but
+                # do not leave an in-process active marker that masks it from
+                # orphan recovery and health checks forever.
+                _ACTIVE_CLAIMS.discard(os.path.abspath(claim_path))
+                raise
+            return AuditSpilloverClaim(path=claim_path, events=events)
 
     def acknowledge_claim(self, claim: AuditSpilloverClaim) -> None:
         """Delete only the segment a successful send actually delivered."""
@@ -370,13 +405,11 @@ class AuditSpilloverStore:
                 continue
             try:
                 payload = json.loads(line)
-            except json.JSONDecodeError:
-                logger.warning(
-                    "Skipping malformed runtime audit spillover record",
-                )
-                continue
-            if isinstance(payload, dict):
-                events.append(payload)
+            except json.JSONDecodeError as exc:
+                raise ValueError("runtime audit backlog contains a malformed record") from exc
+            if not isinstance(payload, dict):
+                raise ValueError("runtime audit backlog contains a non-object record")
+            events.append(payload)
         return events
 
     def _read_bytes_locked(self, path: Path) -> bytes:

--- a/src/agent_bom/runtime/gateway_events.py
+++ b/src/agent_bom/runtime/gateway_events.py
@@ -21,6 +21,9 @@ class GatewayRuntimeEventType(str, Enum):
     DLP_RESULT_REDACTED = "gateway.dlp.result_redacted"
     DLP_RESULT_BLOCKED = "gateway.dlp.result_blocked"
     VISUAL_REDACTED = "gateway.visual.redacted"
+    RUNTIME_PROFILE_WARNED = "gateway.runtime_profile.warned"
+    RUNTIME_PROFILE_DEV_BYPASS = "gateway.runtime_profile.dev_bypass"
+    RUNTIME_PROFILE_BLOCKED = "gateway.runtime_profile.blocked"
 
 
 GATEWAY_ALLOWED_EVENT_TYPES = frozenset({GatewayRuntimeEventType.TOOL_CALL_ALLOWED.value})
@@ -36,6 +39,22 @@ GATEWAY_DATA_FILTER_EVENT_TYPES = frozenset(
         GatewayRuntimeEventType.DLP_RESULT_REDACTED.value,
         GatewayRuntimeEventType.VISUAL_REDACTED.value,
     }
+)
+GATEWAY_PROFILE_EVENT_TYPES = frozenset(
+    {
+        GatewayRuntimeEventType.RUNTIME_PROFILE_WARNED.value,
+        GatewayRuntimeEventType.RUNTIME_PROFILE_DEV_BYPASS.value,
+        GatewayRuntimeEventType.RUNTIME_PROFILE_BLOCKED.value,
+    }
+)
+GATEWAY_DENIED_EVENT_TYPES = GATEWAY_BLOCKED_EVENT_TYPES | frozenset(
+    {GatewayRuntimeEventType.RUNTIME_PROFILE_BLOCKED.value}
+)
+GATEWAY_CANONICAL_EVENT_TYPES = (
+    GATEWAY_ALLOWED_EVENT_TYPES
+    | GATEWAY_BLOCKED_EVENT_TYPES
+    | GATEWAY_DATA_FILTER_EVENT_TYPES
+    | GATEWAY_PROFILE_EVENT_TYPES
 )
 
 
@@ -103,7 +122,10 @@ def build_gateway_runtime_event(
 __all__ = [
     "GATEWAY_ALLOWED_EVENT_TYPES",
     "GATEWAY_BLOCKED_EVENT_TYPES",
+    "GATEWAY_CANONICAL_EVENT_TYPES",
     "GATEWAY_DATA_FILTER_EVENT_TYPES",
+    "GATEWAY_DENIED_EVENT_TYPES",
+    "GATEWAY_PROFILE_EVENT_TYPES",
     "GatewayRuntimeEventType",
     "build_gateway_runtime_event",
 ]

--- a/src/agent_bom/runtime/gateway_events.py
+++ b/src/agent_bom/runtime/gateway_events.py
@@ -94,11 +94,39 @@ _WARNED_ENFORCEMENT_ACTIONS = frozenset(
         "gateway.anomaly_warned",
         "gateway.drift_warned",
         "gateway.fleet_warned",
+        "gateway.firewall_warned",
         "gateway.graph_reachability_warned",
         "gateway.policy_warned",
     }
 )
-_OBSERVED_ENFORCEMENT_ACTIONS = frozenset({"gateway.firewall_decision", "gateway.identity_jit_grant_used"})
+_OBSERVED_ENFORCEMENT_ACTIONS = frozenset({"gateway.identity_jit_grant_used"})
+
+
+def ensure_gateway_event_identity(event: dict[str, Any]) -> dict[str, Any]:
+    """Assign one occurrence identity before an event enters durable delivery."""
+
+    identified = dict(event)
+    event_id = str(identified.get("event_id") or identified.get("decision_id") or f"gw_{uuid.uuid4().hex}")
+    identified["event_id"] = event_id
+    if not identified.get("decision_id"):
+        identified["decision_id"] = event_id
+    return identified
+
+
+def _positive_revision(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        revision = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, revision)
+
+
+def _policy_ids(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, list | tuple):
+        return ()
+    return tuple(dict.fromkeys(item for item in value if isinstance(item, str) and item))
 
 
 def canonicalize_gateway_enforcement_event(event: dict[str, Any]) -> dict[str, Any]:
@@ -107,7 +135,25 @@ def canonicalize_gateway_enforcement_event(event: dict[str, Any]) -> dict[str, A
     if str(event.get("event_type") or "") in GATEWAY_CANONICAL_EVENT_TYPES:
         return dict(event)
     action = str(event.get("action") or "")
-    if action == "gateway.drift_binding_unavailable":
+    if action == "gateway.firewall_blocked":
+        # This action is emitted only from the in-path tool relay. It therefore
+        # contributes to tool-call blocked KPIs rather than generic posture.
+        event_type = GatewayRuntimeEventType.TOOL_CALL_BLOCKED
+        decision = "deny"
+    elif action == "gateway.firewall_decision":
+        # The read-only decision endpoint may report enforce, dry-run, or allow.
+        # Canonical decisions stay binary; warnings are represented by event type.
+        effective_decision = str(event.get("effective_decision") or event.get("decision") or "allow")
+        if effective_decision == "deny":
+            event_type = GatewayRuntimeEventType.ENFORCEMENT_BLOCKED
+            decision = "deny"
+        elif effective_decision == "warn":
+            event_type = GatewayRuntimeEventType.ENFORCEMENT_WARNED
+            decision = "allow"
+        else:
+            event_type = GatewayRuntimeEventType.ENFORCEMENT_OBSERVED
+            decision = "allow"
+    elif action == "gateway.drift_binding_unavailable":
         blocked = str(event.get("enforcement_mode") or "") == "enforce"
         event_type = GatewayRuntimeEventType.ENFORCEMENT_BLOCKED if blocked else GatewayRuntimeEventType.ENFORCEMENT_WARNED
         decision = "deny" if blocked else "allow"
@@ -123,7 +169,7 @@ def canonicalize_gateway_enforcement_event(event: dict[str, Any]) -> dict[str, A
     else:
         return dict(event)
     reason_code = action.removeprefix("gateway.").replace(".", "_")
-    return build_gateway_runtime_event(
+    canonical = build_gateway_runtime_event(
         event_type,
         tenant_id=str(event.get("tenant_id") or "default"),
         agent_id=str(event.get("source_agent") or event.get("agent_id") or "anonymous"),
@@ -133,8 +179,19 @@ def canonicalize_gateway_enforcement_event(event: dict[str, Any]) -> dict[str, A
         decision=decision,
         policy_source=str(event.get("policy_source") or reason_code),
         trace_id=str(event.get("trace_id") or ""),
+        identity_id=str(event.get("identity_id") or ""),
+        profile_revision=_positive_revision(event.get("profile_revision")),
+        blueprint_id=str(event.get("blueprint_id") or ""),
+        blueprint_revision=_positive_revision(event.get("blueprint_revision")),
+        policy_ids=_policy_ids(event.get("policy_ids")),
         reason_code=reason_code,
+        policy_id=str(event.get("policy_id") or ""),
+        evidence_id=str(event.get("evidence_id") or ""),
     )
+    if event.get("event_id"):
+        canonical["event_id"] = str(event["event_id"])
+        canonical["decision_id"] = str(event.get("decision_id") or event["event_id"])
+    return canonical
 
 
 def build_gateway_runtime_event(
@@ -209,4 +266,5 @@ __all__ = [
     "GatewayRuntimeEventType",
     "build_gateway_runtime_event",
     "canonicalize_gateway_enforcement_event",
+    "ensure_gateway_event_identity",
 ]

--- a/src/agent_bom/runtime/gateway_events.py
+++ b/src/agent_bom/runtime/gateway_events.py
@@ -24,6 +24,9 @@ class GatewayRuntimeEventType(str, Enum):
     RUNTIME_PROFILE_WARNED = "gateway.runtime_profile.warned"
     RUNTIME_PROFILE_DEV_BYPASS = "gateway.runtime_profile.dev_bypass"
     RUNTIME_PROFILE_BLOCKED = "gateway.runtime_profile.blocked"
+    ENFORCEMENT_WARNED = "gateway.enforcement.warned"
+    ENFORCEMENT_OBSERVED = "gateway.enforcement.observed"
+    ENFORCEMENT_BLOCKED = "gateway.enforcement.blocked"
 
 
 GATEWAY_ALLOWED_EVENT_TYPES = frozenset({GatewayRuntimeEventType.TOOL_CALL_ALLOWED.value})
@@ -47,15 +50,91 @@ GATEWAY_PROFILE_EVENT_TYPES = frozenset(
         GatewayRuntimeEventType.RUNTIME_PROFILE_BLOCKED.value,
     }
 )
+GATEWAY_ENFORCEMENT_EVENT_TYPES = frozenset(
+    {
+        GatewayRuntimeEventType.ENFORCEMENT_WARNED.value,
+        GatewayRuntimeEventType.ENFORCEMENT_OBSERVED.value,
+        GatewayRuntimeEventType.ENFORCEMENT_BLOCKED.value,
+    }
+)
 GATEWAY_DENIED_EVENT_TYPES = GATEWAY_BLOCKED_EVENT_TYPES | frozenset(
-    {GatewayRuntimeEventType.RUNTIME_PROFILE_BLOCKED.value}
+    {
+        GatewayRuntimeEventType.RUNTIME_PROFILE_BLOCKED.value,
+        GatewayRuntimeEventType.ENFORCEMENT_BLOCKED.value,
+    }
 )
 GATEWAY_CANONICAL_EVENT_TYPES = (
     GATEWAY_ALLOWED_EVENT_TYPES
     | GATEWAY_BLOCKED_EVENT_TYPES
     | GATEWAY_DATA_FILTER_EVENT_TYPES
     | GATEWAY_PROFILE_EVENT_TYPES
+    | GATEWAY_ENFORCEMENT_EVENT_TYPES
 )
+
+_BLOCKED_ENFORCEMENT_ACTIONS = frozenset(
+    {
+        "gateway.a2a_mutual_auth_blocked",
+        "gateway.anomaly_blocked",
+        "gateway.budget_exceeded",
+        "gateway.conditional_access_blocked",
+        "gateway.firewall_blocked",
+        "gateway.fleet_blocked",
+        "gateway.graph_reachability_blocked",
+        "gateway.identity_blocked",
+        "gateway.oauth_scope_blocked",
+        "gateway.policy_blocked",
+        "gateway.policy_fail_closed",
+        "gateway.policy_quarantined",
+        "gateway.rate_limited",
+    }
+)
+_WARNED_ENFORCEMENT_ACTIONS = frozenset(
+    {
+        "gateway.a2a_mutual_auth_warned",
+        "gateway.anomaly_warned",
+        "gateway.drift_warned",
+        "gateway.fleet_warned",
+        "gateway.graph_reachability_warned",
+        "gateway.policy_warned",
+    }
+)
+_OBSERVED_ENFORCEMENT_ACTIONS = frozenset({"gateway.firewall_decision", "gateway.identity_jit_grant_used"})
+
+
+def canonicalize_gateway_enforcement_event(event: dict[str, Any]) -> dict[str, Any]:
+    """Convert legacy enforcement actions to safe durable event metadata."""
+
+    if str(event.get("event_type") or "") in GATEWAY_CANONICAL_EVENT_TYPES:
+        return dict(event)
+    action = str(event.get("action") or "")
+    if action == "gateway.drift_binding_unavailable":
+        blocked = str(event.get("enforcement_mode") or "") == "enforce"
+        event_type = GatewayRuntimeEventType.ENFORCEMENT_BLOCKED if blocked else GatewayRuntimeEventType.ENFORCEMENT_WARNED
+        decision = "deny" if blocked else "allow"
+    elif action in _BLOCKED_ENFORCEMENT_ACTIONS:
+        event_type = GatewayRuntimeEventType.ENFORCEMENT_BLOCKED
+        decision = "deny"
+    elif action in _WARNED_ENFORCEMENT_ACTIONS:
+        event_type = GatewayRuntimeEventType.ENFORCEMENT_WARNED
+        decision = "allow"
+    elif action in _OBSERVED_ENFORCEMENT_ACTIONS:
+        event_type = GatewayRuntimeEventType.ENFORCEMENT_OBSERVED
+        decision = "allow"
+    else:
+        return dict(event)
+    reason_code = action.removeprefix("gateway.").replace(".", "_")
+    return build_gateway_runtime_event(
+        event_type,
+        tenant_id=str(event.get("tenant_id") or "default"),
+        agent_id=str(event.get("source_agent") or event.get("agent_id") or "anonymous"),
+        profile_id=str(event.get("profile_id") or ""),
+        upstream=str(event.get("upstream") or event.get("target_agent") or ""),
+        tool=str(event.get("tool") or event.get("method") or ""),
+        decision=decision,
+        policy_source=str(event.get("policy_source") or reason_code),
+        trace_id=str(event.get("trace_id") or ""),
+        reason_code=reason_code,
+    )
 
 
 def build_gateway_runtime_event(
@@ -125,7 +204,9 @@ __all__ = [
     "GATEWAY_CANONICAL_EVENT_TYPES",
     "GATEWAY_DATA_FILTER_EVENT_TYPES",
     "GATEWAY_DENIED_EVENT_TYPES",
+    "GATEWAY_ENFORCEMENT_EVENT_TYPES",
     "GATEWAY_PROFILE_EVENT_TYPES",
     "GatewayRuntimeEventType",
     "build_gateway_runtime_event",
+    "canonicalize_gateway_enforcement_event",
 ]

--- a/tests/api/test_gateway_canonical_event_validation.py
+++ b/tests/api/test_gateway_canonical_event_validation.py
@@ -31,6 +31,9 @@ CANONICAL_EVENT_TYPES = [
     "gateway.dlp.result_redacted",
     "gateway.dlp.result_blocked",
     "gateway.visual.redacted",
+    "gateway.runtime_profile.warned",
+    "gateway.runtime_profile.dev_bypass",
+    "gateway.runtime_profile.blocked",
 ]
 
 

--- a/tests/api/test_gateway_canonical_event_validation.py
+++ b/tests/api/test_gateway_canonical_event_validation.py
@@ -34,6 +34,9 @@ CANONICAL_EVENT_TYPES = [
     "gateway.runtime_profile.warned",
     "gateway.runtime_profile.dev_bypass",
     "gateway.runtime_profile.blocked",
+    "gateway.enforcement.warned",
+    "gateway.enforcement.observed",
+    "gateway.enforcement.blocked",
 ]
 
 

--- a/tests/api/test_gateway_feed_durable.py
+++ b/tests/api/test_gateway_feed_durable.py
@@ -210,6 +210,32 @@ def test_profile_posture_is_durable_without_inflating_tool_call_feed_or_kpis() -
     assert kpis.json()["blocked_today"] == 0
 
 
+def test_enforcement_posture_is_durable_without_inflating_tool_call_kpis() -> None:
+    client = TestClient(app)
+    tenant_id = "tenant-enforcement-posture"
+    ingest = client.post(
+        "/v1/proxy/audit",
+        headers=_headers(tenant_id, role="admin"),
+        json={
+            "source_id": "gateway-a",
+            "session_id": "session-a",
+            "alerts": [
+                _profile_event("evt-enforcement-warn", "gateway.enforcement.warned"),
+                _profile_event("evt-enforcement-observed", "gateway.enforcement.observed"),
+                _profile_event("evt-enforcement-block", "gateway.enforcement.blocked", decision="deny"),
+                _event("evt-allow", tool="read_file"),
+            ],
+        },
+    )
+    assert ingest.status_code == 200, ingest.text
+    assert ingest.json()["durable_accepted_count"] == 4
+
+    kpis = client.get("/v1/gateway/feed/kpis", headers=_headers(tenant_id))
+    assert kpis.status_code == 200, kpis.text
+    assert kpis.json()["tool_calls_authorized"] == 1
+    assert kpis.json()["blocked_today"] == 0
+
+
 def test_retention_marks_initial_backfill_partial_and_expires_old_cursor() -> None:
     store = InMemoryGatewayActivityStore(max_events_per_tenant=2)
     set_gateway_activity_store(store)

--- a/tests/api/test_gateway_feed_durable.py
+++ b/tests/api/test_gateway_feed_durable.py
@@ -54,6 +54,19 @@ def _blocked_event(event_id: str) -> dict[str, object]:
     return event
 
 
+def _profile_event(event_id: str, event_type: str, *, decision: str = "allow") -> dict[str, object]:
+    event = _event(event_id, tool="read_file")
+    event.update(
+        {
+            "event_type": event_type,
+            "decision": decision,
+            "reason_code": "profile_revoked",
+            "development_mode": event_type.endswith("dev_bypass"),
+        }
+    )
+    return event
+
+
 @pytest.fixture(autouse=True)
 def _isolated_gateway_feed(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
@@ -163,6 +176,38 @@ def test_kpis_use_exact_utc_window_over_durable_events_after_ring_loss() -> None
     assert body["window"]["start"].endswith("+00:00")
     assert body["window"]["end"].endswith("+00:00")
     assert body["window"]["exact"] is True
+
+
+def test_profile_posture_is_durable_without_inflating_tool_call_feed_or_kpis() -> None:
+    client = TestClient(app)
+    tenant_id = "tenant-profile-posture"
+    ingest = client.post(
+        "/v1/proxy/audit",
+        headers=_headers(tenant_id, role="admin"),
+        json={
+            "source_id": "gateway-a",
+            "session_id": "session-a",
+            "alerts": [
+                _profile_event("evt-profile-warn", "gateway.runtime_profile.warned"),
+                _profile_event("evt-profile-bypass", "gateway.runtime_profile.dev_bypass"),
+                _profile_event("evt-profile-block", "gateway.runtime_profile.blocked", decision="deny"),
+                _event("evt-allow", tool="read_file"),
+            ],
+        },
+    )
+    assert ingest.status_code == 200, ingest.text
+    assert ingest.json()["durable_accepted_count"] == 4
+    proxy_routes._reset_proxy_runtime_for_tests()
+
+    feed = client.get("/v1/gateway/feed", headers=_headers(tenant_id), params={"limit": 20})
+    assert feed.status_code == 200, feed.text
+    assert [event["event_id"] for event in feed.json()["events"]] == ["evt-allow"]
+    assert feed.json()["completeness"]["status"] == "complete"
+
+    kpis = client.get("/v1/gateway/feed/kpis", headers=_headers(tenant_id))
+    assert kpis.status_code == 200, kpis.text
+    assert kpis.json()["tool_calls_authorized"] == 1
+    assert kpis.json()["blocked_today"] == 0
 
 
 def test_retention_marks_initial_backfill_partial_and_expires_old_cursor() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import os
 import sys
 import tempfile
 import types
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -30,7 +31,7 @@ os.environ.setdefault("COLUMNS", "200")
 # tests. Each worker process gets its own dir, so workers never collide.
 os.environ.setdefault(
     "AGENT_BOM_STATE_DIR",
-    tempfile.mkdtemp(prefix="agent-bom-test-state-"),
+    str(Path(tempfile.mkdtemp(prefix="agent-bom-test-state-")).resolve()),
 )
 
 # The control-plane lifecycle stores (agent identity, JIT grants, runtime

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -493,6 +493,7 @@ def test_helm_gateway_service_account_defaults():
     assert gateway["profileEnforcement"] == "off"
     assert gateway["profileEnvironment"] == ""
     assert gateway["profileIssuer"] == "agent-bom"
+    assert gateway["stateDir"] == "/tmp/agent-bom"
 
 
 def test_helm_gateway_network_policy_defaults_to_explicit_egress_allowlist():
@@ -532,6 +533,8 @@ def test_helm_gateway_template_wires_control_plane_and_runtime_flags():
     assert "--profile-issuer" in template
     assert "$gatewayEnvFrom = .Values.controlPlane.api.envFrom" not in template
     assert "gateway profile enforcement requires gateway.envFrom" in template
+    assert "AGENT_BOM_STATE_DIR" in template
+    assert ".Values.gateway.stateDir" in template
 
 
 def test_helm_examples_do_not_ship_duplicate_sqlite_pilot_profile():

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -558,6 +558,24 @@ def test_helm_gateway_autoscaling_defaults():
     assert autoscaling["keda"]["prometheus"]["pressureRateThreshold"] == "1"
 
 
+def test_helm_gateway_persistent_audit_backlog_is_single_replica_and_pvc_bound():
+    values = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    persistence = values["gateway"]["persistence"]
+    template = (HELM_DIR / "templates" / "gateway-deployment.yaml").read_text()
+
+    assert persistence == {
+        "enabled": False,
+        "existingClaim": "",
+        "mountPath": "/var/lib/agent-bom",
+    }
+    assert "gateway persistence requires gateway.replicas=1" in template
+    assert "gateway persistence is incompatible with gateway autoscaling" in template
+    assert "gateway.persistence.existingClaim is required" in template
+    assert "persistentVolumeClaim" in template
+    assert "$gatewayPersistence.mountPath" in template
+    assert "path: /readyz" in template
+
+
 def test_helm_gateway_keda_template_suppresses_static_hpa():
     """Gateway KEDA must own autoscaling when enabled, not stack with a static HPA."""
     hpa_template = (HELM_DIR / "templates" / "gateway-hpa.yaml").read_text()

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -579,7 +579,7 @@ def test_helm_gateway_persistent_audit_backlog_is_single_replica_and_pvc_bound()
 
 
 @pytest.mark.skipif(shutil.which("helm") is None, reason="helm not installed")
-def test_helm_gateway_renders_runtime_replica_truth_and_recreate_persistence() -> None:
+def test_helm_gateway_renders_restart_stable_single_writer_persistence() -> None:
     def _render(*sets: str) -> list[dict]:
         args = ["helm", "template", "abom", str(HELM_DIR)]
         for item in sets:
@@ -593,36 +593,13 @@ def test_helm_gateway_renders_runtime_replica_truth_and_recreate_persistence() -
             doc for doc in documents if doc.get("kind") == "Deployment" and doc.get("metadata", {}).get("name", "").endswith("-gateway")
         )
 
-    replicated = _gateway_deployment(
-        _render(
-            "gateway.enabled=true",
-            "gateway.replicas=2",
-            "gateway.controlPlaneDiscovery.url=https://control.example.test",
-            "gateway.runtimeRateLimitPerTenantPerMinute=10",
-        )
-    )
-    replicated_env = {item["name"]: item["value"] for item in replicated["spec"]["template"]["spec"]["containers"][0]["env"]}
-    assert replicated_env["AGENT_BOM_GATEWAY_REPLICAS"] == "2"
-    assert "strategy" not in replicated["spec"]
-
-    autoscaled = _gateway_deployment(
-        _render(
-            "gateway.enabled=true",
-            "gateway.autoscaling.enabled=true",
-            "gateway.autoscaling.maxReplicas=7",
-            "gateway.controlPlaneDiscovery.url=https://control.example.test",
-            "gateway.runtimeRateLimitPerTenantPerMinute=10",
-        )
-    )
-    autoscaled_env = {item["name"]: item["value"] for item in autoscaled["spec"]["template"]["spec"]["containers"][0]["env"]}
-    assert autoscaled_env["AGENT_BOM_GATEWAY_REPLICAS"] == "7"
-
     persistent = _gateway_deployment(
         _render(
             "gateway.enabled=true",
             "gateway.replicas=1",
             "gateway.persistence.enabled=true",
             "gateway.persistence.existingClaim=gateway-audit",
+            "gateway.controlPlaneDiscovery.url=https://control.example.test",
         )
     )
     assert persistent["spec"]["strategy"] == {"type": "Recreate"}
@@ -648,7 +625,30 @@ def test_helm_gateway_rejects_local_only_ephemeral_audit_state() -> None:
     )
 
     assert result.returncode != 0
-    assert "local-only gateway audit requires gateway.persistence.enabled=true" in result.stderr
+    assert "gateway audit requires gateway.persistence.enabled=true" in result.stderr
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm not installed")
+def test_helm_gateway_rejects_remote_connected_ephemeral_audit_state() -> None:
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "abom",
+            str(HELM_DIR),
+            "--set",
+            "gateway.enabled=true",
+            "--set",
+            "gateway.controlPlaneDiscovery.url=https://control.example.test",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "gateway audit requires gateway.persistence.enabled=true" in result.stderr
 
 
 @pytest.mark.skipif(shutil.which("helm") is None, reason="helm not installed")

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -534,6 +534,7 @@ def test_helm_gateway_template_wires_control_plane_and_runtime_flags():
     assert "$gatewayEnvFrom = .Values.controlPlane.api.envFrom" not in template
     assert "gateway profile enforcement requires gateway.envFrom" in template
     assert "AGENT_BOM_STATE_DIR" in template
+    assert "AGENT_BOM_GATEWAY_REPLICAS" in template
     assert ".Values.gateway.stateDir" in template
 
 
@@ -574,6 +575,100 @@ def test_helm_gateway_persistent_audit_backlog_is_single_replica_and_pvc_bound()
     assert "persistentVolumeClaim" in template
     assert "$gatewayPersistence.mountPath" in template
     assert "path: /readyz" in template
+    assert "type: Recreate" in template
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm not installed")
+def test_helm_gateway_renders_runtime_replica_truth_and_recreate_persistence() -> None:
+    def _render(*sets: str) -> list[dict]:
+        args = ["helm", "template", "abom", str(HELM_DIR)]
+        for item in sets:
+            args.extend(("--set", item))
+        result = subprocess.run(args, capture_output=True, text=True, timeout=120, check=False)
+        assert result.returncode == 0, result.stderr
+        return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+
+    def _gateway_deployment(documents: list[dict]) -> dict:
+        return next(
+            doc
+            for doc in documents
+            if doc.get("kind") == "Deployment" and doc.get("metadata", {}).get("name", "").endswith("-gateway")
+        )
+
+    replicated = _gateway_deployment(
+        _render(
+            "gateway.enabled=true",
+            "gateway.replicas=2",
+            "gateway.runtimeRateLimitPerTenantPerMinute=10",
+        )
+    )
+    replicated_env = {item["name"]: item["value"] for item in replicated["spec"]["template"]["spec"]["containers"][0]["env"]}
+    assert replicated_env["AGENT_BOM_GATEWAY_REPLICAS"] == "2"
+    assert "strategy" not in replicated["spec"]
+
+    autoscaled = _gateway_deployment(
+        _render(
+            "gateway.enabled=true",
+            "gateway.autoscaling.enabled=true",
+            "gateway.autoscaling.maxReplicas=7",
+            "gateway.runtimeRateLimitPerTenantPerMinute=10",
+        )
+    )
+    autoscaled_env = {item["name"]: item["value"] for item in autoscaled["spec"]["template"]["spec"]["containers"][0]["env"]}
+    assert autoscaled_env["AGENT_BOM_GATEWAY_REPLICAS"] == "7"
+
+    persistent = _gateway_deployment(
+        _render(
+            "gateway.enabled=true",
+            "gateway.replicas=1",
+            "gateway.persistence.enabled=true",
+            "gateway.persistence.existingClaim=gateway-audit",
+        )
+    )
+    assert persistent["spec"]["strategy"] == {"type": "Recreate"}
+    persistent_env = {item["name"]: item["value"] for item in persistent["spec"]["template"]["spec"]["containers"][0]["env"]}
+    assert persistent_env["AGENT_BOM_GATEWAY_REPLICAS"] == "1"
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm not installed")
+@pytest.mark.parametrize(
+    ("sets", "expected_error"),
+    [
+        (
+            ("gateway.replicas=2",),
+            "gateway persistence requires gateway.replicas=1",
+        ),
+        (
+            ("gateway.replicas=1", "gateway.autoscaling.enabled=true"),
+            "gateway persistence is incompatible with gateway autoscaling",
+        ),
+        (
+            ("gateway.replicas=1", "gateway.autoscaling.keda.enabled=true"),
+            "gateway persistence is incompatible with gateway autoscaling",
+        ),
+    ],
+)
+def test_helm_gateway_persistence_rejects_overlapping_owners(
+    sets: tuple[str, ...],
+    expected_error: str,
+) -> None:
+    args = [
+        "helm",
+        "template",
+        "abom",
+        str(HELM_DIR),
+        "--set",
+        "gateway.enabled=true",
+        "--set",
+        "gateway.persistence.enabled=true",
+        "--set",
+        "gateway.persistence.existingClaim=gateway-audit",
+    ]
+    for item in sets:
+        args.extend(("--set", item))
+    result = subprocess.run(args, capture_output=True, text=True, timeout=120, check=False)
+    assert result.returncode != 0
+    assert expected_error in result.stderr
 
 
 def test_helm_gateway_keda_template_suppresses_static_hpa():

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -590,15 +590,14 @@ def test_helm_gateway_renders_runtime_replica_truth_and_recreate_persistence() -
 
     def _gateway_deployment(documents: list[dict]) -> dict:
         return next(
-            doc
-            for doc in documents
-            if doc.get("kind") == "Deployment" and doc.get("metadata", {}).get("name", "").endswith("-gateway")
+            doc for doc in documents if doc.get("kind") == "Deployment" and doc.get("metadata", {}).get("name", "").endswith("-gateway")
         )
 
     replicated = _gateway_deployment(
         _render(
             "gateway.enabled=true",
             "gateway.replicas=2",
+            "gateway.controlPlaneDiscovery.url=https://control.example.test",
             "gateway.runtimeRateLimitPerTenantPerMinute=10",
         )
     )
@@ -611,6 +610,7 @@ def test_helm_gateway_renders_runtime_replica_truth_and_recreate_persistence() -
             "gateway.enabled=true",
             "gateway.autoscaling.enabled=true",
             "gateway.autoscaling.maxReplicas=7",
+            "gateway.controlPlaneDiscovery.url=https://control.example.test",
             "gateway.runtimeRateLimitPerTenantPerMinute=10",
         )
     )
@@ -628,6 +628,27 @@ def test_helm_gateway_renders_runtime_replica_truth_and_recreate_persistence() -
     assert persistent["spec"]["strategy"] == {"type": "Recreate"}
     persistent_env = {item["name"]: item["value"] for item in persistent["spec"]["template"]["spec"]["containers"][0]["env"]}
     assert persistent_env["AGENT_BOM_GATEWAY_REPLICAS"] == "1"
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm not installed")
+def test_helm_gateway_rejects_local_only_ephemeral_audit_state() -> None:
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "abom",
+            str(HELM_DIR),
+            "--set",
+            "gateway.enabled=true",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "local-only gateway audit requires gateway.persistence.enabled=true" in result.stderr
 
 
 @pytest.mark.skipif(shutil.which("helm") is None, reason="helm not installed")

--- a/tests/test_deploy_profiles.py
+++ b/tests/test_deploy_profiles.py
@@ -87,7 +87,12 @@ def test_gateway_runtime_profile_uses_shipped_upstreams_example():
     repo_root = Path(__file__).resolve().parent.parent
     profiles = {profile.name: profile for profile in helm_validation_profiles(repo_root)}
     gateway = profiles["gateway-runtime"]
-    assert gateway.set_arguments == ("gateway.enabled=true",)
+    assert gateway.set_arguments == (
+        "gateway.enabled=true",
+        "gateway.replicas=1",
+        "gateway.persistence.enabled=true",
+        "gateway.persistence.existingClaim=agent-bom-gateway-audit",
+    )
     assert gateway.set_file_arguments == (
         ("gateway.upstreamsYaml", repo_root / "deploy" / "helm" / "agent-bom" / "examples" / "gateway-upstreams.example.yaml"),
     )
@@ -103,8 +108,8 @@ def test_keda_profile_layers_production_and_keda_overlay():
         example_dir / "eks-production-values.yaml",
         example_dir / "eks-keda-values.yaml",
     )
-    assert keda.set_arguments == ("gateway.enabled=true",)
-    assert keda.set_file_arguments == (("gateway.upstreamsYaml", example_dir / "gateway-upstreams.example.yaml"),)
+    assert keda.set_arguments == ()
+    assert keda.set_file_arguments == ()
 
 
 def test_postgres_secret_example_documents_byo_postgres_contract():

--- a/tests/test_gateway_audit_delivery.py
+++ b/tests/test_gateway_audit_delivery.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -147,9 +150,7 @@ async def test_gateway_audit_delivers_at_most_500_events_in_order(tmp_path: Path
 
     assert await sink.flush_once() is True
     assert [len(batch) for batch in delivered] == [500, 1]
-    assert [event_id for batch in delivered for event_id in batch] == [
-        f"event-{index:04d}" for index in range(501)
-    ]
+    assert [event_id for batch in delivered for event_id in batch] == [f"event-{index:04d}" for index in range(501)]
     assert sink._delivery_state.store.read_spillover() == []
 
 
@@ -389,6 +390,121 @@ async def test_gateway_audit_retries_the_same_durable_event_after_503(tmp_path: 
     assert sink.health()["status"] == "healthy"
 
 
+def test_tool_call_requires_remote_durable_ack_before_upstream_execution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    upstream_calls = 0
+
+    async def sender(_payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        raise RuntimeError("control plane unavailable")
+
+    async def upstream_caller(_upstream: object, message: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        nonlocal upstream_calls
+        upstream_calls += 1
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"side_effect": True}}
+
+    spill, dlq = _paths(tmp_path)
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        None,
+        tenant_id="default",
+        spill_path=spill,
+        dlq_path=dlq,
+        sender=sender,
+    )
+    settings = GatewaySettings(
+        registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://filesystem.local")]),
+        policy={},
+        audit_sink=sink,
+        upstream_caller=upstream_caller,
+    )
+
+    with TestClient(create_gateway_app(settings), raise_server_exceptions=False) as client:
+        response = client.post(
+            "/mcp/filesystem",
+            json={
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "tools/call",
+                "params": {"name": "write_file", "arguments": {"path": "/tmp/output"}},
+            },
+        )
+
+    assert response.status_code == 503
+    assert upstream_calls == 0
+    assert sink.health()["backlog_bytes"] > 0, response.text
+
+
+def test_post_forward_result_audit_capacity_failure_returns_completed_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import agent_bom.gateway_server as gateway_module
+
+    upstream_calls = 0
+
+    async def sender(payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        count = len(payload["alerts"])
+        return {
+            "accepted_alert_count": count,
+            "duplicate_alert_count": 0,
+            "durable_accepted_count": count,
+            "durable_duplicate_count": 0,
+            "durable_conflict_count": 0,
+        }
+
+    spill, dlq = _paths(tmp_path)
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        None,
+        tenant_id="default",
+        spill_path=spill,
+        dlq_path=dlq,
+        max_spillover_bytes=10_000,
+        max_dlq_bytes=1,
+        sender=sender,
+    )
+
+    async def upstream_caller(_upstream: object, message: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        nonlocal upstream_calls
+        upstream_calls += 1
+        # Reproduce a concurrent capacity loss after pre-execution admission.
+        sink._delivery_state.store.max_spillover_bytes = sink._delivery_state.store.spillover_size_bytes() + 1
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"email": "person@example.com"}}
+
+    monkeypatch.setattr(
+        gateway_module,
+        "scan_tool_response",
+        lambda *_args, **_kwargs: [SimpleNamespace(blocked=False, scanner="pii", rule_id="email")],
+    )
+    settings = GatewaySettings(
+        registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://filesystem.local")]),
+        policy={},
+        audit_sink=sink,
+        upstream_caller=upstream_caller,
+        dlp_enabled=True,
+        dlp_mode="audit",
+    )
+
+    with TestClient(create_gateway_app(settings), raise_server_exceptions=False) as client:
+        response = client.post(
+            "/mcp/filesystem",
+            json={
+                "jsonrpc": "2.0",
+                "id": 13,
+                "method": "tools/call",
+                "params": {"name": "write_file", "arguments": {}},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["result"] == {"email": "person@example.com"}
+    assert response.headers["x-agent-bom-audit-delivery"] == "degraded"
+    assert upstream_calls == 1
+    assert sink.health()["accepting_events"] is False
+
+
 @pytest.mark.asyncio
 async def test_gateway_audit_restart_loads_and_delivers_sanitized_backlog(tmp_path: Path) -> None:
     spill, dlq = _paths(tmp_path)
@@ -602,6 +718,140 @@ def test_relay_builds_local_durable_audit_when_remote_sink_is_not_configured(
     assert entries[0].details["tool"] == "write_file"
 
 
+def test_local_audit_key_survives_subprocess_restart_and_concurrent_open(tmp_path: Path) -> None:
+    db_path = tmp_path / "runtime-audit" / "gateway-local-audit.db"
+    script = """
+import asyncio
+import json
+import sys
+from pathlib import Path
+from agent_bom.api.audit_log import SQLiteAuditLog
+from agent_bom.gateway_server import LocalGatewayAuditSink
+
+db_path = Path(sys.argv[1])
+mode = sys.argv[2]
+if mode == "append":
+    asyncio.run(LocalGatewayAuditSink(db_path)({
+        "action": "gateway.tool_call",
+        "tenant_id": "tenant-a",
+        "upstream": "filesystem",
+        "event_id": sys.argv[3],
+    }))
+else:
+    store = SQLiteAuditLog(str(db_path), hmac_key=LocalGatewayAuditSink.load_key(db_path))
+    print(json.dumps({
+        "count": store.count(tenant_id="tenant-a"),
+        "integrity": store.verify_integrity(tenant_id="tenant-a"),
+    }))
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).parents[1] / "src")
+    for name in (
+        "AGENT_BOM_AUDIT_HMAC_KEY",
+        "AGENT_BOM_AUDIT_HMAC_KEY_FILE",
+        "AGENT_BOM_REQUIRE_AUDIT_HMAC",
+        "AGENT_BOM_ENV",
+        "AGENT_BOM_DEPLOYMENT_ENV",
+        "ENVIRONMENT",
+    ):
+        env.pop(name, None)
+
+    first = subprocess.run(
+        [sys.executable, "-c", script, str(db_path), "append", "event-1"],
+        cwd=Path(__file__).parents[1],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert first.returncode == 0, first.stderr
+    writers = [
+        subprocess.Popen(
+            [sys.executable, "-c", script, str(db_path), "append", event_id],
+            cwd=Path(__file__).parents[1],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for event_id in ("event-2", "event-3")
+    ]
+    for writer in writers:
+        _stdout, stderr = writer.communicate(timeout=30)
+        assert writer.returncode == 0, stderr
+
+    verified = subprocess.run(
+        [sys.executable, "-c", script, str(db_path), "verify", "unused"],
+        cwd=Path(__file__).parents[1],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert verified.returncode == 0, verified.stderr
+    payload = json.loads(verified.stdout.strip().splitlines()[-1])
+    assert payload == {"count": 3, "integrity": [3, 0]}
+    key_path = db_path.with_suffix(".hmac.key")
+    assert key_path.is_file()
+    assert key_path.stat().st_mode & 0o777 == 0o600
+
+
+def test_existing_local_audit_db_fails_closed_if_key_is_missing(tmp_path: Path) -> None:
+    from agent_bom.gateway_server import LocalGatewayAuditSink
+
+    db_path = tmp_path / "runtime-audit" / "gateway-local-audit.db"
+    sink = LocalGatewayAuditSink(db_path)
+    key_path = db_path.with_suffix(".hmac.key")
+    assert key_path.is_file()
+    key_path.unlink()
+
+    with pytest.raises(ValueError, match="key is missing"):
+        LocalGatewayAuditSink(db_path)
+
+    assert sink.health()["durable"] is True
+
+
+def test_local_audit_initialization_failure_degrades_health_and_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", "/proc/agent-bom-audit-unwritable")
+    upstream_calls = 0
+
+    async def upstream_caller(_upstream: object, message: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        nonlocal upstream_calls
+        upstream_calls += 1
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"side_effect": True}}
+
+    settings = GatewaySettings(
+        registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://filesystem.local")]),
+        policy={},
+        audit_sink=None,
+        upstream_caller=upstream_caller,
+    )
+    with TestClient(create_gateway_app(settings), raise_server_exceptions=False) as client:
+        health = client.get("/healthz")
+        readiness = client.get("/readyz")
+        tool_call = client.post(
+            "/mcp/filesystem",
+            json={
+                "jsonrpc": "2.0",
+                "id": 12,
+                "method": "tools/call",
+                "params": {"name": "write_file", "arguments": {}},
+            },
+        )
+
+    assert health.status_code == 200
+    assert health.json()["status"] == "degraded"
+    assert health.json()["audit_delivery"]["durable"] is False
+    assert readiness.status_code == 503
+    assert readiness.json()["ready"] is False
+    assert tool_call.status_code == 503
+    assert upstream_calls == 0
+
+
 def test_relay_does_not_execute_tool_if_durable_audit_sink_becomes_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -696,8 +946,8 @@ async def test_gateway_health_truthfully_reports_delivery_degradation_without_se
         readiness = client.get("/readyz")
 
     assert response.status_code == 200
-    assert readiness.status_code == 200
-    assert readiness.json()["ready"] is True
+    assert readiness.status_code == 503
+    assert readiness.json()["ready"] is False
     payload = response.json()
     assert payload["status"] == "degraded"
     assert payload["audit_delivery"]["status"] == "degraded"

--- a/tests/test_gateway_audit_delivery.py
+++ b/tests/test_gateway_audit_delivery.py
@@ -1,0 +1,272 @@
+"""Durable standalone-gateway audit delivery contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.gateway_server import (
+    GatewayAuditDeliveryUnavailableError,
+    GatewaySettings,
+    _emit_gateway_governance_event,
+    build_control_plane_audit_sink,
+    create_gateway_app,
+)
+from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+from agent_bom.runtime.gateway_events import GatewayRuntimeEventType, build_gateway_runtime_event
+
+
+def _event(event_id: str = "gw_delivery_1", **overrides: object) -> dict[str, Any]:
+    event = build_gateway_runtime_event(
+        GatewayRuntimeEventType.TOOL_CALL_BLOCKED,
+        tenant_id="tenant-a",
+        agent_id="agent-a",
+        profile_id="profile-a",
+        upstream="filesystem",
+        tool="read_file",
+        decision="deny",
+        policy_source="runtime_profile",
+        trace_id="trace-a",
+        reason_code="profile_revoked",
+    )
+    event["event_id"] = event_id
+    event["decision_id"] = event_id
+    event.update(overrides)
+    return event
+
+
+def _paths(tmp_path: Path) -> tuple[Path, Path]:
+    return tmp_path / "gateway-audit.spill.jsonl", tmp_path / "gateway-audit.dlq.jsonl"
+
+
+@pytest.mark.asyncio
+async def test_gateway_audit_retries_the_same_durable_event_after_503(tmp_path: Path) -> None:
+    attempts: list[list[str]] = []
+
+    async def sender(payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        event_ids = [str(event["event_id"]) for event in payload["alerts"]]
+        attempts.append(event_ids)
+        if len(attempts) == 1:
+            raise RuntimeError("503 control plane temporarily unavailable")
+        return {
+            "accepted_alert_count": len(event_ids),
+            "duplicate_alert_count": 0,
+            "durable_accepted_count": len(event_ids),
+            "durable_duplicate_count": 0,
+            "durable_conflict_count": 0,
+        }
+
+    spill, dlq = _paths(tmp_path)
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        "token",
+        spill_path=spill,
+        dlq_path=dlq,
+        sender=sender,
+    )
+
+    await sink(_event())
+    assert spill.exists()
+    assert sink.health()["status"] == "degraded"
+
+    assert await sink.flush_once() is True
+    assert attempts == [["gw_delivery_1"], ["gw_delivery_1"]]
+    assert not spill.exists()
+    assert sink.health()["status"] == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_gateway_audit_restart_loads_and_delivers_sanitized_backlog(tmp_path: Path) -> None:
+    spill, dlq = _paths(tmp_path)
+    secret = "sk-" + "gateway-restart-secret-value-1234567890"
+
+    async def unavailable(_payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        raise RuntimeError(f"503 token={secret} path=/private/runtime/audit")
+
+    first = build_control_plane_audit_sink(
+        "https://control.example.test",
+        secret,
+        spill_path=spill,
+        dlq_path=dlq,
+        sender=unavailable,
+    )
+    await first(_event(api_token=secret, headers={"authorization": f"Bearer {secret}"}))
+    persisted = spill.read_text(encoding="utf-8")
+    assert secret not in persisted
+    await first.aclose()
+
+    delivered: list[dict[str, Any]] = []
+
+    async def recovered(payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        delivered.extend(payload["alerts"])
+        return {
+            "accepted_alert_count": len(payload["alerts"]),
+            "duplicate_alert_count": 0,
+            "durable_accepted_count": len(payload["alerts"]),
+            "durable_duplicate_count": 0,
+            "durable_conflict_count": 0,
+        }
+
+    restarted = build_control_plane_audit_sink(
+        "https://control.example.test",
+        secret,
+        spill_path=spill,
+        dlq_path=dlq,
+        sender=recovered,
+    )
+    await restarted.start()
+    await restarted.aclose()
+
+    assert [event["event_id"] for event in delivered] == ["gw_delivery_1"]
+    assert secret not in json.dumps(delivered)
+    assert not spill.exists()
+
+
+@pytest.mark.asyncio
+async def test_gateway_audit_cancellation_restores_the_claimed_batch(tmp_path: Path) -> None:
+    entered = asyncio.Event()
+
+    async def pending(_payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        entered.set()
+        await asyncio.Future()
+        raise AssertionError("unreachable")
+
+    spill, dlq = _paths(tmp_path)
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        None,
+        spill_path=spill,
+        dlq_path=dlq,
+        sender=pending,
+    )
+    sink._delivery_state.store.append_events([_event("gw_cancelled")])
+
+    delivery = asyncio.create_task(sink.flush_once())
+    await entered.wait()
+    delivery.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await delivery
+
+    recovered = sink._delivery_state.store.read_spillover()
+    assert [event["event_id"] for event in recovered] == ["gw_cancelled"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_audit_fails_closed_when_bounded_persistence_is_full(tmp_path: Path) -> None:
+    async def sender(_payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        raise AssertionError("a non-durable event must never reach the transport")
+
+    spill, dlq = _paths(tmp_path)
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        None,
+        spill_path=spill,
+        dlq_path=dlq,
+        max_spillover_bytes=1,
+        max_dlq_bytes=1,
+        sender=sender,
+    )
+
+    with pytest.raises(GatewayAuditDeliveryUnavailableError, match="durable audit backlog is full"):
+        await sink(_event())
+
+    health = sink.health()
+    assert health["status"] == "degraded"
+    assert health["accepting_events"] is False
+    assert health["dropped_events"] == 1
+
+
+@pytest.mark.asyncio
+async def test_gateway_health_truthfully_reports_delivery_degradation_without_secrets(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    secret = "gateway-health-secret-value-1234567890"
+
+    async def sender(_payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        raise RuntimeError(f"503 token={secret} path=/private/gateway/audit")
+
+    spill, dlq = _paths(tmp_path)
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        secret,
+        spill_path=spill,
+        dlq_path=dlq,
+        sender=sender,
+    )
+    await sink(_event())
+
+    settings = GatewaySettings(
+        registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://filesystem.local")]),
+        policy={},
+        audit_sink=sink,
+    )
+    with TestClient(create_gateway_app(settings)) as client:
+        response = client.get("/healthz")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "degraded"
+    assert payload["audit_delivery"]["status"] == "degraded"
+    assert payload["audit_delivery"]["backlog_bytes"] > 0
+    assert secret not in response.text
+    assert "/private/gateway/audit" not in response.text
+    assert secret not in caplog.text
+    assert "/private/gateway/audit" not in caplog.text
+
+
+def test_gateway_default_delivery_paths_are_restart_stable_and_secret_free(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path))
+    secret = "gateway-token-must-not-enter-path"
+
+    first = build_control_plane_audit_sink(
+        "https://control.example.test",
+        secret,
+        source_id="gateway-a",
+    )
+    second = build_control_plane_audit_sink(
+        "https://control.example.test",
+        "rotated-token",
+        source_id="gateway-a",
+    )
+
+    first_store = first._delivery_state.store
+    second_store = second._delivery_state.store
+    assert first_store.spill_path == second_store.spill_path
+    assert first_store.dlq_path == second_store.dlq_path
+    assert first._session_id == second._session_id
+    assert first_store.spill_path.parent == tmp_path / "runtime-audit"
+    assert secret not in str(first_store.spill_path)
+
+
+def test_gateway_governance_emit_does_not_log_hostile_exception_content(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from agent_bom.api import webhook_store
+
+    opaque = "postgresql://audit:secret@db.internal/runtime"
+
+    def fail_emit(**_kwargs: object) -> None:
+        raise RuntimeError(f"{opaque} /private/tenant/audit.json")
+
+    monkeypatch.setattr(webhook_store, "emit_governance_event", fail_emit)
+    with caplog.at_level(logging.DEBUG):
+        _emit_gateway_governance_event(
+            "gateway.test",
+            tenant_id="tenant-a",
+            subject_id="agent-a",
+            payload={"safe": True},
+        )
+
+    assert opaque not in caplog.text
+    assert "/private/tenant/audit.json" not in caplog.text

--- a/tests/test_gateway_audit_delivery.py
+++ b/tests/test_gateway_audit_delivery.py
@@ -45,22 +45,73 @@ def _paths(tmp_path: Path) -> tuple[Path, Path]:
     return tmp_path / "gateway-audit.spill.jsonl", tmp_path / "gateway-audit.dlq.jsonl"
 
 
-def test_gateway_audit_eventless_idempotency_is_stable_without_colliding() -> None:
-    first = {"action": "gateway.rate_limited", "tenant_id": "tenant-a", "tool": "read_file"}
-    second = {"action": "gateway.budget_exceeded", "tenant_id": "tenant-a", "tool": "read_file"}
+@pytest.mark.asyncio
+async def test_gateway_audit_assigns_distinct_stable_ids_to_identical_event_occurrences(tmp_path: Path) -> None:
+    delivered: list[dict[str, Any]] = []
 
-    first_key = build_control_plane_audit_sink(
-        "https://control.example.test", None, tenant_id="tenant-a"
-    )._batch_idempotency_key("session", [first])
-    repeated_key = build_control_plane_audit_sink(
-        "https://control.example.test", None, tenant_id="tenant-a"
-    )._batch_idempotency_key("session", [first])
-    second_key = build_control_plane_audit_sink(
-        "https://control.example.test", None, tenant_id="tenant-a"
-    )._batch_idempotency_key("session", [second])
+    async def sender(payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        delivered.append(payload)
+        count = len(payload["alerts"])
+        return {
+            "accepted_alert_count": count,
+            "duplicate_alert_count": 0,
+            "durable_accepted_count": 0,
+            "durable_duplicate_count": 0,
+            "durable_conflict_count": 0,
+        }
 
-    assert first_key == repeated_key
-    assert first_key != second_key
+    spill, dlq = _paths(tmp_path)
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        None,
+        tenant_id="tenant-a",
+        spill_path=spill,
+        dlq_path=dlq,
+        sender=sender,
+    )
+    occurrence = {"action": "gateway.upstream_error", "tenant_id": "tenant-a", "upstream": "filesystem"}
+
+    await sink(dict(occurrence))
+    await sink(dict(occurrence))
+
+    first, second = delivered
+    assert first["alerts"][0]["event_id"] != second["alerts"][0]["event_id"]
+    assert first["alerts"][0]["decision_id"] == first["alerts"][0]["event_id"]
+    assert second["alerts"][0]["decision_id"] == second["alerts"][0]["event_id"]
+    assert first["idempotency_key"] != second["idempotency_key"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_audit_eventless_occurrence_keeps_identity_across_retry(tmp_path: Path) -> None:
+    attempts: list[dict[str, Any]] = []
+
+    async def sender(payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        attempts.append(payload)
+        if len(attempts) == 1:
+            raise RuntimeError("control plane unavailable")
+        return {
+            "accepted_alert_count": 1,
+            "duplicate_alert_count": 0,
+            "durable_accepted_count": 0,
+            "durable_duplicate_count": 0,
+            "durable_conflict_count": 0,
+        }
+
+    spill, dlq = _paths(tmp_path)
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        None,
+        tenant_id="tenant-a",
+        spill_path=spill,
+        dlq_path=dlq,
+        sender=sender,
+    )
+
+    await sink({"action": "gateway.upstream_error", "tenant_id": "tenant-a", "upstream": "filesystem"})
+    assert await sink.flush_once() is True
+
+    assert attempts[0]["alerts"][0]["event_id"] == attempts[1]["alerts"][0]["event_id"]
+    assert attempts[0]["idempotency_key"] == attempts[1]["idempotency_key"]
 
 
 @pytest.mark.asyncio
@@ -183,7 +234,7 @@ async def test_gateway_audit_dlq_poison_keeps_later_events_fail_closed(tmp_path:
     ("action", "expected_type", "decision"),
     [
         ("gateway.a2a_mutual_auth_blocked", "gateway.enforcement.blocked", "deny"),
-        ("gateway.firewall_blocked", "gateway.enforcement.blocked", "deny"),
+        ("gateway.firewall_blocked", "gateway.tool_call.blocked", "deny"),
         ("gateway.rate_limited", "gateway.enforcement.blocked", "deny"),
         ("gateway.budget_exceeded", "gateway.enforcement.blocked", "deny"),
         ("gateway.anomaly_blocked", "gateway.enforcement.blocked", "deny"),
@@ -197,6 +248,7 @@ async def test_gateway_audit_dlq_poison_keeps_later_events_fail_closed(tmp_path:
         ("gateway.drift_warned", "gateway.enforcement.warned", "allow"),
         ("gateway.graph_reachability_warned", "gateway.enforcement.warned", "allow"),
         ("gateway.policy_warned", "gateway.enforcement.warned", "allow"),
+        ("gateway.firewall_warned", "gateway.enforcement.warned", "allow"),
         ("gateway.identity_jit_grant_used", "gateway.enforcement.observed", "allow"),
     ],
 )
@@ -242,6 +294,60 @@ async def test_gateway_audit_canonicalizes_enforcement_decisions_before_delivery
     assert delivered[0]["event_type"] == expected_type
     assert delivered[0]["decision"] == decision
     assert "authorization" not in delivered[0]
+
+
+@pytest.mark.asyncio
+async def test_gateway_audit_canonicalizes_actual_firewall_decision_and_preserves_provenance(tmp_path: Path) -> None:
+    delivered: list[dict[str, Any]] = []
+
+    async def sender(payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        delivered.extend(payload["alerts"])
+        return {
+            "accepted_alert_count": 1,
+            "duplicate_alert_count": 0,
+            "durable_accepted_count": 1,
+            "durable_duplicate_count": 0,
+            "durable_conflict_count": 0,
+        }
+
+    spill, dlq = _paths(tmp_path)
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        "token",
+        tenant_id="tenant-a",
+        spill_path=spill,
+        dlq_path=dlq,
+        sender=sender,
+    )
+    await sink(
+        {
+            "action": "gateway.firewall_decision",
+            "tenant_id": "tenant-a",
+            "source_agent": "agent-a",
+            "target_agent": "filesystem",
+            "decision": "deny",
+            "effective_decision": "deny",
+            "identity_id": "identity-a",
+            "profile_id": "profile-a",
+            "profile_revision": 4,
+            "blueprint_id": "blueprint-a",
+            "blueprint_revision": 7,
+            "policy_ids": ["policy-a", "policy-b"],
+            "policy_id": "policy-a",
+            "evidence_id": "evidence-a",
+        }
+    )
+
+    event = delivered[0]
+    assert event["event_type"] == "gateway.enforcement.blocked"
+    assert event["decision"] == "deny"
+    assert event["identity_id"] == "identity-a"
+    assert event["profile_revision"] == 4
+    assert event["blueprint_id"] == "blueprint-a"
+    assert event["blueprint_revision"] == 7
+    assert event["policy_ids"] == ["policy-a", "policy-b"]
+    assert event["policy_id"] == "policy-a"
+    assert event["evidence_id"] == "evidence-a"
 
 
 @pytest.mark.asyncio
@@ -417,7 +523,8 @@ async def test_gateway_health_truthfully_reports_delivery_degradation_without_se
         readiness = client.get("/readyz")
 
     assert response.status_code == 200
-    assert readiness.status_code == 503
+    assert readiness.status_code == 200
+    assert readiness.json()["ready"] is True
     payload = response.json()
     assert payload["status"] == "degraded"
     assert payload["audit_delivery"]["status"] == "degraded"
@@ -440,6 +547,16 @@ def test_gateway_health_marks_inaccessible_persistence_non_durable() -> None:
     health = sink.health()
     assert health["durable"] is False
     assert health["accepting_events"] is False
+
+    settings = GatewaySettings(
+        registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://filesystem.local")]),
+        policy={},
+        audit_sink=sink,
+    )
+    with TestClient(create_gateway_app(settings)) as client:
+        readiness = client.get("/readyz")
+    assert readiness.status_code == 503
+    assert readiness.json()["ready"] is False
 
 
 def test_gateway_default_delivery_paths_are_restart_stable_and_secret_free(

--- a/tests/test_gateway_audit_delivery.py
+++ b/tests/test_gateway_audit_delivery.py
@@ -45,6 +45,205 @@ def _paths(tmp_path: Path) -> tuple[Path, Path]:
     return tmp_path / "gateway-audit.spill.jsonl", tmp_path / "gateway-audit.dlq.jsonl"
 
 
+def test_gateway_audit_eventless_idempotency_is_stable_without_colliding() -> None:
+    first = {"action": "gateway.rate_limited", "tenant_id": "tenant-a", "tool": "read_file"}
+    second = {"action": "gateway.budget_exceeded", "tenant_id": "tenant-a", "tool": "read_file"}
+
+    first_key = build_control_plane_audit_sink(
+        "https://control.example.test", None, tenant_id="tenant-a"
+    )._batch_idempotency_key("session", [first])
+    repeated_key = build_control_plane_audit_sink(
+        "https://control.example.test", None, tenant_id="tenant-a"
+    )._batch_idempotency_key("session", [first])
+    second_key = build_control_plane_audit_sink(
+        "https://control.example.test", None, tenant_id="tenant-a"
+    )._batch_idempotency_key("session", [second])
+
+    assert first_key == repeated_key
+    assert first_key != second_key
+
+
+@pytest.mark.asyncio
+async def test_gateway_audit_delivers_at_most_500_events_in_order(tmp_path: Path) -> None:
+    delivered: list[list[str]] = []
+
+    async def sender(payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        ids = [str(event["event_id"]) for event in payload["alerts"]]
+        delivered.append(ids)
+        assert len(ids) <= 500
+        return {
+            "accepted_alert_count": len(ids),
+            "duplicate_alert_count": 0,
+            "durable_accepted_count": len(ids),
+            "durable_duplicate_count": 0,
+            "durable_conflict_count": 0,
+        }
+
+    spill, dlq = _paths(tmp_path)
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        "token",
+        tenant_id="tenant-a",
+        spill_path=spill,
+        dlq_path=dlq,
+        max_spillover_bytes=2_000_000,
+        sender=sender,
+    )
+    events = [_event(f"event-{index:04d}") for index in range(501)]
+    sink._delivery_state.store.append_events(events)
+
+    assert await sink.flush_once() is True
+    assert [len(batch) for batch in delivered] == [500, 1]
+    assert [event_id for batch in delivered for event_id in batch] == [
+        f"event-{index:04d}" for index in range(501)
+    ]
+    assert sink._delivery_state.store.read_spillover() == []
+
+
+@pytest.mark.asyncio
+async def test_gateway_audit_partial_chunk_ack_restores_only_unsent_tail(tmp_path: Path) -> None:
+    attempts = 0
+
+    async def sender(payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 2:
+            raise RuntimeError("control plane unavailable")
+        count = len(payload["alerts"])
+        return {
+            "accepted_alert_count": count,
+            "duplicate_alert_count": 0,
+            "durable_accepted_count": count,
+            "durable_duplicate_count": 0,
+            "durable_conflict_count": 0,
+        }
+
+    spill, dlq = _paths(tmp_path)
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        "token",
+        tenant_id="tenant-a",
+        spill_path=spill,
+        dlq_path=dlq,
+        max_spillover_bytes=3_000_000,
+        sender=sender,
+    )
+    sink._delivery_state.store.append_events([_event(f"event-{index:04d}") for index in range(750)])
+
+    assert await sink.flush_once() is False
+    assert [event["event_id"] for event in sink._delivery_state.store.read_spillover()] == [
+        f"event-{index:04d}" for index in range(500, 750)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gateway_audit_rejects_cross_tenant_rebinding(tmp_path: Path) -> None:
+    spill, dlq = _paths(tmp_path)
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        "tenant-a-token",
+        tenant_id="tenant-a",
+        spill_path=spill,
+        dlq_path=dlq,
+    )
+
+    with pytest.raises(GatewayAuditDeliveryUnavailableError, match="tenant"):
+        await sink(_event(tenant_id="tenant-b"))
+    assert not spill.exists()
+
+
+@pytest.mark.asyncio
+async def test_gateway_audit_dlq_poison_keeps_later_events_fail_closed(tmp_path: Path) -> None:
+    sent: list[dict[str, Any]] = []
+
+    async def sender(payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        sent.extend(payload["alerts"])
+        return {}
+
+    spill, dlq = _paths(tmp_path)
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        None,
+        tenant_id="tenant-a",
+        spill_path=spill,
+        dlq_path=dlq,
+        max_spillover_bytes=200,
+        max_dlq_bytes=2_000,
+        sender=sender,
+    )
+    with pytest.raises(GatewayAuditDeliveryUnavailableError):
+        await sink(_event("oversized", reason_code="x" * 500))
+    with pytest.raises(GatewayAuditDeliveryUnavailableError):
+        await sink(_event("small"))
+    assert sent == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("action", "expected_type", "decision"),
+    [
+        ("gateway.a2a_mutual_auth_blocked", "gateway.enforcement.blocked", "deny"),
+        ("gateway.firewall_blocked", "gateway.enforcement.blocked", "deny"),
+        ("gateway.rate_limited", "gateway.enforcement.blocked", "deny"),
+        ("gateway.budget_exceeded", "gateway.enforcement.blocked", "deny"),
+        ("gateway.anomaly_blocked", "gateway.enforcement.blocked", "deny"),
+        ("gateway.fleet_blocked", "gateway.enforcement.blocked", "deny"),
+        ("gateway.conditional_access_blocked", "gateway.enforcement.blocked", "deny"),
+        ("gateway.graph_reachability_blocked", "gateway.enforcement.blocked", "deny"),
+        ("gateway.oauth_scope_blocked", "gateway.enforcement.blocked", "deny"),
+        ("gateway.policy_quarantined", "gateway.enforcement.blocked", "deny"),
+        ("gateway.anomaly_warned", "gateway.enforcement.warned", "allow"),
+        ("gateway.fleet_warned", "gateway.enforcement.warned", "allow"),
+        ("gateway.drift_warned", "gateway.enforcement.warned", "allow"),
+        ("gateway.graph_reachability_warned", "gateway.enforcement.warned", "allow"),
+        ("gateway.policy_warned", "gateway.enforcement.warned", "allow"),
+        ("gateway.identity_jit_grant_used", "gateway.enforcement.observed", "allow"),
+    ],
+)
+async def test_gateway_audit_canonicalizes_enforcement_decisions_before_delivery(
+    tmp_path: Path,
+    action: str,
+    expected_type: str,
+    decision: str,
+) -> None:
+    delivered: list[dict[str, Any]] = []
+
+    async def sender(payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        delivered.extend(payload["alerts"])
+        return {
+            "accepted_alert_count": 1,
+            "duplicate_alert_count": 0,
+            "durable_accepted_count": 1,
+            "durable_duplicate_count": 0,
+            "durable_conflict_count": 0,
+        }
+
+    spill, dlq = _paths(tmp_path)
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        "token",
+        tenant_id="tenant-a",
+        spill_path=spill,
+        dlq_path=dlq,
+        sender=sender,
+    )
+
+    await sink(
+        {
+            "action": action,
+            "tenant_id": "tenant-a",
+            "source_agent": "agent-a",
+            "upstream": "filesystem",
+            "tool": "read_file",
+            "authorization": "must-not-survive",
+        }
+    )
+
+    assert delivered[0]["event_type"] == expected_type
+    assert delivered[0]["decision"] == decision
+    assert "authorization" not in delivered[0]
+
+
 @pytest.mark.asyncio
 async def test_gateway_audit_retries_the_same_durable_event_after_503(tmp_path: Path) -> None:
     attempts: list[list[str]] = []
@@ -66,6 +265,7 @@ async def test_gateway_audit_retries_the_same_durable_event_after_503(tmp_path: 
     sink = build_control_plane_audit_sink(
         "https://control.example.test",
         "token",
+        tenant_id="tenant-a",
         spill_path=spill,
         dlq_path=dlq,
         sender=sender,
@@ -92,6 +292,7 @@ async def test_gateway_audit_restart_loads_and_delivers_sanitized_backlog(tmp_pa
     first = build_control_plane_audit_sink(
         "https://control.example.test",
         secret,
+        tenant_id="tenant-a",
         spill_path=spill,
         dlq_path=dlq,
         sender=unavailable,
@@ -116,6 +317,7 @@ async def test_gateway_audit_restart_loads_and_delivers_sanitized_backlog(tmp_pa
     restarted = build_control_plane_audit_sink(
         "https://control.example.test",
         secret,
+        tenant_id="tenant-a",
         spill_path=spill,
         dlq_path=dlq,
         sender=recovered,
@@ -141,6 +343,7 @@ async def test_gateway_audit_cancellation_restores_the_claimed_batch(tmp_path: P
     sink = build_control_plane_audit_sink(
         "https://control.example.test",
         None,
+        tenant_id="tenant-a",
         spill_path=spill,
         dlq_path=dlq,
         sender=pending,
@@ -166,6 +369,7 @@ async def test_gateway_audit_fails_closed_when_bounded_persistence_is_full(tmp_p
     sink = build_control_plane_audit_sink(
         "https://control.example.test",
         None,
+        tenant_id="tenant-a",
         spill_path=spill,
         dlq_path=dlq,
         max_spillover_bytes=1,
@@ -196,6 +400,7 @@ async def test_gateway_health_truthfully_reports_delivery_degradation_without_se
     sink = build_control_plane_audit_sink(
         "https://control.example.test",
         secret,
+        tenant_id="tenant-a",
         spill_path=spill,
         dlq_path=dlq,
         sender=sender,
@@ -209,8 +414,10 @@ async def test_gateway_health_truthfully_reports_delivery_degradation_without_se
     )
     with TestClient(create_gateway_app(settings)) as client:
         response = client.get("/healthz")
+        readiness = client.get("/readyz")
 
     assert response.status_code == 200
+    assert readiness.status_code == 503
     payload = response.json()
     assert payload["status"] == "degraded"
     assert payload["audit_delivery"]["status"] == "degraded"
@@ -219,6 +426,20 @@ async def test_gateway_health_truthfully_reports_delivery_degradation_without_se
     assert "/private/gateway/audit" not in response.text
     assert secret not in caplog.text
     assert "/private/gateway/audit" not in caplog.text
+
+
+def test_gateway_health_marks_inaccessible_persistence_non_durable() -> None:
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        None,
+        tenant_id="tenant-a",
+        spill_path=Path("/proc/agent-bom-audit.spill.jsonl"),
+        dlq_path=Path("/proc/agent-bom-audit.dlq.jsonl"),
+    )
+
+    health = sink.health()
+    assert health["durable"] is False
+    assert health["accepting_events"] is False
 
 
 def test_gateway_default_delivery_paths_are_restart_stable_and_secret_free(
@@ -231,11 +452,13 @@ def test_gateway_default_delivery_paths_are_restart_stable_and_secret_free(
     first = build_control_plane_audit_sink(
         "https://control.example.test",
         secret,
+        tenant_id="tenant-a",
         source_id="gateway-a",
     )
     second = build_control_plane_audit_sink(
         "https://control.example.test",
         "rotated-token",
+        tenant_id="tenant-a",
         source_id="gateway-a",
     )
 

--- a/tests/test_gateway_audit_delivery.py
+++ b/tests/test_gateway_audit_delivery.py
@@ -492,6 +492,55 @@ async def test_gateway_audit_fails_closed_when_bounded_persistence_is_full(tmp_p
     assert health["dropped_events"] == 1
 
 
+def test_relay_does_not_execute_tool_when_audit_persistence_is_already_full(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An allowed tool must be durably audited before its upstream side effect."""
+
+    monkeypatch.setenv("AGENT_BOM_TENANT_ID", "tenant-a")
+    upstream_calls = 0
+
+    async def upstream_caller(_upstream: object, message: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        nonlocal upstream_calls
+        upstream_calls += 1
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    async def sender(_payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        raise AssertionError("a poisoned backlog must not reach the transport")
+
+    spill, dlq = _paths(tmp_path)
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        None,
+        tenant_id="tenant-a",
+        spill_path=spill,
+        dlq_path=dlq,
+        max_spillover_bytes=1,
+        max_dlq_bytes=2_000,
+        sender=sender,
+    )
+    assert sink._delivery_state.store.append_events([_event("poison")]) == "dlq"
+    settings = GatewaySettings(
+        registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://filesystem.local")]),
+        policy={},
+        audit_sink=sink,
+        upstream_caller=upstream_caller,
+    )
+    message = {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "tools/call",
+        "params": {"name": "read_file", "arguments": {}},
+    }
+
+    with TestClient(create_gateway_app(settings), raise_server_exceptions=False) as client:
+        response = client.post("/mcp/filesystem", json=message)
+
+    assert response.status_code == 503
+    assert upstream_calls == 0
+
+
 @pytest.mark.asyncio
 async def test_gateway_health_truthfully_reports_delivery_degradation_without_secrets(
     tmp_path: Path,

--- a/tests/test_gateway_audit_delivery.py
+++ b/tests/test_gateway_audit_delivery.py
@@ -6,11 +6,13 @@ import asyncio
 import json
 import logging
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from starlette.testclient import TestClient
 
+from agent_bom.api.auth import Role
 from agent_bom.gateway_server import (
     GatewayAuditDeliveryUnavailableError,
     GatewaySettings,
@@ -539,6 +541,128 @@ def test_relay_does_not_execute_tool_when_audit_persistence_is_already_full(
 
     assert response.status_code == 503
     assert upstream_calls == 0
+
+
+def test_relay_builds_local_durable_audit_when_remote_sink_is_not_configured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_BOM_TENANT_ID", "tenant-a")
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path))
+    upstream_calls = 0
+
+    class _TenantKeyStore:
+        def has_keys(self) -> bool:
+            return True
+
+        def verify(self, raw_key: str) -> SimpleNamespace | None:
+            if raw_key != "tenant-a-key":
+                return None
+            return SimpleNamespace(
+                tenant_id="tenant-a",
+                role=Role.ANALYST,
+                scopes=["gateway:relay"],
+                has_scope=lambda required: required == "gateway:relay",
+            )
+
+    monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _TenantKeyStore())
+
+    async def upstream_caller(_upstream: object, message: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        nonlocal upstream_calls
+        upstream_calls += 1
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"side_effect": True}}
+
+    settings = GatewaySettings(
+        registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://filesystem.local")]),
+        policy={},
+        audit_sink=None,
+        upstream_caller=upstream_caller,
+    )
+    message = {
+        "jsonrpc": "2.0",
+        "id": 9,
+        "method": "tools/call",
+        "params": {"name": "write_file", "arguments": {"path": "/tmp/output"}},
+    }
+
+    with TestClient(create_gateway_app(settings), raise_server_exceptions=False) as client:
+        response = client.post("/mcp/filesystem", headers={"X-API-Key": "tenant-a-key"}, json=message)
+
+    assert response.status_code == 200
+    assert upstream_calls == 1
+    db_path = tmp_path / "runtime-audit" / "gateway-local-audit.db"
+    assert db_path.is_file()
+    assert settings.audit_sink is not None
+    from agent_bom.api.audit_log import SQLiteAuditLog
+
+    entries = SQLiteAuditLog(str(db_path)).list_entries(tenant_id="tenant-a", limit=10)
+    assert len(entries) == 1
+    assert entries[0].action == "gateway.tool_call"
+    assert entries[0].details["decision"] == "allow"
+    assert entries[0].details["tool"] == "write_file"
+
+
+def test_relay_does_not_execute_tool_if_durable_audit_sink_becomes_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_BOM_TENANT_ID", "tenant-a")
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path))
+    upstream_calls = 0
+
+    async def upstream_caller(_upstream: object, message: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        nonlocal upstream_calls
+        upstream_calls += 1
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"side_effect": True}}
+
+    settings = GatewaySettings(
+        registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://filesystem.local")]),
+        policy={},
+        audit_sink=None,
+        upstream_caller=upstream_caller,
+    )
+    app = create_gateway_app(settings)
+    settings.audit_sink = None
+    message = {
+        "jsonrpc": "2.0",
+        "id": 10,
+        "method": "tools/call",
+        "params": {"name": "write_file", "arguments": {"path": "/tmp/output"}},
+    }
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post("/mcp/filesystem", json=message)
+
+    assert response.status_code == 503
+    assert upstream_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_malformed_backlog_is_retained_and_blocks_new_audit_admission(tmp_path: Path) -> None:
+    sent: list[dict[str, Any]] = []
+
+    async def sender(payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        sent.extend(payload["alerts"])
+        return {}
+
+    spill, dlq = _paths(tmp_path)
+    spill.parent.mkdir(parents=True, exist_ok=True)
+    spill.write_text("{not-json}\n", encoding="utf-8")
+    sink = build_control_plane_audit_sink(
+        "https://control.example.test",
+        None,
+        tenant_id="tenant-a",
+        spill_path=spill,
+        dlq_path=dlq,
+        sender=sender,
+    )
+
+    assert await sink.flush_once() is False
+    assert sent == []
+    assert any(spill.parent.glob(f"{spill.name}.claim-*"))
+    assert sink.health()["accepting_events"] is False
+    with pytest.raises(GatewayAuditDeliveryUnavailableError, match="unavailable"):
+        await sink(_event("after-corruption"))
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway_firewall.py
+++ b/tests/test_gateway_firewall.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 from fastapi.testclient import TestClient
 
 from agent_bom.gateway_server import GatewaySettings, create_gateway_app
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+from agent_bom.rbac import Role
 
 
 def _registry() -> UpstreamRegistry:
@@ -97,6 +99,42 @@ def test_firewall_check_loads_file_and_denies(tmp_path: Path) -> None:
     assert event["effective_decision"] == "deny"
     assert event["source_agent"] == "cursor"
     assert event["target_agent"] == "snowflake-cli"
+
+
+def test_firewall_check_fails_closed_on_authenticated_policy_tenant_mismatch(tmp_path: Path, monkeypatch) -> None:
+    policy_path = _write_policy(
+        tmp_path / "fw.json",
+        tenant_id="tenant-alpha",
+        rules=[{"source": "cursor", "target": "snowflake-cli", "decision": "deny"}],
+    )
+
+    class _FakeKeyStore:
+        def has_keys(self) -> bool:
+            return True
+
+        def verify(self, raw_key: str):
+            if raw_key != "tenant-beta-key":
+                return None
+            return SimpleNamespace(tenant_id="tenant-beta", role=Role.ANALYST, has_scope=lambda _scope: True)
+
+    monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
+    audit = _AuditCapture()
+    settings = GatewaySettings(
+        registry=_registry(),
+        policy={},
+        firewall_policy_path=policy_path,
+        audit_sink=audit,
+    )
+    with TestClient(create_gateway_app(settings)) as client:
+        response = client.post(
+            "/v1/firewall/check",
+            headers={"X-API-Key": "tenant-beta-key"},
+            json={"source_agent": "cursor", "target_agent": "snowflake-cli"},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "firewall policy is not bound to the authenticated tenant"
+    assert audit.events == []
 
 
 def test_firewall_check_dry_run_downgrades_deny_to_warn(tmp_path: Path) -> None:
@@ -300,6 +338,33 @@ def test_p1_20_firewall_check_requires_bearer_when_configured() -> None:
             headers={"Authorization": "Bearer s3cr3t"},
         )
         assert ok.status_code == 200
+
+
+def test_firewall_static_bearer_uses_configured_tenant_binding(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_TENANT_ID", "tenant-alpha")
+    policy_path = _write_policy(
+        tmp_path / "fw.json",
+        tenant_id="tenant-alpha",
+        rules=[{"source": "cursor", "target": "snowflake-cli", "decision": "deny"}],
+    )
+    audit = _AuditCapture()
+    settings = GatewaySettings(
+        registry=_registry(),
+        policy={},
+        bearer_token="s3cr3t",  # noqa: S106
+        firewall_policy_path=policy_path,
+        audit_sink=audit,
+    )
+    with TestClient(create_gateway_app(settings)) as client:
+        response = client.post(
+            "/v1/firewall/check",
+            headers={"Authorization": "Bearer s3cr3t"},
+            json={"source_agent": "cursor", "target_agent": "snowflake-cli"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["policy"]["tenant_id"] == "tenant-alpha"
+    assert audit.events[0]["tenant_id"] == "tenant-alpha"
 
 
 def test_p1_20_metrics_requires_bearer_when_configured() -> None:

--- a/tests/test_gateway_oauth_broker.py
+++ b/tests/test_gateway_oauth_broker.py
@@ -326,7 +326,7 @@ def test_dlp_redacts_pii_in_result() -> None:
     assert "[REDACTED:email]" in body["result"]["content"]
 
 
-def test_gateway_emits_typed_events_for_argument_and_result_redaction_then_allow() -> None:
+def test_gateway_durably_admits_after_argument_redaction_and_before_result_redaction() -> None:
     caller, captured = _echo_caller(result={"content": "owner@example.com"})
     audits: list[dict[str, Any]] = []
 
@@ -354,8 +354,8 @@ def test_gateway_emits_typed_events_for_argument_and_result_redaction_then_allow
     typed = [event for event in audits if event.get("event_type")]
     assert [event["event_type"] for event in typed] == [
         "gateway.dlp.arguments_redacted",
-        "gateway.dlp.result_redacted",
         "gateway.tool_call.allowed",
+        "gateway.dlp.result_redacted",
     ]
     assert all(event["decision"] == "allow" for event in typed)
     assert all(event["tenant_id"] == "default" for event in typed)
@@ -363,8 +363,8 @@ def test_gateway_emits_typed_events_for_argument_and_result_redaction_then_allow
     assert all(event["profile_id"] == "" for event in typed)
     assert all(event["upstream"] == "filesystem" for event in typed)
     assert all(event["tool"] == "fs.lookup" for event in typed)
-    assert [event["policy_source"] for event in typed] == ["dlp", "dlp", "file"]
-    assert [event.get("data_action", "") for event in typed] == ["pii_redacted", "pii_redacted", ""]
+    assert [event["policy_source"] for event in typed] == ["dlp", "file", "dlp"]
+    assert [event.get("data_action", "") for event in typed] == ["pii_redacted", "", "pii_redacted"]
 
 
 def test_gateway_emits_typed_sensitive_result_block_without_secret() -> None:

--- a/tests/test_gateway_profile_enforcement.py
+++ b/tests/test_gateway_profile_enforcement.py
@@ -221,6 +221,9 @@ def test_upstream_restriction_applies_to_non_tool_jsonrpc_messages() -> None:
     assert response.json()["error"]["data"]["reason_code"] == "upstream_not_allowed"
     assert calls == []
     assert all(event.get("event_type") != "gateway.tool_call.blocked" for event in audits)
+    profile_blocked = [event for event in audits if event.get("event_type") == "gateway.runtime_profile.blocked"]
+    assert len(profile_blocked) == 1
+    assert profile_blocked[0]["decision"] == "deny"
 
 
 def test_caller_environment_header_cannot_satisfy_operator_profile_environment() -> None:
@@ -258,6 +261,9 @@ def test_loopback_profile_bypass_requires_explicit_flag_and_is_audited() -> None
     assert len(calls) == 1
     bypass = [event for event in audits if event.get("action") == "gateway.runtime_profile_dev_bypass"]
     assert len(bypass) == 1
+    assert bypass[0]["event_type"] == "gateway.runtime_profile.dev_bypass"
+    assert bypass[0]["decision"] == "allow"
+    assert bypass[0]["decision_id"] == bypass[0]["event_id"]
     assert bypass[0]["reason_code"] == "profile_not_found"
     assert bypass[0]["development_mode"] is True
     allowed_events = [event for event in audits if event.get("event_type") == "gateway.tool_call.allowed"]
@@ -295,6 +301,9 @@ def test_warn_mode_audits_unsanctioned_profile_without_claiming_profile_attribut
     assert len(calls) == 1
     warned = [event for event in audits if event.get("action") == "gateway.runtime_profile_warned"]
     assert len(warned) == 1
+    assert warned[0]["event_type"] == "gateway.runtime_profile.warned"
+    assert warned[0]["decision"] == "allow"
+    assert warned[0]["decision_id"] == warned[0]["event_id"]
     assert warned[0]["reason_code"] == "profile_not_found"
     allowed = [event for event in audits if event.get("event_type") == "gateway.tool_call.allowed"]
     assert allowed[0]["profile_id"] == ""

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -1129,7 +1129,9 @@ def test_relay_upstream_error_surfaces_as_502_and_is_audited() -> None:
     )
     assert resp.status_code == 502
     assert resp.json()["detail"] == "upstream error: An internal error occurred. Please contact support."
-    assert audit_events == [
+    assert audit_events[0]["event_type"] == "gateway.tool_call.allowed"
+    assert audit_events[0]["tool"] == "read_file"
+    assert audit_events[1:] == [
         {
             "action": "gateway.upstream_error",
             "upstream": "filesystem",
@@ -1163,7 +1165,9 @@ def test_relay_upstream_timeout_surfaces_as_502_and_is_audited() -> None:
     )
     assert resp.status_code == 502
     assert resp.json()["detail"] == "upstream error: timeout"
-    assert audit_events == [
+    assert audit_events[0]["event_type"] == "gateway.tool_call.allowed"
+    assert audit_events[0]["tool"] == "read_file"
+    assert audit_events[1:] == [
         {
             "action": "gateway.upstream_error",
             "upstream": "filesystem",
@@ -1335,7 +1339,9 @@ def test_relay_returns_503_when_managed_circuit_is_open() -> None:
     assert resp.status_code == 503
     assert resp.headers["retry-after"] == "12"
     assert resp.json()["detail"] == "upstream circuit open"
-    assert audit_events == [
+    assert audit_events[0]["event_type"] == "gateway.tool_call.allowed"
+    assert audit_events[0]["tool"] == "read_file"
+    assert audit_events[1:] == [
         {
             "action": "gateway.upstream_circuit_open",
             "upstream": "filesystem",

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -76,6 +76,17 @@ def test_healthz_lists_configured_upstreams() -> None:
         "status": "ok",
         "upstreams": ["filesystem", "jira"],
         "auth": {"incoming_token_required": False},
+        "audit_delivery": {
+            "configured": True,
+            "mode": "local_hmac_sqlite",
+            "status": "healthy",
+            "durable": True,
+            "accepting_events": True,
+            "backlog_observable": True,
+            "retry_worker_running": False,
+            "backlog_bytes": 0,
+            "dropped_events": 0,
+        },
         "upstream_runtime": {
             "pooled_http_client": True,
             "circuit_breaker_enabled": True,

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -1189,6 +1189,59 @@ def test_relay_upstream_timeout_surfaces_as_502_and_is_audited() -> None:
     ]
 
 
+@pytest.mark.parametrize(
+    ("failure", "expected_status", "expected_detail", "expected_retry_after"),
+    [
+        ("timeout", 502, "upstream error: timeout", None),
+        ("circuit", 503, "upstream circuit open", "12"),
+        ("general", 502, "upstream error: An internal error occurred. Please contact support.", None),
+    ],
+)
+def test_post_forward_error_audit_failure_never_masks_upstream_error(
+    failure: str,
+    expected_status: int,
+    expected_detail: str,
+    expected_retry_after: str | None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    audit_calls = 0
+
+    async def failing_caller(upstream, message, extra_headers):
+        if failure == "timeout":
+            raise asyncio.TimeoutError()
+        if failure == "circuit":
+            from agent_bom.gateway_server import GatewayCircuitOpenError
+
+            raise GatewayCircuitOpenError(upstream.name, 12)
+        raise RuntimeError("upstream-secret-token")
+
+    async def failing_after_admission_audit(event):
+        nonlocal audit_calls
+        audit_calls += 1
+        if audit_calls > 1:
+            raise RuntimeError("audit-secret-token")
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={},
+        upstream_caller=failing_caller,
+        audit_sink=failing_after_admission_audit,
+    )
+    with TestClient(create_gateway_app(settings), raise_server_exceptions=False) as client:
+        response = client.post(
+            "/mcp/filesystem",
+            json=_json_rpc("tools/call", name="read_file", arguments={"path": "/tmp/x"}),
+        )
+
+    assert response.status_code == expected_status
+    assert response.json()["detail"] == expected_detail
+    assert response.headers.get("Retry-After") == expected_retry_after
+    assert response.headers["X-Agent-Bom-Audit-Delivery"] == "degraded"
+    assert audit_calls == 2
+    assert "audit-secret-token" not in caplog.text
+    assert "upstream-secret-token" not in caplog.text
+
+
 def test_managed_upstream_relay_opens_circuit_after_repeated_failures() -> None:
     class _FailingResponse:
         content = b'{"error":"boom"}'

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1287,6 +1287,79 @@ def test_response_hmac_differs_from_payload_hash():
     assert compute_response_hmac(msg, "some-key") != compute_payload_hash(msg)
 
 
+@pytest.mark.asyncio
+async def test_proxy_restart_recovers_failed_audit_delivery_from_stable_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two real proxy lifecycles share the same durable delivery identity."""
+    from unittest.mock import AsyncMock
+
+    state_dir = tmp_path / "state"
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("AGENT_BOM_PROXY_POLICY_CACHE_PATH", str(tmp_path / "policy-cache.json"))
+    monkeypatch.delenv("AGENT_BOM_PROXY_AUDIT_SPILLOVER_PATH", raising=False)
+    monkeypatch.delenv("AGENT_BOM_PROXY_AUDIT_DLQ_PATH", raising=False)
+    monkeypatch.setattr(proxy_mod, "create_async_stdin_reader", AsyncMock(return_value=object()))
+    monkeypatch.setattr(proxy_mod, "read_async_stdin_line", AsyncMock(return_value=b""))
+    monkeypatch.setattr(proxy_mod, "_fetch_enabled_gateway_policies", AsyncMock(return_value=([], None)))
+
+    control_plane_url = "https://control.example.test"
+    paths = proxy_mod._proxy_audit_delivery_paths(
+        control_plane_url,
+        "default",
+        proxy_mod._generate_proxy_source_id(),
+    )
+    seeded = AuditSpilloverStore(
+        paths.spill_path,
+        paths.dlq_path,
+        max_spillover_bytes=8 * 1024 * 1024,
+    )
+    assert seeded.append_events([{"event_id": "restart-event", "decision": "deny"}]) == "spillover"
+
+    delivered: list[str] = []
+    attempts = 0
+
+    async def push_with_one_failure(
+        _base_url: str,
+        _token: str | None,
+        _source_id: str,
+        _session_id: str,
+        alerts: list[dict],
+        _summary: dict | None,
+    ) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            seeded.append_events([{"event_id": "during-failed-send", "decision": "deny"}])
+            raise RuntimeError("temporary 503")
+        if attempts == 2:
+            seeded.append_events([{"event_id": "during-successful-send", "decision": "deny"}])
+        delivered.extend(str(alert["event_id"]) for alert in alerts)
+
+    monkeypatch.setattr(proxy_mod, "_push_proxy_audit_batch", push_with_one_failure)
+    server_cmd = ["python3", "-c", "pass"]
+
+    assert await proxy_mod.run_proxy(server_cmd, control_plane_url=control_plane_url, metrics_port=0) == 0
+    after_failure = AuditSpilloverStore(
+        paths.spill_path,
+        paths.dlq_path,
+        max_spillover_bytes=8 * 1024 * 1024,
+    )
+    assert after_failure.read_spillover() == [
+        {"decision": "deny", "event_id": "restart-event"},
+        {"decision": "deny", "event_id": "during-failed-send"},
+    ]
+
+    assert await proxy_mod.run_proxy(server_cmd, control_plane_url=control_plane_url, metrics_port=0) == 0
+    assert delivered == ["restart-event", "during-failed-send"]
+    assert after_failure.read_spillover() == [{"decision": "deny", "event_id": "during-successful-send"}]
+
+    assert await proxy_mod.run_proxy(server_cmd, control_plane_url=control_plane_url, metrics_port=0) == 0
+    assert delivered == ["restart-event", "during-failed-send", "during-successful-send"]
+    assert after_failure.read_spillover() == []
+
+
 # ── ProxyMetrics relay_errors ───────────────────────────────────────────────
 
 

--- a/tests/test_runtime_audit_delivery.py
+++ b/tests/test_runtime_audit_delivery.py
@@ -8,8 +8,13 @@ backlog, retry, and health semantics in the next delivery slice.
 from __future__ import annotations
 
 import json
+import os
 import stat
+import threading
+import time
 from pathlib import Path
+
+import pytest
 
 from agent_bom.proxy import AuditDeliveryController as ProxyAuditDeliveryController
 from agent_bom.proxy import AuditSpilloverStore as ProxyAuditSpilloverStore
@@ -17,6 +22,7 @@ from agent_bom.runtime.audit_delivery import (
     AuditDeliveryController,
     AuditDeliveryState,
     AuditSpilloverStore,
+    audit_delivery_paths,
 )
 
 
@@ -130,3 +136,143 @@ def test_health_contains_only_sanitized_scalar_backlog_state(tmp_path: Path) -> 
     assert health["status"] == "degraded"
     assert health["backlog_bytes"] == 7 + store.spillover_size_bytes()
     assert secret_in_path not in json.dumps(health)
+
+
+def test_claim_ack_does_not_delete_an_event_appended_during_delivery(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.append_events([{"event_id": "before-send"}])
+
+    claim = store.claim_spillover()
+    assert claim is not None
+    assert [event["event_id"] for event in claim.events] == ["before-send"]
+
+    store.append_events([{"event_id": "during-send"}])
+    store.acknowledge_claim(claim)
+
+    assert store.read_spillover() == [{"event_id": "during-send"}]
+
+
+def test_failed_claim_restore_precedes_events_appended_during_delivery(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.append_events([{"event_id": "before-send"}])
+    claim = store.claim_spillover()
+    assert claim is not None
+
+    store.append_events([{"event_id": "during-send"}])
+    store.restore_claim(claim)
+
+    assert store.read_spillover() == [
+        {"event_id": "before-send"},
+        {"event_id": "during-send"},
+    ]
+
+
+def test_failed_claim_restore_persists_in_memory_snapshot_before_new_appends(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.append_events([{"event_id": "spilled-before-send"}])
+    claim = store.claim_spillover()
+    assert claim is not None
+
+    store.append_events([{"event_id": "spilled-during-send"}])
+    assert store.restore_claim(claim, [{"event_id": "memory-before-send"}]) == "spillover"
+
+    assert store.read_spillover() == [
+        {"event_id": "spilled-before-send"},
+        {"event_id": "memory-before-send"},
+        {"event_id": "spilled-during-send"},
+    ]
+
+
+def test_second_store_does_not_recover_a_live_claim(tmp_path: Path) -> None:
+    first = _store(tmp_path)
+    second = _store(tmp_path)
+    first.append_events([{"event_id": "first-claim"}])
+    first_claim = first.claim_spillover()
+    assert first_claim is not None
+
+    second.append_events([{"event_id": "second-claim"}])
+    second_claim = second.claim_spillover()
+    assert second_claim is not None
+
+    assert [event["event_id"] for event in first_claim.events] == ["first-claim"]
+    assert [event["event_id"] for event in second_claim.events] == ["second-claim"]
+    first.acknowledge_claim(first_claim)
+    second.restore_claim(second_claim)
+    assert second.read_spillover() == [{"event_id": "second-claim"}]
+
+
+def test_restart_load_recovers_an_unregistered_claim(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.append_events([{"event_id": "crash-recovery"}])
+    orphan = store.spill_path.with_name(
+        f"{store.spill_path.name}.claim-{time.time_ns():020d}-{os.getpid()}-orphan"
+    )
+    store.spill_path.rename(orphan)
+
+    restarted = _store(tmp_path)
+    assert restarted.read_spillover() == [{"event_id": "crash-recovery"}]
+    assert not orphan.exists()
+
+
+def test_two_store_instances_share_one_bound_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    spill = tmp_path / "shared.spill.jsonl"
+    dlq = tmp_path / "shared.dlq.jsonl"
+    first = AuditSpilloverStore(spill, dlq, max_spillover_bytes=90, max_dlq_bytes=90)
+    second = AuditSpilloverStore(spill, dlq, max_spillover_bytes=90, max_dlq_bytes=90)
+    original_size = AuditSpilloverStore._size_bytes
+    def synchronized_size(path: Path) -> int:
+        size = original_size(path)
+        if path == spill:
+            # Release the GIL between the bound check and append. Independent
+            # per-instance locks then deterministically observe the same size;
+            # the shared lock must serialize this whole critical section.
+            time.sleep(0.05)
+        return size
+
+    monkeypatch.setattr(AuditSpilloverStore, "_size_bytes", staticmethod(synchronized_size))
+    results: list[str] = []
+
+    def append(store: AuditSpilloverStore, event_id: str) -> None:
+        results.append(store.append_events([{"event_id": event_id, "padding": "x" * 30}]))
+
+    threads = [
+        threading.Thread(target=append, args=(first, "event-a")),
+        threading.Thread(target=append, args=(second, "event-b")),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=3)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert first.spillover_size_bytes() <= first.max_spillover_bytes
+    assert first.dlq_size_bytes() <= first.dlq_limit_bytes
+    assert sorted(results) == ["dlq", "spillover"]
+
+
+def test_direct_symlink_parent_is_rejected(tmp_path: Path) -> None:
+    real_parent = tmp_path / "real"
+    real_parent.mkdir()
+    symlink_parent = tmp_path / "linked"
+    symlink_parent.symlink_to(real_parent, target_is_directory=True)
+    store = AuditSpilloverStore(
+        spill_path=symlink_parent / "spill.jsonl",
+        dlq_path=symlink_parent / "dlq.jsonl",
+        max_spillover_bytes=4096,
+        max_dlq_bytes=4096,
+    )
+
+    with pytest.raises(ValueError, match="parent directory must not be a symlink"):
+        store.append_events([{"event_id": "symlink-parent"}])
+
+
+def test_state_dir_paths_are_stable_and_do_not_embed_identity(tmp_path: Path) -> None:
+    identity = "https://user:secret@control.example.test/default/proxy-a"
+
+    first = audit_delivery_paths(tmp_path, surface="proxy", identity=identity)
+    second = audit_delivery_paths(tmp_path, surface="proxy", identity=identity)
+
+    assert first == second
+    assert first.spill_path.parent == tmp_path / "runtime-audit"
+    assert identity not in str(first.spill_path)
+    assert "secret" not in str(first.spill_path)

--- a/tests/test_runtime_audit_delivery.py
+++ b/tests/test_runtime_audit_delivery.py
@@ -281,6 +281,31 @@ def test_direct_symlink_parent_is_rejected(tmp_path: Path) -> None:
         store.append_events([{"event_id": "symlink-parent"}])
 
 
+def test_hardlinked_spill_file_is_rejected_without_mutating_target(tmp_path: Path) -> None:
+    victim = tmp_path / "victim.jsonl"
+    victim.write_text('{"private":"unchanged"}\n', encoding="utf-8")
+    store = _store(tmp_path)
+    os.link(victim, store.spill_path)
+
+    with pytest.raises(ValueError, match="single-link regular file"):
+        store.append_events([{"event_id": "must-not-append"}])
+
+    assert victim.read_text(encoding="utf-8") == '{"private":"unchanged"}\n'
+
+
+def test_hardlinked_lock_file_is_rejected_without_mutating_target(tmp_path: Path) -> None:
+    victim = tmp_path / "victim.lock"
+    victim.write_text("unchanged\n", encoding="utf-8")
+    store = _store(tmp_path)
+    lock_path = store.spill_path.with_name(f".{store.spill_path.name}.lock")
+    os.link(victim, lock_path)
+
+    with pytest.raises(ValueError, match="single-link regular file"):
+        store.append_events([{"event_id": "must-not-lock"}])
+
+    assert victim.read_text(encoding="utf-8") == "unchanged\n"
+
+
 def test_state_dir_paths_are_stable_and_do_not_embed_identity(tmp_path: Path) -> None:
     identity = "https://user:secret@control.example.test/default/proxy-a"
 

--- a/tests/test_runtime_audit_delivery.py
+++ b/tests/test_runtime_audit_delivery.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import os
 import stat
+import sys
 import threading
 import time
 from pathlib import Path
@@ -23,6 +24,7 @@ from agent_bom.runtime.audit_delivery import (
     AuditDeliveryState,
     AuditSpilloverStore,
     audit_delivery_paths,
+    canonical_runtime_state_path,
 )
 
 
@@ -219,9 +221,7 @@ def test_second_store_does_not_recover_a_live_claim(tmp_path: Path) -> None:
 def test_restart_load_recovers_an_unregistered_claim(tmp_path: Path) -> None:
     store = _store(tmp_path)
     store.append_events([{"event_id": "crash-recovery"}])
-    orphan = store.spill_path.with_name(
-        f"{store.spill_path.name}.claim-{time.time_ns():020d}-{os.getpid()}-orphan"
-    )
+    orphan = store.spill_path.with_name(f"{store.spill_path.name}.claim-{time.time_ns():020d}-{os.getpid()}-orphan")
     store.spill_path.rename(orphan)
 
     restarted = _store(tmp_path)
@@ -235,6 +235,7 @@ def test_two_store_instances_share_one_bound_lock(tmp_path: Path, monkeypatch: p
     first = AuditSpilloverStore(spill, dlq, max_spillover_bytes=90, max_dlq_bytes=90)
     second = AuditSpilloverStore(spill, dlq, max_spillover_bytes=90, max_dlq_bytes=90)
     original_size = AuditSpilloverStore._size_bytes
+
     def synchronized_size(path: Path) -> int:
         size = original_size(path)
         if path == spill:
@@ -322,6 +323,28 @@ def test_hardlinked_lock_file_is_rejected_without_mutating_target(tmp_path: Path
         store.append_events([{"event_id": "must-not-lock"}])
 
     assert victim.read_text(encoding="utf-8") == "unchanged\n"
+
+
+def test_private_key_rejects_symlink_and_hardlink_aliases(tmp_path: Path) -> None:
+    victim = tmp_path / "victim.key"
+    victim.write_bytes(b"v" * 32)
+
+    symlink_key = tmp_path / "symlink.key"
+    symlink_key.symlink_to(victim)
+    with pytest.raises((OSError, ValueError)):
+        AuditSpilloverStore.load_or_create_private_key(symlink_key)
+
+    hardlink_key = tmp_path / "hardlink.key"
+    os.link(victim, hardlink_key)
+    with pytest.raises(ValueError, match="single-link regular file"):
+        AuditSpilloverStore.load_or_create_private_key(hardlink_key)
+
+    assert victim.read_bytes() == b"v" * 32
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS fixed /tmp alias only")
+def test_macos_fixed_tmp_alias_is_canonicalized_without_general_symlink_following() -> None:
+    assert canonical_runtime_state_path(Path("/tmp/agent-bom/audit")) == Path("/private/tmp/agent-bom/audit")
 
 
 def test_state_dir_paths_are_stable_and_do_not_embed_identity(tmp_path: Path) -> None:

--- a/tests/test_runtime_audit_delivery.py
+++ b/tests/test_runtime_audit_delivery.py
@@ -1,0 +1,132 @@
+"""Shared runtime audit-delivery foundation contracts.
+
+The stdio proxy remains a compatibility surface, while the implementation is
+owned by ``agent_bom.runtime`` so the HTTP gateway can reuse the same bounded
+backlog, retry, and health semantics in the next delivery slice.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+from agent_bom.proxy import AuditDeliveryController as ProxyAuditDeliveryController
+from agent_bom.proxy import AuditSpilloverStore as ProxyAuditSpilloverStore
+from agent_bom.runtime.audit_delivery import (
+    AuditDeliveryController,
+    AuditDeliveryState,
+    AuditSpilloverStore,
+)
+
+
+def _store(tmp_path: Path, *, spill_bytes: int = 4096, dlq_bytes: int = 4096) -> AuditSpilloverStore:
+    return AuditSpilloverStore(
+        spill_path=tmp_path / "audit.spill.jsonl",
+        dlq_path=tmp_path / "audit.dlq.jsonl",
+        max_spillover_bytes=spill_bytes,
+        max_dlq_bytes=dlq_bytes,
+    )
+
+
+def test_proxy_exports_the_shared_delivery_primitives_without_behavioral_fork() -> None:
+    assert ProxyAuditDeliveryController is AuditDeliveryController
+    assert ProxyAuditSpilloverStore is AuditSpilloverStore
+
+    controller = ProxyAuditDeliveryController(
+        base_interval_seconds=10,
+        max_backoff_seconds=60,
+        breaker_failure_threshold=3,
+        breaker_cooldown_seconds=30,
+    )
+    controller.record_failure(now=100.0)
+    controller.record_failure(now=101.0)
+    controller.record_failure(now=102.0)
+
+    assert controller.is_circuit_open(now=102.0) is True
+    assert controller.current_backoff_seconds(now=102.0) == 30
+    controller.record_success()
+    assert controller.current_backoff_seconds(now=102.0) == 10
+
+
+def test_persisted_backlog_is_bounded_private_and_secret_safe(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    opaque = "sk-" + "audit-delivery-example-value-1234567890"
+    event = {
+        "event_id": "gw_event_1",
+        "api_token": opaque,
+        "headers": {"authorization": f"Bearer {opaque}"},
+        "safe": "profile_revoked",
+    }
+
+    assert store.append_events([event]) == "spillover"
+
+    persisted = store.spill_path.read_text(encoding="utf-8")
+    assert opaque not in persisted
+    assert "Bearer" not in persisted
+    assert json.loads(persisted)["event_id"] == "gw_event_1"
+    assert json.loads(persisted)["safe"] == "profile_revoked"
+    assert stat.S_IMODE(store.spill_path.stat().st_mode) == 0o600
+    assert store.spillover_size_bytes() <= store.max_spillover_bytes
+
+    dlq_store = _store(tmp_path / "dlq", spill_bytes=1)
+    assert dlq_store.append_events([event]) == "dlq"
+    dlq_persisted = dlq_store.dlq_path.read_text(encoding="utf-8")
+    assert opaque not in dlq_persisted
+    assert "Bearer" not in dlq_persisted
+    assert stat.S_IMODE(dlq_store.dlq_path.stat().st_mode) == 0o600
+    assert dlq_store.dlq_size_bytes() <= dlq_store.dlq_limit_bytes
+
+
+def test_backlog_survives_a_new_delivery_state_and_loads_sanitized_events(tmp_path: Path) -> None:
+    first_store = _store(tmp_path)
+    assert first_store.append_events([{"event_id": "gw_restart_1", "decision": "deny"}]) == "spillover"
+
+    restarted_store = _store(tmp_path)
+    restarted = AuditDeliveryState(
+        controller=AuditDeliveryController(base_interval_seconds=5),
+        store=restarted_store,
+    )
+
+    assert restarted_store.read_spillover() == [{"decision": "deny", "event_id": "gw_restart_1"}]
+    assert restarted.health(buffer_bytes=0)["backlog_bytes"] == restarted_store.spillover_size_bytes()
+
+
+def test_dlq_is_bounded_and_reports_drop_without_persisting_payload(tmp_path: Path) -> None:
+    store = _store(tmp_path, spill_bytes=1, dlq_bytes=1)
+
+    assert store.append_events([{"event_id": "too-large", "payload": "x" * 100}]) == "dropped"
+    assert store.spillover_size_bytes() == 0
+    assert store.dlq_size_bytes() == 0
+    assert store.dropped_events == 1
+
+
+def test_health_contains_only_sanitized_scalar_backlog_state(tmp_path: Path) -> None:
+    secret_in_path = "do-not-surface-this-token"
+    store = AuditSpilloverStore(
+        spill_path=tmp_path / secret_in_path / "spill.jsonl",
+        dlq_path=tmp_path / secret_in_path / "dlq.jsonl",
+        max_spillover_bytes=4096,
+        max_dlq_bytes=4096,
+    )
+    store.append_events([{"event_id": "gw_health_1", "token": secret_in_path}])
+    controller = AuditDeliveryController(base_interval_seconds=10)
+    controller.record_failure(now=100.0)
+    state = AuditDeliveryState(controller=controller, store=store)
+
+    health = state.health(buffer_bytes=7, now=100.0)
+
+    assert set(health) == {
+        "status",
+        "buffer_bytes",
+        "spillover_bytes",
+        "dlq_bytes",
+        "backlog_bytes",
+        "consecutive_failures",
+        "backoff_seconds",
+        "circuit_open",
+        "dropped_events",
+    }
+    assert health["status"] == "degraded"
+    assert health["backlog_bytes"] == 7 + store.spillover_size_bytes()
+    assert secret_in_path not in json.dumps(health)

--- a/tests/test_runtime_audit_delivery.py
+++ b/tests/test_runtime_audit_delivery.py
@@ -183,6 +183,21 @@ def test_failed_claim_restore_persists_in_memory_snapshot_before_new_appends(tmp
     ]
 
 
+def test_acknowledging_claim_prefix_leaves_only_ordered_remainder(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    events = [{"event_id": f"event-{index}"} for index in range(7)]
+    store.append_events(events)
+
+    claim = store.claim_spillover()
+    assert claim is not None
+    remainder = store.acknowledge_claim_prefix(claim, 5)
+
+    assert remainder is not None
+    assert [event["event_id"] for event in remainder.events] == ["event-5", "event-6"]
+    store.restore_claim(remainder)
+    assert store.read_spillover() == events[5:]
+
+
 def test_second_store_does_not_recover_a_live_claim(tmp_path: Path) -> None:
     first = _store(tmp_path)
     second = _store(tmp_path)

--- a/tests/test_runtime_audit_delivery.py
+++ b/tests/test_runtime_audit_delivery.py
@@ -277,8 +277,26 @@ def test_direct_symlink_parent_is_rejected(tmp_path: Path) -> None:
         max_dlq_bytes=4096,
     )
 
-    with pytest.raises(ValueError, match="parent directory must not be a symlink"):
+    with pytest.raises(ValueError, match="must not contain symlink ancestors"):
         store.append_events([{"event_id": "symlink-parent"}])
+
+
+def test_symlinked_parent_ancestor_is_rejected_without_creating_external_state(tmp_path: Path) -> None:
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(victim, target_is_directory=True)
+    store = AuditSpilloverStore(
+        spill_path=alias / "nested" / "spill.jsonl",
+        dlq_path=alias / "nested" / "dlq.jsonl",
+        max_spillover_bytes=4096,
+        max_dlq_bytes=4096,
+    )
+
+    with pytest.raises(ValueError, match="must not contain symlink ancestors"):
+        store.append_events([{"event_id": "symlink-ancestor"}])
+
+    assert not (victim / "nested").exists()
 
 
 def test_hardlinked_spill_file_is_rejected_without_mutating_target(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- persist canonical gateway decisions through bounded, retryable audit delivery before tool execution
- retain ordering, idempotency, tenant binding, redaction, and restart-stable local audit integrity
- fail closed when admission is unavailable while preserving already-produced upstream outcomes if post-forward auditing degrades
- require the supported single-writer PVC topology for Helm gateway deployments

## Verification

- `uv run pytest -q` on the focused gateway/runtime/API/Helm matrix: 229 passed
- exact blocker subset: 11 passed
- eight-process local audit stress: 600 entries; all tenant chains verified
- `uv run ruff check` on changed Python/tests
- `uv run mypy` on changed production modules
- `uv run python scripts/check_exception_sanitization.py`
- `uv run python scripts/check_public_docs_hygiene.py`
- `python scripts/validate_helm_profiles.py`
- `helm lint` and supported profile renders
- `make preflight`
- `git diff --check`

## Notes

- Gateway runtime remains single-writer for durable local spool ownership. Multi-writer scaling stays disabled until shared delivery leases are implemented.
- A gateway process currently uses one tenant-bound control-plane audit credential; cross-tenant events fail closed.