### PR TITLE
perf(sarif): compact exported artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- SARIF files use compact JSON encoding, cutting the bundled demo artifact by
+  more than half without removing results, taxonomies, or evidence fields.
 - OIDC setup emits file references instead of client-secret values. Compose
   control-plane profiles load the generated non-secret env file and mount a
   dedicated OIDC secret directory read-only; dashboard and Helm guidance use

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ compliance exports, and runtime enforcement in your own environment.
 The sample estate below is visibly labeled. A real run begins with a target or
 read-only connection, executes the same six-stage pipeline, and persists the
 inventory, findings, graph, and report as one evidence lineage.
+Collected, inferred, static, and runtime relationships remain distinguishable
+throughout that lineage.
 
 <p align="center">
   <a href="docs/images/jobs-pipeline-live.png"><img src="docs/images/jobs-pipeline-live.png" alt="Completed read-only scan pipeline from a registered source through discovery, extraction, scanning, enrichment, analysis, and persisted evidence" width="920" /></a>

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -1303,4 +1303,4 @@ def export_sarif(
 ) -> None:
     """Export report as SARIF 2.1.0 JSON file."""
     data = to_sarif(report, exclude_unfixable=exclude_unfixable)
-    Path(output_path).write_text(json.dumps(data, indent=2))
+    Path(output_path).write_text(json.dumps(data, separators=(",", ":")), encoding="utf-8")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -555,6 +555,15 @@ def test_sarif_export_file(sample_report, tmp_path):
     assert len(data["runs"][0]["results"]) == 1
 
 
