### PR TITLE
fix(auth): remove legacy secret CLI input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - OIDC setup emits file references instead of client-secret values. Compose
   control-plane profiles load the generated non-secret env file and mount a
   dedicated OIDC secret directory read-only; dashboard and Helm guidance use
-  the same file-first contract. Literal `auth setup-oidc --client-secret`
-  values now fail before discovery or file writes. Released automation can use
-  the deprecated safe migration form `--client-secret @<absolute-runtime-path>` before
-  moving to `--client-secret-file`; secret bytes are never echoed or read.
+  the same file-first contract. `auth setup-oidc` no longer accepts a
+  `--client-secret` option; automation must use
+  `--client-secret-file <absolute-runtime-path>`. Secret bytes are never
+  accepted, echoed, read, or written by the wizard.
 
 ## [0.102.0] - 2026-08-23
 

--- a/docs/AUTH_SSO.md
+++ b/docs/AUTH_SSO.md
@@ -43,21 +43,19 @@ For Compose, provision the secret as `deploy/secrets/oidc/client_secret` before
 starting the stack. The shipped platform and full-stack profiles mount that
 dedicated directory read-only and load `oidc.env` automatically when present.
 
-### Migrating released automation
+### Migrating automation
 
-Literal `--client-secret <value>` arguments are rejected before issuer
-discovery or file writes because process arguments and shell history can expose
-the value. Update automation to `--client-secret-file <absolute-runtime-path>`. A
-deprecated transition form keeps the released option name without accepting
-secret bytes; the value must be an absolute, normalized runtime path:
+The setup command does not accept a `--client-secret` option because process
+arguments and shell history can expose secret values. Update automation to use
+an absolute, normalized runtime file reference:
 
 ```bash
 agent-bom auth setup-oidc ... \
-  --client-secret @/run/agent-bom/oidc/client_secret
+  --client-secret-file /run/agent-bom/oidc/client_secret
 ```
 
-The `@` value is a runtime **file reference**, not a secret. It produces the
-same `AGENT_BOM_OIDC_CLIENT_SECRET_FILE` output and a deprecation notice.
+The wizard emits `AGENT_BOM_OIDC_CLIENT_SECRET_FILE`; it never reads the
+referenced file or emits its contents.
 
 > The redirect URI is always derived as `<base-url>/v1/auth/oidc/callback` — the
 > dashboard's OIDC callback route. It must be allowlisted at the IdP **exactly**.

--- a/src/agent_bom/cli/_auth_group.py
+++ b/src/agent_bom/cli/_auth_group.py
@@ -255,7 +255,6 @@ def auth_group() -> None:
     default=None,
     help="Runtime path to an operator-managed OAuth client-secret file (omit for a PKCE public client).",
 )
-@click.option("--client-secret", default=None, hidden=True)
 @click.option("--base-url", default=None, help="Deployment base URL; the redirect URI is derived from it.")
 @click.option("--redirect-uri", default=None, help="Override the derived redirect URI (must match the IdP allowlist).")
 @click.option("--audience", default=None, help="Expected JWT audience (defaults to the client ID).")
