### PR TITLE
perf(graph): bound SQLite edge reads to selected nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Budgeted and filtered SQLite graph loads now seek edges from the selected
+  node ids instead of scanning every edge in the snapshot and discarding most
+  of them in Python.
 - Purging secret-shaped legacy material from an already-retired credential
   reference now records one tenant-scoped, sanitized audit event without
   duplicating the event on idempotent DELETE retries.

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -1179,11 +1179,34 @@ def load_graph(
         reason="node_budget" if budget is not None and total_nodes > returned_nodes else "",
     )
 
-    eq = "SELECT * FROM graph_edges WHERE tenant_id = ? AND scan_id = ?"
-    eparams: list[Any] = [tenant_id, effective_scan_id]
+    sql_scoped_edges = budget is not None or bool(entity_types) or bool(sev_sql)
+    if sql_scoped_edges:
+        # Drive the edge read from the exact node ids loaded above. Encoding the
+        # bounded set as one JSON parameter avoids SQLite's variable limit and
+        # avoids repeating the ranked node query. The endpoint index makes the
+        # work proportional to edges touching those nodes instead of every edge
+        # in the snapshot; the second join preserves the induced-subgraph
+        # contract.
+        eq = """
+            WITH selected_node_ids AS MATERIALIZED (
+                SELECT CAST(value AS TEXT) AS id FROM json_each(?)
+            )
+            SELECT edge.*
+            FROM selected_node_ids AS source_node
+            CROSS JOIN graph_edges AS edge INDEXED BY idx_ge_tenant_scan_source
+            JOIN selected_node_ids AS target_node
+              ON target_node.id = edge.target_id
+            WHERE edge.tenant_id = ?
+              AND edge.scan_id = ?
+              AND edge.source_id = source_node.id
+        """
+        eparams: list[Any] = [json.dumps(sorted(node_ids)), tenant_id, effective_scan_id]
+    else:
+        eq = "SELECT * FROM graph_edges WHERE tenant_id = ? AND scan_id = ?"
+        eparams = [tenant_id, effective_scan_id]
     if relationship_types:
         placeholders = ",".join("?" * len(relationship_types))
-        eq += f" AND relationship IN ({placeholders})"
+        eq += f" AND edge.relationship IN ({placeholders})" if sql_scoped_edges else f" AND relationship IN ({placeholders})"
         eparams.extend(sorted(relationship_types))
     for row in conn.execute(eq, eparams):
         if row["source_id"] not in node_ids or row["target_id"] not in node_ids:

--- a/tests/test_graph_backend_semantics.py
+++ b/tests/test_graph_backend_semantics.py
@@ -14,7 +14,9 @@ and edge-dedup (#4762) work:
 
 2. **A node budget must bound the read, not the result.** Postgres pushes the
    budget into SQL; SQLite materialized the whole snapshot and trimmed
-   afterwards — a bound that is declared but applied too late to help.
+   afterwards — a bound that is declared but applied too late to help. The
+   selected nodes must also drive endpoint-indexed edge reads; otherwise the
+   store still scans every edge in the snapshot and filters them in Python.
 
 3. **Deep ``offset`` is O(offset).** ``/v1/graph`` and ``/v1/graph/agents``
    reject it past a cap; ``/v1/graph/search`` accepted any offset.
@@ -33,6 +35,7 @@ and edge-dedup (#4762) work:
 from __future__ import annotations
 
 import os
+import sqlite3
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -300,6 +303,60 @@ class TestNodeBudgetBoundsTheRead:
         graph = store.load_graph(tenant_id="default", node_budget=10)
         for edge in graph.edges:
             assert edge.source in graph.nodes and edge.target in graph.nodes
+
+    def test_sqlite_budgeted_edge_read_seeks_from_selected_node_ids(self, tmp_path: Path) -> None:
+        """A node budget must also keep the edge read off the snapshot-wide index."""
+        from agent_bom.db import graph_store as sqlite_graph_store
+
+        graph = UnifiedGraph(scan_id="budget-edge-plan", tenant_id="default")
+        for i in range(40):
+            graph.add_node(
+                UnifiedNode(
+                    id=f"asset:{i}",
+                    entity_type=EntityType.CLOUD_RESOURCE,
+                    label=f"asset-{i}",
+                    risk_score=float(i),
+                )
+            )
+        for i in range(39):
+            graph.add_edge(
+                UnifiedEdge(
+                    source=f"asset:{i}",
+                    target=f"asset:{i + 1}",
+                    relationship=RelationshipType.DEPENDS_ON,
+                )
+            )
+
+        db_path = tmp_path / "graph.db"
+        SQLiteGraphStore(db_path).save_graph(graph)
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        captured: list[tuple[str, list[Any]]] = []
+
+        class _RecordingConnection:
+            def execute(self, sql: str, params: list[Any] | tuple[Any, ...] = ()):
+                if "graph_edges" in sql:
+                    captured.append((sql, list(params)))
+                return conn.execute(sql, params)
+
+        try:
+            loaded = sqlite_graph_store.load_graph(
+                _RecordingConnection(),  # type: ignore[arg-type]
+                tenant_id="default",
+                scan_id="budget-edge-plan",
+                node_budget=10,
+            )
+            edge_sql, edge_params = captured[-1]
+            plan = [str(row[3]) for row in conn.execute(f"EXPLAIN QUERY PLAN {edge_sql}", edge_params)]
+        finally:
+            conn.close()
+
+        assert len(loaded.nodes) == 10
+        graph_edge_steps = [step for step in plan if "graph_edges" in step or "idx_ge_tenant_scan_source" in step]
+        assert graph_edge_steps, plan
+        assert all("source_id=?" in step or "rowid=?" in step for step in graph_edge_steps), (
+            f"budgeted load still reads the whole edge snapshot: {graph_edge_steps}"
+        )
 
 
 # ── the API surfaces ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- drive bounded SQLite edge reads from the exact node IDs selected by the graph budget
- use the existing tenant/scan/source endpoint index while preserving induced-subgraph semantics
- add a regression that rejects snapshot-wide edge query plans

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-graph-uv-cache uv run pytest -q tests/test_graph_backend.py tests/test_graph_backend_semantics.py tests/test_graph_api.py tests/test_graph_store_streamed_persistence.py` — 143 passed, 9 skipped
- `UV_CACHE_DIR=/tmp/agent-bom-graph-uv-cache uv run ruff check src/agent_bom/db/graph_store.py tests/test_graph_backend_semantics.py`
- `UV_CACHE_DIR=/tmp/agent-bom-graph-uv-cache uv run ruff format --check src/agent_bom/db/graph_store.py tests/test_graph_backend_semantics.py`
- public-docs hygiene, duplicate-artifact, package-layout, and comment-hygiene guards

## Notes

A 20,000-edge isolated query benchmark dropped from 58.417 ms and 19,999 rows read to 0.174 ms and 49 rows read for a 50-node budget. The API contract and returned graph topology are unchanged.