### PR TITLE
fix(api): offload full scan response redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - Purging secret-shaped legacy material from an already-retired credential
   reference now records one tenant-scoped, sanitized audit event without
   duplicating the event on idempotent DELETE retries.
+- Full scan-result API responses now sanitize large AI-BOM payloads in the
+  bounded worker pool so polling them cannot monopolize the server event loop.
 
 ## [0.102.0] - 2026-08-23
 

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1299,6 +1299,14 @@ def _job_response_payload(job: ScanJob) -> ScanJob:
     return job.model_copy(update={"result": redacted_result})
 
 
+async def _job_response_payload_off_loop(job: ScanJob) -> ScanJob:
+    """Sanitize a potentially large full result in the bounded worker pool."""
+    return cast(
+        ScanJob,
+        await anyio.to_thread.run_sync(partial(_job_response_payload, job)),
+    )
+
+
 def enqueue_scan_job(
     *,
     tenant_id: str,
@@ -1578,7 +1586,7 @@ async def get_scan(request: Request, job_id: str) -> ScanJob:
     non-json ``format``, ``result_document`` carries that rendering and
     ``result_format`` names it.
     """
-    return _job_response_payload(await _load_job_for_request(request, job_id))
+    return await _job_response_payload_off_loop(await _load_job_for_request(request, job_id))
 
 
 @router.get("/scan/{job_id}/status", tags=["scan"])

--- a/tests/api/test_scan_response_offload.py
+++ b/tests/api/test_scan_response_offload.py
@@ -1,0 +1,41 @@
+"""Regression coverage for large full-result scan responses."""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import cast
+
+import pytest
+from starlette.requests import Request
+
+from agent_bom.api.models import ScanJob, ScanRequest
+
+
+@pytest.mark.anyio
+async def test_get_scan_offloads_full_result_redaction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Full AI-BOM sanitization must not run on the server event-loop thread."""
+    from agent_bom.api.routes import scan as scan_routes
+
+    job = ScanJob(
+        job_id="large-result",
+        created_at="2026-08-28T00:00:00Z",
+        request=ScanRequest(),
+        result={"findings": [], "summary": {"total_findings": 0}},
+    )
+    offloaded: list[partial[ScanJob]] = []
+
+    async def fake_load(_request: Request, _job_id: str) -> ScanJob:
+        return job
+
+    async def fake_run_sync(fn: partial[ScanJob]) -> ScanJob:
+        offloaded.append(fn)
+        return fn()
+
+    monkeypatch.setattr(scan_routes, "_load_job_for_request", fake_load)
+    monkeypatch.setattr(scan_routes.anyio.to_thread, "run_sync", fake_run_sync)
+
+    response = await scan_routes.get_scan(cast(Request, object()), job.job_id)
+
+    assert response.job_id == job.job_id
+    assert len(offloaded) == 1
+    assert offloaded[0].func is scan_routes._job_response_payload


### PR DESCRIPTION
## Summary

- sanitize full AI-BOM scan responses in the bounded AnyIO worker pool
- keep lightweight scan-status polling unchanged
- add a regression proving the full-result route delegates redaction off the event loop

## Verification

- UV_CACHE_DIR=/tmp/agent-bom-coverage-gap-cache uv run pytest -q tests/api/test_api_scan_types.py tests/api/test_route_event_loop_guard.py tests/test_worker_thread_limit.py tests/api/test_scan_response_offload.py
- UV_CACHE_DIR=/tmp/agent-bom-coverage-gap-cache uv run ruff check src/agent_bom/api/routes/scan.py tests/api/test_scan_response_offload.py
- UV_CACHE_DIR=/tmp/agent-bom-coverage-gap-cache uv run ruff format --check src/agent_bom/api/routes/scan.py tests/api/test_scan_response_offload.py
- UV_CACHE_DIR=/tmp/agent-bom-coverage-gap-cache uv run mypy src/agent_bom
- UV_CACHE_DIR=/tmp/agent-bom-coverage-gap-cache make preflight
- UV_CACHE_DIR=/tmp/agent-bom-coverage-gap-cache uv run python scripts/check_public_docs_hygiene.py

## Notes

- The endpoint remains auth- and tenant-scoped through the existing job loader.
- Redaction remains fail-closed; only its CPU work moves to the bounded worker pool.