@@ -269,7 +268,6 @@ def setup_oidc_cmd(
     issuer: Optional[str],
     client_id: Optional[str],
     client_secret_file: Optional[str],
-    client_secret: Optional[str],
     base_url: Optional[str],
     redirect_uri: Optional[str],
     audience: Optional[str],
@@ -290,21 +288,6 @@ def setup_oidc_cmd(
 
     con = Console()
     interactive = (not non_interactive) and _stdin_is_tty()
-
-    used_legacy_file_reference = False
-    if client_secret is not None:
-        legacy_value = client_secret
-        if legacy_value.startswith("@") and legacy_value[1:]:
-            if client_secret_file:
-                raise OIDCSetupError("Pass either --client-secret-file or deprecated --client-secret @<absolute-runtime-path>, not both.")
-            client_secret_file = legacy_value[1:]
-            used_legacy_file_reference = True
-        else:
-            raise OIDCSetupError(
-                "Literal --client-secret input is no longer accepted because command arguments can leak. "
-                "Store the value in a protected file and pass its runtime path with --client-secret-file. "
-                "Released automation may migrate safely with --client-secret @<absolute-runtime-path>."
-            )
 
     if not provider:
         if interactive:
@@ -362,11 +345,6 @@ def setup_oidc_cmd(
 
     # Connectivity check (warn, never fail).
     con.print(f"\n  [bold]OIDC setup[/bold] [dim]· provider {provider} · issuer {issuer}[/dim]")
-    if used_legacy_file_reference:
-        con.print(
-            "  [yellow]Deprecated option[/yellow] [dim]· --client-secret @<absolute-runtime-path> is a file-reference migration shim; "
-            "use --client-secret-file on the next update.[/dim]"
-        )
     check = check_issuer_connectivity(issuer)
     if check.get("reachable") and check.get("complete"):
         con.print("  [green]Issuer discovery OK[/green] [dim]· authorization, token, and JWKS endpoints resolved.[/dim]")

--- a/tests/test_auth_setup_oidc.py
+++ b/tests/test_auth_setup_oidc.py
@@ -301,7 +301,8 @@ def test_cli_rejects_removed_client_secret_option_without_echoing_or_side_effect
         )
 
     assert result.exit_code != 0
-    assert "No such option: --client-secret" in result.output
+    assert "No such option" in result.output
+    assert "--client-secret" in result.output
     assert sensitive_fragment not in result.output
     discover.assert_not_called()
     assert not output.exists()

--- a/tests/test_auth_setup_oidc.py
+++ b/tests/test_auth_setup_oidc.py
@@ -261,81 +261,24 @@ def test_cli_generic_provider_requires_issuer():
     assert "issuer" in result.output.lower()
 
 
-def test_cli_rejects_literal_client_secret_without_echoing_or_side_effects(tmp_path: Path):
-    runner = CliRunner()
-    output = tmp_path / "must-not-exist.env"
-
-    with patch("agent_bom.api.oidc.discover_oidc") as discover:
-        result = runner.invoke(
-            main,
-            [
-                "auth",
-                "setup-oidc",
-                "--non-interactive",
-                "--provider",
-                "google",
-                "--client-id",
-                "cid",
-                "--client-secret",
-                "do-not-echo-this",
-                "--base-url",
-                "https://abom.example.com",
-                "--write",
-                "--output",
-                str(output),
-            ],
-        )
-
-    assert result.exit_code != 0
-    assert "do-not-echo-this" not in result.output
-    assert "client-secret-file" in result.output
-    discover.assert_not_called()
-    assert not output.exists()
-
-
-def test_cli_legacy_client_secret_accepts_only_an_at_file_reference():
-    """Released automation can migrate without putting secret bytes in argv."""
-    runner = CliRunner()
-    with patch("agent_bom.api.oidc.discover_oidc", return_value=dict(_DISCOVERY_OK)):
-        result = runner.invoke(
-            main,
-            [
-                "auth",
-                "setup-oidc",
-                "--non-interactive",
-                "--provider",
-                "google",
-                "--client-id",
-                "cid",
-                "--client-secret",
-                "@/run/agent-bom/oidc/client_secret",
-                "--base-url",
-                "https://abom.example.com",
-            ],
-        )
-
-    assert result.exit_code == 0, result.output
-    assert "AGENT_BOM_OIDC_CLIENT_SECRET_FILE=/run/agent-bom/oidc/client_secret" in result.output
-    assert "AGENT_BOM_OIDC_CLIENT_SECRET=" not in result.output
-    assert "deprecated" in result.output.lower()
-
-
 @pytest.mark.parametrize(
     ("legacy_value", "sensitive_fragment"),
     (
-        ("@literal-secret-sentinel", "literal-secret-sentinel"),
+        ("do-not-echo-this", "do-not-echo-this"),
+        ("@/run/agent-bom/oidc/client_secret", "/run/agent-bom/oidc/client_secret"),
         ("@../secret-file", "../secret-file"),
         ("@/run/agent-bom/../secret-file", "../secret-file"),
         ("@/run/agent-bom/oidc/client_secret\nAGENT_BOM_API_KEYS=attacker:admin", "attacker:admin"),
     ),
 )
-def test_cli_legacy_client_secret_rejects_unsafe_file_references_before_side_effects(
+def test_cli_rejects_removed_client_secret_option_without_echoing_or_side_effects(
     tmp_path: Path,
     legacy_value: str,
     sensitive_fragment: str,
 ):
-    output = tmp_path / "must-not-exist.env"
     runner = CliRunner()
+    output = tmp_path / "must-not-exist.env"
+
     with patch("agent_bom.api.oidc.discover_oidc") as discover:
         result = runner.invoke(
             main,
@@ -358,7 +301,7 @@ def test_cli_legacy_client_secret_rejects_unsafe_file_references_before_side_eff
         )
 
     assert result.exit_code != 0
-    assert "absolute normalized runtime file path" in result.output
+    assert "No such option: --client-secret" in result.output
     assert sensitive_fragment not in result.output
     discover.assert_not_called()
     assert not output.exists()


### PR DESCRIPTION
## Summary

- remove the hidden legacy `auth setup-oidc --client-secret` input that CodeQL traced to the env-file write sink
- retain only the normalized `--client-secret-file` reference contract for confidential OIDC clients
- reject removed-option values before discovery or file writes without echoing secret-shaped input; align operator docs and the changelog

## Verification

- `uv run pytest -q tests/test_auth_setup_oidc.py tests/api/test_api_oidc_browser.py` (51 passed)
- `uv run ruff check src/agent_bom/cli/_auth_group.py tests/test_auth_setup_oidc.py`
- `uv run ruff format --check src/agent_bom/cli/_auth_group.py tests/test_auth_setup_oidc.py`
- `uv run mypy src/agent_bom/cli/_auth_group.py`
- `uv run python scripts/check_public_docs_hygiene.py`
- `make preflight`
- `uv run agent-bom auth setup-oidc --help`
- `uv run agent-bom scan --demo --offline --format json --quiet -o /tmp/agent-bom-1853-demo.json` (valid 24-finding artifact; exit 1 because findings were present)

## Notes

- Fixes the `py/clear-text-storage-sensitive-data` data flow reported by CodeQL alert 1853 at `src/agent_bom/cli/_auth_group.py`.
- Fail-closed behavior: the removed option exits during Click argument parsing, before issuer discovery and before any output file can be created.
