### PR TITLE
docs(readme): map shipped proof to buyer roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,16 +85,18 @@ terminal state without switching evidence systems.
 
 | Role | Start here | Primary outcome |
 |---|---|---|
-| Developer / AI engineer | `agent-bom scan .` | See dependencies, secrets, IaC, agents, MCP, models, datasets, and reachable impact before shipping |
-| AppSec / product security | `agent-bom scan . -f sarif -o findings.sarif` | Gate CI on evidence-backed findings and retain a reviewable SARIF artifact |
+| Developer / AI engineer | `agent-bom scan .` | See dependencies, secrets, IaC, agents, MCP, and whether Click, Flask, or FastAPI entry points can reach vulnerable packages before shipping |
+| AppSec / product security | `agent-bom agents --gha . --offline` | Inventory remote actions and reusable workflows with their refs, source provenance, and CI-hardening findings |
 | Cloud security | Add a read-only connection, then run a scan | Build scoped cloud, identity, and posture inventory with explicit coverage and provenance |
 | Platform / DevOps | `pip install 'agent-bom[ui]' && agent-bom serve` | Schedule scans, centralize evidence, assign owners and SLAs, and verify remediation |
 | GRC / audit | `agent-bom report compliance-narrative scan.json` | Export mapped evidence while preserving unavailable, partial, and not-assessed states |
-| CISO / engineering leader | Open the self-hosted posture and investigation views | See material paths, coverage, ownership, and change over time—not another raw alert count |
+| CISO / engineering leader | Open **Architecture** in the self-hosted graph | Compare observed **Current** state with modeled **Proposed** and **Difference** views; proposals remain labeled as not observed or deployed |
 
 Security engineering and GRC remain separate workflows: findings and
 reachability are not presented as audit certification. See
-[product boundaries](docs/PRODUCT_BOUNDARIES.md).
+[product boundaries](docs/PRODUCT_BOUNDARIES.md). GitHub Actions collection and
+credential requirements are documented in [permissions](docs/PERMISSIONS.md);
+scenario truth boundaries are defined by the [graph contract](docs/graph/CONTRACT.md).
 
 ## Quick start
 

--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -234,7 +234,7 @@ def test_persona_table_rows_all_carry_a_concrete_first_action() -> None:
     for role in ("Developer / AI engineer", "AppSec / product security", "Platform / DevOps", "GRC / audit"):
         assert "`agent-bom " in rows[role] or "`pip install " in rows[role], (role, rows[role])
     assert rows["Cloud security"] == "Add a read-only connection, then run a scan"
-    assert rows["CISO / engineering leader"] == "Open the self-hosted posture and investigation views"
+    assert rows["CISO / engineering leader"] == "Open **Architecture** in the self-hosted graph"
 
 
 def test_persona_card_copy_fits_inside_its_card() -> None:

--- a/tests/test_public_frontdoor_contract.py
+++ b/tests/test_public_frontdoor_contract.py
@@ -159,9 +159,10 @@ def test_persona_routes_start_with_their_actual_work() -> None:
     personas = readme.split("## Value by role", 1)[1].split("\n## ", 1)[0]
 
     assert "| Developer / AI engineer | `agent-bom scan .`" in personas
-    assert "| AppSec / product security | `agent-bom scan . -f sarif -o findings.sarif`" in personas
+    assert "| AppSec / product security | `agent-bom agents --gha . --offline`" in personas
     assert "| Cloud security | Add a read-only connection, then run a scan" in personas
     assert "| Platform / DevOps | `pip install 'agent-bom[ui]' && agent-bom serve`" in personas
+    assert "| CISO / engineering leader | Open **Architecture** in the self-hosted graph" in personas
     assert "owners and slas" in personas.lower()
 
 


### PR DESCRIPTION
## Summary

- map Developer, AppSec, and CISO rows to shipped non-MCP reachability, GitHub Actions inventory, and architecture comparison
- replace generic outcomes with a first action and concrete artifact or decision value
- lock the exact Architecture action in the README regression test

## Verification

- ........................................                                                                                                                                                         [100%]
40 passed in 3.00s (40 passed)
- Public-docs hygiene check passed (782 files scanned).
- No tracked duplicate or agent-session artifacts found.
- 