### PR TITLE
fix(docker): restore Alpine arm64 source builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1735,15 +1735,26 @@ jobs:
           path: dist/
 
   # 5. Docker Build + Scan (multi-arch)
-  # Runs on main push only — Docker builds are slow and not needed per-PR
+  # Runs on main and on PRs that change release-image inputs. The PR path is
+  # intentionally narrow because the emulated arm64 build is slow, but it must
+  # run before a Dockerfile/lockfile change can reach a tag-triggered release.
   docker:
     name: Docker (multi-arch)
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      !cancelled() &&
+      needs.security.result == 'success' &&
+      needs.lint.result == 'success' &&
+      needs.test.result == 'success' && (
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        (github.event_name == 'pull_request' &&
+         needs.changes.result == 'success' &&
+         needs.changes.outputs.alpine_full == 'true')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
       contents: read
-    needs: [security, lint, test]
+    needs: [changes, security, lint, test]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Alpine arm64 API image builds now supply the exact missing
+  `tree-sitter-typescript` 0.23.2 parser header, and Docker input changes run
+  the release-shaped multi-architecture gate before merge.
+
 ## [0.103.0] - 2026-08-29
 
 This release expands repository and architecture evidence beyond MCP-only

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,22 @@ COPY src/ ./src/
 COPY deploy/supabase/postgres/ ./deploy/supabase/postgres/
 COPY deploy/docker/runtime-security-requirements.txt ./deploy/docker/runtime-security-requirements.txt
 
+# tree-sitter-typescript 0.23.2 has no musllinux aarch64 wheel and its PyPI
+# sdist omits the internal header needed to compile the bundled grammars.
+# Keep the exact upstream v0.23.2 header in the build context so Python 3.14
+# arm64 builds do not depend on an incomplete sdist. See the adjacent README
+# and license for provenance and the pinned source digest.
+COPY deploy/docker/vendor/tree-sitter-typescript-0.23.2/tree_sitter/parser.h \
+    /usr/local/include/tree_sitter/parser.h
+
 # Extras baked into the published control-plane image. Cloud SDKs (aws/azure/gcp)
 # ship by default so self-hosted BYOC (connect an AWS/Azure/GCP account read-only,
 # incl. IRSA/workload-identity) works out of the box (#3832). Override at build
 # time for a lean image, e.g. --build-arg AGENT_BOM_EXTRAS=api,snowflake,postgres.
 ARG AGENT_BOM_EXTRAS=api,snowflake,postgres,aws,azure,gcp
 RUN set -eu; \
+    test "$(sha256sum /usr/local/include/tree_sitter/parser.h | cut -d ' ' -f 1)" = \
+        "a1f6ef161fbaf48a0e10fca90ef5290a062462b307b3898aa562993853b9f80a"; \
     sync_args=""; \
     for extra in $(printf '%s' "${AGENT_BOM_EXTRAS}" | tr ',' ' '); do \
         case "${extra}" in *[!a-zA-Z0-9_-]*|'') exit 2 ;; esac; \

--- a/deploy/docker/vendor/tree-sitter-typescript-0.23.2/LICENSE
+++ b/deploy/docker/vendor/tree-sitter-typescript-0.23.2/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Max Brunsfeld
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/deploy/docker/vendor/tree-sitter-typescript-0.23.2/README.md
+++ b/deploy/docker/vendor/tree-sitter-typescript-0.23.2/README.md
@@ -1,0 +1,15 @@
+# tree-sitter-typescript 0.23.2 build header
+
+`tree-sitter-typescript==0.23.2` does not publish a musllinux aarch64 wheel.
+Its PyPI source distribution also omits `tree_sitter/parser.h`, so an Alpine
+aarch64 source build fails before agent-bom can be installed.
+
+This directory vendors only the missing header from the signed upstream
+`v0.23.2` tag:
+
+- source: `https://github.com/tree-sitter/tree-sitter-typescript/blob/v0.23.2/typescript/src/tree_sitter/parser.h`
+- SHA-256: `a1f6ef161fbaf48a0e10fca90ef5290a062462b307b3898aa562993853b9f80a`
+- license: MIT; see `LICENSE`
+
+The root Dockerfile copies the header into the builder only. The installed
+Python package and runtime image contents otherwise remain unchanged.

