### PR TITLE
fix(auth): preserve OIDC file-reference migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - OIDC setup emits file references instead of client-secret values. Compose
   control-plane profiles load the generated non-secret env file and mount a
   dedicated OIDC secret directory read-only; dashboard and Helm guidance use
-  the same file-first contract. `auth setup-oidc` no longer accepts a
-  `--client-secret` option; automation must use
+  the same file-first contract. The deprecated `--client-secret` compatibility
+  alias accepts only `@/absolute/runtime/path`; new automation must use
   `--client-secret-file <absolute-runtime-path>`. Secret bytes are never
   accepted, echoed, read, or written by the wizard.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- OIDC setup preserves the released `--client-secret @/absolute/runtime/path`
+  migration form as a file-reference-only compatibility alias. Literal secret
+  values still fail before discovery, output, or file writes; new automation
+  should use `--client-secret-file`.
+
 ### Changed
 
 - SARIF files use compact JSON encoding, cutting the bundled demo artifact by

--- a/src/agent_bom/cli/_auth_group.py
+++ b/src/agent_bom/cli/_auth_group.py
@@ -70,7 +70,7 @@ def _normalize_runtime_secret_file_path(value: Optional[str]) -> str:
     return value
 
 
-def _legacy_client_secret_file_reference(value: Optional[str]) -> str:
+def _legacy_file_reference(value: Optional[str]) -> str:
     """Translate the released ``--client-secret @/path`` form without reading it."""
     if value is None:
         return ""
