### PR TITLE
fix(credentials): audit retired legacy secret purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
   the deprecated safe migration form `--client-secret @<absolute-runtime-path>` before
   moving to `--client-secret-file`; secret bytes are never echoed or read.
 
+### Fixed
+
+- Purging secret-shaped legacy material from an already-retired credential
+  reference now records one tenant-scoped, sanitized audit event without
+  duplicating the event on idempotent DELETE retries.
+
 ## [0.102.0] - 2026-08-23
 
 A release-integrity and evidence-truth release. Published Python images remove

--- a/src/agent_bom/api/routes/credentials.py
+++ b/src/agent_bom/api/routes/credentials.py
@@ -231,34 +231,50 @@ async def test_credential_ref(request: Request, credential_ref_id: str) -> dict:
 @router.delete("/credentials/{credential_ref_id}", tags=["credentials"], status_code=204)
 async def delete_credential_ref(request: Request, credential_ref_id: str) -> None:
     tenant_id = _tenant_id(request)
+    already_retired = False
+    retired_legacy_secret_purged = False
     with tenant_quota_guard(tenant_id):
         credential = _credential_for_request(request, credential_ref_id)
         if credential.status == CredentialRefStatus.RETIRED:
+            already_retired = True
             if value_looks_like_secret(credential.external_ref):
                 credential.external_ref = None
                 credential.updated_at = _now()
                 _get_credential_ref_store().put(credential)
-            return
-        attached_sources = [
-            source for source in _get_source_store().list_all(tenant_id=credential.tenant_id) if source.credential_ref == credential_ref_id
-        ]
-        if attached_sources:
-            count = len(attached_sources)
-            noun = "source" if count == 1 else "sources"
-            raise HTTPException(
-                status_code=409,
-                detail=f"Credential reference is attached to {count} {noun}; detach it before retiring the reference",
+                retired_legacy_secret_purged = True
+        else:
+            attached_sources = [
+                source
+                for source in _get_source_store().list_all(tenant_id=credential.tenant_id)
+                if source.credential_ref == credential_ref_id
+            ]
+            if attached_sources:
+                count = len(attached_sources)
+                noun = "source" if count == 1 else "sources"
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Credential reference is attached to {count} {noun}; detach it before retiring the reference",
+                )
+            credential.enabled = False
+            credential.status = CredentialRefStatus.RETIRED
+            # Older releases could persist credential material in this metadata
+            # field. Retirement is terminal, so scrub detected legacy material
+            # before making the record immutable; otherwise no later API call can
+            # remove the secret from durable storage.
+            if value_looks_like_secret(credential.external_ref):
+                credential.external_ref = None
+            credential.updated_at = _now()
+            _get_credential_ref_store().put(credential)
+    if already_retired:
+        if retired_legacy_secret_purged:
+            log_action(
+                "credential_ref.retired_legacy_secret_purge",
+                actor=_actor(request),
+                resource=f"credential/{credential_ref_id}",
+                tenant_id=credential.tenant_id,
+                provider=credential.provider,
             )