--- a/deploy/docker/vendor/tree-sitter-typescript-0.23.2/tree_sitter/parser.h
+++ b/deploy/docker/vendor/tree-sitter-typescript-0.23.2/tree_sitter/parser.h
@@ -1,0 +1,266 @@
+#ifndef TREE_SITTER_PARSER_H_
+#define TREE_SITTER_PARSER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define ts_builtin_sym_error ((TSSymbol)-1)
+#define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
+
+#ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
+typedef uint16_t TSSymbol;
+typedef uint16_t TSFieldId;
+typedef struct TSLanguage TSLanguage;
+#endif
+
+typedef struct {
+  TSFieldId field_id;
+  uint8_t child_index;
+  bool inherited;
+} TSFieldMapEntry;
+
+typedef struct {
+  uint16_t index;
+  uint16_t length;
+} TSFieldMapSlice;
+
+typedef struct {
+  bool visible;
+  bool named;
+  bool supertype;
+} TSSymbolMetadata;
+
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
+  int32_t lookahead;
+  TSSymbol result_symbol;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(const TSLexer *);
+  bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
+};
+
+typedef enum {
+  TSParseActionTypeShift,
+  TSParseActionTypeReduce,
+  TSParseActionTypeAccept,
+  TSParseActionTypeRecover,
+} TSParseActionType;
+
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
+} TSParseAction;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+} TSLexMode;
+
+typedef union {
+  TSParseAction action;
+  struct {
+    uint8_t count;
+    bool reusable;
+  } entry;
+} TSParseActionEntry;
+
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
+struct TSLanguage {
+  uint32_t version;
+  uint32_t symbol_count;
+  uint32_t alias_count;
+  uint32_t token_count;
+  uint32_t external_token_count;
+  uint32_t state_count;
+  uint32_t large_state_count;
+  uint32_t production_id_count;
+  uint32_t field_count;
+  uint16_t max_alias_sequence_length;
+  const uint16_t *parse_table;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSParseActionEntry *parse_actions;
+  const char * const *symbol_names;
+  const char * const *field_names;
+  const TSFieldMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const TSSymbolMetadata *symbol_metadata;
+  const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  const TSSymbol *alias_sequences;
+  const TSLexMode *lex_modes;
+  bool (*lex_fn)(TSLexer *, TSStateId);
+  bool (*keyword_lex_fn)(TSLexer *, TSStateId);
+  TSSymbol keyword_capture_token;
+  struct {
+    const bool *states;
+    const TSSymbol *symbol_map;
+    void *(*create)(void);
+    void (*destroy)(void *);
+    bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
+  } external_scanner;
+  const TSStateId *primary_state_ids;
+};
+
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
+/*
+ *  Lexer Macros
+ */
+
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
+#define START_LEXER()           \
+  bool result = false;          \
+  bool skip = false;            \
+  UNUSED                        \
+  bool eof = false;             \
+  int32_t lookahead;            \
+  goto start;                   \
+  next_state:                   \
+  lexer->advance(lexer, skip);  \
+  start:                        \
+  skip = false;                 \
+  lookahead = lexer->lookahead;
+
+#define ADVANCE(state_value) \
+  {                          \
+    state = state_value;     \
+    goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
+  }
+
+#define SKIP(state_value) \
+  {                       \
+    skip = true;          \
+    state = state_value;  \
+    goto next_state;      \
+  }
+
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
+
+#define END_STATE() return result;
+
+/*
+ *  Parse Table Macros
+ */
+
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+
+#define STATE(id) id
+
+#define ACTIONS(id) id
+
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value)          \
+    }                                 \
+  }}
+
+#define SHIFT_REPEAT(state_value)     \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value),         \
+      .repetition = true              \
+    }                                 \
+  }}
+
+#define SHIFT_EXTRA()                 \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
+  }}
+
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
+  }}
+
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_PARSER_H_

--- a/tests/test_docker_arm64_sdist_guard.py
+++ b/tests/test_docker_arm64_sdist_guard.py
@@ -1,0 +1,33 @@
+"""Regression contract for Alpine arm64 source-only grammar dependencies."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HEADER = ROOT / "deploy/docker/vendor/tree-sitter-typescript-0.23.2/tree_sitter/parser.h"
+HEADER_SHA256 = "a1f6ef161fbaf48a0e10fca90ef5290a062462b307b3898aa562993853b9f80a"
+
+
+def test_vendored_parser_header_matches_signed_upstream_release() -> None:
+    assert HEADER.is_file()
+    assert hashlib.sha256(HEADER.read_bytes()).hexdigest() == HEADER_SHA256
+    assert (HEADER.parent.parent / "LICENSE").is_file()
+
+
+def test_release_image_installs_the_missing_header_before_uv_sync() -> None:
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+    copy = "COPY deploy/docker/vendor/tree-sitter-typescript-0.23.2/tree_sitter/parser.h"
+    assert copy in dockerfile
+    assert dockerfile.index(copy) < dockerfile.index("uv sync --locked")
+    assert HEADER_SHA256 in dockerfile
+
+
+def test_docker_input_prs_run_the_release_shaped_multiarch_gate() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    docker_job = workflow.split("\n  docker:\n", 1)[1].split("\n  action-dogfood:\n", 1)[0]
+    assert "needs: [changes, security, lint, test]" in docker_job
+    assert "github.event_name == 'pull_request'" in docker_job
+    assert "needs.changes.outputs.alpine_full == 'true'" in docker_job
+    assert "--platform linux/amd64,linux/arm64" in docker_job


### PR DESCRIPTION
## Summary

- supply the exact upstream `tree-sitter-typescript` 0.23.2 parser and scanner headers that its PyPI sdist omits on source-only Alpine arm64 installs
- pin both vendored headers by SHA-256 and retain the upstream MIT license and source provenance
- run the release-shaped amd64+arm64 Docker gate on pull requests that change Dockerfile, lockfile, or package inputs

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-0.103.1-uv-cache uv run pytest -q tests/test_docker_arm64_sdist_guard.py tests/test_docker_base_policy.py tests/test_container_supply_chain_repair.py` — 17 passed
- `actionlint .github/workflows/ci.yml`
- `python scripts/check_docker_base_policy.py`
- `python scripts/lint_release_workflow.py .github/workflows/release.yml`
- `UV_CACHE_DIR=/tmp/agent-bom-0.103.1-uv-cache make preflight`
- `UV_CACHE_DIR=/tmp/agent-bom-0.103.1-uv-cache make lint`

## Notes

- release run `33285750017` failed only the API-image build when `tree-sitter-typescript==0.23.2` compiled from sdist on Linux arm64/Python 3.14
- the first PR multi-arch run proved `parser.h` was repaired and exposed the same sdist's second omission, `common/scanner.h`; the exact archive's C sources include only those two external headers
- upstream tracks the incomplete grammar sdist class at tree-sitter/tree-sitter#5458
- the new pull-request multi-arch job is the authoritative proof for this fix; no local Docker daemon was available
