### PR TITLE
fix(docker): complete Alpine arm64 source builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -906,9 +906,10 @@ jobs:
 
   # 3. Python correctness
   # Fast changed-domain/product-boundary feedback starts package proof while
-  # the exhaustive PR shards continue in parallel. The small aggregator below
-  # preserves the branch-protection context `Test (Python 3.13)` and requires
-  # every applicable shard plus measured graph evidence.
+  # the exhaustive PR shards continue in parallel. The core aggregator below
+  # requires every applicable shard plus measured graph evidence. The existing
+  # branch-protection context `Test (Python 3.13)` is finalized after the
+  # conditional release-image gate so Docker input PRs cannot merge early.
   test-smoke:
     name: Python changed-domain and contract smoke
     runs-on: ubuntu-latest
@@ -1151,8 +1152,8 @@ jobs:
           uv run pytest tests/test_release_output_scale_contract.py -q
           --tb=short --durations=10 -m output_performance -p no:randomly
 
-  test:
-    name: Test (Python 3.13)
+  test-core:
+    name: Python correctness aggregation
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -1744,7 +1745,7 @@ jobs:
       !cancelled() &&
       needs.security.result == 'success' &&
       needs.lint.result == 'success' &&
-      needs.test.result == 'success' && (
+      needs.test-core.result == 'success' && (
         (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
         (github.event_name == 'pull_request' &&
          needs.changes.result == 'success' &&
@@ -1754,7 +1755,7 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
-    needs: [changes, security, lint, test]
+    needs: [changes, security, lint, test-core]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -1839,6 +1840,45 @@ jobs:
           except Exception as e:
               print(f'OS scan parse error (non-blocking): {e}')
           " || true
+
+  # Preserve the existing required branch-protection context while making the
+  # conditional release-shaped Docker build part of that context. A new job
+  # name alone is not automatically required by branch protection.
+  test:
+    name: Test (Python 3.13)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    needs: [changes, test-core, docker]
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Require correctness and applicable release-image proof
+        env:
+          CORE_RESULT: ${{ needs.test-core.result }}
+          DOCKER_RESULT: ${{ needs.docker.result }}
+          DOCKER_REQUIRED: >-
+            ${{
+              (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+              (github.event_name == 'pull_request' &&
+               needs.changes.result == 'success' &&
+               needs.changes.outputs.alpine_full == 'true')
+            }}
+        run: |
+          set -euo pipefail
+          if [ "$CORE_RESULT" != "success" ]; then
+            echo "Core correctness aggregation ended with: $CORE_RESULT" >&2
+            exit 1
+          fi
+          if [ "$DOCKER_REQUIRED" = "true" ] && [ "$DOCKER_RESULT" != "success" ]; then
+            echo "Required release-image proof ended with: $DOCKER_RESULT" >&2
+            exit 1
+          fi
+          case "$DOCKER_RESULT" in
+            success|skipped) ;;
+            *) echo "Release-image lane ended with: $DOCKER_RESULT" >&2; exit 1 ;;
+          esac
+          echo "Correctness and applicable release-image proof passed."
 
   # 6. Dogfood GitHub Action (test action.yml via uses: ./)
   action-dogfood:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Alpine arm64 API image builds now supply the exact missing
-  `tree-sitter-typescript` 0.23.2 parser header, and Docker input changes run
+  `tree-sitter-typescript` 0.23.2 build headers, and Docker input changes run
   the release-shaped multi-architecture gate before merge.
 
 ## [0.103.0] - 2026-08-29

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,14 @@ COPY deploy/supabase/postgres/ ./deploy/supabase/postgres/
 COPY deploy/docker/runtime-security-requirements.txt ./deploy/docker/runtime-security-requirements.txt
 
 # tree-sitter-typescript 0.23.2 has no musllinux aarch64 wheel and its PyPI
-# sdist omits the internal header needed to compile the bundled grammars.
-# Keep the exact upstream v0.23.2 header in the build context so Python 3.14
+# sdist omits internal headers needed to compile the bundled grammars.
+# Keep the exact upstream v0.23.2 headers in the build context so Python 3.14
 # arm64 builds do not depend on an incomplete sdist. See the adjacent README
-# and license for provenance and the pinned source digest.
+# and license for provenance and the pinned source digests.
 COPY deploy/docker/vendor/tree-sitter-typescript-0.23.2/tree_sitter/parser.h \
     /usr/local/include/tree_sitter/parser.h
+COPY deploy/docker/vendor/tree-sitter-typescript-0.23.2/common/scanner.h \
+    /usr/local/include/tree-sitter-typescript/common/scanner.h
 
 # Extras baked into the published control-plane image. Cloud SDKs (aws/azure/gcp)
 # ship by default so self-hosted BYOC (connect an AWS/Azure/GCP account read-only,
@@ -44,12 +46,16 @@ ARG AGENT_BOM_EXTRAS=api,snowflake,postgres,aws,azure,gcp
 RUN set -eu; \
     test "$(sha256sum /usr/local/include/tree_sitter/parser.h | cut -d ' ' -f 1)" = \
         "a1f6ef161fbaf48a0e10fca90ef5290a062462b307b3898aa562993853b9f80a"; \
+    test "$(sha256sum /usr/local/include/tree-sitter-typescript/common/scanner.h | cut -d ' ' -f 1)" = \
+        "da66ef2bd14a3f7ea743e25ba068c6c9aae2c3509db200ff80c4a0e6116e564c"; \
+    mkdir -p /usr/local/include/tree-sitter-typescript/tsx/src; \
     sync_args=""; \
     for extra in $(printf '%s' "${AGENT_BOM_EXTRAS}" | tr ',' ' '); do \
         case "${extra}" in *[!a-zA-Z0-9_-]*|'') exit 2 ;; esac; \
         sync_args="${sync_args} --extra ${extra}"; \
     done; \
-    uv sync --locked --no-dev --no-editable ${sync_args}; \
+    CFLAGS="-I/usr/local/include/tree-sitter-typescript/tsx/src" \
+        uv sync --locked --no-dev --no-editable ${sync_args}; \
     uv pip install --no-config --python /app/.venv/bin/python --no-deps --require-hashes \
         -r deploy/docker/runtime-security-requirements.txt
 

--- a/deploy/docker/vendor/tree-sitter-typescript-0.23.2/README.md
+++ b/deploy/docker/vendor/tree-sitter-typescript-0.23.2/README.md
@@ -1,15 +1,20 @@
-# tree-sitter-typescript 0.23.2 build header
+# tree-sitter-typescript 0.23.2 build headers
 
 `tree-sitter-typescript==0.23.2` does not publish a musllinux aarch64 wheel.
-Its PyPI source distribution also omits `tree_sitter/parser.h`, so an Alpine
-aarch64 source build fails before agent-bom can be installed.
+Its PyPI source distribution also omits `tree_sitter/parser.h` and
+`common/scanner.h`, so an Alpine aarch64 source build fails before agent-bom
+can be installed.
 
-This directory vendors only the missing header from the signed upstream
+This directory vendors only the missing headers from the signed upstream
 `v0.23.2` tag:
 
-- source: `https://github.com/tree-sitter/tree-sitter-typescript/blob/v0.23.2/typescript/src/tree_sitter/parser.h`
-- SHA-256: `a1f6ef161fbaf48a0e10fca90ef5290a062462b307b3898aa562993853b9f80a`
+- `typescript/src/tree_sitter/parser.h`
+  - source: `https://github.com/tree-sitter/tree-sitter-typescript/blob/v0.23.2/typescript/src/tree_sitter/parser.h`
+  - SHA-256: `a1f6ef161fbaf48a0e10fca90ef5290a062462b307b3898aa562993853b9f80a`
+- `common/scanner.h`
+  - source: `https://github.com/tree-sitter/tree-sitter-typescript/blob/v0.23.2/common/scanner.h`
+  - SHA-256: `da66ef2bd14a3f7ea743e25ba068c6c9aae2c3509db200ff80c4a0e6116e564c`
 - license: MIT; see `LICENSE`
 
-The root Dockerfile copies the header into the builder only. The installed
+The root Dockerfile copies the headers into the builder only. The installed
 Python package and runtime image contents otherwise remain unchanged.

--- a/deploy/docker/vendor/tree-sitter-typescript-0.23.2/common/scanner.h
+++ b/deploy/docker/vendor/tree-sitter-typescript-0.23.2/common/scanner.h
@@ -1,0 +1,347 @@
+#include "tree_sitter/parser.h"
+
+#include <wctype.h>
+
+enum TokenType {
+    AUTOMATIC_SEMICOLON,
+    TEMPLATE_CHARS,
+    TERNARY_QMARK,
+    HTML_COMMENT,
+    LOGICAL_OR,
+    ESCAPE_SEQUENCE,
+    REGEX_PATTERN,
+    JSX_TEXT,
+    FUNCTION_SIGNATURE_AUTOMATIC_SEMICOLON,
+    ERROR_RECOVERY,
+};
+
+static void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
+
+static void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
+
+static bool scan_template_chars(TSLexer *lexer) {
+    lexer->result_symbol = TEMPLATE_CHARS;
+    for (bool has_content = false;; has_content = true) {
+        lexer->mark_end(lexer);
+        switch (lexer->lookahead) {
+            case '`':
+                return has_content;
+            case '\0':
+                return false;
+            case '$':
+                advance(lexer);
+                if (lexer->lookahead == '{') {
+                    return has_content;
+                }
+                break;
+            case '\\':
+                return has_content;
+            default:
+                advance(lexer);
+        }
+    }
+}
+
+static bool scan_whitespace_and_comments(TSLexer *lexer, bool *scanned_comment) {
+    for (;;) {
+        while (iswspace(lexer->lookahead)) {
+            skip(lexer);
+        }
+
+        if (lexer->lookahead == '/') {
+            skip(lexer);
+
+            if (lexer->lookahead == '/') {
+                skip(lexer);
+                while (lexer->lookahead != 0 && lexer->lookahead != '\n') {
+                    skip(lexer);
+                }
+                *scanned_comment = true;
+            } else if (lexer->lookahead == '*') {
+                skip(lexer);
+                while (lexer->lookahead != 0) {
+                    if (lexer->lookahead == '*') {
+                        skip(lexer);
+                        if (lexer->lookahead == '/') {
+                            skip(lexer);
+                            break;
+                        }
+                    } else {
+                        skip(lexer);
+                    }
+                }
+            } else {
+                return false;
+            }
+        } else {
+            return true;
+        }
+    }
+}
+
+static bool scan_automatic_semicolon(TSLexer *lexer, const bool *valid_symbols, bool *scanned_comment) {
+    lexer->result_symbol = AUTOMATIC_SEMICOLON;
+    lexer->mark_end(lexer);
+
+    for (;;) {
+        if (lexer->lookahead == 0) {
+            return true;
+        }
+        if (lexer->lookahead == '}') {
+            // Automatic semicolon insertion breaks detection of object patterns
+            // in a typed context:
+            //   type F = ({a}: {a: number}) => number;
+            // Therefore, disable automatic semicolons when followed by typing
+            do {
+                skip(lexer);
+            } while (iswspace(lexer->lookahead));
+            if (lexer->lookahead == ':') {
+                return valid_symbols[LOGICAL_OR]; // Don't return false if we're in a ternary by checking if || is valid
+            }
+            return true;
+        }
+        if (!iswspace(lexer->lookahead)) {
+            return false;
+        }
+        if (lexer->lookahead == '\n') {
+            break;
+        }
+        skip(lexer);
+    }
+
+    skip(lexer);
+
+    if (!scan_whitespace_and_comments(lexer, scanned_comment)) {
+        return false;
+    }
+
+    switch (lexer->lookahead) {
+        case '`':
+        case ',':
+        case '.':
+        case ';':
+        case '*':
+        case '%':
+        case '>':
+        case '<':
+        case '=':
+        case '?':
+        case '^':
+        case '|':
+        case '&':
+        case '/':
+        case ':':
+            return false;
+
+        case '{':
+            if (valid_symbols[FUNCTION_SIGNATURE_AUTOMATIC_SEMICOLON]) {
+                return false;
+            }
+            break;
+
+            // Don't insert a semicolon before a '[' or '(', unless we're parsing
+            // a type. Detect whether we're parsing a type or an expression using
+            // the validity of a binary operator token.
+        case '(':
+        case '[':
+            if (valid_symbols[LOGICAL_OR]) {
+                return false;
+            }
+            break;
+
+            // Insert a semicolon before `--` and `++`, but not before binary `+` or `-`.
+        case '+':
+            skip(lexer);
+            return lexer->lookahead == '+';
+        case '-':
+            skip(lexer);
+            return lexer->lookahead == '-';
+
+            // Don't insert a semicolon before `!=`, but do insert one before a unary `!`.
+        case '!':
+            skip(lexer);
+            return lexer->lookahead != '=';
+
+            // Don't insert a semicolon before `in` or `instanceof`, but do insert one
+            // before an identifier.
+        case 'i':
+            skip(lexer);
+
+            if (lexer->lookahead != 'n') {
+                return true;
+            }
+            skip(lexer);
+
+            if (!iswalpha(lexer->lookahead)) {
+                return false;
+            }
+
+            for (unsigned i = 0; i < 8; i++) {
+                if (lexer->lookahead != "stanceof"[i]) {
+                    return true;
+                }
+                skip(lexer);
+            }
+
+            if (!iswalpha(lexer->lookahead)) {
+                return false;
+            }
+            break;
+    }
+
+    return true;
+}
+
+static bool scan_ternary_qmark(TSLexer *lexer) {
+    for (;;) {
+        if (!iswspace(lexer->lookahead)) {
+            break;
+        }
+        skip(lexer);
+    }
+
+    if (lexer->lookahead == '?') {
+        advance(lexer);
+
+        /* Optional chaining. */
+        if (lexer->lookahead == '?' || lexer->lookahead == '.') {
+            return false;
+        }
+
+        lexer->mark_end(lexer);
+        lexer->result_symbol = TERNARY_QMARK;
+
+        /* TypeScript optional arguments contain the ?: sequence, possibly
+           with whitespace. */
+        for (;;) {
+            if (!iswspace(lexer->lookahead)) {
+                break;
+            }
+            advance(lexer);
+        }
+
+        if (lexer->lookahead == ':' || lexer->lookahead == ')' || lexer->lookahead == ',') {
+            return false;
+        }
+
+        if (lexer->lookahead == '.') {
+            advance(lexer);
+            if (iswdigit(lexer->lookahead)) {
+                return true;
+            }
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+static bool scan_closing_comment(TSLexer *lexer) {
+    while (iswspace(lexer->lookahead) || lexer->lookahead == 0x2028 || lexer->lookahead == 0x2029) {
+        skip(lexer);
+    }
+
+    const char *comment_start = "<!--";
+    const char *comment_end = "-->";
+
+    if (lexer->lookahead == '<') {
+        for (unsigned i = 0; i < 4; i++) {
+            if (lexer->lookahead != comment_start[i]) {
+                return false;
+            }
+            advance(lexer);
+        }
+    } else if (lexer->lookahead == '-') {
+        for (unsigned i = 0; i < 3; i++) {
+            if (lexer->lookahead != comment_end[i]) {
+                return false;
+            }
+            advance(lexer);
+        }
+    } else {
+        return false;
+    }
+
+    while (lexer->lookahead != 0 && lexer->lookahead != '\n' && lexer->lookahead != 0x2028 &&
+           lexer->lookahead != 0x2029) {
+        advance(lexer);
+    }
+
+    lexer->result_symbol = HTML_COMMENT;
+    lexer->mark_end(lexer);
+
+    return true;
+}
+
+static bool scan_jsx_text(TSLexer *lexer) {
+    // saw_text will be true if we see any non-whitespace content, or any whitespace content that is not a newline and
+    // does not immediately follow a newline.
+    bool saw_text = false;
+    // at_newline will be true if we are currently at a newline, or if we are at whitespace that is not a newline but
+    // immediately follows a newline.
+    bool at_newline = false;
+
+    while (lexer->lookahead != 0 && lexer->lookahead != '<' && lexer->lookahead != '>' && lexer->lookahead != '{' &&
+           lexer->lookahead != '}' && lexer->lookahead != '&') {
+        bool is_wspace = iswspace(lexer->lookahead);
+        if (lexer->lookahead == '\n') {
+            at_newline = true;
+        } else {
+            // If at_newline is already true, and we see some whitespace, then it must stay true.
+            // Otherwise, it should be false.
+            //
+            // See the table below to determine the logic for computing `saw_text`.
+            //
+            // |------------------------------------|
+            // | at_newline | is_wspace | saw_text  |
+            // |------------|-----------|-----------|
+            // | false (0)  | false (0) | true  (1) |
+            // | false (0)  | true  (1) | true  (1) |
+            // | true  (1)  | false (0) | true  (1) |
+            // | true  (1)  | true  (1) | false (0) |
+            // |------------------------------------|
+
+            at_newline &= is_wspace;
+            if (!at_newline) {
+                saw_text = true;
+            }
+        }
+
+        advance(lexer);
+    }
+
+    lexer->result_symbol = JSX_TEXT;
+    return saw_text;
+}
+
+static inline bool external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
+    if (valid_symbols[TEMPLATE_CHARS]) {
+        if (valid_symbols[AUTOMATIC_SEMICOLON]) {
+            return false;
+        }
+        return scan_template_chars(lexer);
+    }
+
+    if (valid_symbols[JSX_TEXT] && scan_jsx_text(lexer)) {
+        return true;
+    }
+
+    if (valid_symbols[AUTOMATIC_SEMICOLON] || valid_symbols[FUNCTION_SIGNATURE_AUTOMATIC_SEMICOLON]) {
+        bool scanned_comment = false;
+        bool ret = scan_automatic_semicolon(lexer, valid_symbols, &scanned_comment);
+        if (!ret && !scanned_comment && valid_symbols[TERNARY_QMARK] && lexer->lookahead == '?') {
+            return scan_ternary_qmark(lexer);
+        }
+        return ret;
+    }
+    if (valid_symbols[TERNARY_QMARK]) {
+        return scan_ternary_qmark(lexer);
+    }
+
+    if (valid_symbols[HTML_COMMENT] && !valid_symbols[LOGICAL_OR] && !valid_symbols[ESCAPE_SEQUENCE] &&
+        !valid_symbols[REGEX_PATTERN]) {
+        return scan_closing_comment(lexer);
+    }
+
+    return false;
+}

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -190,10 +190,14 @@ def test_pull_request_correctness_is_sharded_behind_required_aggregator() -> Non
     assert "scripts/pytest_ci_plan.py shard" in shard_run
     assert "not graph_performance" in shard_run
 
+    core = jobs["test-core"]
+    assert "test-pr-shard" in core["needs"]
+    assert "graph-performance" in core["needs"]
+
     required = jobs["test"]
     assert required["name"] == "Test (Python 3.13)"
-    assert "test-pr-shard" in required["needs"]
-    assert "graph-performance" in required["needs"]
+    assert "test-core" in required["needs"]
+    assert "docker" in required["needs"]
 
 
 def test_python_smoke_gate_combines_changed_domain_and_cross_surface_contracts() -> None:
@@ -249,11 +253,11 @@ def test_output_scale_budgets_run_in_a_dedicated_uninstrumented_lane() -> None:
     main_run = next(step["run"] for step in jobs["test-main"]["steps"] if step.get("name") == "Run full correctness suite")
     assert "not slow" in main_run
 
-    required = jobs["test"]
-    assert "output-scale-performance" in required["needs"]
-    required_run = next(step["run"] for step in required["steps"] if step.get("name") == "Require every applicable correctness lane")
-    assert "OUTPUT_SCALE_RESULT" in required_run
-    assert '"$OUTPUT_SCALE_RESULT"' in required_run
+    core = jobs["test-core"]
+    assert "output-scale-performance" in core["needs"]
+    core_run = next(step["run"] for step in core["steps"] if step.get("name") == "Require every applicable correctness lane")
+    assert "OUTPUT_SCALE_RESULT" in core_run
+    assert '"$OUTPUT_SCALE_RESULT"' in core_run
 
     scale_test = (ROOT / "tests" / "test_release_output_scale_contract.py").read_text(encoding="utf-8")
     assert "pytest.mark.slow" in scale_test

--- a/tests/test_docker_arm64_sdist_guard.py
+++ b/tests/test_docker_arm64_sdist_guard.py
@@ -38,7 +38,13 @@ def test_release_image_installs_the_missing_headers_before_uv_sync() -> None:
 def test_docker_input_prs_run_the_release_shaped_multiarch_gate() -> None:
     workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
     docker_job = workflow.split("\n  docker:\n", 1)[1].split("\n  action-dogfood:\n", 1)[0]
-    assert "needs: [changes, security, lint, test]" in docker_job
+    assert "needs: [changes, security, lint, test-core]" in docker_job
     assert "github.event_name == 'pull_request'" in docker_job
     assert "needs.changes.outputs.alpine_full == 'true'" in docker_job
     assert "--platform linux/amd64,linux/arm64" in docker_job
+
+    required_job = workflow.split("\n  test:\n", 1)[1].split("\n  # 6. Dogfood", 1)[0]
+    assert "name: Test (Python 3.13)" in required_job
+    assert "needs: [changes, test-core, docker]" in required_job
+    assert 'DOCKER_RESULT: ${{ needs.docker.result }}' in required_job
+    assert 'if [ "$DOCKER_REQUIRED" = "true" ] && [ "$DOCKER_RESULT" != "success" ]' in required_job

--- a/tests/test_docker_arm64_sdist_guard.py
+++ b/tests/test_docker_arm64_sdist_guard.py
@@ -6,22 +6,33 @@ import hashlib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-HEADER = ROOT / "deploy/docker/vendor/tree-sitter-typescript-0.23.2/tree_sitter/parser.h"
-HEADER_SHA256 = "a1f6ef161fbaf48a0e10fca90ef5290a062462b307b3898aa562993853b9f80a"
+VENDOR_ROOT = ROOT / "deploy/docker/vendor/tree-sitter-typescript-0.23.2"
+HEADERS = {
+    VENDOR_ROOT / "tree_sitter/parser.h": "a1f6ef161fbaf48a0e10fca90ef5290a062462b307b3898aa562993853b9f80a",
+    VENDOR_ROOT / "common/scanner.h": "da66ef2bd14a3f7ea743e25ba068c6c9aae2c3509db200ff80c4a0e6116e564c",
+}
 
 
-def test_vendored_parser_header_matches_signed_upstream_release() -> None:
-    assert HEADER.is_file()
-    assert hashlib.sha256(HEADER.read_bytes()).hexdigest() == HEADER_SHA256
-    assert (HEADER.parent.parent / "LICENSE").is_file()
+def test_vendored_headers_match_signed_upstream_release() -> None:
+    for header, expected_sha256 in HEADERS.items():
+        assert header.is_file()
+        assert hashlib.sha256(header.read_bytes()).hexdigest() == expected_sha256
+    assert (VENDOR_ROOT / "LICENSE").is_file()
 
 
-def test_release_image_installs_the_missing_header_before_uv_sync() -> None:
+def test_release_image_installs_the_missing_headers_before_uv_sync() -> None:
     dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
-    copy = "COPY deploy/docker/vendor/tree-sitter-typescript-0.23.2/tree_sitter/parser.h"
-    assert copy in dockerfile
-    assert dockerfile.index(copy) < dockerfile.index("uv sync --locked")
-    assert HEADER_SHA256 in dockerfile
+    copies = (
+        "COPY deploy/docker/vendor/tree-sitter-typescript-0.23.2/tree_sitter/parser.h",
+        "COPY deploy/docker/vendor/tree-sitter-typescript-0.23.2/common/scanner.h",
+    )
+    for copy in copies:
+        assert copy in dockerfile
+        assert dockerfile.index(copy) < dockerfile.index("uv sync --locked")
+    for expected_sha256 in HEADERS.values():
+        assert expected_sha256 in dockerfile
+    assert "mkdir -p /usr/local/include/tree-sitter-typescript/tsx/src" in dockerfile
+    assert 'CFLAGS="-I/usr/local/include/tree-sitter-typescript/tsx/src"' in dockerfile
 
 
 def test_docker_input_prs_run_the_release_shaped_multiarch_gate() -> None:

--- a/tests/test_docker_arm64_sdist_guard.py
+++ b/tests/test_docker_arm64_sdist_guard.py
@@ -46,5 +46,5 @@ def test_docker_input_prs_run_the_release_shaped_multiarch_gate() -> None:
     required_job = workflow.split("\n  test:\n", 1)[1].split("\n  # 6. Dogfood", 1)[0]
     assert "name: Test (Python 3.13)" in required_job
     assert "needs: [changes, test-core, docker]" in required_job
-    assert 'DOCKER_RESULT: ${{ needs.docker.result }}' in required_job
+    assert "DOCKER_RESULT: ${{ needs.docker.result }}" in required_job
     assert 'if [ "$DOCKER_REQUIRED" = "true" ] && [ "$DOCKER_RESULT" != "success" ]' in required_job


### PR DESCRIPTION
## Summary

- supply the exact upstream `tree-sitter-typescript` 0.23.2 parser and scanner headers that its PyPI sdist omits on source-only Alpine arm64 installs
- pin both vendored headers by SHA-256 and retain the upstream MIT license and source provenance
- run the release-shaped amd64+arm64 Docker gate on pull requests that change Dockerfile, lockfile, or package inputs
- finalize the existing required `Test (Python 3.13)` context only after applicable multi-architecture image proof succeeds

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-0.103.1-uv-cache uv run pytest -q tests/test_docker_arm64_sdist_guard.py tests/test_ci_workflow_contract.py tests/test_docker_base_policy.py tests/test_container_supply_chain_repair.py` — 43 passed
- `actionlint .github/workflows/ci.yml`
- `python scripts/check_docker_base_policy.py`
- `python scripts/lint_release_workflow.py .github/workflows/release.yml`
- `UV_CACHE_DIR=/tmp/agent-bom-0.103.1-uv-cache make preflight`
- `UV_CACHE_DIR=/tmp/agent-bom-0.103.1-uv-cache make lint`

## Notes

- release run `33285750017` failed only the API-image build when `tree-sitter-typescript==0.23.2` compiled from sdist on Linux arm64/Python 3.14
- the first PR multi-arch run proved `parser.h` was repaired and exposed the same sdist's second omission, `common/scanner.h`; the exact archive's C sources include only those two external headers
- PR #4997 merged when its pre-existing required contexts passed; the new Docker job was not itself required, so this PR binds that proof into the existing required correctness context
- upstream tracks the incomplete grammar sdist class at tree-sitter/tree-sitter#5458
- the new pull-request multi-arch job is the authoritative proof for this fix; no local Docker daemon was available