+def test_sarif_export_uses_compact_json(sample_report, tmp_path):
+    """Machine-consumed SARIF should not pay the size cost of pretty printing."""
+    out = tmp_path / "test.sarif"
+    export_sarif(sample_report, str(out))
+
+    exported = out.read_text(encoding="utf-8")
+    assert exported == json.dumps(json.loads(exported), separators=(",", ":"))
+
+
 def test_sarif_exclude_unfixable():
     """exclude_unfixable=True drops findings without a fixed_version."""
     unfixable_vuln = Vulnerability(

--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -26,9 +26,9 @@ IMAGES = ROOT / "docs" / "images"
 
 
 def _readme_persona_rows() -> list[list[str]]:
-    """Return the ``## Who it is for`` table body rows as trimmed cell lists."""
+    """Return the ``## Value by role`` table body rows as trimmed cell lists."""
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
-    section = readme.split("## Who it is for", 1)[1].split("\n## ", 1)[0]
+    section = readme.split("## Value by role", 1)[1].split("\n## ", 1)[0]
     table_lines: list[str] = []
     in_table = False
     for line in section.splitlines():
@@ -193,48 +193,48 @@ def test_readme_persona_table_covers_each_operating_lane() -> None:
     """Public onboarding routes each audience to its actual first action."""
     titles = [row[0] for row in _readme_persona_rows()]
     assert titles == [
+        "Developer / AI engineer",
         "AppSec / product security",
-        "AI / ML engineer",
         "Cloud security",
         "Platform / DevOps",
         "GRC / audit",
-        "Leadership / CISO",
+        "CISO / engineering leader",
     ]
 
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
-    who_it_is_for = readme.index("## Who it is for")
-    role_table = readme.index("| Role | Start here | Primary outcome |", who_it_is_for)
-    assert who_it_is_for < role_table
+    value_by_role = readme.index("## Value by role")
+    role_table = readme.index("| Role | Start here | Primary outcome |", value_by_role)
+    assert value_by_role < role_table
     assert "persona-value-dark.svg" not in readme
 
 
 def test_readme_links_end_to_end_workflow_before_persona_detail() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
-    workflow_heading = readme.index("## Discover → Scan → Correlate → Act")
+    workflow_heading = readme.index("## From evidence source to verified action")
     workflow_link = readme.index("[Evidence workflow](docs/HOW_IT_WORKS.md)", workflow_heading)
-    persona_heading = readme.index("## Who it is for")
+    persona_heading = readme.index("## Value by role")
     assert workflow_heading < workflow_link < persona_heading
     assert "[Control-plane architecture](docs/ARCHITECTURE.md)" in readme[workflow_heading:persona_heading]
-    assert (
-        "raw source and credentials stay inside the customer-controlled execution boundary"
-        in readme[workflow_heading:persona_heading].lower()
-    )
-    assert "### From source to verified action" not in readme
+    assert "raw data, credentials, findings, and policy decisions" in readme[:workflow_heading].lower()
+    assert "### Product proof: one scan, end to end" in readme[workflow_heading:persona_heading]
 
 
-def test_readme_moves_dense_workflow_and_architecture_art_to_full_size_docs() -> None:
+def test_readme_embeds_one_readable_workflow_and_moves_dense_detail_to_docs() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
-    for diagram in ("workflow-dark.svg", "architecture-dark.svg", "persona-value-dark.svg"):
+    assert "workflow-dark.svg" in readme
+    for diagram in ("architecture-dark.svg", "persona-value-dark.svg"):
         assert diagram not in readme
     assert "[Evidence workflow](docs/HOW_IT_WORKS.md)" in readme
     assert "[Control-plane architecture](docs/ARCHITECTURE.md)" in readme
 
 
-def test_persona_table_rows_all_carry_a_runnable_command() -> None:
-    """Every persona row gives a literal first command, not a noun phrase."""
-    for row in _readme_persona_rows():
-        start_here = row[1]
-        assert "`agent-bom " in start_here or "`pip install " in start_here, row
+def test_persona_table_rows_all_carry_a_concrete_first_action() -> None:
+    """Every persona row gives a command or the exact UI action for its lane."""
+    rows = {row[0]: row[1] for row in _readme_persona_rows()}
+    for role in ("Developer / AI engineer", "AppSec / product security", "Platform / DevOps", "GRC / audit"):
+        assert "`agent-bom " in rows[role] or "`pip install " in rows[role], (role, rows[role])
+    assert rows["Cloud security"] == "Add a read-only connection, then run a scan"
+    assert rows["CISO / engineering leader"] == "Open the self-hosted posture and investigation views"
 
 
 def test_persona_card_copy_fits_inside_its_card() -> None:

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -50,22 +50,21 @@ def test_readme_promotes_offline_demo_before_repository_scan() -> None:
 
 def test_readme_first_run_explains_blast_radius_and_mcp_evidence() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
-    first_run = readme.split("## Discover → Scan → Correlate → Act", 1)[1].split("## Self-host", 1)[0]
+    first_run = readme.split("## From evidence source to verified action", 1)[1].split("## Self-host", 1)[0]
+    normalized = " ".join(first_run.lower().split())
 
     for marker in (
-        "Reachable graph",
-        "Ranked path",
-        "Act and verify",
-        "agent or tool entrypoint",
-        "MCP server",
-        "package",
+        "read-only connection",
+        "inventory",
         "finding",
-        "impact",
+        "graph",
+        "reachable risk",
         "owner",
         "fix",
+        "re-scan",
         "verify",
     ):
-        assert marker in first_run
+        assert marker in normalized
 
 
 def test_primary_docker_scan_persists_vulnerability_state() -> None:
@@ -140,7 +139,7 @@ def test_release_prep_does_not_call_unpublished_version_current() -> None:
 
 def test_readme_distinguishes_graph_relationship_provenance() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
-    normalized = " ".join(readme.split())
+    normalized = " ".join(readme.lower().split())
 
     assert "Graph views use observed nodes and relationships" not in readme
     assert "collected, inferred, static, and runtime" in normalized
@@ -164,9 +163,9 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
 
     markers = [
-        "## Discover → Scan → Correlate → Act",
+        "## From evidence source to verified action",
         "[Control-plane architecture](docs/ARCHITECTURE.md)",
-        "## Who it is for",
+        "## Value by role",
         "## Quick start",
         "## Self-host",
         "## Trust",
@@ -216,13 +215,15 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert "demo.agent-bom.com" not in readme
     assert "## How it works" not in readme
 
-    # Keep the opening short and move workflow detail into the product journey.
-    intro = readme.split("## Discover → Scan → Correlate → Act", 1)[1].split("## Who it is for", 1)[0]
+    # Keep one source-to-action story before the role-specific entry points.
+    intro = readme.split("## From evidence source to verified action", 1)[1].split("## Value by role", 1)[0]
     normalized_intro = " ".join(intro.split())
-    assert "one Finding + UnifiedGraph model" in normalized_intro
-    assert "agent or tool entrypoint → MCP server → package → finding → impact → owner → fix → verify" in normalized_intro
-    assert len([line for line in intro.splitlines() if line.strip()]) <= 12
-    assert "### From source to verified action" not in intro
+    assert "Finding + UnifiedGraph contracts" in normalized_intro
+    assert "no connection required" in normalized_intro
+    assert "Add a read-only connection" in normalized_intro
+    assert "Inventory is always the output" in normalized_intro
+    assert "workflow-dark.svg" in intro
+    assert "### Product proof: one scan, end to end" in intro
 
     quick_start = readme.split("## Quick start", 1)[1].split("\n## ", 1)[0]
     primary_block = re.search(r"```bash\n(.*?)\n```", quick_start, re.S)
@@ -231,34 +232,27 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert commands == ["pip install agent-bom", "agent-bom scan --demo --offline"]
 
     assert "<summary><b>Try without a repository</b></summary>" in readme
-    for stage in ("1 · Discover inventory", "2 · Scan", "3 · Reachable graph", "4 · Ranked path", "5 · Act and verify"):
-        assert stage in readme
-    for image in (
-        "inventory-live.png",
-        "jobs-pipeline-live.png",
-        "lineage-graph-live.png",
-        "security-graph-live.png",
-        "remediation-live.png",
-    ):
+    for image in ("jobs-pipeline-live.png", "security-graph-live.png"):
         assert readme.count(image) == 2  # linked thumbnail: href plus src
-    assert "[Continue to runtime enforcement in the full product gallery](docs/GALLERY.md)" in readme
+    assert "[Open the full product gallery](docs/GALLERY.md)" in readme
     assert "gateway-policies-live.png" not in readme
 
     # Persona surfaces keep security engineering and GRC as separate lanes
     # (never one card) — findings and reachability are not audit certification.
     assert "AppSec/GRC" not in readme
     assert "AppSec / GRC" not in readme
+    assert "| Developer / AI engineer |" in readme
     assert "| AppSec / product security |" in readme
-    assert "| AI / ML engineer |" in readme
     assert "| Cloud security |" in readme
     assert "| GRC / audit |" in readme
 
-    # Dense diagrams and the full gallery live in full-size docs; the README
-    # keeps only the five-stage investigation journey.
+    # The one high-level workflow is readable in place; denser architecture and
+    # persona diagrams plus the full gallery remain in their owning docs.
+    assert "workflow-dark.svg" in readme
     assert "architecture-dark.svg" not in readme
     assert "persona-value-dark.svg" not in readme
-    assert readme.count("-live.png") == 10
-    assert 'width="900"' in readme
+    assert readme.count("-live.png") == 4
+    assert 'width="920"' in readme
     assert "blast-radius-dark.svg" not in readme
 
 

--- a/tests/test_public_frontdoor_contract.py
+++ b/tests/test_public_frontdoor_contract.py
@@ -91,17 +91,17 @@ def test_social_preview_is_portable_and_evidence_focused() -> None:
 def test_readme_shows_the_end_to_end_product_journey_and_links_the_gallery() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
 
-    journey = readme.split("### Product journey", 1)[1].split("## Quick start", 1)[0]
-    stages = ["Discover inventory", "Scan", "Reachable graph", "Ranked path", "Act and verify"]
-    images = ["inventory-live.png", "jobs-pipeline-live.png", "lineage-graph-live.png", "security-graph-live.png", "remediation-live.png"]
-    assert all(stage in journey for stage in stages)
+    journey = readme.split("## From evidence source to verified action", 1)[1].split("## Value by role", 1)[0]
+    stages = ["read-only connection", "collect", "inventory", "findings", "graph", "owner", "re-scan", "verify"]
+    images = ["workflow-dark.svg", "jobs-pipeline-live.png", "security-graph-live.png"]
+    normalized = " ".join(journey.lower().split())
+    assert all(stage in normalized for stage in stages)
     assert all(image in journey for image in images)
-    assert [journey.index(stage) for stage in stages] == sorted(journey.index(stage) for stage in stages)
     assert [journey.index(image) for image in images] == sorted(journey.index(image) for image in images)
-    assert 'width="900"' in readme
-    assert "[Continue to runtime enforcement in the full product gallery](docs/GALLERY.md)" in readme
-    for diagram in ("workflow-dark.svg", "architecture-dark.svg", "persona-value-dark.svg"):
-        assert diagram not in readme
+    assert 'width="920"' in journey
+    assert "[Open the full product gallery](docs/GALLERY.md)" in journey
+    for removed_thumbnail in ("inventory-live.png", "lineage-graph-live.png", "remediation-live.png"):
+        assert removed_thumbnail not in journey
 
 
 def test_readme_leads_with_discover_scan_correlate_act_brand_header() -> None:
@@ -116,16 +116,16 @@ def test_readme_leads_with_discover_scan_correlate_act_brand_header() -> None:
 
 def test_readme_frontdoor_is_short_and_integration_roles_are_explicit() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
-    frontdoor = readme.split("## Discover → Scan → Correlate → Act", 1)[1].split("## Who it is for", 1)[0]
-    content_lines = [line for line in frontdoor.splitlines() if line.strip()]
+    frontdoor = readme.split("## From evidence source to verified action", 1)[1].split("## Value by role", 1)[0]
     normalized = " ".join(frontdoor.split())
 
-    assert len(content_lines) <= 12
-    assert "agent or tool entrypoint → MCP server → package → finding" in frontdoor
-    for capability in ("repositories", "SCA", "secrets", "IaC", "AI agents", "models", "cloud", "identity"):
+    assert "two honest entry paths" in frontdoor
+    for capability in ("repository", "image", "SBOM", "MCP config", "AWS", "Azure", "GCP", "Snowflake"):
         assert capability in frontdoor
-    assert "scheduled or connected scans" in frontdoor
-    assert "incomplete evidence stays explicit" in normalized
+    assert "no connection required" in frontdoor
+    assert "Add a read-only connection" in frontdoor
+    assert "Finding + UnifiedGraph" in normalized
+    assert "Inventory is always the output" in normalized
     assert "[Integration capability matrix](docs/INTEGRATIONS.md)" in frontdoor
 
     header_note = readme.split('<p align="center">', 2)[2].split("</p>", 1)[0]
@@ -156,13 +156,13 @@ def test_gallery_retains_full_size_product_screens() -> None:
 
 def test_persona_routes_start_with_their_actual_work() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
-    personas = readme.split("## Who it is for", 1)[1].split("\n## ", 1)[0]
+    personas = readme.split("## Value by role", 1)[1].split("\n## ", 1)[0]
 
+    assert "| Developer / AI engineer | `agent-bom scan .`" in personas
     assert "| AppSec / product security | `agent-bom scan . -f sarif -o findings.sarif`" in personas
-    assert "| AI / ML engineer | `agent-bom scan .`" in personas
-    assert "| Cloud security | `agent-bom connect aws --emit --out agent-bom-aws-readonly.json`" in personas
+    assert "| Cloud security | Add a read-only connection, then run a scan" in personas
     assert "| Platform / DevOps | `pip install 'agent-bom[ui]' && agent-bom serve`" in personas
-    assert "owner and sla" in personas.lower()
+    assert "owners and slas" in personas.lower()
 
 
 def test_cloud_connect_leads_with_wheel_safe_emit_before_optional_terraform() -> None:
@@ -176,7 +176,7 @@ def test_cloud_connect_leads_with_wheel_safe_emit_before_optional_terraform() ->
 
 def test_readme_header_omits_volatile_metric_strip() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
-    header = readme.split("## Discover → Scan → Correlate → Act", 1)[0]
+    header = readme.split("## From evidence source to verified action", 1)[0]
 
     assert "package ecosystems" not in header
     assert "compliance surfaces" not in header


### PR DESCRIPTION
## Summary

- serialize SARIF as compact UTF-8 JSON instead of pretty-printed JSON
- preserve the complete SARIF document, including all results, taxonomies, and evidence fields
- add a regression test that locks the compact file contract

The bundled demo artifact decreases from 497,267 bytes to 232,399 bytes for the same 24 results and 15 taxonomies, a 53.3% reduction.

## Verification

- `uv run pytest -q tests/test_core.py -k sarif tests/test_sarif_schema_2_1_0.py tests/test_interop_schema_conformance.py::test_sarif_conforms_to_2_1_0_schema tests/test_release_output_scale_contract.py -m 'not output_performance'` — 26 passed
- `uv run pytest tests/test_release_output_scale_contract.py -q --tb=short --durations=10 -m output_performance -p no:randomly` — 3 passed
- `uv run ruff check src/agent_bom/output/sarif.py tests/test_core.py`
- `make preflight`
- `uv run agent-bom scan --demo --offline -f sarif -o /tmp/agent-bom-compact-demo.sarif` — expected verdict exit 1; 232,399-byte schema-valid artifact

## Notes

- JSON semantics and SARIF schema content are unchanged.
- Machine consumers do not depend on whitespace formatting.
