### PR TITLE
perf(sarif): index repeated taxonomy references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- SARIF files use compact JSON encoding, cutting the bundled demo artifact by
-  more than half without removing results, taxonomies, or evidence fields.
+- SARIF files use compact JSON encoding and indexed result taxonomy references;
+  extension taxa omit names that duplicate their IDs. The bundled demo
+  artifact is less than half its former size without removing results,
+  taxonomies, or evidence fields.
 - OIDC setup emits file references instead of client-secret values. Compose
   control-plane profiles load the generated non-secret env file and mount a
   dedicated OIDC secret directory read-only; dashboard and Helm guidance use

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -348,14 +348,47 @@ def _taxonomies_as_tool_extensions(taxonomies: list[dict]) -> list[dict]:
     """Expose framework catalogs as SARIF tool extensions for catalog readers."""
     extensions: list[dict] = []
     for taxonomy in taxonomies:
+        extension_taxa: list[dict] = []
+        for taxon in taxonomy.get("taxa", []):
+            compact_taxon = dict(taxon)
+            if compact_taxon.get("name") == compact_taxon.get("id"):
+                compact_taxon.pop("name", None)
+            extension_taxa.append(compact_taxon)
         extension = {
             "name": taxonomy["name"],
             "fullName": taxonomy.get("fullName", taxonomy["name"]),
             "informationUri": taxonomy.get("informationUri", ""),
-            "taxa": taxonomy.get("taxa", []),
+            "taxa": extension_taxa,
         }
         extensions.append(extension)
     return extensions
+
+
+def _compact_taxa_references(results: list[dict], taxonomies: list[dict]) -> None:
+    """Replace repeated taxonomy names and IDs with SARIF index references."""
+    taxonomy_indexes = {taxonomy.get("name"): index for index, taxonomy in enumerate(taxonomies)}
+    taxon_indexes = {
+        (taxonomy.get("name"), taxon.get("id")): index for taxonomy in taxonomies for index, taxon in enumerate(taxonomy.get("taxa") or [])
+    }
+    for result in results:
+        references = result.get("taxa")
+        if not isinstance(references, list):
+            continue
+        compact: list[dict] = []
+        for reference in references:
+            if not isinstance(reference, dict):
+                compact.append(reference)
+                continue
+            component = reference.get("toolComponent")
+            taxonomy_name = component.get("name") if isinstance(component, dict) else None
+            taxon_id = reference.get("id")
+            taxonomy_index = taxonomy_indexes.get(taxonomy_name)
+            taxon_index = taxon_indexes.get((taxonomy_name, taxon_id))
+            if taxonomy_index is None or taxon_index is None:
+                compact.append(reference)
+                continue
+            compact.append({"index": taxon_index, "toolComponent": {"index": taxonomy_index}})
+        result["taxa"] = compact
 
 
 _GUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")
@@ -1247,6 +1280,7 @@ def to_sarif(
             )
 
     taxonomies = _build_run_taxonomies(results)
+    _compact_taxa_references(results, taxonomies)
     run: dict = {
         "tool": {
             "driver": {

--- a/tests/test_exploit_likelihood.py
+++ b/tests/test_exploit_likelihood.py
@@ -142,9 +142,17 @@ def test_sarif_embeds_run_level_framework_taxonomies():
     taxa_by_name = {taxonomy["name"]: {taxon["id"] for taxon in taxonomy["taxa"]} for taxonomy in taxonomies}
     assert "LLM05" in taxa_by_name["owasp-llm-top10"]
     assert "AML.T0010" in taxa_by_name["mitre-atlas"]
-    result_taxa = sarif["runs"][0]["results"][0]["taxa"]
-    assert {"id": "LLM05", "toolComponent": {"name": "owasp-llm-top10"}} in result_taxa
-    assert {"id": "AML.T0010", "toolComponent": {"name": "mitre-atlas"}} in result_taxa
+    run = sarif["runs"][0]
+    extensions = run["tool"]["extensions"]
+    resolved_result_taxa = {
+        (
+            extensions[reference["toolComponent"]["index"]]["name"],
+            extensions[reference["toolComponent"]["index"]]["taxa"][reference["index"]]["id"],
+        )
+        for reference in run["results"][0]["taxa"]
+    }
+    assert ("owasp-llm-top10", "LLM05") in resolved_result_taxa
+    assert ("mitre-atlas", "AML.T0010") in resolved_result_taxa
 
 
 def test_sarif_mirrors_framework_taxonomies_as_tool_extensions():

--- a/tests/test_sarif_schema_2_1_0.py
+++ b/tests/test_sarif_schema_2_1_0.py
@@ -311,6 +311,33 @@ def test_sarif_framework_taxonomy_labels_mappings_vendor_asserted() -> None:
     assert all(t["name"] == t["id"] for t in nist["taxa"])  # name == id, no title text
 
 
+def test_sarif_result_taxa_use_compact_resolvable_index_references(sarif_doc: dict) -> None:
+    """Repeated result references resolve through tool extensions without IDs."""
+    from agent_bom.output.sarif import _FRAMEWORK_TAXONOMY_META
+
+    run = sarif_doc["runs"][0]
+    extensions = run["tool"]["extensions"]
+    tagged_results = [result for result in run["results"] if result.get("taxa")]
+    assert tagged_results
+
+    for result in tagged_results:
+        resolved: set[tuple[str, str]] = set()
+        for reference in result["taxa"]:
+            assert set(reference) == {"index", "toolComponent"}
+            assert set(reference["toolComponent"]) == {"index"}
+            extension = extensions[reference["toolComponent"]["index"]]
+            taxon = extension["taxa"][reference["index"]]
+            assert set(taxon) == {"id"}, "extension taxa must not repeat name when it equals id"
+            resolved.add((extension["name"], taxon["id"]))
+
+        expected = {
+            (taxonomy_name, str(tag))
+            for property_name, (taxonomy_name, _full_name, _uri) in _FRAMEWORK_TAXONOMY_META.items()
+            for tag in result["properties"].get(property_name, [])
+        }
+        assert resolved == expected
+
+
 def _full_chain_report() -> AIBOMReport:
     """A report whose blast radius spans agent → server → package → CVE → tool."""
     vuln = Vulnerability(


### PR DESCRIPTION
## Summary

- replace repeated per-result taxonomy names and IDs with SARIF 2.1.0 index references
- keep run taxonomies and tool extensions resolvable while omitting extension names that duplicate IDs
- add schema-backed regression coverage for every compact reference

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-graph-uv-cache uv run pytest -q tests/test_*sarif*.py tests/test_release_output_scale_contract.py tests/test_code_scan_json_to_sarif.py` — 88 passed
- `UV_CACHE_DIR=/tmp/agent-bom-graph-uv-cache uv run ruff check src/agent_bom/output/sarif.py tests/test_sarif_schema_2_1_0.py`
- `UV_CACHE_DIR=/tmp/agent-bom-graph-uv-cache uv run ruff format --check src/agent_bom/output/sarif.py tests/test_sarif_schema_2_1_0.py`
- `agent-bom scan --demo --offline --format sarif` — expected vulnerability verdict 1; complete artifact written
- public-docs hygiene, duplicate-artifact, package-layout, and comment-hygiene guards

## Notes

The same 24-result demo artifact decreased from 232,471 bytes on main to 210,287 bytes, a further 9.5% reduction on top of the compact JSON change already merged in #4990. Result count and 15 run taxonomies/tool extensions are preserved.