@@ -273,7 +273,7 @@ def auth_group() -> None:
 )
 @click.option(
     "--client-secret",
-    "legacy_client_secret",
+    "legacy_file_reference",
     default=None,
     hidden=True,
     metavar="@/ABSOLUTE/RUNTIME/PATH",
@@ -291,7 +291,7 @@ def setup_oidc_cmd(
     issuer: Optional[str],
     client_id: Optional[str],
     client_secret_file: Optional[str],
-    legacy_client_secret: Optional[str],
+    legacy_file_reference: Optional[str],
     base_url: Optional[str],
     redirect_uri: Optional[str],
     audience: Optional[str],
@@ -316,11 +316,11 @@ def setup_oidc_cmd(
     # Preserve released automation that used ``--client-secret @/path`` while
     # continuing to reject literal secret values. Resolve this before prompts,
     # discovery, output, or writes so invalid input cannot have side effects.
-    legacy_secret_file = _legacy_client_secret_file_reference(legacy_client_secret)
-    if legacy_secret_file and client_secret_file is not None:
+    migrated_file_reference = _legacy_file_reference(legacy_file_reference)
+    if migrated_file_reference and client_secret_file is not None:
         raise OIDCSetupError("--client-secret and --client-secret-file are mutually exclusive; prefer --client-secret-file.")
-    if legacy_secret_file:
-        client_secret_file = legacy_secret_file
+    if migrated_file_reference:
+        client_secret_file = migrated_file_reference
 
     if not provider:
         if interactive:

--- a/src/agent_bom/cli/_auth_group.py
+++ b/src/agent_bom/cli/_auth_group.py
@@ -70,6 +70,22 @@ def _normalize_runtime_secret_file_path(value: Optional[str]) -> str:
     return value
 
 
+def _legacy_client_secret_file_reference(value: Optional[str]) -> str:
+    """Translate the released ``--client-secret @/path`` form without reading it."""
+    if value is None:
+        return ""
+    message = (
+        "--client-secret accepts only a file reference in the form @/absolute/runtime/path; "
+        "prefer --client-secret-file /absolute/runtime/path."
+    )
+    if not value.startswith("@") or len(value) == 1:
+        raise OIDCSetupError(message)
+    try:
+        return _normalize_runtime_secret_file_path(value[1:])
+    except OIDCSetupError:
+        raise OIDCSetupError(message) from None
+
+
 def _stdin_is_tty() -> bool:
     """Whether stdin is an interactive terminal (patch point for tests)."""
     try:
@@ -255,6 +271,13 @@ def auth_group() -> None:
     default=None,
     help="Runtime path to an operator-managed OAuth client-secret file (omit for a PKCE public client).",
 )
+@click.option(
+    "--client-secret",
+    "legacy_client_secret",
+    default=None,
+    hidden=True,
+    metavar="@/ABSOLUTE/RUNTIME/PATH",
+)
 @click.option("--base-url", default=None, help="Deployment base URL; the redirect URI is derived from it.")
 @click.option("--redirect-uri", default=None, help="Override the derived redirect URI (must match the IdP allowlist).")
 @click.option("--audience", default=None, help="Expected JWT audience (defaults to the client ID).")
@@ -268,6 +291,7 @@ def setup_oidc_cmd(
     issuer: Optional[str],
     client_id: Optional[str],
     client_secret_file: Optional[str],
+    legacy_client_secret: Optional[str],
     base_url: Optional[str],
     redirect_uri: Optional[str],
     audience: Optional[str],
@@ -288,6 +312,15 @@ def setup_oidc_cmd(
 
     con = Console()
     interactive = (not non_interactive) and _stdin_is_tty()
+
+    # Preserve released automation that used ``--client-secret @/path`` while
+    # continuing to reject literal secret values. Resolve this before prompts,
+    # discovery, output, or writes so invalid input cannot have side effects.
+    legacy_secret_file = _legacy_client_secret_file_reference(legacy_client_secret)
+    if legacy_secret_file and client_secret_file is not None:
+        raise OIDCSetupError("--client-secret and --client-secret-file are mutually exclusive; prefer --client-secret-file.")
+    if legacy_secret_file:
+        client_secret_file = legacy_secret_file
 
     if not provider:
         if interactive:

--- a/tests/test_auth_setup_oidc.py
+++ b/tests/test_auth_setup_oidc.py
@@ -265,13 +265,12 @@ def test_cli_generic_provider_requires_issuer():
     ("legacy_value", "sensitive_fragment"),
     (
         ("do-not-echo-this", "do-not-echo-this"),
-        ("@/run/agent-bom/oidc/client_secret", "/run/agent-bom/oidc/client_secret"),
         ("@../secret-file", "../secret-file"),
         ("@/run/agent-bom/../secret-file", "../secret-file"),
         ("@/run/agent-bom/oidc/client_secret\nAGENT_BOM_API_KEYS=attacker:admin", "attacker:admin"),
     ),
 )
-def test_cli_rejects_removed_client_secret_option_without_echoing_or_side_effects(
+def test_cli_rejects_literal_or_invalid_legacy_client_secret_without_echoing_or_side_effects(
     tmp_path: Path,
     legacy_value: str,
     sensitive_fragment: str,
@@ -301,11 +300,62 @@ def test_cli_rejects_removed_client_secret_option_without_echoing_or_side_effect
         )
 
     assert result.exit_code != 0
-    assert "No such option" in result.output
     assert "--client-secret" in result.output
     assert sensitive_fragment not in result.output
     discover.assert_not_called()
     assert not output.exists()
+
+
+def test_cli_accepts_legacy_file_reference_without_reading_or_emitting_a_secret():
+    runner = CliRunner()
+    with patch("agent_bom.api.oidc.discover_oidc", return_value=dict(_DISCOVERY_OK)):
+        result = runner.invoke(
+            main,
+            [
+                "auth",
+                "setup-oidc",
+                "--non-interactive",
+                "--provider",
+                "google",
+                "--client-id",
+                "cid",
+                "--client-secret",
+                "@/run/agent-bom/oidc/client_secret",
+                "--base-url",
+                "https://abom.example.com",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "AGENT_BOM_OIDC_CLIENT_SECRET_FILE=/run/agent-bom/oidc/client_secret" in result.output
+    assert "AGENT_BOM_OIDC_CLIENT_SECRET=" not in result.output
+
+
+def test_cli_rejects_both_secret_file_options_before_discovery():
+    runner = CliRunner()
+    with patch("agent_bom.api.oidc.discover_oidc") as discover:
+        result = runner.invoke(
+            main,
+            [
+                "auth",
+                "setup-oidc",
+                "--non-interactive",
+                "--provider",
+                "google",
+                "--client-id",
+                "cid",
+                "--client-secret",
+                "@/run/agent-bom/oidc/client_secret",
+                "--client-secret-file",
+                "/run/agent-bom/oidc/client_secret",
+                "--base-url",
+                "https://abom.example.com",
+            ],
+        )
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+    discover.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- restore the released `--client-secret @/absolute/runtime/path` migration form as a hidden compatibility alias
- translate only validated absolute file references to `AGENT_BOM_OIDC_CLIENT_SECRET_FILE`
- reject literal, malformed, injected, or conflicting secret inputs before discovery, output, or writes

## Verification

- `uv run pytest -q tests/test_auth_setup_oidc.py tests/api/test_api_oidc.py tests/api/test_api_oidc_browser.py tests/api/test_auth_oidc_invalid_decision.py tests/test_oidc_discovery_shim.py tests/test_compose_secrets_healthcheck.py --tb=short` (168 passed)
- `uv run ruff check src/agent_bom/cli/_auth_group.py tests/test_auth_setup_oidc.py`
- `uv run ruff format --check src/agent_bom/cli/_auth_group.py tests/test_auth_setup_oidc.py`
- `uv run python scripts/check_exception_sanitization.py`
- `make preflight`

## Notes

- `--client-secret-file` remains the documented interface.
- Literal secret values remain unsupported and are never echoed.