-        credential.enabled = False
-        credential.status = CredentialRefStatus.RETIRED
-        # Older releases could persist credential material in this metadata
-        # field. Retirement is terminal, so scrub detected legacy material
-        # before making the record immutable; otherwise no later API call can
-        # remove the secret from durable storage.
-        if value_looks_like_secret(credential.external_ref):
-            credential.external_ref = None
-        credential.updated_at = _now()
-        _get_credential_ref_store().put(credential)
+        return
     log_action(
         "credential_ref.retire",
         actor=_actor(request),

--- a/tests/api/test_api_sources.py
+++ b/tests/api/test_api_sources.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import datetime, timedelta, timezone
 from threading import Event, Thread
 from types import SimpleNamespace
@@ -617,9 +618,24 @@ def test_credential_retirement_purges_legacy_secret_reference_at_rest(source_cli
     assert secret not in fetched.text
 
 
-def test_repeated_credential_retirement_purges_legacy_secret_reference_at_rest(
+@pytest.mark.parametrize("credential_store_backend", ["memory", "sqlite"])
+def test_repeated_credential_retirement_purges_legacy_secret_reference_at_rest_and_audits_once(
     source_client: TestClient,
+    credential_store_backend: str,
+    tmp_path,
 ) -> None:
+    from agent_bom.api.audit_log import InMemoryAuditLog, get_audit_log, set_audit_log
+    from agent_bom.api.credential_store import SQLiteCredentialRefStore
+
+    credential_store = (
+        InMemoryCredentialRefStore()
+        if credential_store_backend == "memory"
+        else SQLiteCredentialRefStore(str(tmp_path / "credential-purge.db"))
+    )
+    _stores.set_credential_ref_store(credential_store)
+    original_audit_log = get_audit_log()
+    audit_log = InMemoryAuditLog()
+    set_audit_log(audit_log)
     secret = "ghp_" + "abcdefghijklmnopqrstuvwxyz1234567890"
     legacy = CredentialRefRecord(
         credential_ref_id="legacy-secret-already-retired",
@@ -632,28 +648,47 @@ def test_repeated_credential_retirement_purges_legacy_secret_reference_at_rest(
         created_at="2026-08-27T00:00:00+00:00",
         updated_at="2026-08-27T00:00:00+00:00",
     )
-    _stores._credential_ref_store.put(legacy)
+    credential_store.put(legacy)
 
-    retired = source_client.delete(
-        "/v1/credentials/legacy-secret-already-retired",
-        headers=ADMIN_HEADERS,
-    )
-
-    assert retired.status_code == 204
-    persisted = _stores._credential_ref_store.get(
-        "legacy-secret-already-retired",
-        tenant_id="tenant-alpha",
-    )
-    assert persisted is not None
-    assert persisted.status == CredentialRefStatus.RETIRED
-    assert persisted.external_ref is None
-    assert (
-        secret
-        not in source_client.get(
+    try:
+        retired = source_client.delete(
             "/v1/credentials/legacy-secret-already-retired",
-            headers=VIEWER_HEADERS,
-        ).text
-    )
+            headers=ADMIN_HEADERS,
+        )
+        repeated = source_client.delete(
+            "/v1/credentials/legacy-secret-already-retired",
+            headers=ADMIN_HEADERS,
+        )
+
+        assert retired.status_code == 204
+        assert repeated.status_code == 204
+        persisted = credential_store.get(
+            "legacy-secret-already-retired",
+            tenant_id="tenant-alpha",
+        )
+        assert persisted is not None
+        assert persisted.status == CredentialRefStatus.RETIRED
+        assert persisted.external_ref is None
+        entries = audit_log.list_entries(
+            action="credential_ref.retired_legacy_secret_purge",
+            tenant_id="tenant-alpha",
+        )
+        assert len(entries) == 1
+        assert entries[0].resource == "credential/legacy-secret-already-retired"
+        assert entries[0].details == {
+            "provider": "github",
+            "tenant_id": "tenant-alpha",
+        }
+        assert secret not in json.dumps(entries[0].to_dict())
+        assert (
+            secret
+            not in source_client.get(
+                "/v1/credentials/legacy-secret-already-retired",
+                headers=VIEWER_HEADERS,
+            ).text
+        )
+    finally:
+        set_audit_log(original_audit_log)
 
 
 @pytest.mark.parametrize("depth", range(1, 7))

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -3,10 +3,12 @@
 Uses a mock psycopg_pool to avoid needing a real PostgreSQL instance.
 """
 
+import asyncio
 import json
 import sys
 import types
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -105,6 +107,8 @@ class MockConnection:
                     table = "trend_history"
                 elif "scan_schedules" in sql:
                     table = "scan_schedules"
+                elif "credential_refs" in sql:
+                    table = "credential_refs"
                 elif "control_plane_schema_versions" in sql:
                     table = "control_plane_schema_versions"
                 elif "osv_cache" in sql:
@@ -1554,6 +1558,64 @@ def test_credential_ref_store_put_get_list_delete(mock_pool):
     assert isinstance(listed, list)
 
     assert store.delete("cred-1", tenant_id="tenant-alpha") is True
+
+
+def test_retired_legacy_credential_purge_audits_once_with_postgres_store(mock_pool):
+    from agent_bom.api import stores
+    from agent_bom.api.audit_log import InMemoryAuditLog, get_audit_log, set_audit_log
+    from agent_bom.api.models import CredentialRefRecord, CredentialRefStatus
+    from agent_bom.api.postgres_store import PostgresCredentialRefStore
+    from agent_bom.api.routes.credentials import delete_credential_ref
+
+    credential_store = PostgresCredentialRefStore(pool=mock_pool)
+    secret = "ghp_" + "abcdefghijklmnopqrstuvwxyz1234567890"
+    credential_store.put(
+        CredentialRefRecord(
+            credential_ref_id="legacy-secret-already-retired",
+            tenant_id="tenant-alpha",
+            display_name="Legacy retired credential",
+            provider="github",
+            external_ref=secret,
+            enabled=False,
+            status=CredentialRefStatus.RETIRED,
+            created_at="2026-08-27T00:00:00+00:00",
+            updated_at="2026-08-27T00:00:00+00:00",
+        )
+    )
+    original_credential_store = stores._credential_ref_store
+    original_audit_log = get_audit_log()
+    audit_log = InMemoryAuditLog()
+    stores.set_credential_ref_store(credential_store)
+    set_audit_log(audit_log)
+    request = SimpleNamespace(
+        state=SimpleNamespace(
+            tenant_id="tenant-alpha",
+            api_key_name="postgres-admin",
+        )
+    )
+
+    try:
+        asyncio.run(delete_credential_ref(request, "legacy-secret-already-retired"))
+        asyncio.run(delete_credential_ref(request, "legacy-secret-already-retired"))
+
+        persisted = credential_store.get("legacy-secret-already-retired", tenant_id="tenant-alpha")
+        assert persisted is not None
+        assert persisted.external_ref is None
+        entries = audit_log.list_entries(
+            action="credential_ref.retired_legacy_secret_purge",
+            tenant_id="tenant-alpha",
+        )
+        assert len(entries) == 1
+        assert entries[0].actor == "postgres-admin"
+        assert entries[0].resource == "credential/legacy-secret-already-retired"
+        assert entries[0].details == {
+            "provider": "github",
+            "tenant_id": "tenant-alpha",
+        }
+        assert secret not in json.dumps(entries[0].to_dict())
+    finally:
+        stores._credential_ref_store = original_credential_store
+        set_audit_log(original_audit_log)
 
 
 def test_tenant_context_is_applied_to_postgres_session(mock_pool):


### PR DESCRIPTION
## Summary

- emit `credential_ref.retired_legacy_secret_purge` when an already-retired credential record is mutated to remove secret-shaped legacy material
- keep the event tenant-scoped and limited to sanitized actor, resource, tenant, and provider identity
- preserve idempotent DELETE behavior and emit no duplicate event when no purge occurs
- cover InMemory, SQLite, and Postgres persistence paths

## Verification

- red-first regression: 3 failed because no purge audit event existed
- targeted regression after fix: 3 passed
- `uv run pytest -q tests/api/test_api_sources.py tests/api/test_api_tenant_isolation.py tests/test_postgres_store.py tests/test_audit_round2.py` (208 passed)
- `uv run ruff check src tests scripts fuzz`
- `uv run ruff format --check src tests scripts fuzz` (2,216 files formatted)
- `uv run mypy src/agent_bom/api/routes/credentials.py`
- `make preflight`
- `uv run python scripts/check_public_docs_hygiene.py` (782 files scanned)
- `git diff --check`

## Notes

The audit payload never receives the purged `external_ref` or credential material. The first DELETE that mutates durable state records one event; subsequent DELETE retries remain `204` and do not add events.

Closes #4978.
