### PR TITLE
fix(runtime): isolate tenant audit routing

### DIFF
--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -105,6 +105,13 @@ the same `/v1/proxy/audit` HMAC-chained relay. Each event carries:
 - the policy version that produced it,
 - a hash chain link so tampering is detectable.
 
+For a control-plane-connected multi-tenant gateway, an API key is first
+validated by the gateway and then reused only for that tenant's audit ingest.
+Each tenant has a distinct restart-stable backlog and retry state; an event is
+rejected before upstream execution if its tenant does not match the validated
+credential. Static gateway bearer and broker tokens remain bound to the
+operator-configured `AGENT_BOM_TENANT_ID` and do not impersonate other tenants.
+
 The chain is described in `docs/PROXY_AUDIT_LOG.md`. Operators reading
 audit output can attribute every denial to exactly one layer; the
 precedence rules in `docs/POLICY_PRECEDENCE.md` guarantee no event has

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -111,6 +111,10 @@ Each tenant has a distinct restart-stable backlog and retry state; an event is
 rejected before upstream execution if its tenant does not match the validated
 credential. Static gateway bearer and broker tokens remain bound to the
 operator-configured `AGENT_BOM_TENANT_ID` and do not impersonate other tenants.
+The restart registry stores only a bounded tenant identifier marker—never an
+API key or bearer token. After restart, any discovered tenant backlog remains
+degraded and blocks readiness until a newly authenticated request rebinds that
+tenant's credential; malformed or unsafe registry state fails closed.
 
 The chain is described in `docs/PROXY_AUDIT_LOG.md`. Operators reading
 audit output can attribute every denial to exactly one layer; the

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -120,6 +120,8 @@ UpstreamCaller = Callable[[UpstreamConfig, dict[str, Any], dict[str, str]], Awai
 _GATEWAY_AUDIT_SPILLOVER_BYTES = 8 * 1024 * 1024
 _GATEWAY_AUDIT_DLQ_BYTES = 64 * 1024 * 1024
 _GATEWAY_AUDIT_MAX_TENANT_SINKS = 256
+_GATEWAY_AUDIT_TENANT_MARKER_MAX_BYTES = 4096
+_GATEWAY_AUDIT_TENANT_ID_MAX_BYTES = 512
 
 
 class GatewayAuditDeliveryUnavailableError(RuntimeError):
@@ -1267,6 +1269,135 @@ async def _send_gateway_audit_batch(
     return body
 
 
+class _GatewayAuditTenantRegistry:
+    """Secret-free durable discovery markers for tenant audit backlogs."""
+
+    def __init__(self, state_dir: Path, *, source_id: str, audit_url: str) -> None:
+        router_identity = f"{source_id}\0{audit_url}"
+        router_digest = hashlib.sha256(router_identity.encode("utf-8")).hexdigest()[:20]
+        self._root = canonical_runtime_state_path(state_dir) / "runtime-audit"
+        self._prefix = f"gateway-router-{router_digest}-"
+
+    @staticmethod
+    def _normalize_tenant_id(tenant_id: str) -> str:
+        normalized = tenant_id.strip()
+        encoded = normalized.encode("utf-8")
+        if not normalized or len(encoded) > _GATEWAY_AUDIT_TENANT_ID_MAX_BYTES or any(ord(character) < 32 for character in normalized):
+            raise ValueError("gateway audit tenant id is invalid")
+        return normalized
+
+    def _marker_name(self, tenant_id: str) -> str:
+        normalized = self._normalize_tenant_id(tenant_id)
+        digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:20]
+        return f"{self._prefix}{digest}.tenant.json"
+
+    def _parent_fd(self) -> int:
+        return AuditSpilloverStore._safe_parent_fd(self._root / ".tenant-registry")
+
+    def register(self, tenant_id: str) -> None:
+        """Atomically persist one tenant identity without its credential."""
+
+        normalized = self._normalize_tenant_id(tenant_id)
+        marker_name = self._marker_name(normalized)
+        content = json.dumps(
+            {"schema_version": 1, "tenant_id": normalized},
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        if len(content) > _GATEWAY_AUDIT_TENANT_MARKER_MAX_BYTES:
+            raise ValueError("gateway audit tenant marker is too large")
+        parent_fd = self._parent_fd()
+        temp_name = f".{marker_name}.tmp-{os.urandom(8).hex()}"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        if hasattr(os, "O_CLOEXEC"):
+            flags |= os.O_CLOEXEC
+        fd = -1
+        try:
+            try:
+                existing = os.stat(marker_name, dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                pass
+            else:
+                AuditSpilloverStore._validate_single_link_regular(existing)
+            fd = os.open(temp_name, flags, 0o600, dir_fd=parent_fd)
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "wb") as handle:
+                fd = -1
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_name, marker_name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            os.fsync(parent_fd)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            try:
+                os.unlink(temp_name, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+            os.close(parent_fd)
+
+    def discover(self) -> list[str]:
+        """Load and validate every marker for this control-plane route."""
+
+        parent_fd = self._parent_fd()
+        tenants: set[str] = set()
+        read_flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            read_flags |= os.O_NOFOLLOW
+        if hasattr(os, "O_CLOEXEC"):
+            read_flags |= os.O_CLOEXEC
+        try:
+            names = sorted(
+                name
+                for name in os.listdir(parent_fd)
+                if name.startswith(self._prefix) and name.endswith(".tenant.json")
+            )
+            for name in names:
+                fd = os.open(name, read_flags, dir_fd=parent_fd)
+                try:
+                    file_stat = os.fstat(fd)
+                    AuditSpilloverStore._validate_single_link_regular(file_stat)
+                    if file_stat.st_mode & 0o077:
+                        raise ValueError("gateway audit tenant marker permissions must be owner-only")
+                    if file_stat.st_size > _GATEWAY_AUDIT_TENANT_MARKER_MAX_BYTES:
+                        raise ValueError("gateway audit tenant marker is too large")
+                    with os.fdopen(fd, "rb") as handle:
+                        fd = -1
+                        raw = handle.read(_GATEWAY_AUDIT_TENANT_MARKER_MAX_BYTES + 1)
+                finally:
+                    if fd >= 0:
+                        os.close(fd)
+                payload = json.loads(raw.decode("utf-8"))
+                if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+                    raise ValueError("gateway audit tenant marker schema is invalid")
+                tenant_id = self._normalize_tenant_id(str(payload.get("tenant_id") or ""))
+                if name != self._marker_name(tenant_id):
+                    raise ValueError("gateway audit tenant marker identity is invalid")
+                tenants.add(tenant_id)
+        finally:
+            os.close(parent_fd)
+        return sorted(tenants)
+
+    def unregister(self, tenant_id: str) -> None:
+        """Remove a marker only after its durable backlog is empty."""
+
+        marker_name = self._marker_name(tenant_id)
+        parent_fd = self._parent_fd()
+        try:
+            try:
+                existing = os.stat(marker_name, dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                return
+            AuditSpilloverStore._validate_single_link_regular(existing)
+            os.unlink(marker_name, dir_fd=parent_fd)
+            os.fsync(parent_fd)
+        finally:
+            os.close(parent_fd)
+
+
 class ControlPlaneAuditSink:
     """Durably queue and retry standalone-gateway audit delivery.
 
@@ -1286,6 +1417,7 @@ class ControlPlaneAuditSink:
         session_id: str,
         delivery_state: AuditDeliveryState,
         sender: GatewayAuditSender,
+        tenant_registry: _GatewayAuditTenantRegistry | None = None,
         tenant_routing_enabled: bool = True,
         max_tenant_sinks: int = _GATEWAY_AUDIT_MAX_TENANT_SINKS,
     ) -> None:
@@ -1296,6 +1428,8 @@ class ControlPlaneAuditSink:
         self._session_id = session_id
         self._delivery_state = delivery_state
         self._sender = sender
+        self._tenant_registry = tenant_registry
+        self._tenant_registry_available = True
         self._lock = asyncio.Lock()
         self._worker: asyncio.Task[None] | None = None
         self._closed = False
@@ -1312,6 +1446,8 @@ class ControlPlaneAuditSink:
         normalized_tenant = tenant_id.strip()
         if not normalized_tenant:
             raise GatewayAuditDeliveryUnavailableError("authenticated audit tenant is unavailable")
+        if self._tenant_registry is not None and not self._tenant_registry_available:
+            raise GatewayAuditDeliveryUnavailableError("tenant audit routing registry is unavailable")
         if normalized_tenant == self._tenant_id:
             if token:
                 self._token = token
@@ -1323,6 +1459,14 @@ class ControlPlaneAuditSink:
             if sink is None:
                 if len(self._tenant_sinks) >= self._max_tenant_sinks:
                     raise GatewayAuditDeliveryUnavailableError("tenant audit routing capacity is unavailable")
+                if self._tenant_registry is None:
+                    raise GatewayAuditDeliveryUnavailableError("tenant audit routing registry is unavailable")
+                try:
+                    self._tenant_registry.register(normalized_tenant)
+                except Exception as exc:  # noqa: BLE001 - registry integrity is fail-closed
+                    self._tenant_registry_available = False
+                    logger.error("Gateway audit tenant registry unavailable (error_type=%s)", type(exc).__name__)
+                    raise GatewayAuditDeliveryUnavailableError("tenant audit routing registry is unavailable") from None
                 sink = build_control_plane_audit_sink(
                     self._base_url,
                     token,
@@ -1336,8 +1480,44 @@ class ControlPlaneAuditSink:
                 await sink.start()
             else:
                 sink._token = token
+                sink._remote_ack_available = True
+                await sink.start()
+
+    async def _recover_tenant_sinks(self) -> None:
+        """Reconstruct unbound child queues so restart health remains truthful."""
+
+        if self._tenant_registry is None or self._tenant_sinks:
+            return
+        try:
+            tenant_ids = self._tenant_registry.discover()
+            for tenant_id in tenant_ids:
+                if tenant_id == self._tenant_id:
+                    self._tenant_registry.unregister(tenant_id)
+                    continue
+                if len(self._tenant_sinks) >= self._max_tenant_sinks:
+                    raise ValueError("gateway audit tenant registry exceeds configured capacity")
+                sink = build_control_plane_audit_sink(
+                    self._base_url,
+                    None,
+                    tenant_id=tenant_id,
+                    source_id=self._source_id,
+                    sender=self._sender,
+                    tenant_routing_enabled=False,
+                    max_tenant_sinks=0,
+                )
+                child_health = sink._own_health()
+                if bool(child_health["backlog_observable"]) and int(child_health["backlog_bytes"]) == 0:
+                    self._tenant_registry.unregister(tenant_id)
+                    continue
+                sink._remote_ack_available = False
+                self._tenant_sinks[tenant_id] = sink
+        except Exception as exc:  # noqa: BLE001 - undiscoverable durable state is fail-closed
+            self._tenant_registry_available = False
+            logger.error("Gateway audit tenant registry recovery failed (error_type=%s)", type(exc).__name__)
 
     def _sink_for_event(self, event: dict[str, Any]) -> ControlPlaneAuditSink:
+        if self._tenant_registry is not None and not self._tenant_registry_available:
+            raise GatewayAuditDeliveryUnavailableError("tenant audit routing registry is unavailable")
         event_tenant = str(event.get("tenant_id") or "")
         if event_tenant == self._tenant_id:
             return self
@@ -1490,14 +1670,24 @@ class ControlPlaneAuditSink:
         if self._worker is not None:
             return
         self._closed = False
+        await self._recover_tenant_sinks()
         await self.flush_once()
         self._worker = asyncio.create_task(self._retry_loop(), name="gateway-audit-delivery")
 
     async def aclose(self) -> None:
         self._closed = True
-        children = list(self._tenant_sinks.values())
-        for child in children:
+        children = list(self._tenant_sinks.items())
+        for _tenant_id, child in children:
             await child.aclose()
+        if self._tenant_registry is not None:
+            for tenant_id, child in children:
+                try:
+                    child_health = child._own_health()
+                    if bool(child_health["backlog_observable"]) and int(child_health["backlog_bytes"]) == 0:
+                        self._tenant_registry.unregister(tenant_id)
+                except Exception as exc:  # noqa: BLE001 - shutdown remains secret-free
+                    self._tenant_registry_available = False
+                    logger.error("Gateway audit tenant registry cleanup failed (error_type=%s)", type(exc).__name__)
         if self._worker is None:
             return
         self._worker.cancel()
@@ -1547,29 +1737,39 @@ class ControlPlaneAuditSink:
     def health(self) -> dict[str, str | int | bool]:
         health = self._own_health()
         child_health = [sink._own_health() for sink in self._tenant_sinks.values()]
-        if not child_health:
-            return health
-        all_health = [health, *child_health]
-        health.update(
-            {
-                "status": "degraded" if any(item["status"] != "healthy" for item in all_health) else "healthy",
-                "durable": all(bool(item["durable"]) for item in all_health),
-                "accepting_events": all(bool(item["accepting_events"]) for item in all_health),
-                "backlog_observable": all(bool(item["backlog_observable"]) for item in all_health),
-                "remote_acknowledgement_available": all(bool(item["remote_acknowledgement_available"]) for item in all_health),
-                "retry_worker_running": all(bool(item["retry_worker_running"]) for item in all_health),
-                "buffer_bytes": sum(int(item["buffer_bytes"]) for item in all_health),
-                "spillover_bytes": sum(int(item["spillover_bytes"]) for item in all_health),
-                "dlq_bytes": sum(int(item["dlq_bytes"]) for item in all_health),
-                "backlog_bytes": sum(int(item["backlog_bytes"]) for item in all_health),
-                "consecutive_failures": sum(int(item["consecutive_failures"]) for item in all_health),
-                "backoff_seconds": max(int(item["backoff_seconds"]) for item in all_health),
-                "circuit_open": any(bool(item["circuit_open"]) for item in all_health),
-                "dropped_events": sum(int(item["dropped_events"]) for item in all_health),
-                "tenant_sink_count": len(child_health) + 1,
-                "tenant_sink_capacity": self._max_tenant_sinks + 1,
-            }
-        )
+        if child_health:
+            all_health = [health, *child_health]
+            health.update(
+                {
+                    "status": "degraded" if any(item["status"] != "healthy" for item in all_health) else "healthy",
+                    "durable": all(bool(item["durable"]) for item in all_health),
+                    "accepting_events": all(bool(item["accepting_events"]) for item in all_health),
+                    "backlog_observable": all(bool(item["backlog_observable"]) for item in all_health),
+                    "remote_acknowledgement_available": all(bool(item["remote_acknowledgement_available"]) for item in all_health),
+                    "retry_worker_running": all(bool(item["retry_worker_running"]) for item in all_health),
+                    "buffer_bytes": sum(int(item["buffer_bytes"]) for item in all_health),
+                    "spillover_bytes": sum(int(item["spillover_bytes"]) for item in all_health),
+                    "dlq_bytes": sum(int(item["dlq_bytes"]) for item in all_health),
+                    "backlog_bytes": sum(int(item["backlog_bytes"]) for item in all_health),
+                    "consecutive_failures": sum(int(item["consecutive_failures"]) for item in all_health),
+                    "backoff_seconds": max(int(item["backoff_seconds"]) for item in all_health),
+                    "circuit_open": any(bool(item["circuit_open"]) for item in all_health),
+                    "dropped_events": sum(int(item["dropped_events"]) for item in all_health),
+                    "tenant_sink_count": len(child_health) + 1,
+                    "tenant_sink_capacity": self._max_tenant_sinks + 1,
+                }
+            )
+        if self._tenant_registry is not None:
+            health["tenant_registry_available"] = self._tenant_registry_available
+            if not self._tenant_registry_available:
+                health.update(
+                    {
+                        "status": "degraded",
+                        "durable": False,
+                        "accepting_events": False,
+                        "backlog_observable": False,
+                    }
+                )
         return health
 
 
@@ -1701,6 +1901,11 @@ def build_control_plane_audit_sink(
     )
     active_spill_path = spill_path or stable_paths.spill_path
     active_dlq_path = dlq_path or stable_paths.dlq_path
+    tenant_registry = (
+        _GatewayAuditTenantRegistry(state_dir, source_id=source_id, audit_url=audit_url)
+        if tenant_routing_enabled and max_tenant_sinks > 0
+        else None
+    )
     controller = AuditDeliveryController()
     store = AuditSpilloverStore(
         spill_path=active_spill_path,
@@ -1726,6 +1931,7 @@ def build_control_plane_audit_sink(
         session_id=active_session_id,
         delivery_state=AuditDeliveryState(controller=controller, store=store),
         sender=active_sender,
+        tenant_registry=tenant_registry,
         tenant_routing_enabled=tenant_routing_enabled,
         max_tenant_sinks=max_tenant_sinks,
     )

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -119,6 +119,7 @@ UpstreamCaller = Callable[[UpstreamConfig, dict[str, Any], dict[str, str]], Awai
 
 _GATEWAY_AUDIT_SPILLOVER_BYTES = 8 * 1024 * 1024
 _GATEWAY_AUDIT_DLQ_BYTES = 64 * 1024 * 1024
+_GATEWAY_AUDIT_MAX_TENANT_SINKS = 256
 
 
 class GatewayAuditDeliveryUnavailableError(RuntimeError):
@@ -1278,13 +1279,17 @@ class ControlPlaneAuditSink:
     def __init__(
         self,
         *,
+        base_url: str,
         token: str | None,
         tenant_id: str,
         source_id: str,
         session_id: str,
         delivery_state: AuditDeliveryState,
         sender: GatewayAuditSender,
+        tenant_routing_enabled: bool = True,
+        max_tenant_sinks: int = _GATEWAY_AUDIT_MAX_TENANT_SINKS,
     ) -> None:
+        self._base_url = base_url.rstrip("/")
         self._token = token
         self._tenant_id = tenant_id
         self._source_id = source_id
@@ -1296,6 +1301,50 @@ class ControlPlaneAuditSink:
         self._closed = False
         self._persistence_available = True
         self._remote_ack_available = True
+        self._tenant_routing_enabled = tenant_routing_enabled
+        self._max_tenant_sinks = max_tenant_sinks
+        self._tenant_sinks: dict[str, ControlPlaneAuditSink] = {}
+        self._tenant_sinks_lock = asyncio.Lock()
+
+    async def bind_authenticated_tenant(self, tenant_id: str, token: str | None) -> None:
+        """Bind one verified request credential to an isolated tenant queue."""
+
+        normalized_tenant = tenant_id.strip()
+        if not normalized_tenant:
+            raise GatewayAuditDeliveryUnavailableError("authenticated audit tenant is unavailable")
+        if normalized_tenant == self._tenant_id:
+            if token:
+                self._token = token
+            return
+        if not self._tenant_routing_enabled or not token:
+            raise GatewayAuditDeliveryUnavailableError("no tenant-bound audit credential is available")
+        async with self._tenant_sinks_lock:
+            sink = self._tenant_sinks.get(normalized_tenant)
+            if sink is None:
+                if len(self._tenant_sinks) >= self._max_tenant_sinks:
+                    raise GatewayAuditDeliveryUnavailableError("tenant audit routing capacity is unavailable")
+                sink = build_control_plane_audit_sink(
+                    self._base_url,
+                    token,
+                    tenant_id=normalized_tenant,
+                    source_id=self._source_id,
+                    sender=self._sender,
+                    tenant_routing_enabled=False,
+                    max_tenant_sinks=0,
+                )
+                self._tenant_sinks[normalized_tenant] = sink
+                await sink.start()
+            else:
+                sink._token = token
+
+    def _sink_for_event(self, event: dict[str, Any]) -> ControlPlaneAuditSink:
+        event_tenant = str(event.get("tenant_id") or "")
+        if event_tenant == self._tenant_id:
+            return self
+        sink = self._tenant_sinks.get(event_tenant)
+        if sink is None:
+            raise GatewayAuditDeliveryUnavailableError("no tenant-bound audit credential is available")
+        return sink
 
     @staticmethod
     def _batch_idempotency_key(session_id: str, events: list[dict[str, Any]]) -> str:
@@ -1367,11 +1416,19 @@ class ControlPlaneAuditSink:
                 raise GatewayAuditDeliveryUnavailableError("control-plane durable acknowledgement is unavailable")
 
     async def __call__(self, event: dict[str, Any]) -> None:
+        sink = self._sink_for_event(event)
+        if sink is not self:
+            await sink(event)
+            return
         await self._persist_and_flush(event, require_remote_ack=False)
 
     async def admit_before_tool_execution(self, event: dict[str, Any]) -> None:
         """Require the control plane to durably acknowledge before execution."""
 
+        sink = self._sink_for_event(event)
+        if sink is not self:
+            await sink.admit_before_tool_execution(event)
+            return
         await self._persist_and_flush(event, require_remote_ack=True)
 
     async def _flush_locked(self) -> bool:
@@ -1438,6 +1495,9 @@ class ControlPlaneAuditSink:
 
     async def aclose(self) -> None:
         self._closed = True
+        children = list(self._tenant_sinks.values())
+        for child in children:
+            await child.aclose()
         if self._worker is None:
             return
         self._worker.cancel()
@@ -1447,7 +1507,7 @@ class ControlPlaneAuditSink:
             pass
         self._worker = None
 
-    def health(self) -> dict[str, str | int | bool]:
+    def _own_health(self) -> dict[str, str | int | bool]:
         try:
             health = self._delivery_state.health(buffer_bytes=0)
             backlog_observable = True
@@ -1483,6 +1543,36 @@ class ControlPlaneAuditSink:
             "retry_worker_running": self._worker is not None and not self._worker.done() and not self._closed,
             **health,
         }
+
+    def health(self) -> dict[str, str | int | bool]:
+        health = self._own_health()
+        child_health = [sink._own_health() for sink in self._tenant_sinks.values()]
+        if not child_health:
+            return health
+        all_health = [health, *child_health]
+        health.update(
+            {
+                "status": "degraded" if any(item["status"] != "healthy" for item in all_health) else "healthy",
+                "durable": all(bool(item["durable"]) for item in all_health),
+                "accepting_events": all(bool(item["accepting_events"]) for item in all_health),
+                "backlog_observable": all(bool(item["backlog_observable"]) for item in all_health),
+                "remote_acknowledgement_available": all(
+                    bool(item["remote_acknowledgement_available"]) for item in all_health
+                ),
+                "retry_worker_running": all(bool(item["retry_worker_running"]) for item in all_health),
+                "buffer_bytes": sum(int(item["buffer_bytes"]) for item in all_health),
+                "spillover_bytes": sum(int(item["spillover_bytes"]) for item in all_health),
+                "dlq_bytes": sum(int(item["dlq_bytes"]) for item in all_health),
+                "backlog_bytes": sum(int(item["backlog_bytes"]) for item in all_health),
+                "consecutive_failures": sum(int(item["consecutive_failures"]) for item in all_health),
+                "backoff_seconds": max(int(item["backoff_seconds"]) for item in all_health),
+                "circuit_open": any(bool(item["circuit_open"]) for item in all_health),
+                "dropped_events": sum(int(item["dropped_events"]) for item in all_health),
+                "tenant_sink_count": len(child_health) + 1,
+                "tenant_sink_capacity": self._max_tenant_sinks + 1,
+            }
+        )
+        return health
 
 
 class LocalGatewayAuditSink:
@@ -1592,6 +1682,8 @@ def build_control_plane_audit_sink(
     max_spillover_bytes: int = _GATEWAY_AUDIT_SPILLOVER_BYTES,
     max_dlq_bytes: int = _GATEWAY_AUDIT_DLQ_BYTES,
     sender: GatewayAuditSender | None = None,
+    tenant_routing_enabled: bool = True,
+    max_tenant_sinks: int = _GATEWAY_AUDIT_MAX_TENANT_SINKS,
 ) -> ControlPlaneAuditSink:
     """Build the gateway's shared bounded control-plane audit delivery sink."""
 
@@ -1599,6 +1691,8 @@ def build_control_plane_audit_sink(
     normalized_tenant_id = tenant_id.strip()
     if not normalized_tenant_id:
         raise ValueError("gateway audit tenant_id must not be empty")
+    if max_tenant_sinks < 0:
+        raise ValueError("gateway audit max_tenant_sinks must not be negative")
     delivery_identity = f"{source_id}\0{audit_url}\0{normalized_tenant_id}"
     active_session_id = session_id or "gateway-" + hashlib.sha256(delivery_identity.encode("utf-8")).hexdigest()[:20]
     state_dir = Path(os.environ.get("AGENT_BOM_STATE_DIR", Path.home() / ".agent-bom")).expanduser()
@@ -1627,12 +1721,15 @@ def build_control_plane_audit_sink(
     else:
         active_sender = sender
     return ControlPlaneAuditSink(
+        base_url=base_url,
         token=token,
         tenant_id=normalized_tenant_id,
         source_id=source_id,
         session_id=active_session_id,
         delivery_state=AuditDeliveryState(controller=controller, store=store),
         sender=active_sender,
+        tenant_routing_enabled=tenant_routing_enabled,
+        max_tenant_sinks=max_tenant_sinks,
     )
 
 
@@ -1856,6 +1953,40 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
 
     app = FastAPI(title="agent-bom gateway", version="1", lifespan=_lifespan)
 
+    def _audit_unavailable_response(message_id: object, *, headers: dict[str, str] | None = None) -> JSONResponse:
+        return JSONResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": message_id,
+                "error": {
+                    "code": -32003,
+                    "message": "Gateway audit persistence unavailable",
+                    "data": {
+                        "reason": "Tool call was not executed because durable audit admission failed",
+                        "policy_source": "audit_delivery",
+                    },
+                },
+            },
+            status_code=503,
+            headers=headers,
+        )
+
+    @app.exception_handler(GatewayAuditDeliveryUnavailableError)
+    async def _audit_delivery_unavailable(request: Request, _exc: GatewayAuditDeliveryUnavailableError) -> JSONResponse:
+        """Turn any pre-upstream audit outage into a stable fail-closed response."""
+
+        if request.url.path.startswith("/mcp/"):
+            record_gateway_relay(str(getattr(request.state, "gateway_upstream", "unknown")), "audit_unavailable")
+            return _audit_unavailable_response(getattr(request.state, "gateway_message_id", None))
+        return JSONResponse(status_code=503, content={"detail": "Gateway audit persistence unavailable"})
+
+    async def _bind_authenticated_audit_tenant(request: Request, tenant_id: str, auth_method: str) -> None:
+        sink = settings.audit_sink
+        if not isinstance(sink, ControlPlaneAuditSink):
+            return
+        request_token = _extract_request_token(request) if auth_method == "api_key" else None
+        await sink.bind_authenticated_tenant(tenant_id, request_token)
+
     # OAuth 2.1 Authorization Server (broker AS): mount the unauthenticated
     # discovery/registration/PKCE/token/JWKS endpoints so standard MCP clients
     # can auto-authenticate to brokered MCPs. These deliberately sit outside the
@@ -1979,10 +2110,12 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         # the policy evaluator is reachable unauthenticated on shared
         # deployments and leaks every rule via the matched_rule field.
         tenant_id = _configured_gateway_tenant_id()
+        auth_method = "none"
         if _gateway_requires_auth(settings):
             tenant_id, auth_method = _authenticate_gateway_request(request, settings)
             request.state.tenant_id = tenant_id
             request.state.auth_method = auth_method
+        await _bind_authenticated_audit_tenant(request, tenant_id, auth_method)
         try:
             payload = await request.json()
         except json.JSONDecodeError as exc:
@@ -2106,6 +2239,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         upstream = settings.registry.get(server_name, tenant_id=tenant_id)
         if upstream is None:
             raise HTTPException(status_code=404, detail=f"unknown upstream {server_name!r}")
+        request.state.gateway_upstream = upstream.name
 
         content_length = request.headers.get("content-length")
         if content_length:
@@ -2125,8 +2259,10 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         # Parse the JSON-RPC envelope so check_policy sees the real message shape.
         if isinstance(body, dict) and "jsonrpc" in body:
             message = body
+            request.state.gateway_message_id = message.get("id")
         else:
             raise HTTPException(status_code=400, detail="request must be a JSON-RPC message")
+        await _bind_authenticated_audit_tenant(request, tenant_id, auth_method)
 
         # Inline policy check — reuse the exact evaluator the per-MCP proxy uses.
         tenant_id = getattr(request.state, "tenant_id", None) or "default"
@@ -3517,22 +3653,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 )
             except GatewayAuditDeliveryUnavailableError:
                 record_gateway_relay(upstream.name, "audit_unavailable")
-                return JSONResponse(
-                    {
-                        "jsonrpc": "2.0",
-                        "id": message.get("id"),
-                        "error": {
-                            "code": -32003,
-                            "message": "Gateway audit persistence unavailable",
-                            "data": {
-                                "reason": "Tool call was not executed because durable audit admission failed",
-                                "policy_source": "audit_delivery",
-                            },
-                        },
-                    },
-                    status_code=503,
-                    headers=rate_limit_headers or None,
-                )
+                return _audit_unavailable_response(message.get("id"), headers=rate_limit_headers or None)
 
         post_forward_audit_degraded = False
 

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -1398,6 +1398,17 @@ class _GatewayAuditTenantRegistry:
             os.close(parent_fd)
 
 
+def _audit_health_has_pending_state(health: dict[str, str | int | bool]) -> bool:
+    """Return whether a tenant marker must remain for unresolved audit state."""
+
+    return (
+        not bool(health.get("backlog_observable", False))
+        or int(health.get("backlog_bytes", 0)) > 0
+        or int(health.get("dlq_bytes", 0)) > 0
+        or int(health.get("dropped_events", 0)) > 0
+    )
+
+
 class ControlPlaneAuditSink:
     """Durably queue and retry standalone-gateway audit delivery.
 
@@ -1506,7 +1517,7 @@ class ControlPlaneAuditSink:
                     max_tenant_sinks=0,
                 )
                 child_health = sink._own_health()
-                if bool(child_health["backlog_observable"]) and int(child_health["backlog_bytes"]) == 0:
+                if not _audit_health_has_pending_state(child_health):
                     self._tenant_registry.unregister(tenant_id)
                     continue
                 sink._remote_ack_available = False
@@ -1683,7 +1694,7 @@ class ControlPlaneAuditSink:
             for tenant_id, child in children:
                 try:
                     child_health = child._own_health()
-                    if bool(child_health["backlog_observable"]) and int(child_health["backlog_bytes"]) == 0:
+                    if not _audit_health_has_pending_state(child_health):
                         self._tenant_registry.unregister(tenant_id)
                 except Exception as exc:  # noqa: BLE001 - shutdown remains secret-free
                     self._tenant_registry_available = False
@@ -1724,7 +1735,7 @@ class ControlPlaneAuditSink:
         )
         if not accepting_events:
             health["status"] = "degraded"
-        return {
+        result: dict[str, str | int | bool] = {
             "configured": True,
             "durable": self._persistence_available and backlog_observable,
             "accepting_events": accepting_events,
@@ -1733,6 +1744,8 @@ class ControlPlaneAuditSink:
             "retry_worker_running": self._worker is not None and not self._worker.done() and not self._closed,
             **health,
         }
+        result["pending_audit_state"] = _audit_health_has_pending_state(result)
+        return result
 
     def health(self) -> dict[str, str | int | bool]:
         health = self._own_health()
@@ -1755,6 +1768,7 @@ class ControlPlaneAuditSink:
                     "backoff_seconds": max(int(item["backoff_seconds"]) for item in all_health),
                     "circuit_open": any(bool(item["circuit_open"]) for item in all_health),
                     "dropped_events": sum(int(item["dropped_events"]) for item in all_health),
+                    "pending_audit_state": any(_audit_health_has_pending_state(item) for item in all_health),
                     "tenant_sink_count": len(child_health) + 1,
                     "tenant_sink_capacity": self._max_tenant_sinks + 1,
                 }

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -1556,9 +1556,7 @@ class ControlPlaneAuditSink:
                 "durable": all(bool(item["durable"]) for item in all_health),
                 "accepting_events": all(bool(item["accepting_events"]) for item in all_health),
                 "backlog_observable": all(bool(item["backlog_observable"]) for item in all_health),
-                "remote_acknowledgement_available": all(
-                    bool(item["remote_acknowledgement_available"]) for item in all_health
-                ),
+                "remote_acknowledgement_available": all(bool(item["remote_acknowledgement_available"]) for item in all_health),
                 "retry_worker_running": all(bool(item["retry_worker_running"]) for item in all_health),
                 "buffer_bytes": sum(int(item["buffer_bytes"]) for item in all_health),
                 "spillover_bytes": sum(int(item["spillover_bytes"]) for item in all_health),

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -1350,11 +1350,7 @@ class _GatewayAuditTenantRegistry:
         if hasattr(os, "O_CLOEXEC"):
             read_flags |= os.O_CLOEXEC
         try:
-            names = sorted(
-                name
-                for name in os.listdir(parent_fd)
-                if name.startswith(self._prefix) and name.endswith(".tenant.json")
-            )
+            names = sorted(name for name in os.listdir(parent_fd) if name.startswith(self._prefix) and name.endswith(".tenant.json"))
             for name in names:
                 fd = os.open(name, read_flags, dir_fd=parent_fd)
                 try:

--- a/tests/test_gateway_audit_delivery.py
+++ b/tests/test_gateway_audit_delivery.py
@@ -200,6 +200,49 @@ async def test_restart_discovers_unbound_tenant_backlog_and_reports_degraded_hea
 
 
 @pytest.mark.asyncio
+async def test_restart_discovers_unbound_tenant_dlq_only_backlog_and_reports_degraded_health(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path))
+
+    async def unavailable_sender(_payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        raise RuntimeError("control plane unavailable")
+
+    first = build_control_plane_audit_sink(
+        "https://control.invalid",
+        "alpha-token",
+        tenant_id="tenant-alpha",
+        sender=unavailable_sender,
+    )
+    await first.start()
+    await first.bind_authenticated_tenant("tenant-beta", "beta-token")
+    beta = first._tenant_sinks["tenant-beta"]
+    beta._delivery_state.store.max_spillover_bytes = 1
+    with pytest.raises(GatewayAuditDeliveryUnavailableError, match="durable audit backlog is full"):
+        await first(_event(tenant_id="tenant-beta"))
+    assert int(first.health()["backlog_bytes"]) == 0
+    assert int(first.health()["dlq_bytes"]) > 0
+    await first.aclose()
+
+    restarted = build_control_plane_audit_sink(
+        "https://control.invalid",
+        "alpha-token-rotated",
+        tenant_id="tenant-alpha",
+        sender=unavailable_sender,
+    )
+    await restarted.start()
+    health = restarted.health()
+    await restarted.aclose()
+
+    assert health["status"] == "degraded"
+    assert int(health["backlog_bytes"]) == 0
+    assert int(health["dlq_bytes"]) > 0
+    assert health["accepting_events"] is False
+    assert int(health["tenant_sink_count"]) == 2
+
+
+@pytest.mark.asyncio
 async def test_restart_fails_closed_on_symlinked_tenant_registry_marker(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_gateway_audit_delivery.py
+++ b/tests/test_gateway_audit_delivery.py
@@ -175,11 +175,7 @@ async def test_restart_discovers_unbound_tenant_backlog_and_reports_degraded_hea
     assert int(first.health()["backlog_bytes"]) > 0
     await first.aclose()
 
-    persisted = "".join(
-        path.read_text(encoding="utf-8", errors="replace")
-        for path in tmp_path.rglob("*")
-        if path.is_file()
-    )
+    persisted = "".join(path.read_text(encoding="utf-8", errors="replace") for path in tmp_path.rglob("*") if path.is_file())
     assert alpha_token not in persisted
     assert beta_token not in persisted
 

--- a/tests/test_gateway_audit_delivery.py
+++ b/tests/test_gateway_audit_delivery.py
@@ -15,6 +15,7 @@ from typing import Any
 import pytest
 from starlette.testclient import TestClient
 
+import agent_bom.gateway_server as gateway_server
 from agent_bom.api.auth import Role
 from agent_bom.gateway_server import (
     GatewayAuditDeliveryUnavailableError,
@@ -48,6 +49,182 @@ def _event(event_id: str = "gw_delivery_1", **overrides: object) -> dict[str, An
 
 def _paths(tmp_path: Path) -> tuple[Path, Path]:
     return tmp_path / "gateway-audit.spill.jsonl", tmp_path / "gateway-audit.dlq.jsonl"
+
+
+def test_control_plane_audit_routes_each_authenticated_api_key_to_its_tenant(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path))
+    upstream_tenants: list[str] = []
+    delivered: list[tuple[str, str]] = []
+
+    class _TenantKeyStore:
+        @staticmethod
+        def has_keys() -> bool:
+            return True
+
+        @staticmethod
+        def verify(raw_key: str) -> SimpleNamespace | None:
+            if raw_key not in {"tenant-alpha-key", "tenant-beta-key"}:
+                return None
+            tenant_id = raw_key.removesuffix("-key")
+            return SimpleNamespace(
+                tenant_id=tenant_id,
+                role=Role.ANALYST,
+                has_scope=lambda required: required == "gateway:relay",
+            )
+
+    async def sender(payload: dict[str, Any], headers: dict[str, str]) -> dict[str, Any]:
+        events = payload["alerts"]
+        delivered.extend((str(event["tenant_id"]), headers.get("Authorization", "")) for event in events)
+        count = len(events)
+        return {
+            "accepted_alert_count": count,
+            "duplicate_alert_count": 0,
+            "durable_accepted_count": count,
+            "durable_duplicate_count": 0,
+            "durable_conflict_count": 0,
+        }
+
+    async def upstream(upstream_config: object, message: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        upstream_tenants.append(str(getattr(upstream_config, "tenant_id", "")))
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    monkeypatch.setattr(gateway_server, "get_key_store", lambda: _TenantKeyStore())
+    registry = UpstreamRegistry(
+        [
+            UpstreamConfig(name="jira", tenant_id="tenant-alpha", url="https://alpha.invalid/mcp"),
+            UpstreamConfig(name="jira", tenant_id="tenant-beta", url="https://beta.invalid/mcp"),
+        ]
+    )
+    sink = build_control_plane_audit_sink(
+        "https://control.invalid",
+        "tenant-alpha-bootstrap",
+        tenant_id="tenant-alpha",
+        sender=sender,
+    )
+    app = create_gateway_app(GatewaySettings(registry=registry, policy={}, audit_sink=sink, upstream_caller=upstream))
+    message = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "query_issues", "arguments": {}},
+    }
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        alpha = client.post("/mcp/jira", headers={"X-API-Key": "tenant-alpha-key"}, json=message)
+        beta = client.post("/mcp/jira", headers={"X-API-Key": "tenant-beta-key"}, json=message)
+
+    assert alpha.status_code == 200
+    assert beta.status_code == 200
+    assert upstream_tenants == ["tenant-alpha", "tenant-beta"]
+    assert ("tenant-alpha", "Bearer tenant-alpha-key") in delivered
+    assert ("tenant-beta", "Bearer tenant-beta-key") in delivered
+
+
+@pytest.mark.asyncio
+async def test_tenant_child_audit_degradation_rolls_up_to_gateway_health(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path))
+
+    async def unavailable_sender(_payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        raise RuntimeError("hostile transport detail /private/tenant-beta")
+
+    sink = build_control_plane_audit_sink(
+        "https://control.invalid",
+        "tenant-alpha-token",
+        tenant_id="tenant-alpha",
+        sender=unavailable_sender,
+    )
+    await sink.start()
+    await sink.bind_authenticated_tenant("tenant-beta", "tenant-beta-token")
+    await sink(_event(tenant_id="tenant-beta"))
+    health = sink.health()
+    await sink.aclose()
+
+    assert health["status"] == "degraded"
+    assert health["accepting_events"] is False
+    assert health["remote_acknowledgement_available"] is False
+    assert int(health["backlog_bytes"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_control_plane_audit_tenant_routing_is_bounded_and_requires_verified_request_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path))
+    sink = build_control_plane_audit_sink(
+        "https://control.invalid",
+        "tenant-alpha-token",
+        tenant_id="tenant-alpha",
+        max_tenant_sinks=1,
+    )
+
+    with pytest.raises(GatewayAuditDeliveryUnavailableError, match="tenant-bound"):
+        await sink.bind_authenticated_tenant("tenant-beta", None)
+    await sink.bind_authenticated_tenant("tenant-beta", "tenant-beta-token")
+    with pytest.raises(GatewayAuditDeliveryUnavailableError, match="capacity"):
+        await sink.bind_authenticated_tenant("tenant-gamma", "tenant-gamma-token")
+    await sink.aclose()
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        {"rules": [{"id": "no-shell", "action": "block", "block_tools": ["run_shell"]}]},
+        {"require_agent_identity": True},
+    ],
+    ids=["policy-deny", "identity-deny"],
+)
+def test_pre_upstream_audit_outage_returns_deterministic_jsonrpc_denial(
+    policy: dict[str, Any],
+) -> None:
+    upstream_calls = 0
+
+    async def upstream(_upstream: object, message: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        nonlocal upstream_calls
+        upstream_calls += 1
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"side_effect": True}}
+
+    async def unavailable_audit(_event: dict[str, Any]) -> None:
+        raise GatewayAuditDeliveryUnavailableError("hostile internal path /private/audit.db")
+
+    settings = GatewaySettings(
+        registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://filesystem.invalid")]),
+        policy=policy,
+        audit_sink=unavailable_audit,
+        upstream_caller=upstream,
+    )
+    with TestClient(create_gateway_app(settings), raise_server_exceptions=False) as client:
+        response = client.post(
+            "/mcp/filesystem",
+            json={
+                "jsonrpc": "2.0",
+                "id": 71,
+                "method": "tools/call",
+                "params": {"name": "run_shell", "arguments": {}},
+            },
+        )
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 71,
+        "error": {
+            "code": -32003,
+            "message": "Gateway audit persistence unavailable",
+            "data": {
+                "reason": "Tool call was not executed because durable audit admission failed",
+                "policy_source": "audit_delivery",
+            },
+        },
+    }
+    assert upstream_calls == 0
+    assert "/private/audit.db" not in response.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway_audit_delivery.py
+++ b/tests/test_gateway_audit_delivery.py
@@ -152,6 +152,97 @@ async def test_tenant_child_audit_degradation_rolls_up_to_gateway_health(
 
 
 @pytest.mark.asyncio
+async def test_restart_discovers_unbound_tenant_backlog_and_reports_degraded_health(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path))
+    alpha_token = "alpha-token-must-not-persist"
+    beta_token = "beta-token-must-not-persist"
+
+    async def unavailable_sender(_payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        raise RuntimeError("control plane unavailable")
+
+    first = build_control_plane_audit_sink(
+        "https://control.invalid",
+        alpha_token,
+        tenant_id="tenant-alpha",
+        sender=unavailable_sender,
+    )
+    await first.start()
+    await first.bind_authenticated_tenant("tenant-beta", beta_token)
+    await first(_event(tenant_id="tenant-beta"))
+    assert int(first.health()["backlog_bytes"]) > 0
+    await first.aclose()
+
+    persisted = "".join(
+        path.read_text(encoding="utf-8", errors="replace")
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    )
+    assert alpha_token not in persisted
+    assert beta_token not in persisted
+
+    restarted = build_control_plane_audit_sink(
+        "https://control.invalid",
+        "alpha-token-rotated",
+        tenant_id="tenant-alpha",
+        sender=unavailable_sender,
+    )
+    await restarted.start()
+    health = restarted.health()
+    await restarted.aclose()
+
+    assert health["status"] == "degraded"
+    assert int(health["backlog_bytes"]) > 0
+    assert health["accepting_events"] is False
+    assert int(health["tenant_sink_count"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_restart_fails_closed_on_symlinked_tenant_registry_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path))
+
+    async def unavailable_sender(_payload: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        raise RuntimeError("control plane unavailable")
+
+    first = build_control_plane_audit_sink(
+        "https://control.invalid",
+        "alpha-token",
+        tenant_id="tenant-alpha",
+        sender=unavailable_sender,
+    )
+    await first.start()
+    await first.bind_authenticated_tenant("tenant-beta", "beta-token")
+    await first(_event(tenant_id="tenant-beta"))
+    await first.aclose()
+
+    markers = list((tmp_path / "runtime-audit").glob("gateway-router-*.tenant.json"))
+    assert len(markers) == 1
+    outside = tmp_path / "outside-tenant.json"
+    outside.write_text('{"tenant_id":"hostile"}', encoding="utf-8")
+    markers[0].unlink()
+    markers[0].symlink_to(outside)
+
+    restarted = build_control_plane_audit_sink(
+        "https://control.invalid",
+        "alpha-token-rotated",
+        tenant_id="tenant-alpha",
+        sender=unavailable_sender,
+    )
+    await restarted.start()
+    health = restarted.health()
+    await restarted.aclose()
+
+    assert health["status"] == "degraded"
+    assert health["accepting_events"] is False
+    assert health["backlog_observable"] is False
+
+
+@pytest.mark.asyncio
 async def test_control_plane_audit_tenant_routing_is_bounded_and_requires_verified_request_token(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_gateway_firewall.py
+++ b/tests/test_gateway_firewall.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from fastapi.testclient import TestClient
 
-from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+from agent_bom.gateway_server import GatewayAuditDeliveryUnavailableError, GatewaySettings, create_gateway_app
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
 from agent_bom.rbac import Role
 
@@ -479,3 +479,36 @@ def test_relay_firewall_dry_run_warns_without_blocking(tmp_path: Path) -> None:
     assert len(warned) == 1
     assert warned[0]["effective_decision"] == "warn"
     assert not [e for e in audit.events if e["action"] == "gateway.firewall_blocked"]
+
+
+def test_relay_firewall_warn_audit_outage_fails_closed_before_upstream(tmp_path: Path) -> None:
+    policy_path = _write_policy(
+        tmp_path / "fw.json",
+        enforcement_mode="dry_run",
+        rules=[{"source": "cursor", "target": "filesystem", "decision": "deny"}],
+    )
+    upstream_calls = 0
+
+    async def unavailable_audit(_event: dict[str, Any]) -> None:
+        raise GatewayAuditDeliveryUnavailableError("hostile audit detail /private/firewall.db")
+
+    async def caller(_upstream: object, message: dict[str, Any], _headers: dict[str, str]) -> dict[str, Any]:
+        nonlocal upstream_calls
+        upstream_calls += 1
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"side_effect": True}}
+
+    settings = GatewaySettings(
+        registry=_registry(),
+        policy={"agent_tokens": {"tok-cursor": "cursor"}},
+        firewall_policy_path=policy_path,
+        upstream_caller=caller,
+        audit_sink=unavailable_audit,
+    )
+    with TestClient(create_gateway_app(settings), raise_server_exceptions=False) as client:
+        response = client.post("/mcp/filesystem", json=_relay_message())
+
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == -32003
+    assert response.json()["id"] == 7
+    assert "/private/firewall.db" not in response.text
+    assert upstream_calls == 0

--- a/tests/test_gateway_profile_enforcement.py
+++ b/tests/test_gateway_profile_enforcement.py
@@ -19,7 +19,7 @@ from agent_bom.api.mcp_config_store import (
     McpClientConfigAssignment,
     set_mcp_config_store,
 )
-from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+from agent_bom.gateway_server import GatewayAuditDeliveryUnavailableError, GatewaySettings, create_gateway_app
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
 
 
@@ -115,6 +115,25 @@ def _relay(
         headers=headers,
         json=_call(token),
     )
+
+
+@pytest.mark.parametrize("mode", ["warn", "enforce"])
+def test_profile_audit_outage_fails_closed_before_upstream(mode: str) -> None:
+    calls: list[dict[str, Any]] = []
+    settings = _settings(calls, [], listener_host="127.0.0.1", mode=mode)
+
+    async def unavailable_audit(_event: dict[str, Any]) -> None:
+        raise GatewayAuditDeliveryUnavailableError("hostile audit detail /private/profile.db")
+
+    settings.audit_sink = unavailable_audit
+    with TestClient(create_gateway_app(settings), raise_server_exceptions=False) as client:
+        response = client.post("/mcp/filesystem", json=_call(""))
+
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == -32003
+    assert response.json()["id"] == 1
+    assert "/private/profile.db" not in response.text
+    assert calls == []
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

- route control-plane gateway audit delivery through tenant-specific, restart-stable queues only after the request API key is authenticated
- bound tenant audit routing capacity and roll child delivery health into gateway readiness
- preserve a deterministic sanitized JSON-RPC denial for policy, identity, firewall, and profile audit outages before any upstream execution

## Verification

- red state on exact main 0d1c738d5: 7 focused failures reproduced cross-tenant delivery and raw 500 denial paths
- 8 focused regressions passed
- 451 runtime, gateway, audit, persistence, API, and Helm contract tests passed
- make lint
- exception sanitization guard
- published count/version guard
- Helm profile validation
- public docs hygiene guard
- make preflight

## Notes

- commit ad53c6a0bdfa36575030406501528b06336da7c5 is signed
- upstream execution is asserted absent on every new audit-outage path
- auto-merge remains disabled pending independent review