### PR TITLE
feat(graph): add correlation evidence foundation

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260830_01_graph_correlations.py
+++ b/deploy/supabase/postgres/alembic/versions/20260830_01_graph_correlations.py
@@ -1,0 +1,101 @@
+"""Add immutable graph correlation runs and snapshot provenance.
+
+Revision ID: 20260830_01
+Revises: 20260827_01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260830_01"
+down_revision = "20260827_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS snapshot_kind "
+        "TEXT NOT NULL DEFAULT 'scan' CHECK (snapshot_kind IN ('scan', 'correlation'))"
+    )
+    op.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS correlation_id TEXT DEFAULT NULL")
+    op.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS evidence_manifest_sha256 TEXT NOT NULL DEFAULT ''")
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS graph_correlation_runs (
+            correlation_id TEXT NOT NULL,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            idempotency_key TEXT NOT NULL,
+            name TEXT NOT NULL DEFAULT '',
+            status TEXT NOT NULL CHECK (status IN ('pending', 'running', 'complete', 'failed')),
+            max_age_hours INTEGER NOT NULL CHECK (max_age_hours BETWEEN 1 AND 8760),
+            allow_stale INTEGER NOT NULL DEFAULT 0 CHECK (allow_stale IN (0, 1)),
+            input_manifest TEXT NOT NULL DEFAULT '[]',
+            manifest_sha256 TEXT NOT NULL DEFAULT '',
+            output_scan_id TEXT NOT NULL DEFAULT '',
+            failure_code TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL,
+            started_at TEXT NOT NULL DEFAULT '',
+            completed_at TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (correlation_id, tenant_id),
+            UNIQUE (tenant_id, idempotency_key)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_pg_graph_correlation_runs_recent "
+        "ON graph_correlation_runs(tenant_id, created_at DESC)"
+    )
+    op.execute("ALTER TABLE graph_correlation_runs ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE graph_correlation_runs FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_policies
+                WHERE schemaname = current_schema()
+                  AND tablename = 'graph_correlation_runs'
+                  AND policyname = 'graph_correlation_runs_tenant_isolation'
+            ) THEN
+                CREATE POLICY graph_correlation_runs_tenant_isolation ON graph_correlation_runs
+                    USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+                    WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+            END IF;
+        END
+        $$
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'agent_bom_app') THEN
+                GRANT SELECT, INSERT, UPDATE, DELETE ON graph_correlation_runs TO agent_bom_app;
+            END IF;
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'agent_bom_rls_maintenance') THEN
+                GRANT SELECT, INSERT, UPDATE, DELETE ON graph_correlation_runs TO agent_bom_rls_maintenance;
+            END IF;
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'agent_bom_readonly') THEN
+                GRANT SELECT ON graph_correlation_runs TO agent_bom_readonly;
+            END IF;
+        END
+        $$
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO control_plane_schema_versions(component, version, updated_at)
+        VALUES ('graph', 2, now())
+        ON CONFLICT(component) DO UPDATE SET
+            version = GREATEST(control_plane_schema_versions.version, EXCLUDED.version),
+            updated_at = EXCLUDED.updated_at
+        """
+    )
+
+
+def downgrade() -> None:
+    # Retain immutable evidence across rolling downgrades. Older runtimes ignore
+    # the additive table and snapshot columns.
+    return

--- a/deploy/supabase/postgres/alembic/versions/20260830_01_graph_correlations.py
+++ b/deploy/supabase/postgres/alembic/versions/20260830_01_graph_correlations.py
@@ -16,11 +16,22 @@ depends_on = None
 
 def upgrade() -> None:
     op.execute(
-        "ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS snapshot_kind "
-        "TEXT NOT NULL DEFAULT 'scan' CHECK (snapshot_kind IN ('scan', 'correlation'))"
+        """
+        DO $$
+        BEGIN
+            IF to_regclass('public.graph_snapshots') IS NOT NULL THEN
+                ALTER TABLE public.graph_snapshots
+                    ADD COLUMN IF NOT EXISTS snapshot_kind TEXT NOT NULL DEFAULT 'scan'
+                    CHECK (snapshot_kind IN ('scan', 'correlation'));
+                ALTER TABLE public.graph_snapshots
+                    ADD COLUMN IF NOT EXISTS correlation_id TEXT DEFAULT NULL;
+                ALTER TABLE public.graph_snapshots
+                    ADD COLUMN IF NOT EXISTS evidence_manifest_sha256 TEXT NOT NULL DEFAULT '';
+            END IF;
+        END
+        $$
+        """
     )
-    op.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS correlation_id TEXT DEFAULT NULL")
-    op.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS evidence_manifest_sha256 TEXT NOT NULL DEFAULT ''")
     op.execute(
         """
         CREATE TABLE IF NOT EXISTS graph_correlation_runs (
@@ -43,10 +54,7 @@ def upgrade() -> None:
         )
         """
     )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS idx_pg_graph_correlation_runs_recent "
-        "ON graph_correlation_runs(tenant_id, created_at DESC)"
-    )
+    op.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_correlation_runs_recent ON graph_correlation_runs(tenant_id, created_at DESC)")
     op.execute("ALTER TABLE graph_correlation_runs ENABLE ROW LEVEL SECURITY")
     op.execute("ALTER TABLE graph_correlation_runs FORCE ROW LEVEL SECURITY")
     op.execute(

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -524,10 +524,35 @@ CREATE TABLE IF NOT EXISTS graph_snapshots (
     risk_summary TEXT DEFAULT '{}',
     node_type_counts TEXT DEFAULT NULL,
     analysis_status TEXT NOT NULL DEFAULT '{}',
+    snapshot_kind TEXT NOT NULL DEFAULT 'scan' CHECK (snapshot_kind IN ('scan', 'correlation')),
+    correlation_id TEXT DEFAULT NULL,
+    evidence_manifest_sha256 TEXT NOT NULL DEFAULT '',
     PRIMARY KEY (scan_id, tenant_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_pg_graph_snapshots_recent ON graph_snapshots(tenant_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS graph_correlation_runs (
+    correlation_id TEXT NOT NULL,
+    tenant_id TEXT NOT NULL DEFAULT 'default',
+    idempotency_key TEXT NOT NULL,
+    name TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL CHECK (status IN ('pending', 'running', 'complete', 'failed')),
+    max_age_hours INTEGER NOT NULL CHECK (max_age_hours BETWEEN 1 AND 8760),
+    allow_stale INTEGER NOT NULL DEFAULT 0 CHECK (allow_stale IN (0, 1)),
+    input_manifest TEXT NOT NULL DEFAULT '[]',
+    manifest_sha256 TEXT NOT NULL DEFAULT '',
+    output_scan_id TEXT NOT NULL DEFAULT '',
+    failure_code TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    started_at TEXT NOT NULL DEFAULT '',
+    completed_at TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (correlation_id, tenant_id),
+    UNIQUE (tenant_id, idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pg_graph_correlation_runs_recent
+    ON graph_correlation_runs(tenant_id, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS attack_paths (
     source_node         TEXT NOT NULL,
@@ -1163,6 +1188,24 @@ BEGIN
 END
 $$;
 
+ALTER TABLE graph_correlation_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE graph_correlation_runs FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'graph_correlation_runs'
+          AND policyname = 'graph_correlation_runs_tenant_isolation'
+    ) THEN
+        CREATE POLICY graph_correlation_runs_tenant_isolation ON graph_correlation_runs
+            USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
 ALTER TABLE attack_paths ENABLE ROW LEVEL SECURITY;
 ALTER TABLE attack_paths FORCE ROW LEVEL SECURITY;
 
@@ -1677,6 +1720,7 @@ $$;
 --   graph_nodes        — per-scan graph entities with severity/risk ordering
 --   graph_edges        — per-scan traversable relationships
 --   graph_snapshots    — graph snapshot summary + recency cursor
+--   graph_correlation_runs — immutable multi-snapshot correlation requests and state
 --   attack_paths       — persisted fix-first attack-path projections
 --   interaction_risks  — agent interaction / toxic-combo risk overlays
 --   graph_filter_presets — tenant-scoped saved graph filters

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-27",
+  "generated_on": "2026-08-29",
   "version": "0.103.1",
   "metrics": [
     {
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 875,
+      "value": 876,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-27`
+- Generated on: `2026-08-29`
 - Version: `0.103.1`
 
 | Metric | Value | Source | Notes |
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 49 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 875 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 876 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -41,6 +41,7 @@ from agent_bom.graph.completeness import (
     graph_completeness,
     impact_completeness,
 )
+from agent_bom.graph.correlation import CorrelationRunStatus, GraphCorrelationRun
 from agent_bom.graph.ocsf import FINDING_ENTITY_TYPES
 from agent_bom.graph.severity_floor import severity_floor_sql
 
@@ -174,7 +175,29 @@ class GraphStoreProtocol(Protocol):
         interaction_risks: Iterable[Any] = (),
         analysis_status: Mapping[str, GraphAnalysisStatus] | None = None,
         created_at: str = "",
+        snapshot_kind: str = "scan",
+        correlation_id: str = "",
+        evidence_manifest_sha256: str = "",
     ) -> dict[str, int]: ...
+
+    def create_correlation_run(self, run: GraphCorrelationRun) -> tuple[GraphCorrelationRun, bool]: ...
+
+    def get_correlation_run(self, *, tenant_id: str, correlation_id: str) -> GraphCorrelationRun | None: ...
+
+    def list_correlation_runs(self, *, tenant_id: str, limit: int = 100) -> list[GraphCorrelationRun]: ...
+
+    def update_correlation_run(
+        self,
+        *,
+        tenant_id: str,
+        correlation_id: str,
+        status: CorrelationRunStatus,
+        manifest_sha256: str = "",
+        output_scan_id: str = "",
+        failure_code: str = "",
+        started_at: str = "",
+        completed_at: str = "",
+    ) -> GraphCorrelationRun: ...
 
     def prior_delta_digest(self, *, tenant_id: str = "", scan_id: str = "") -> "PriorSnapshotDigest": ...
 
@@ -1541,6 +1564,9 @@ class SQLiteGraphStore:
         interaction_risks: Iterable[Any] = (),
         analysis_status: Mapping[str, GraphAnalysisStatus] | None = None,
         created_at: str = "",
+        snapshot_kind: str = "scan",
+        correlation_id: str = "",
+        evidence_manifest_sha256: str = "",
     ) -> dict[str, int]:
         """Persist a snapshot from node/edge iterables without materialising a graph.
 
@@ -1560,6 +1586,9 @@ class SQLiteGraphStore:
                 interaction_risks=interaction_risks,
                 analysis_status=analysis_status,
                 created_at=created_at,
+                snapshot_kind=snapshot_kind,
+                correlation_id=correlation_id,
+                evidence_manifest_sha256=evidence_manifest_sha256,
             )
             self._refresh_snapshot_search_index(conn, tenant_id=tenant_id, scan_id=scan_id)
             sqlite_graph_store._backfill_empty_tenant_ids(conn, _API_GRAPH_TENANT_TABLE_KEYS)
@@ -1708,6 +1737,53 @@ class SQLiteGraphStore:
             return sqlite_graph_store.list_snapshots(conn, tenant_id=tenant_id, limit=limit, since=since)
         finally:
             conn.close()
+
+    def create_correlation_run(self, run: GraphCorrelationRun) -> tuple[GraphCorrelationRun, bool]:
+        with sqlite_graph_store.open_graph_db(self._db_path) as conn:
+            return sqlite_graph_store.create_correlation_run(conn, run)
+
+    def get_correlation_run(self, *, tenant_id: str, correlation_id: str) -> GraphCorrelationRun | None:
+        conn = self._open_ro_conn()
+        if conn is None:
+            return None
+        try:
+            return sqlite_graph_store.get_correlation_run(conn, tenant_id=tenant_id, correlation_id=correlation_id)
+        finally:
+            conn.close()
+
+    def list_correlation_runs(self, *, tenant_id: str, limit: int = 100) -> list[GraphCorrelationRun]:
+        conn = self._open_ro_conn()
+        if conn is None:
+            return []
+        try:
+            return sqlite_graph_store.list_correlation_runs(conn, tenant_id=tenant_id, limit=limit)
+        finally:
+            conn.close()
+
+    def update_correlation_run(
+        self,
+        *,
+        tenant_id: str,
+        correlation_id: str,
+        status: CorrelationRunStatus,
+        manifest_sha256: str = "",
+        output_scan_id: str = "",
+        failure_code: str = "",
+        started_at: str = "",
+        completed_at: str = "",
+    ) -> GraphCorrelationRun:
+        with sqlite_graph_store.open_graph_db(self._db_path) as conn:
+            return sqlite_graph_store.update_correlation_run(
+                conn,
+                tenant_id=tenant_id,
+                correlation_id=correlation_id,
+                status=status,
+                manifest_sha256=manifest_sha256,
+                output_scan_id=output_scan_id,
+                failure_code=failure_code,
+                started_at=started_at,
+                completed_at=completed_at,
+            )
 
     def graph_history(self, *, tenant_id: str = "", limit: int = 50, since: str | None = None) -> dict[str, Any]:
         tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)

--- a/src/agent_bom/api/neptune_graph.py
+++ b/src/agent_bom/api/neptune_graph.py
@@ -20,6 +20,7 @@ from agent_bom.graph.container import apply_node_budget
 from agent_bom.graph.severity_floor import node_passes_severity_floor
 
 if TYPE_CHECKING:
+    from agent_bom.graph.correlation import CorrelationRunStatus, GraphCorrelationRun
     from agent_bom.graph.delta_digest import PriorSnapshotDigest
 
 
@@ -262,6 +263,9 @@ class NeptuneGraphStore:
         interaction_risks: Iterable[Any] = (),
         analysis_status: Mapping[str, GraphAnalysisStatus] | None = None,
         created_at: str = "",
+        snapshot_kind: str = "scan",
+        correlation_id: str = "",
+        evidence_manifest_sha256: str = "",
     ) -> dict[str, int]:
         """Persist a snapshot from node/edge iterables.
 
@@ -271,6 +275,8 @@ class NeptuneGraphStore:
         NOT yet realise the #4055 peak-RSS bound the SQLite/Postgres streaming
         paths do — see the PR notes. Neptune is not the millions-of-nodes target.
         """
+        if snapshot_kind != "scan" or correlation_id or evidence_manifest_sha256:
+            self._unsupported("correlation snapshot persistence")
         graph = UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id, created_at=created_at)
         for node in nodes:
             graph.add_node(node)
@@ -319,6 +325,29 @@ class NeptuneGraphStore:
             bindings,
         )
         return [self._snapshot_from_record(row) for row in rows]
+
+    def create_correlation_run(self, run: "GraphCorrelationRun") -> tuple["GraphCorrelationRun", bool]:
+        self._unsupported("create_correlation_run")
+
+    def get_correlation_run(self, *, tenant_id: str, correlation_id: str) -> "GraphCorrelationRun | None":
+        self._unsupported("get_correlation_run")
+
+    def list_correlation_runs(self, *, tenant_id: str, limit: int = 100) -> list["GraphCorrelationRun"]:
+        self._unsupported("list_correlation_runs")
+
+    def update_correlation_run(
+        self,
+        *,
+        tenant_id: str,
+        correlation_id: str,
+        status: "CorrelationRunStatus",
+        manifest_sha256: str = "",
+        output_scan_id: str = "",
+        failure_code: str = "",
+        started_at: str = "",
+        completed_at: str = "",
+    ) -> "GraphCorrelationRun":
+        self._unsupported("update_correlation_run")
 
     def graph_history(self, *, tenant_id: str = "", limit: int = 50, since: str | None = None) -> dict[str, Any]:
         self._unsupported("graph_history")

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -34,6 +34,7 @@ from agent_bom.graph.completeness import (
     graph_completeness,
     impact_completeness,
 )
+from agent_bom.graph.correlation import CorrelationRunStatus, GraphCorrelationRun, validate_correlation_update
 from agent_bom.graph.severity_floor import severity_floor_sql
 from agent_bom.security import sanitize_text
 
@@ -47,6 +48,7 @@ from .postgres_common import (
 )
 
 logger = logging.getLogger(__name__)
+_GRAPH_STORAGE_SCHEMA_VERSION = 2
 
 
 def select_expired_snapshot_ids(
@@ -115,6 +117,7 @@ _GRAPH_TENANT_TABLE_KEYS: dict[str, tuple[str, ...]] = {
     "graph_nodes": ("id", "scan_id"),
     "graph_edges": ("source_id", "target_id", "relationship", "scan_id"),
     "graph_snapshots": ("scan_id",),
+    "graph_correlation_runs": ("correlation_id",),
     "attack_paths": ("source_node", "target_node", "scan_id"),
     "interaction_risks": ("pattern", "agents", "scan_id"),
     "graph_filter_presets": ("name",),
@@ -215,6 +218,34 @@ def _decode_json_array(value: Any, *, field: str) -> list[Any]:
     return list(decoded)
 
 
+_CORRELATION_RUN_COLUMNS = """
+    correlation_id, tenant_id, idempotency_key, name, status,
+    max_age_hours, allow_stale, input_manifest, manifest_sha256,
+    output_scan_id, failure_code, created_at, started_at, completed_at
+"""
+
+
+def _correlation_run_from_row(row: Sequence[Any]) -> GraphCorrelationRun:
+    return GraphCorrelationRun.from_mapping(
+        {
+            "correlation_id": row[0],
+            "tenant_id": row[1],
+            "idempotency_key": row[2],
+            "name": row[3],
+            "status": row[4],
+            "max_age_hours": row[5],
+            "allow_stale": bool(row[6]),
+            "input_manifest": _decode_json_array(row[7], field="input_manifest"),
+            "manifest_sha256": row[8],
+            "output_scan_id": row[9],
+            "failure_code": row[10],
+            "created_at": row[11],
+            "started_at": row[12],
+            "completed_at": row[13],
+        }
+    )
+
+
 def _diff_summary_counts(diff: dict[str, Any]) -> dict[str, int]:
     return {
         "nodes_added": len(diff.get("nodes_added") or []),
@@ -258,7 +289,7 @@ class PostgresGraphStore:
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
-            if not ensure_postgres_schema_version(conn, "graph"):
+            if not ensure_postgres_schema_version(conn, "graph", _GRAPH_STORAGE_SCHEMA_VERSION):
                 return
             conn.execute(
                 """
@@ -350,6 +381,9 @@ class PostgresGraphStore:
                     risk_summary TEXT DEFAULT '{}',
                     node_type_counts TEXT DEFAULT NULL,
                     analysis_status TEXT NOT NULL DEFAULT '{}',
+                    snapshot_kind TEXT NOT NULL DEFAULT 'scan' CHECK (snapshot_kind IN ('scan', 'correlation')),
+                    correlation_id TEXT DEFAULT NULL,
+                    evidence_manifest_sha256 TEXT NOT NULL DEFAULT '',
                     PRIMARY KEY (scan_id, tenant_id)
                 )
                 """
@@ -357,7 +391,36 @@ class PostgresGraphStore:
             # Additive and nullable, matching the SQLite column: snapshots written
             # before it existed read NULL and fall back to the live GROUP BY.
             conn.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS node_type_counts TEXT DEFAULT NULL")
+            conn.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS snapshot_kind TEXT NOT NULL DEFAULT 'scan'")
+            conn.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS correlation_id TEXT DEFAULT NULL")
+            conn.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS evidence_manifest_sha256 TEXT NOT NULL DEFAULT ''")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_snapshots_recent ON graph_snapshots(tenant_id, created_at DESC)")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS graph_correlation_runs (
+                    correlation_id TEXT NOT NULL,
+                    tenant_id TEXT NOT NULL DEFAULT 'default',
+                    idempotency_key TEXT NOT NULL,
+                    name TEXT NOT NULL DEFAULT '',
+                    status TEXT NOT NULL CHECK (status IN ('pending', 'running', 'complete', 'failed')),
+                    max_age_hours INTEGER NOT NULL CHECK (max_age_hours BETWEEN 1 AND 8760),
+                    allow_stale INTEGER NOT NULL DEFAULT 0 CHECK (allow_stale IN (0, 1)),
+                    input_manifest TEXT NOT NULL DEFAULT '[]',
+                    manifest_sha256 TEXT NOT NULL DEFAULT '',
+                    output_scan_id TEXT NOT NULL DEFAULT '',
+                    failure_code TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL,
+                    started_at TEXT NOT NULL DEFAULT '',
+                    completed_at TEXT NOT NULL DEFAULT '',
+                    PRIMARY KEY (correlation_id, tenant_id),
+                    UNIQUE (tenant_id, idempotency_key)
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_pg_graph_correlation_runs_recent "
+                "ON graph_correlation_runs(tenant_id, created_at DESC)"
+            )
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS attack_paths (
@@ -471,6 +534,7 @@ class PostgresGraphStore:
             _ensure_tenant_rls(conn, "graph_nodes", "tenant_id")
             _ensure_tenant_rls(conn, "graph_edges", "tenant_id")
             _ensure_tenant_rls(conn, "graph_snapshots", "tenant_id")
+            _ensure_tenant_rls(conn, "graph_correlation_runs", "tenant_id")
             _ensure_tenant_rls(conn, "attack_paths", "tenant_id")
             _ensure_tenant_rls(conn, "interaction_risks", "tenant_id")
             _ensure_tenant_rls(conn, "graph_filter_presets", "tenant_id")
@@ -607,6 +671,9 @@ class PostgresGraphStore:
         interaction_risks: Iterable[Any] = (),
         analysis_status: Mapping[str, GraphAnalysisStatus] | None = None,
         created_at: str = "",
+        snapshot_kind: str = "scan",
+        correlation_id: str = "",
+        evidence_manifest_sha256: str = "",
     ) -> dict[str, int]:
         """Persist a snapshot from node/edge iterables without materialising a graph.
 
@@ -625,6 +692,10 @@ class PostgresGraphStore:
         scan = scan_id or ""
         tenant = normalize_graph_tenant_id(tenant_id)
         now = created_at or datetime.now(timezone.utc).isoformat()
+        if snapshot_kind not in {"scan", "correlation"}:
+            raise ValueError("snapshot_kind must be 'scan' or 'correlation'")
+        if snapshot_kind == "correlation" and correlation_id != scan:
+            raise ValueError("correlation snapshot ID must equal correlation_id")
         batch_size = _graph_write_batch_size()
 
         node_count = 0
@@ -982,15 +1053,20 @@ class PostgresGraphStore:
             conn.execute(
                 """
                 INSERT INTO graph_snapshots
-                    (scan_id, tenant_id, created_at, node_count, edge_count, risk_summary, node_type_counts, analysis_status)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                    (scan_id, tenant_id, created_at, node_count, edge_count, risk_summary,
+                     node_type_counts, analysis_status, snapshot_kind, correlation_id,
+                     evidence_manifest_sha256)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (scan_id, tenant_id) DO UPDATE SET
                     created_at = EXCLUDED.created_at,
                     node_count = EXCLUDED.node_count,
                     edge_count = EXCLUDED.edge_count,
                     risk_summary = EXCLUDED.risk_summary,
                     node_type_counts = EXCLUDED.node_type_counts,
-                    analysis_status = EXCLUDED.analysis_status
+                    analysis_status = EXCLUDED.analysis_status,
+                    snapshot_kind = EXCLUDED.snapshot_kind,
+                    correlation_id = EXCLUDED.correlation_id,
+                    evidence_manifest_sha256 = EXCLUDED.evidence_manifest_sha256
                 """,
                 (
                     scan,
@@ -1001,6 +1077,9 @@ class PostgresGraphStore:
                     json.dumps(dict(severity_counts)),
                     json.dumps(dict(type_counts)),
                     json.dumps(analysis_status_map_to_dict(analysis_status or {})),
+                    snapshot_kind,
+                    correlation_id or None,
+                    evidence_manifest_sha256,
                 ),
             )
             conn.commit()
@@ -2199,7 +2278,8 @@ class PostgresGraphStore:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
                 f"""
-                SELECT scan_id, created_at, node_count, edge_count, risk_summary, analysis_status
+                SELECT scan_id, created_at, node_count, edge_count, risk_summary, analysis_status,
+                       snapshot_kind, correlation_id, evidence_manifest_sha256
                 FROM graph_snapshots
                 {where}
                 ORDER BY created_at DESC
@@ -2215,9 +2295,133 @@ class PostgresGraphStore:
                     "edge_count": row[3],
                     "risk_summary": _decode_json_object(row[4]),
                     "analysis_status": analysis_status_map_to_dict(analysis_status_map_from_dict(_decode_json_object(row[5]))),
+                    "snapshot_kind": row[6] or "scan",
+                    "correlation_id": row[7] or "",
+                    "evidence_manifest_sha256": row[8] or "",
                 }
                 for row in rows
             ]
+
+    def get_correlation_run(self, *, tenant_id: str, correlation_id: str) -> GraphCorrelationRun | None:
+        tenant = normalize_graph_tenant_id(tenant_id)
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                f"SELECT {_CORRELATION_RUN_COLUMNS} FROM graph_correlation_runs "
+                "WHERE tenant_id = %s AND correlation_id = %s",  # nosec B608 - static internal column list
+                (tenant, correlation_id),
+            ).fetchone()
+        return _correlation_run_from_row(row) if row is not None else None
+
+    def create_correlation_run(self, run: GraphCorrelationRun) -> tuple[GraphCorrelationRun, bool]:
+        tenant = normalize_graph_tenant_id(run.tenant_id)
+        with _tenant_connection(self._pool) as conn:
+            existing = conn.execute(
+                f"SELECT {_CORRELATION_RUN_COLUMNS} FROM graph_correlation_runs "
+                "WHERE tenant_id = %s AND idempotency_key = %s",  # nosec B608 - static internal column list
+                (tenant, run.idempotency_key),
+            ).fetchone()
+            if existing is not None:
+                replay = _correlation_run_from_row(existing)
+                if replay.request_fingerprint() != run.request_fingerprint():
+                    raise ValueError("idempotency key was already used for a different correlation request")
+                return replay, False
+            row = conn.execute(
+                f"""
+                INSERT INTO graph_correlation_runs ({_CORRELATION_RUN_COLUMNS})
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT DO NOTHING
+                RETURNING {_CORRELATION_RUN_COLUMNS}
+                """,  # nosec B608 - static internal column list
+                (
+                    run.correlation_id,
+                    tenant,
+                    run.idempotency_key,
+                    run.name,
+                    run.status.value,
+                    run.max_age_hours,
+                    int(run.allow_stale),
+                    json.dumps(run.input_manifest, sort_keys=True, separators=(",", ":")),
+                    run.manifest_sha256,
+                    run.output_scan_id,
+                    run.failure_code,
+                    run.created_at,
+                    run.started_at,
+                    run.completed_at,
+                ),
+            ).fetchone()
+            if row is not None:
+                conn.commit()
+                return _correlation_run_from_row(row), True
+            replay_row = conn.execute(
+                f"SELECT {_CORRELATION_RUN_COLUMNS} FROM graph_correlation_runs "
+                "WHERE tenant_id = %s AND idempotency_key = %s",  # nosec B608 - static internal column list
+                (tenant, run.idempotency_key),
+            ).fetchone()
+            if replay_row is None:
+                raise ValueError("correlation_id already exists with a different idempotency key")
+            concurrent_replay = _correlation_run_from_row(replay_row)
+            if concurrent_replay.request_fingerprint() != run.request_fingerprint():
+                raise ValueError("idempotency key was already used for a different correlation request")
+            return concurrent_replay, False
+
+    def list_correlation_runs(self, *, tenant_id: str, limit: int = 100) -> list[GraphCorrelationRun]:
+        tenant = normalize_graph_tenant_id(tenant_id)
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                f"SELECT {_CORRELATION_RUN_COLUMNS} FROM graph_correlation_runs "
+                "WHERE tenant_id = %s ORDER BY created_at DESC, correlation_id DESC LIMIT %s",  # nosec B608
+                (tenant, max(1, min(int(limit), 1000))),
+            ).fetchall()
+        return [_correlation_run_from_row(row) for row in rows]
+
+    def update_correlation_run(
+        self,
+        *,
+        tenant_id: str,
+        correlation_id: str,
+        status: CorrelationRunStatus,
+        manifest_sha256: str = "",
+        output_scan_id: str = "",
+        failure_code: str = "",
+        started_at: str = "",
+        completed_at: str = "",
+    ) -> GraphCorrelationRun:
+        tenant = normalize_graph_tenant_id(tenant_id)
+        existing = self.get_correlation_run(tenant_id=tenant, correlation_id=correlation_id)
+        if existing is None:
+            raise KeyError("correlation run not found")
+        resolved_manifest, resolved_output, resolved_failure = validate_correlation_update(
+            existing,
+            status=status,
+            manifest_sha256=manifest_sha256,
+            output_scan_id=output_scan_id,
+            failure_code=failure_code,
+        )
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                f"""
+                UPDATE graph_correlation_runs
+                SET status = %s, manifest_sha256 = %s, output_scan_id = %s,
+                    failure_code = %s, started_at = %s, completed_at = %s
+                WHERE tenant_id = %s AND correlation_id = %s AND status = %s
+                RETURNING {_CORRELATION_RUN_COLUMNS}
+                """,  # nosec B608 - static internal column list
+                (
+                    status.value,
+                    resolved_manifest,
+                    resolved_output,
+                    resolved_failure,
+                    started_at or existing.started_at,
+                    completed_at or existing.completed_at,
+                    tenant,
+                    correlation_id,
+                    existing.status.value,
+                ),
+            ).fetchone()
+            if row is None:
+                raise ValueError("correlation run status changed concurrently")
+            conn.commit()
+            return _correlation_run_from_row(row)
 
     def _snapshot_digests(self, conn: Any, *, tenant_id: str, scan_id: str) -> tuple[str, str, dict[str, int]]:
         graph_rows: dict[str, list[dict[str, Any]]] = {"nodes": [], "edges": []}

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -418,8 +418,7 @@ class PostgresGraphStore:
                 """
             )
             conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_pg_graph_correlation_runs_recent "
-                "ON graph_correlation_runs(tenant_id, created_at DESC)"
+                "CREATE INDEX IF NOT EXISTS idx_pg_graph_correlation_runs_recent ON graph_correlation_runs(tenant_id, created_at DESC)"
             )
             conn.execute(
                 """
@@ -2306,8 +2305,7 @@ class PostgresGraphStore:
         tenant = normalize_graph_tenant_id(tenant_id)
         with _tenant_connection(self._pool) as conn:
             row = conn.execute(
-                f"SELECT {_CORRELATION_RUN_COLUMNS} FROM graph_correlation_runs "
-                "WHERE tenant_id = %s AND correlation_id = %s",  # nosec B608 - static internal column list
+                f"SELECT {_CORRELATION_RUN_COLUMNS} FROM graph_correlation_runs WHERE tenant_id = %s AND correlation_id = %s",  # nosec B608 - static internal column list
                 (tenant, correlation_id),
             ).fetchone()
         return _correlation_run_from_row(row) if row is not None else None
@@ -2316,8 +2314,7 @@ class PostgresGraphStore:
         tenant = normalize_graph_tenant_id(run.tenant_id)
         with _tenant_connection(self._pool) as conn:
             existing = conn.execute(
-                f"SELECT {_CORRELATION_RUN_COLUMNS} FROM graph_correlation_runs "
-                "WHERE tenant_id = %s AND idempotency_key = %s",  # nosec B608 - static internal column list
+                f"SELECT {_CORRELATION_RUN_COLUMNS} FROM graph_correlation_runs WHERE tenant_id = %s AND idempotency_key = %s",  # nosec B608 - static internal column list
                 (tenant, run.idempotency_key),
             ).fetchone()
             if existing is not None:
@@ -2353,8 +2350,7 @@ class PostgresGraphStore:
                 conn.commit()
                 return _correlation_run_from_row(row), True
             replay_row = conn.execute(
-                f"SELECT {_CORRELATION_RUN_COLUMNS} FROM graph_correlation_runs "
-                "WHERE tenant_id = %s AND idempotency_key = %s",  # nosec B608 - static internal column list
+                f"SELECT {_CORRELATION_RUN_COLUMNS} FROM graph_correlation_runs WHERE tenant_id = %s AND idempotency_key = %s",  # nosec B608 - static internal column list
                 (tenant, run.idempotency_key),
             ).fetchone()
             if replay_row is None:

--- a/src/agent_bom/api/storage_schema.py
+++ b/src/agent_bom/api/storage_schema.py
@@ -59,7 +59,12 @@ CONTROL_PLANE_SCHEMA_COMPONENTS: tuple[StorageSchemaComponent, ...] = (
     StorageSchemaComponent("access_review_campaigns", "sqlite/postgres", ("access_review_campaigns", "access_review_items")),
     StorageSchemaComponent("risk_campaign_workflows", "sqlite/postgres", ("risk_campaign_workflows",)),
     StorageSchemaComponent("fleet", "sqlite/postgres/snowflake", ("fleet_agents", "fleet_endpoints")),
-    StorageSchemaComponent("graph", "sqlite/postgres", ("graph_nodes", "graph_edges", "graph_node_search")),
+    StorageSchemaComponent(
+        "graph",
+        "sqlite/postgres",
+        ("graph_nodes", "graph_edges", "graph_node_search", "graph_snapshots", "graph_correlation_runs"),
+        version=2,
+    ),
     StorageSchemaComponent("graph_scenarios", "sqlite/postgres", ("graph_scenarios",)),
     StorageSchemaComponent("identity_scim", "sqlite/postgres", ("scim_users", "scim_groups")),
     # Agent-identity lifecycle is durable by default (SQLite single-node) and

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -42,6 +42,7 @@ from agent_bom.graph.analysis import (
     not_recorded_analysis_status,
 )
 from agent_bom.graph.container import GraphCompleteness, resolve_node_budget
+from agent_bom.graph.correlation import CorrelationRunStatus, GraphCorrelationRun, validate_correlation_update
 from agent_bom.graph.severity_floor import severity_floor_sql
 from agent_bom.security import sanitize_text
 
@@ -52,7 +53,7 @@ logger = logging.getLogger(__name__)
 # ═══════════════════════════════════════════════════════════════════════════
 
 DEFAULT_GRAPH_TENANT_ID = "default"
-_GRAPH_SCHEMA_VERSION = 3
+_GRAPH_SCHEMA_VERSION = 4
 _DEFAULT_GRAPH_WRITE_BATCH_SIZE = 1000
 _DEFAULT_GRAPH_RETENTION_DAYS = 180
 _FINDING_ENTITY_TYPES = {
@@ -77,6 +78,7 @@ _GRAPH_TENANT_TABLE_KEYS: dict[str, tuple[str, ...]] = {
     "graph_nodes": ("id", "scan_id"),
     "graph_edges": ("source_id", "target_id", "relationship", "scan_id"),
     "graph_snapshots": ("scan_id",),
+    "graph_correlation_runs": ("correlation_id",),
     "attack_paths": ("source_node", "target_node", "scan_id"),
     "interaction_risks": ("pattern", "agents", "scan_id"),
 }
@@ -204,9 +206,33 @@ CREATE TABLE IF NOT EXISTS graph_snapshots (
     risk_summary    TEXT DEFAULT '{}',
     node_type_counts TEXT DEFAULT NULL,
     analysis_status TEXT DEFAULT '{}',
+    snapshot_kind   TEXT NOT NULL DEFAULT 'scan' CHECK (snapshot_kind IN ('scan', 'correlation')),
+    correlation_id  TEXT DEFAULT NULL,
+    evidence_manifest_sha256 TEXT NOT NULL DEFAULT '',
     PRIMARY KEY (scan_id, tenant_id)
 );
 CREATE INDEX IF NOT EXISTS idx_gs_recent ON graph_snapshots(tenant_id, created_at DESC);
+
+-- ── Immutable graph correlation requests + monotonic execution state ──
+CREATE TABLE IF NOT EXISTS graph_correlation_runs (
+    correlation_id  TEXT NOT NULL,
+    tenant_id       TEXT NOT NULL DEFAULT 'default',
+    idempotency_key TEXT NOT NULL,
+    name            TEXT NOT NULL DEFAULT '',
+    status          TEXT NOT NULL CHECK (status IN ('pending', 'running', 'complete', 'failed')),
+    max_age_hours   INTEGER NOT NULL CHECK (max_age_hours BETWEEN 1 AND 8760),
+    allow_stale     INTEGER NOT NULL DEFAULT 0 CHECK (allow_stale IN (0, 1)),
+    input_manifest  TEXT NOT NULL DEFAULT '[]',
+    manifest_sha256 TEXT NOT NULL DEFAULT '',
+    output_scan_id  TEXT NOT NULL DEFAULT '',
+    failure_code    TEXT NOT NULL DEFAULT '',
+    created_at      TEXT NOT NULL,
+    started_at      TEXT NOT NULL DEFAULT '',
+    completed_at    TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (correlation_id, tenant_id),
+    UNIQUE (tenant_id, idempotency_key)
+);
+CREATE INDEX IF NOT EXISTS idx_gcr_recent ON graph_correlation_runs(tenant_id, created_at DESC);
 
 -- ── Attack paths (per scan) ──
 CREATE TABLE IF NOT EXISTS attack_paths (
@@ -392,6 +418,13 @@ def _init_db(conn: sqlite3.Connection, *, backfill_legacy_tenants: bool = True) 
         conn.execute("ALTER TABLE graph_snapshots ADD COLUMN node_type_counts TEXT DEFAULT NULL")
     if "analysis_status" not in snapshot_columns:
         conn.execute("ALTER TABLE graph_snapshots ADD COLUMN analysis_status TEXT DEFAULT '{}'")
+    if "snapshot_kind" not in snapshot_columns:
+        conn.execute("ALTER TABLE graph_snapshots ADD COLUMN snapshot_kind TEXT NOT NULL DEFAULT 'scan'")
+    if "correlation_id" not in snapshot_columns:
+        conn.execute("ALTER TABLE graph_snapshots ADD COLUMN correlation_id TEXT DEFAULT NULL")
+    if "evidence_manifest_sha256" not in snapshot_columns:
+        conn.execute("ALTER TABLE graph_snapshots ADD COLUMN evidence_manifest_sha256 TEXT NOT NULL DEFAULT ''")
+    conn.execute("INSERT OR IGNORE INTO graph_schema_version (version) VALUES (?)", (_GRAPH_SCHEMA_VERSION,))
     if backfill_legacy_tenants:
         _backfill_empty_tenant_ids(conn)
     conn.commit()
@@ -763,6 +796,9 @@ def save_graph_streaming(
     interaction_risks: Iterable[InteractionRisk] = (),
     analysis_status: Mapping[str, GraphAnalysisStatus] | None = None,
     created_at: str = "",
+    snapshot_kind: str = "scan",
+    correlation_id: str = "",
+    evidence_manifest_sha256: str = "",
 ) -> dict[str, int]:
     """Persist a graph snapshot from streamed node/edge iterables.
 
@@ -789,6 +825,10 @@ def save_graph_streaming(
     tenant = normalize_graph_tenant_id(tenant_id)
     scan = scan_id
     now = created_at or _now_iso()
+    if snapshot_kind not in {"scan", "correlation"}:
+        raise ValueError("snapshot_kind must be 'scan' or 'correlation'")
+    if snapshot_kind == "correlation" and correlation_id != scan:
+        raise ValueError("correlation snapshot ID must equal correlation_id")
     batch_size = _graph_write_batch_size()
     previous_scan = latest_snapshot_id(conn, tenant_id=tenant)
     if previous_scan == scan:
@@ -1039,8 +1079,10 @@ def save_graph_streaming(
     conn.execute(
         """
         INSERT OR REPLACE INTO graph_snapshots
-            (scan_id, tenant_id, created_at, node_count, edge_count, risk_summary, node_type_counts, analysis_status)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            (scan_id, tenant_id, created_at, node_count, edge_count, risk_summary,
+             node_type_counts, analysis_status, snapshot_kind, correlation_id,
+             evidence_manifest_sha256)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             scan,
@@ -1051,6 +1093,9 @@ def save_graph_streaming(
             json.dumps(dict(severity_counts)),
             json.dumps(dict(type_counts)),
             json.dumps(analysis_status_map_to_dict(analysis_status or {})),
+            snapshot_kind,
+            correlation_id or None,
+            evidence_manifest_sha256,
         ),
     )
 
@@ -1632,7 +1677,8 @@ def list_snapshots(
     params.append(limit)
     rows = conn.execute(
         f"""\
-        SELECT scan_id, created_at, node_count, edge_count, risk_summary, analysis_status
+        SELECT scan_id, created_at, node_count, edge_count, risk_summary, analysis_status,
+               snapshot_kind, correlation_id, evidence_manifest_sha256
         FROM graph_snapshots
         {where}
         ORDER BY created_at DESC LIMIT ?
@@ -1647,9 +1693,159 @@ def list_snapshots(
             "edge_count": r["edge_count"],
             "risk_summary": json.loads(r["risk_summary"]),
             "analysis_status": analysis_status_map_to_dict(analysis_status_map_from_dict(json.loads(r["analysis_status"] or "{}"))),
+            "snapshot_kind": r["snapshot_kind"] or "scan",
+            "correlation_id": r["correlation_id"] or "",
+            "evidence_manifest_sha256": r["evidence_manifest_sha256"] or "",
         }
         for r in rows
     ]
+
+
+def _correlation_run_from_row(row: sqlite3.Row) -> GraphCorrelationRun:
+    return GraphCorrelationRun.from_mapping(
+        {
+            "correlation_id": row["correlation_id"],
+            "tenant_id": row["tenant_id"],
+            "idempotency_key": row["idempotency_key"],
+            "name": row["name"],
+            "status": row["status"],
+            "max_age_hours": row["max_age_hours"],
+            "allow_stale": bool(row["allow_stale"]),
+            "input_manifest": json.loads(row["input_manifest"] or "[]"),
+            "manifest_sha256": row["manifest_sha256"],
+            "output_scan_id": row["output_scan_id"],
+            "failure_code": row["failure_code"],
+            "created_at": row["created_at"],
+            "started_at": row["started_at"],
+            "completed_at": row["completed_at"],
+        }
+    )
+
+
+def get_correlation_run(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    correlation_id: str,
+) -> GraphCorrelationRun | None:
+    tenant = normalize_graph_tenant_id(tenant_id)
+    row = conn.execute(
+        "SELECT * FROM graph_correlation_runs WHERE tenant_id = ? AND correlation_id = ?",
+        (tenant, correlation_id),
+    ).fetchone()
+    return _correlation_run_from_row(row) if row is not None else None
+
+
+def create_correlation_run(
+    conn: sqlite3.Connection,
+    run: GraphCorrelationRun,
+) -> tuple[GraphCorrelationRun, bool]:
+    """Create an immutable request or return its tenant-scoped idempotent replay."""
+
+    tenant = normalize_graph_tenant_id(run.tenant_id)
+    existing = conn.execute(
+        "SELECT * FROM graph_correlation_runs WHERE tenant_id = ? AND idempotency_key = ?",
+        (tenant, run.idempotency_key),
+    ).fetchone()
+    if existing is not None:
+        replay = _correlation_run_from_row(existing)
+        if replay.request_fingerprint() != run.request_fingerprint():
+            raise ValueError("idempotency key was already used for a different correlation request")
+        return replay, False
+    collision = get_correlation_run(conn, tenant_id=tenant, correlation_id=run.correlation_id)
+    if collision is not None:
+        raise ValueError("correlation_id already exists with a different idempotency key")
+    conn.execute(
+        """
+        INSERT INTO graph_correlation_runs (
+            correlation_id, tenant_id, idempotency_key, name, status,
+            max_age_hours, allow_stale, input_manifest, manifest_sha256,
+            output_scan_id, failure_code, created_at, started_at, completed_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            run.correlation_id,
+            tenant,
+            run.idempotency_key,
+            run.name,
+            run.status.value,
+            run.max_age_hours,
+            int(run.allow_stale),
+            json.dumps(run.input_manifest, sort_keys=True, separators=(",", ":")),
+            run.manifest_sha256,
+            run.output_scan_id,
+            run.failure_code,
+            run.created_at,
+            run.started_at,
+            run.completed_at,
+        ),
+    )
+    conn.commit()
+    created = get_correlation_run(conn, tenant_id=tenant, correlation_id=run.correlation_id)
+    if created is None:  # pragma: no cover - defensive persistence invariant
+        raise RuntimeError("correlation run was not persisted")
+    return created, True
+
+
+def list_correlation_runs(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    limit: int = 100,
+) -> list[GraphCorrelationRun]:
+    tenant = normalize_graph_tenant_id(tenant_id)
+    rows = conn.execute(
+        "SELECT * FROM graph_correlation_runs WHERE tenant_id = ? ORDER BY created_at DESC, correlation_id DESC LIMIT ?",
+        (tenant, max(1, min(int(limit), 1000))),
+    ).fetchall()
+    return [_correlation_run_from_row(row) for row in rows]
+
+
+def update_correlation_run(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    correlation_id: str,
+    status: CorrelationRunStatus,
+    manifest_sha256: str = "",
+    output_scan_id: str = "",
+    failure_code: str = "",
+    started_at: str = "",
+    completed_at: str = "",
+) -> GraphCorrelationRun:
+    existing = get_correlation_run(conn, tenant_id=tenant_id, correlation_id=correlation_id)
+    if existing is None:
+        raise KeyError("correlation run not found")
+    resolved_manifest, resolved_output, resolved_failure = validate_correlation_update(
+        existing,
+        status=status,
+        manifest_sha256=manifest_sha256,
+        output_scan_id=output_scan_id,
+        failure_code=failure_code,
+    )
+    conn.execute(
+        """
+        UPDATE graph_correlation_runs
+        SET status = ?, manifest_sha256 = ?, output_scan_id = ?, failure_code = ?,
+            started_at = ?, completed_at = ?
+        WHERE tenant_id = ? AND correlation_id = ?
+        """,
+        (
+            status.value,
+            resolved_manifest,
+            resolved_output,
+            resolved_failure,
+            started_at or existing.started_at,
+            completed_at or existing.completed_at,
+            normalize_graph_tenant_id(tenant_id),
+            correlation_id,
+        ),
+    )
+    conn.commit()
+    updated = get_correlation_run(conn, tenant_id=tenant_id, correlation_id=correlation_id)
+    if updated is None:  # pragma: no cover - defensive persistence invariant
+        raise RuntimeError("correlation run disappeared after update")
+    return updated
 
 
 def _diff_summary_counts(diff: dict[str, Any]) -> dict[str, int]:

--- a/src/agent_bom/graph/correlation.py
+++ b/src/agent_bom/graph/correlation.py
@@ -524,9 +524,7 @@ def merge_graph_snapshots(
             "node_conflict_count": sum(
                 bool(node.attributes.get(_CORRELATION_ATTR, {}).get("conflict_fields")) for node in output.nodes.values()
             ),
-            "edge_conflict_count": sum(
-                bool(edge.provenance.get(_CORRELATION_ATTR, {}).get("conflict_fields")) for edge in output.edges
-            ),
+            "edge_conflict_count": sum(bool(edge.provenance.get(_CORRELATION_ATTR, {}).get("conflict_fields")) for edge in output.edges),
         },
     }
     return CorrelationMergeResult(graph=output, manifest=manifest, manifest_sha256=_digest(manifest))

--- a/src/agent_bom/graph/correlation.py
+++ b/src/agent_bom/graph/correlation.py
@@ -1,0 +1,543 @@
+"""Deterministic correlation of immutable graph snapshots.
+
+Correlation is deliberately conservative: it merges observations only when
+their typed canonical identity is exact, and it never creates relationships
+that were absent from every input snapshot. Mutable container tags are scoped
+to their source snapshot unless an OCI digest is present.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Iterable, Mapping, Sequence
+
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import NodeDimensions, UnifiedNode
+from agent_bom.graph.severity import SEVERITY_RANK
+from agent_bom.graph.types import EntityType, RelationshipType
+from agent_bom.graph.util import _now_iso
+
+_EMPTY_VALUES: tuple[Any, ...] = (None, "", [], {})
+_OCI_DIGEST_RE = re.compile(r"sha256:[0-9a-fA-F]{64}")
+_SHA256_RE = re.compile(r"sha256:[0-9a-f]{64}")
+_FAILURE_CODE_RE = re.compile(r"[a-z0-9][a-z0-9_.:-]{0,127}")
+_CORRELATION_ATTR = "correlation"
+_REPOSITORY_ENTITY_TYPES = frozenset(
+    {
+        EntityType.SOURCE_FILE.value,
+        EntityType.CODE_MODULE.value,
+        EntityType.CONFIG_FILE.value,
+        EntityType.EXTERNAL_IMPORT.value,
+        EntityType.CI_JOB.value,
+        EntityType.DIRECTORY.value,
+    }
+)
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _non_empty(value: Any) -> bool:
+    return value not in _EMPTY_VALUES
+
+
+def _entity_value(node: UnifiedNode) -> str:
+    return node.entity_type.value if isinstance(node.entity_type, EntityType) else str(node.entity_type)
+
+
+def _relationship_value(edge: UnifiedEdge) -> str:
+    return edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
+
+
+def _oci_digest(node: UnifiedNode) -> str:
+    for key in ("image_digest", "digest", "repo_digest", "container_image", "image", "image_ref"):
+        value = node.attributes.get(key)
+        if not isinstance(value, str):
+            continue
+        match = _OCI_DIGEST_RE.search(value)
+        if match:
+            return match.group(0).lower()
+    return ""
+
+
+def _snapshot_scoped_identity(node: UnifiedNode, *, scan_id: str) -> tuple[str, str, str]:
+    entity_type = _entity_value(node)
+    return entity_type, f"snapshot:{scan_id}:{node.canonical_id}", "snapshot_scoped_missing_exact_identity"
+
+
+def correlation_identity(node: UnifiedNode, *, scan_id: str) -> tuple[str, str, str]:
+    """Return ``(entity_type, identity, basis)`` for a source observation.
+
+    Containers are the high-risk special case: ``app:latest`` is a locator,
+    not an immutable identity, so it remains snapshot-scoped until an exact OCI
+    digest is available. Other producers already materialize stable canonical
+    IDs; labels are never consulted here.
+    """
+
+    entity_type = _entity_value(node)
+    if entity_type == EntityType.CONTAINER.value:
+        digest = _oci_digest(node)
+        if digest:
+            return entity_type, digest, "oci_digest"
+        scoped_type, scoped_id, _basis = _snapshot_scoped_identity(node, scan_id=scan_id)
+        return scoped_type, scoped_id, "snapshot_scoped_mutable_ref"
+
+    if entity_type == EntityType.PACKAGE.value:
+        purl = node.attributes.get("purl")
+        if isinstance(purl, str) and purl.strip():
+            return entity_type, purl.strip().lower(), "purl"
+        return _snapshot_scoped_identity(node, scan_id=scan_id)
+
+    if entity_type in _REPOSITORY_ENTITY_TYPES:
+        commit = next(
+            (
+                str(node.attributes[key]).strip().lower()
+                for key in ("repository_commit", "commit_sha", "git_commit")
+                if node.attributes.get(key)
+            ),
+            "",
+        )
+        path = next(
+            (
+                str(node.attributes[key]).strip().replace("\\", "/")
+                for key in ("repository_path", "path", "source_file", "config_path")
+                if node.attributes.get(key)
+            ),
+            "",
+        )
+        if commit and path:
+            return entity_type, _digest({"commit": commit, "path": path}), "repository_commit_path"
+        return _snapshot_scoped_identity(node, scan_id=scan_id)
+
+    return entity_type, node.canonical_id, "canonical_id"
+
+
+@dataclass(frozen=True, slots=True)
+class CorrelationSnapshot:
+    """One immutable graph snapshot selected for a correlation run."""
+
+    scan_id: str
+    tenant_id: str
+    created_at: str
+    graph: UnifiedGraph
+    digest: str
+
+    @classmethod
+    def from_graph(cls, graph: UnifiedGraph) -> "CorrelationSnapshot":
+        return cls(
+            scan_id=graph.scan_id,
+            tenant_id=graph.tenant_id,
+            created_at=graph.created_at,
+            graph=graph,
+            digest=_digest(graph.to_dict()),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CorrelationMergeResult:
+    graph: UnifiedGraph
+    manifest: dict[str, Any]
+    manifest_sha256: str
+
+
+class CorrelationRunStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETE = "complete"
+    FAILED = "failed"
+
+
+_CORRELATION_TRANSITIONS = {
+    CorrelationRunStatus.PENDING: {CorrelationRunStatus.RUNNING, CorrelationRunStatus.FAILED},
+    CorrelationRunStatus.RUNNING: {CorrelationRunStatus.COMPLETE, CorrelationRunStatus.FAILED},
+    CorrelationRunStatus.COMPLETE: set(),
+    CorrelationRunStatus.FAILED: set(),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class GraphCorrelationRun:
+    """Immutable request plus monotonic execution state for one correlation."""
+
+    correlation_id: str
+    tenant_id: str
+    idempotency_key: str
+    name: str
+    status: CorrelationRunStatus
+    max_age_hours: int
+    allow_stale: bool
+    input_manifest: list[dict[str, Any]]
+    manifest_sha256: str = ""
+    output_scan_id: str = ""
+    failure_code: str = ""
+    created_at: str = ""
+    started_at: str = ""
+    completed_at: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.correlation_id.strip():
+            raise ValueError("correlation_id is required")
+        if not self.tenant_id.strip():
+            raise ValueError("tenant_id is required")
+        if not self.idempotency_key.strip():
+            raise ValueError("idempotency_key is required")
+        if not 1 <= int(self.max_age_hours) <= 8760:
+            raise ValueError("max_age_hours must be between 1 and 8760")
+        if not 2 <= len(self.input_manifest) <= 32:
+            raise ValueError("input_manifest must contain between 2 and 32 snapshots")
+        scan_ids = [str(item.get("scan_id") or "").strip() for item in self.input_manifest]
+        if any(not scan_id for scan_id in scan_ids) or len(set(scan_ids)) != len(scan_ids):
+            raise ValueError("input_manifest snapshot IDs must be non-empty and unique")
+        if self.failure_code and _FAILURE_CODE_RE.fullmatch(self.failure_code) is None:
+            raise ValueError("failure_code must be a sanitized machine-readable code")
+
+    def request_fingerprint(self) -> str:
+        """Hash immutable request fields for tenant-scoped idempotent replay."""
+
+        return _digest(
+            {
+                "tenant_id": self.tenant_id,
+                "name": self.name,
+                "max_age_hours": self.max_age_hours,
+                "allow_stale": self.allow_stale,
+                "input_manifest": sorted(
+                    (deepcopy(item) for item in self.input_manifest),
+                    key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":"), default=str),
+                ),
+            }
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "correlation_id": self.correlation_id,
+            "tenant_id": self.tenant_id,
+            "idempotency_key": self.idempotency_key,
+            "name": self.name,
+            "status": self.status.value,
+            "max_age_hours": self.max_age_hours,
+            "allow_stale": self.allow_stale,
+            "input_manifest": deepcopy(self.input_manifest),
+            "manifest_sha256": self.manifest_sha256,
+            "output_scan_id": self.output_scan_id,
+            "failure_code": self.failure_code,
+            "created_at": self.created_at,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "GraphCorrelationRun":
+        status = value.get("status", CorrelationRunStatus.PENDING)
+        return cls(
+            correlation_id=str(value.get("correlation_id") or ""),
+            tenant_id=str(value.get("tenant_id") or ""),
+            idempotency_key=str(value.get("idempotency_key") or ""),
+            name=str(value.get("name") or ""),
+            status=status if isinstance(status, CorrelationRunStatus) else CorrelationRunStatus(str(status)),
+            max_age_hours=int(value.get("max_age_hours") or 0),
+            allow_stale=bool(value.get("allow_stale", False)),
+            input_manifest=[dict(item) for item in value.get("input_manifest") or [] if isinstance(item, Mapping)],
+            manifest_sha256=str(value.get("manifest_sha256") or ""),
+            output_scan_id=str(value.get("output_scan_id") or ""),
+            failure_code=str(value.get("failure_code") or ""),
+            created_at=str(value.get("created_at") or ""),
+            started_at=str(value.get("started_at") or ""),
+            completed_at=str(value.get("completed_at") or ""),
+        )
+
+
+def validate_correlation_update(
+    existing: GraphCorrelationRun,
+    *,
+    status: CorrelationRunStatus,
+    manifest_sha256: str = "",
+    output_scan_id: str = "",
+    failure_code: str = "",
+) -> tuple[str, str, str]:
+    """Validate one monotonic state transition and return resolved values."""
+
+    if status not in _CORRELATION_TRANSITIONS[existing.status]:
+        raise ValueError("correlation run is terminal or the status transition is invalid")
+    resolved_manifest = manifest_sha256 or existing.manifest_sha256
+    resolved_output = output_scan_id or existing.output_scan_id
+    if failure_code and _FAILURE_CODE_RE.fullmatch(failure_code) is None:
+        raise ValueError("failure_code must be a sanitized machine-readable code")
+    if status is CorrelationRunStatus.COMPLETE:
+        if resolved_output != existing.correlation_id:
+            raise ValueError("completed correlation output snapshot must equal correlation_id")
+        if _SHA256_RE.fullmatch(resolved_manifest) is None:
+            raise ValueError("completed correlation requires a sha256 evidence manifest")
+        if failure_code:
+            raise ValueError("completed correlation cannot contain a failure code")
+    if status is CorrelationRunStatus.FAILED:
+        if not failure_code:
+            raise ValueError("failed correlation requires a sanitized failure code")
+        if resolved_output:
+            raise ValueError("failed correlation cannot expose an output snapshot")
+    return resolved_manifest, resolved_output, failure_code
+
+
+@dataclass(frozen=True, slots=True)
+class _NodeObservation:
+    snapshot: CorrelationSnapshot
+    node: UnifiedNode
+    identity_basis: str
+
+
+@dataclass(frozen=True, slots=True)
+class _EdgeObservation:
+    snapshot: CorrelationSnapshot
+    edge: UnifiedEdge
+
+
+def _project_mapping(observations: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    """Project newest non-empty top-level values from oldest→newest inputs."""
+
+    projected: dict[str, Any] = {}
+    for values in observations:
+        for key, value in values.items():
+            if key == _CORRELATION_ATTR or not _non_empty(value):
+                continue
+            projected[str(key)] = deepcopy(value)
+    return projected
+
+
+def _conflict_fields(observations: Iterable[Mapping[str, Any]]) -> list[str]:
+    values_by_key: dict[str, set[str]] = {}
+    for values in observations:
+        for key, value in values.items():
+            if key in {_CORRELATION_ATTR, "canonical_id", "stable_id", "source_ids"} or not _non_empty(value):
+                continue
+            values_by_key.setdefault(str(key), set()).add(json.dumps(value, sort_keys=True, separators=(",", ":"), default=str))
+    return sorted(key for key, values in values_by_key.items() if len(values) > 1)
+
+
+def _node_observation_receipt(observation: _NodeObservation) -> dict[str, Any]:
+    node = observation.node
+    return {
+        "scan_id": observation.snapshot.scan_id,
+        "snapshot_created_at": observation.snapshot.created_at,
+        "source_node_id": node.id,
+        "data_sources": sorted(set(node.data_sources)),
+        "risk_score": float(node.risk_score),
+        "severity": node.severity,
+        "attribute_digest": _digest(node.attributes),
+    }
+
+
+def _merge_node(observations: Sequence[_NodeObservation]) -> UnifiedNode:
+    ordered = sorted(observations, key=lambda item: (item.snapshot.created_at, item.snapshot.scan_id, item.node.id))
+    newest = ordered[-1].node
+    attributes = _project_mapping(item.node.attributes for item in ordered)
+    source_scan_ids = sorted({item.snapshot.scan_id for item in ordered})
+    identity_basis = sorted({item.identity_basis for item in ordered})
+    attributes[_CORRELATION_ATTR] = {
+        "identity_basis": identity_basis[0] if len(identity_basis) == 1 else identity_basis,
+        "observation_count": len(ordered),
+        "source_scan_ids": source_scan_ids,
+        "conflict_fields": _conflict_fields(item.node.attributes for item in ordered),
+        "observations": [_node_observation_receipt(item) for item in ordered],
+    }
+
+    severity_source = max(
+        ordered,
+        key=lambda item: (SEVERITY_RANK.get((item.node.severity or "").lower(), 0), item.node.risk_score, item.snapshot.created_at),
+    ).node
+    dimensions = NodeDimensions()
+    for item in ordered:
+        dimensions = dimensions.merge(item.node.dimensions)
+
+    first_seen_values = [item.node.first_seen for item in ordered if item.node.first_seen]
+    last_seen_values = [item.node.last_seen for item in ordered if item.node.last_seen]
+    return UnifiedNode(
+        id=newest.id,
+        entity_type=newest.entity_type,
+        label=newest.label,
+        category_uid=newest.category_uid,
+        class_uid=newest.class_uid,
+        type_uid=newest.type_uid,
+        status=newest.status,
+        risk_score=max(float(item.node.risk_score) for item in ordered),
+        severity=severity_source.severity,
+        severity_id=severity_source.severity_id,
+        first_seen=min(first_seen_values) if first_seen_values else "",
+        last_seen=max(last_seen_values) if last_seen_values else "",
+        attributes=attributes,
+        compliance_tags=sorted({tag for item in ordered for tag in item.node.compliance_tags}),
+        data_sources=sorted({source for item in ordered for source in item.node.data_sources}),
+        dimensions=dimensions,
+    )
+
+
+def _edge_receipt(observation: _EdgeObservation) -> dict[str, Any]:
+    edge = observation.edge
+    return {
+        "scan_id": observation.snapshot.scan_id,
+        "snapshot_created_at": observation.snapshot.created_at,
+        "source_edge_id": edge.id,
+        "confidence": float(edge.confidence),
+        "traversable": bool(edge.traversable),
+        "direction": edge.direction,
+        "evidence_digest": _digest(edge.evidence),
+    }
+
+
+def _merge_edge(
+    observations: Sequence[_EdgeObservation],
+    *,
+    source_id: str,
+    target_id: str,
+    correlation_id: str,
+) -> UnifiedEdge:
+    ordered = sorted(observations, key=lambda item: (item.snapshot.created_at, item.snapshot.scan_id, item.edge.id))
+    newest = ordered[-1].edge
+    first_seen_values = [item.edge.first_seen for item in ordered if item.edge.first_seen]
+    last_seen_values = [item.edge.last_seen for item in ordered if item.edge.last_seen]
+    source_scan_ids = sorted({item.snapshot.scan_id for item in ordered})
+    provenance = _project_mapping(item.edge.provenance for item in ordered)
+    conflict_fields: list[str] = []
+    if len({item.edge.direction for item in ordered}) > 1:
+        conflict_fields.append("direction")
+    if len({bool(item.edge.traversable) for item in ordered}) > 1:
+        conflict_fields.append("traversable")
+    provenance[_CORRELATION_ATTR] = {
+        "observation_count": len(ordered),
+        "source_scan_ids": source_scan_ids,
+        "conflict_fields": conflict_fields,
+        "observations": [_edge_receipt(item) for item in ordered],
+    }
+    return UnifiedEdge(
+        source=source_id,
+        target=target_id,
+        relationship=newest.relationship,
+        # Conservative merge: conflicting directionality cannot expand an
+        # attacker's traversal. Every observation must support bidirectionality.
+        direction="bidirectional" if all(item.edge.direction == "bidirectional" for item in ordered) else "directed",
+        weight=max(float(item.edge.weight) for item in ordered),
+        traversable=all(bool(item.edge.traversable) for item in ordered),
+        first_seen=min(first_seen_values) if first_seen_values else "",
+        last_seen=max(last_seen_values) if last_seen_values else "",
+        valid_from=min((item.edge.valid_from for item in ordered if item.edge.valid_from), default=""),
+        valid_to=newest.valid_to,
+        source_scan_id=correlation_id,
+        source_run_id=correlation_id,
+        evidence=_project_mapping(item.edge.evidence for item in ordered),
+        confidence=max(float(item.edge.confidence) for item in ordered),
+        provenance=provenance,
+        activity_id=newest.activity_id,
+    )
+
+
+def merge_graph_snapshots(
+    *,
+    correlation_id: str,
+    tenant_id: str,
+    snapshots: Sequence[CorrelationSnapshot],
+    created_at: str = "",
+) -> CorrelationMergeResult:
+    """Merge selected immutable snapshots without inventing cross-source edges."""
+
+    if len(snapshots) < 2:
+        raise ValueError("Correlation requires at least 2 graph snapshots")
+    if len(snapshots) > 32:
+        raise ValueError("Correlation accepts at most 32 graph snapshots")
+    if len({snapshot.scan_id for snapshot in snapshots}) != len(snapshots):
+        raise ValueError("Correlation snapshot IDs must be unique")
+    if any(snapshot.tenant_id != tenant_id or snapshot.graph.tenant_id != tenant_id for snapshot in snapshots):
+        raise ValueError("Correlation inputs must belong to the same tenant")
+    if any(not snapshot.graph.nodes for snapshot in snapshots):
+        raise ValueError("Correlation inputs must be non-empty graph snapshots")
+
+    ordered_snapshots = sorted(snapshots, key=lambda item: (item.created_at, item.scan_id))
+    node_groups: dict[tuple[str, str], list[_NodeObservation]] = {}
+    source_to_key: dict[tuple[str, str], tuple[str, str]] = {}
+    for snapshot in ordered_snapshots:
+        for node in sorted(snapshot.graph.nodes.values(), key=lambda item: item.id):
+            entity_type, identity, basis = correlation_identity(node, scan_id=snapshot.scan_id)
+            key = (entity_type, identity)
+            source_to_key[(snapshot.scan_id, node.id)] = key
+            node_groups.setdefault(key, []).append(_NodeObservation(snapshot=snapshot, node=node, identity_basis=basis))
+
+    output = UnifiedGraph(scan_id=correlation_id, tenant_id=tenant_id, created_at=created_at or _now_iso())
+    output_id_by_key: dict[tuple[str, str], str] = {}
+    merged_nodes = [(key, _merge_node(node_groups[key])) for key in sorted(node_groups)]
+    candidate_id_counts: dict[str, int] = {}
+    for _key, node in merged_nodes:
+        candidate_id_counts[node.id] = candidate_id_counts.get(node.id, 0) + 1
+    for key, node in merged_nodes:
+        if candidate_id_counts[node.id] > 1:
+            # Snapshot-scoped identities can legitimately retain the same local
+            # graph ID. Give every colliding observation group a deterministic
+            # correlated ID so UnifiedGraph.add_node cannot conflate them.
+            node.id = f"correlated:{key[0]}:{_digest(key).removeprefix('sha256:')}"
+        output.add_node(node)
+        output_id_by_key[key] = node.id
+
+    edge_groups: dict[tuple[tuple[str, str], tuple[str, str], str], list[_EdgeObservation]] = {}
+    for snapshot in ordered_snapshots:
+        for edge in sorted(snapshot.graph.edges, key=lambda item: (item.source, item.target, _relationship_value(item))):
+            source_key = source_to_key.get((snapshot.scan_id, edge.source))
+            target_key = source_to_key.get((snapshot.scan_id, edge.target))
+            if source_key is None or target_key is None:
+                continue
+            edge_key = (source_key, target_key, _relationship_value(edge))
+            edge_groups.setdefault(edge_key, []).append(_EdgeObservation(snapshot=snapshot, edge=edge))
+
+    for (source_key, target_key, _relationship), observations in sorted(edge_groups.items(), key=lambda item: str(item[0])):
+        output.add_edge(
+            _merge_edge(
+                observations,
+                source_id=output_id_by_key[source_key],
+                target_id=output_id_by_key[target_key],
+                correlation_id=correlation_id,
+            )
+        )
+
+    manifest = {
+        "schema_version": "agent-bom.graph-correlation.v1",
+        "correlation_id": correlation_id,
+        "tenant_id": tenant_id,
+        "created_at": output.created_at,
+        "input_snapshots": [
+            {
+                "scan_id": snapshot.scan_id,
+                "created_at": snapshot.created_at,
+                "digest": snapshot.digest,
+                "node_count": len(snapshot.graph.nodes),
+                "edge_count": len(snapshot.graph.edges),
+                "data_sources": sorted({source for node in snapshot.graph.nodes.values() for source in node.data_sources}),
+            }
+            for snapshot in ordered_snapshots
+        ],
+        "output": {
+            "scan_id": correlation_id,
+            "node_count": len(output.nodes),
+            "edge_count": len(output.edges),
+            "node_conflict_count": sum(
+                bool(node.attributes.get(_CORRELATION_ATTR, {}).get("conflict_fields")) for node in output.nodes.values()
+            ),
+            "edge_conflict_count": sum(
+                bool(edge.provenance.get(_CORRELATION_ATTR, {}).get("conflict_fields")) for edge in output.edges
+            ),
+        },
+    }
+    return CorrelationMergeResult(graph=output, manifest=manifest, manifest_sha256=_digest(manifest))
+
+
+__all__ = [
+    "CorrelationMergeResult",
+    "CorrelationRunStatus",
+    "CorrelationSnapshot",
+    "GraphCorrelationRun",
+    "correlation_identity",
+    "merge_graph_snapshots",
+    "validate_correlation_update",
+]

--- a/tests/test_graph_correlation_foundation.py
+++ b/tests/test_graph_correlation_foundation.py
@@ -1,0 +1,264 @@
+"""Deterministic, provenance-preserving graph correlation contracts."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
+from agent_bom.graph.correlation import CorrelationSnapshot, merge_graph_snapshots
+
+
+def _graph(scan_id: str, tenant_id: str = "acme") -> UnifiedGraph:
+    return UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id, created_at=f"2026-08-{10 + int(scan_id[-1])}T12:00:00+00:00")
+
+
+def _package(graph: UnifiedGraph, *, node_id: str, owner: str, severity: str, risk: float, source: str) -> None:
+    graph.add_node(
+        UnifiedNode(
+            id=node_id,
+            entity_type=EntityType.PACKAGE,
+            label="pillow@9.0.0",
+            severity=severity,
+            risk_score=risk,
+            attributes={
+                "canonical_id": "pkg:pypi/pillow@9.0.0",
+                "purl": "pkg:pypi/pillow@9.0.0",
+                "owner": owner,
+                "retained_when_newer_blank": "keep-me",
+            },
+            data_sources=[source],
+        )
+    )
+
+
+def test_merge_is_order_independent_and_preserves_observations_and_conflicts() -> None:
+    older = _graph("scan-1")
+    newer = _graph("scan-2")
+    _package(older, node_id="pkg:older", owner="platform", severity="critical", risk=9.8, source="repo")
+    _package(newer, node_id="pkg:newer", owner="runtime", severity="medium", risk=5.0, source="image")
+    newer.nodes["pkg:newer"].attributes["retained_when_newer_blank"] = ""
+
+    first = merge_graph_snapshots(
+        correlation_id="corr-1",
+        tenant_id="acme",
+        snapshots=[CorrelationSnapshot.from_graph(older), CorrelationSnapshot.from_graph(newer)],
+        created_at="2026-08-30T00:00:00+00:00",
+    )
+    second = merge_graph_snapshots(
+        correlation_id="corr-1",
+        tenant_id="acme",
+        snapshots=[CorrelationSnapshot.from_graph(deepcopy(newer)), CorrelationSnapshot.from_graph(deepcopy(older))],
+        created_at="2026-08-30T00:00:00+00:00",
+    )
+
+    assert first.graph.to_dict() == second.graph.to_dict()
+    assert len(first.graph.nodes) == 1
+    node = next(iter(first.graph.nodes.values()))
+    assert node.id == "pkg:newer"
+    assert node.severity == "critical"
+    assert node.risk_score == 9.8
+    assert node.attributes["owner"] == "runtime"
+    assert node.attributes["retained_when_newer_blank"] == "keep-me"
+    correlation = node.attributes["correlation"]
+    assert correlation["observation_count"] == 2
+    assert correlation["source_scan_ids"] == ["scan-1", "scan-2"]
+    assert correlation["conflict_fields"] == ["owner"]
+    assert [item["scan_id"] for item in correlation["observations"]] == ["scan-1", "scan-2"]
+    assert node.data_sources == ["image", "repo"]
+
+
+def test_container_images_merge_only_on_exact_oci_digest() -> None:
+    left = _graph("scan-1")
+    right = _graph("scan-2")
+    for graph, node_id in ((left, "container:app:latest"), (right, "container:registry/app:latest")):
+        graph.add_node(
+            UnifiedNode(
+                id=node_id,
+                entity_type=EntityType.CONTAINER,
+                label="app:latest",
+                attributes={"container_image": "app:latest"},
+            )
+        )
+
+    unpinned = merge_graph_snapshots(
+        correlation_id="corr-unpinned",
+        tenant_id="acme",
+        snapshots=[CorrelationSnapshot.from_graph(left), CorrelationSnapshot.from_graph(right)],
+    )
+    assert len(unpinned.graph.nodes) == 2
+
+    digest = "sha256:" + "a" * 64
+    left.nodes["container:app:latest"].attributes["image_digest"] = digest
+    right.nodes["container:registry/app:latest"].attributes["repo_digest"] = f"registry/app@{digest}"
+    pinned = merge_graph_snapshots(
+        correlation_id="corr-pinned",
+        tenant_id="acme",
+        snapshots=[CorrelationSnapshot.from_graph(left), CorrelationSnapshot.from_graph(right)],
+    )
+    assert len(pinned.graph.nodes) == 1
+    node = next(iter(pinned.graph.nodes.values()))
+    assert node.attributes["correlation"]["identity_basis"] == "oci_digest"
+
+
+def test_packages_without_exact_purl_remain_snapshot_scoped() -> None:
+    left = _graph("scan-1")
+    right = _graph("scan-2")
+    for graph in (left, right):
+        graph.add_node(
+            UnifiedNode(
+                id="package:pillow:9.0.0",
+                entity_type=EntityType.PACKAGE,
+                label="pillow@9.0.0",
+                attributes={"name": "pillow", "version": "9.0.0"},
+            )
+        )
+
+    merged = merge_graph_snapshots(
+        correlation_id="corr-no-purl",
+        tenant_id="acme",
+        snapshots=[CorrelationSnapshot.from_graph(left), CorrelationSnapshot.from_graph(right)],
+    )
+
+    assert len(merged.graph.nodes) == 2
+
+
+def test_repository_nodes_require_exact_commit_and_path_identity() -> None:
+    left = _graph("scan-1")
+    right = _graph("scan-2")
+    for graph in (left, right):
+        graph.add_node(
+            UnifiedNode(
+                id="source_file:app/main.py",
+                entity_type=EntityType.SOURCE_FILE,
+                label="main.py",
+                attributes={"path": "app/main.py"},
+            )
+        )
+
+    unpinned = merge_graph_snapshots(
+        correlation_id="corr-unpinned-repo",
+        tenant_id="acme",
+        snapshots=[CorrelationSnapshot.from_graph(left), CorrelationSnapshot.from_graph(right)],
+    )
+    assert len(unpinned.graph.nodes) == 2
+
+    for graph in (left, right):
+        graph.nodes["source_file:app/main.py"].attributes["repository_commit"] = "a" * 40
+    pinned = merge_graph_snapshots(
+        correlation_id="corr-pinned-repo",
+        tenant_id="acme",
+        snapshots=[CorrelationSnapshot.from_graph(left), CorrelationSnapshot.from_graph(right)],
+    )
+    assert len(pinned.graph.nodes) == 1
+    assert next(iter(pinned.graph.nodes.values())).attributes["correlation"]["identity_basis"] == "repository_commit_path"
+
+
+def test_snapshot_scoped_mutable_images_with_same_node_id_remain_distinct() -> None:
+    left = _graph("scan-1")
+    right = _graph("scan-2")
+    left.add_node(
+        UnifiedNode(
+            id="container:app",
+            entity_type=EntityType.CONTAINER,
+            label="app:latest",
+            attributes={"container_image": "registry.example/app:latest"},
+        )
+    )
+    right.add_node(
+        UnifiedNode(
+            id="container:app",
+            entity_type=EntityType.CONTAINER,
+            label="app:stable",
+            attributes={"container_image": "registry.example/app:stable"},
+        )
+    )
+
+    merged = merge_graph_snapshots(
+        correlation_id="corr-same-id",
+        tenant_id="acme",
+        snapshots=[CorrelationSnapshot.from_graph(left), CorrelationSnapshot.from_graph(right)],
+    )
+
+    assert len(merged.graph.nodes) == 2
+    assert len(set(merged.graph.nodes)) == 2
+    assert {node.label for node in merged.graph.nodes.values()} == {"app:latest", "app:stable"}
+
+
+def test_same_label_without_shared_identity_does_not_merge_or_fabricate_edges() -> None:
+    left = _graph("scan-1")
+    right = _graph("scan-2")
+    left.add_node(UnifiedNode(id="resource:left", entity_type=EntityType.CLOUD_RESOURCE, label="production"))
+    right.add_node(UnifiedNode(id="resource:right", entity_type=EntityType.CLOUD_RESOURCE, label="production"))
+    right.add_node(UnifiedNode(id="data:right", entity_type=EntityType.DATA_STORE, label="customer-data"))
+    right.add_edge(UnifiedEdge(source="resource:right", target="data:right", relationship=RelationshipType.STORES))
+
+    merged = merge_graph_snapshots(
+        correlation_id="corr-labels",
+        tenant_id="acme",
+        snapshots=[CorrelationSnapshot.from_graph(left), CorrelationSnapshot.from_graph(right)],
+    )
+
+    assert len(merged.graph.nodes) == 3
+    assert len(merged.graph.edges) == 1
+    edge = merged.graph.edges[0]
+    assert (edge.source, edge.target) == ("resource:right", "data:right")
+
+
+def test_edge_observations_are_union_preserved_after_endpoint_remap() -> None:
+    left = _graph("scan-1")
+    right = _graph("scan-2")
+    for graph, suffix, source in ((left, "old", "repo"), (right, "new", "image")):
+        graph.add_node(
+            UnifiedNode(
+                id=f"pkg:{suffix}",
+                entity_type=EntityType.PACKAGE,
+                label="pillow@9.0.0",
+                attributes={"canonical_id": "pkg:pypi/pillow@9.0.0", "purl": "pkg:pypi/pillow@9.0.0"},
+            )
+        )
+        graph.add_node(
+            UnifiedNode(
+                id=f"vuln:{suffix}",
+                entity_type=EntityType.VULNERABILITY,
+                label="CVE-2023-4863",
+                attributes={"canonical_id": "CVE-2023-4863"},
+            )
+        )
+        graph.add_edge(
+            UnifiedEdge(
+                source=f"pkg:{suffix}",
+                target=f"vuln:{suffix}",
+                relationship=RelationshipType.VULNERABLE_TO,
+                evidence={"source": source},
+                confidence=0.8 if source == "repo" else 1.0,
+            )
+        )
+
+    merged = merge_graph_snapshots(
+        correlation_id="corr-edges",
+        tenant_id="acme",
+        snapshots=[CorrelationSnapshot.from_graph(left), CorrelationSnapshot.from_graph(right)],
+    )
+    assert len(merged.graph.edges) == 1
+    edge = merged.graph.edges[0]
+    assert edge.source == "pkg:new"
+    assert edge.target == "vuln:new"
+    assert edge.confidence == 1.0
+    assert edge.provenance["correlation"]["source_scan_ids"] == ["scan-1", "scan-2"]
+    assert [item["scan_id"] for item in edge.provenance["correlation"]["observations"]] == ["scan-1", "scan-2"]
+
+
+def test_merge_rejects_invalid_snapshot_sets() -> None:
+    one = _graph("scan-1")
+    with pytest.raises(ValueError, match="at least 2"):
+        merge_graph_snapshots(correlation_id="corr", tenant_id="acme", snapshots=[CorrelationSnapshot.from_graph(one)])
+
+    other_tenant = _graph("scan-2", tenant_id="other")
+    with pytest.raises(ValueError, match="same tenant"):
+        merge_graph_snapshots(
+            correlation_id="corr",
+            tenant_id="acme",
+            snapshots=[CorrelationSnapshot.from_graph(one), CorrelationSnapshot.from_graph(other_tenant)],
+        )

--- a/tests/test_graph_correlation_store.py
+++ b/tests/test_graph_correlation_store.py
@@ -1,0 +1,220 @@
+"""SQLite durability contracts for immutable graph correlation runs."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+
+import pytest
+
+from agent_bom.db import graph_store
+from agent_bom.graph import EntityType, UnifiedGraph, UnifiedNode
+from agent_bom.graph.correlation import CorrelationRunStatus, GraphCorrelationRun
+
+
+def _run(*, tenant_id: str = "acme", correlation_id: str = "corr-1", idempotency_key: str = "idem-1") -> GraphCorrelationRun:
+    return GraphCorrelationRun(
+        correlation_id=correlation_id,
+        tenant_id=tenant_id,
+        idempotency_key=idempotency_key,
+        name="reference lab",
+        status=CorrelationRunStatus.PENDING,
+        max_age_hours=168,
+        allow_stale=False,
+        input_manifest=[{"scan_id": "scan-1"}, {"scan_id": "scan-2"}],
+        created_at="2026-08-30T00:00:00+00:00",
+    )
+
+
+def test_sqlite_migration_adds_snapshot_metadata_and_correlation_table(tmp_path) -> None:
+    db = tmp_path / "graph.db"
+    with graph_store.open_graph_db(db) as conn:
+        snapshot_columns = {row["name"] for row in conn.execute("PRAGMA table_info(graph_snapshots)")}
+        run_columns = {row["name"] for row in conn.execute("PRAGMA table_info(graph_correlation_runs)")}
+        version = conn.execute("SELECT MAX(version) FROM graph_schema_version").fetchone()[0]
+
+    assert {"snapshot_kind", "correlation_id", "evidence_manifest_sha256"} <= snapshot_columns
+    assert {
+        "correlation_id",
+        "tenant_id",
+        "idempotency_key",
+        "status",
+        "max_age_hours",
+        "allow_stale",
+        "input_manifest",
+        "manifest_sha256",
+        "output_scan_id",
+        "failure_code",
+    } <= run_columns
+    assert version >= 4
+
+
+def test_correlation_run_is_tenant_isolated_and_idempotent(tmp_path) -> None:
+    db = tmp_path / "graph.db"
+    with graph_store.open_graph_db(db) as conn:
+        created, was_created = graph_store.create_correlation_run(conn, _run())
+        replayed, replay_created = graph_store.create_correlation_run(conn, replace(_run(), correlation_id="corr-retry"))
+        other, other_created = graph_store.create_correlation_run(
+            conn,
+            _run(tenant_id="other", correlation_id="corr-other", idempotency_key="idem-1"),
+        )
+
+        assert was_created is True
+        assert replay_created is False
+        assert replayed.correlation_id == created.correlation_id == "corr-1"
+        assert other_created is True
+        assert other.correlation_id == "corr-other"
+        assert graph_store.get_correlation_run(conn, tenant_id="other", correlation_id="corr-1") is None
+        assert [item.correlation_id for item in graph_store.list_correlation_runs(conn, tenant_id="acme")] == ["corr-1"]
+
+
+def test_idempotency_key_rejects_a_different_request(tmp_path) -> None:
+    db = tmp_path / "graph.db"
+    with graph_store.open_graph_db(db) as conn:
+        graph_store.create_correlation_run(conn, _run())
+        with pytest.raises(ValueError, match="different correlation request"):
+            graph_store.create_correlation_run(conn, replace(_run(), max_age_hours=24))
+
+
+def test_run_contract_rejects_duplicate_inputs_and_unsanitized_failure_text() -> None:
+    with pytest.raises(ValueError, match="non-empty and unique"):
+        replace(_run(), input_manifest=[{"scan_id": "scan-1"}, {"scan_id": "scan-1"}])
+    with pytest.raises(ValueError, match="sanitized machine-readable code"):
+        replace(_run(), status=CorrelationRunStatus.FAILED, failure_code="database failed: /secret/path")
+
+
+def test_correlation_request_is_immutable_but_status_progresses_monotonically(tmp_path) -> None:
+    db = tmp_path / "graph.db"
+    with graph_store.open_graph_db(db) as conn:
+        graph_store.create_correlation_run(conn, _run())
+        with pytest.raises(ValueError, match="sanitized machine-readable code"):
+            graph_store.update_correlation_run(
+                conn,
+                tenant_id="acme",
+                correlation_id="corr-1",
+                status=CorrelationRunStatus.FAILED,
+                failure_code="database failed: /secret/path",
+            )
+        assert graph_store.get_correlation_run(conn, tenant_id="acme", correlation_id="corr-1").status is CorrelationRunStatus.PENDING
+        running = graph_store.update_correlation_run(
+            conn,
+            tenant_id="acme",
+            correlation_id="corr-1",
+            status=CorrelationRunStatus.RUNNING,
+            started_at="2026-08-30T00:01:00+00:00",
+        )
+        complete = graph_store.update_correlation_run(
+            conn,
+            tenant_id="acme",
+            correlation_id="corr-1",
+            status=CorrelationRunStatus.COMPLETE,
+            output_scan_id="corr-1",
+            manifest_sha256="sha256:" + "a" * 64,
+            completed_at="2026-08-30T00:02:00+00:00",
+        )
+
+        assert running.status is CorrelationRunStatus.RUNNING
+        assert complete.status is CorrelationRunStatus.COMPLETE
+        assert complete.input_manifest == _run().input_manifest
+        with pytest.raises(ValueError, match="terminal"):
+            graph_store.update_correlation_run(
+                conn,
+                tenant_id="acme",
+                correlation_id="corr-1",
+                status=CorrelationRunStatus.RUNNING,
+            )
+
+
+def test_complete_requires_manifest_and_output_equal_to_correlation_id(tmp_path) -> None:
+    db = tmp_path / "graph.db"
+    with graph_store.open_graph_db(db) as conn:
+        graph_store.create_correlation_run(conn, _run())
+        graph_store.update_correlation_run(
+            conn,
+            tenant_id="acme",
+            correlation_id="corr-1",
+            status=CorrelationRunStatus.RUNNING,
+        )
+        with pytest.raises(ValueError, match="output snapshot must equal"):
+            graph_store.update_correlation_run(
+                conn,
+                tenant_id="acme",
+                correlation_id="corr-1",
+                status=CorrelationRunStatus.COMPLETE,
+                output_scan_id="other",
+                manifest_sha256="sha256:" + "a" * 64,
+            )
+        with pytest.raises(ValueError, match="requires a sha256"):
+            graph_store.update_correlation_run(
+                conn,
+                tenant_id="acme",
+                correlation_id="corr-1",
+                status=CorrelationRunStatus.COMPLETE,
+                output_scan_id="corr-1",
+            )
+
+
+def test_snapshot_metadata_round_trips_without_changing_legacy_defaults(tmp_path) -> None:
+    db = tmp_path / "graph.db"
+    with graph_store.open_graph_db(db) as conn:
+        legacy = UnifiedGraph(scan_id="scan-legacy", tenant_id="acme")
+        legacy.add_node(UnifiedNode(id="agent:one", entity_type=EntityType.AGENT, label="one"))
+        graph_store.save_graph(conn, legacy)
+
+        correlated = UnifiedGraph(scan_id="corr-1", tenant_id="acme")
+        correlated.add_node(UnifiedNode(id="agent:two", entity_type=EntityType.AGENT, label="two"))
+        graph_store.save_graph_streaming(
+            conn,
+            scan_id="corr-1",
+            tenant_id="acme",
+            nodes=correlated.nodes.values(),
+            edges=(),
+            snapshot_kind="correlation",
+            correlation_id="corr-1",
+            evidence_manifest_sha256="sha256:" + "b" * 64,
+        )
+
+        by_id = {item["scan_id"]: item for item in graph_store.list_snapshots(conn, tenant_id="acme")}
+
+    assert by_id["scan-legacy"]["snapshot_kind"] == "scan"
+    assert by_id["scan-legacy"]["correlation_id"] == ""
+    assert by_id["corr-1"]["snapshot_kind"] == "correlation"
+    assert by_id["corr-1"]["correlation_id"] == "corr-1"
+    assert by_id["corr-1"]["evidence_manifest_sha256"] == "sha256:" + "b" * 64
+
+
+def test_retention_purges_correlated_snapshot_but_keeps_immutable_run_receipt(tmp_path) -> None:
+    db = tmp_path / "graph.db"
+    with graph_store.open_graph_db(db) as conn:
+        graph_store.create_correlation_run(conn, _run())
+        correlated = UnifiedGraph(
+            scan_id="corr-1",
+            tenant_id="acme",
+            created_at="2026-08-29T00:00:00+00:00",
+        )
+        correlated.add_node(UnifiedNode(id="agent:two", entity_type=EntityType.AGENT, label="two"))
+        graph_store.save_graph_streaming(
+            conn,
+            scan_id="corr-1",
+            tenant_id="acme",
+            nodes=correlated.nodes.values(),
+            edges=(),
+            created_at=correlated.created_at,
+            snapshot_kind="correlation",
+            correlation_id="corr-1",
+        )
+        conn.execute(
+            "UPDATE graph_snapshots SET created_at = ? WHERE tenant_id = ? AND scan_id = ?",
+            ("2026-01-01T00:00:00+00:00", "acme", "corr-1"),
+        )
+
+        result = graph_store.purge_expired_graph_snapshots(
+            conn,
+            retention_days=1,
+            now=datetime(2026, 8, 30, tzinfo=timezone.utc),
+            tenant_id="acme",
+        )
+
+        assert result["purged_snapshots"] == [{"scan_id": "corr-1", "tenant_id": "acme"}]
+        assert graph_store.get_correlation_run(conn, tenant_id="acme", correlation_id="corr-1") is not None
+        assert graph_store.list_snapshots(conn, tenant_id="acme") == []

--- a/tests/test_neptune_graph_store.py
+++ b/tests/test_neptune_graph_store.py
@@ -5,7 +5,12 @@ import json
 import pytest
 
 from agent_bom.api import stores as api_stores
-from agent_bom.api.neptune_graph import NeptuneGraphConfig, NeptuneGraphStore, NeptuneGraphStoreConfigError
+from agent_bom.api.neptune_graph import (
+    NeptuneGraphConfig,
+    NeptuneGraphStore,
+    NeptuneGraphStoreConfigError,
+    NeptuneGraphStoreUnsupportedOperationError,
+)
 from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
 from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
 
@@ -169,3 +174,20 @@ def test_neptune_backend_selection_accepts_injected_client(monkeypatch: pytest.M
 
     assert isinstance(store, NeptuneGraphStore)
     assert store.config.endpoint == "wss://neptune.example:8182/gremlin"
+
+
+def test_neptune_correlation_persistence_is_explicitly_unsupported() -> None:
+    client = FakeGremlinClient()
+    store = NeptuneGraphStore(NeptuneGraphConfig(endpoint="wss://neptune.example:8182/gremlin"), client=client)
+
+    with pytest.raises(NeptuneGraphStoreUnsupportedOperationError, match="create_correlation_run"):
+        store.create_correlation_run(None)  # type: ignore[arg-type]
+    with pytest.raises(NeptuneGraphStoreUnsupportedOperationError, match="correlation snapshot persistence"):
+        store.save_graph_streaming(
+            scan_id="corr-1",
+            tenant_id="tenant-a",
+            nodes=(),
+            edges=(),
+            snapshot_kind="correlation",
+            correlation_id="corr-1",
+        )

--- a/tests/test_postgres_graph_correlation.py
+++ b/tests/test_postgres_graph_correlation.py
@@ -1,0 +1,153 @@
+"""Postgres graph-correlation store parity without requiring a live server."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from agent_bom.graph.correlation import CorrelationRunStatus, GraphCorrelationRun
+
+
+class _Cursor:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+
+    def fetchone(self):
+        return self.rows[0] if self.rows else None
+
+    def fetchall(self):
+        return self.rows
+
+
+class _Conn:
+    def __init__(self):
+        self.rows: dict[tuple[str, str], tuple] = {}
+        self.commits = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def execute(self, sql, params=None):
+        low = " ".join(sql.strip().lower().split())
+        params = tuple(params or ())
+        if low.startswith("select set_config"):
+            return _Cursor()
+        if low.startswith("select correlation_id") and "idempotency_key = %s" in low:
+            tenant, key = params
+            return _Cursor([row for row in self.rows.values() if row[1] == tenant and row[2] == key])
+        if low.startswith("select correlation_id") and "correlation_id = %s" in low:
+            tenant, correlation_id = params
+            row = self.rows.get((tenant, correlation_id))
+            return _Cursor([row] if row else [])
+        if low.startswith("select correlation_id") and "order by created_at" in low:
+            tenant, limit = params
+            rows = sorted((row for row in self.rows.values() if row[1] == tenant), key=lambda row: (row[11], row[0]), reverse=True)
+            return _Cursor(rows[:limit])
+        if low.startswith("insert into graph_correlation_runs"):
+            tenant, correlation_id, idem = params[1], params[0], params[2]
+            if (tenant, correlation_id) in self.rows or any(row[1] == tenant and row[2] == idem for row in self.rows.values()):
+                return _Cursor()
+            self.rows[(tenant, correlation_id)] = params
+            return _Cursor([params])
+        if low.startswith("update graph_correlation_runs"):
+            status, manifest, output, failure, started, completed, tenant, correlation_id, expected = params
+            row = self.rows.get((tenant, correlation_id))
+            if row is None or row[4] != expected:
+                return _Cursor()
+            updated = (
+                row[0],
+                row[1],
+                row[2],
+                row[3],
+                status,
+                row[5],
+                row[6],
+                row[7],
+                manifest,
+                output,
+                failure,
+                row[11],
+                started,
+                completed,
+            )
+            self.rows[(tenant, correlation_id)] = updated
+            return _Cursor([updated])
+        return _Cursor()
+
+    def commit(self):
+        self.commits += 1
+
+
+class _Pool:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def connection(self):
+        return self.conn
+
+
+def _store(monkeypatch):
+    from agent_bom.api import postgres_graph
+
+    conn = _Conn()
+    monkeypatch.setattr(postgres_graph.PostgresGraphStore, "_init_tables", lambda self: None)
+    monkeypatch.setattr(postgres_graph.PostgresGraphStore, "_init_optional_search_indexes", lambda self: None)
+    return postgres_graph.PostgresGraphStore(pool=_Pool(conn)), conn
+
+
+def _run(correlation_id="corr-1", tenant="acme", key="idem-1"):
+    return GraphCorrelationRun(
+        correlation_id=correlation_id,
+        tenant_id=tenant,
+        idempotency_key=key,
+        name="reference lab",
+        status=CorrelationRunStatus.PENDING,
+        max_age_hours=168,
+        allow_stale=False,
+        input_manifest=[{"scan_id": "scan-1"}, {"scan_id": "scan-2"}],
+        created_at="2026-08-30T00:00:00+00:00",
+    )
+
+
+def test_postgres_correlation_create_replay_list_and_update(monkeypatch) -> None:
+    store, conn = _store(monkeypatch)
+    created, was_created = store.create_correlation_run(_run())
+    replay, replay_created = store.create_correlation_run(_run(correlation_id="corr-retry"))
+
+    assert was_created is True
+    assert replay_created is False
+    assert replay.correlation_id == created.correlation_id == "corr-1"
+    assert store.get_correlation_run(tenant_id="other", correlation_id="corr-1") is None
+    assert [run.correlation_id for run in store.list_correlation_runs(tenant_id="acme")] == ["corr-1"]
+
+    running = store.update_correlation_run(
+        tenant_id="acme",
+        correlation_id="corr-1",
+        status=CorrelationRunStatus.RUNNING,
+        started_at="2026-08-30T00:01:00+00:00",
+    )
+    complete = store.update_correlation_run(
+        tenant_id="acme",
+        correlation_id="corr-1",
+        status=CorrelationRunStatus.COMPLETE,
+        manifest_sha256="sha256:" + "a" * 64,
+        output_scan_id="corr-1",
+        completed_at="2026-08-30T00:02:00+00:00",
+    )
+    assert running.status is CorrelationRunStatus.RUNNING
+    assert complete.status is CorrelationRunStatus.COMPLETE
+    assert json.loads(conn.rows[("acme", "corr-1")][7]) == _run().input_manifest
+    assert conn.commits == 3
+
+
+def test_postgres_correlation_rejects_idempotency_key_reuse_for_different_request(monkeypatch) -> None:
+    store, _conn = _store(monkeypatch)
+    store.create_correlation_run(_run())
+
+    with pytest.raises(ValueError, match="different correlation request"):
+        store.create_correlation_run(replace(_run(), max_age_hours=24))

--- a/tests/test_postgres_graph_streaming.py
+++ b/tests/test_postgres_graph_streaming.py
@@ -391,9 +391,7 @@ def test_snapshot_history_accepts_psycopg_jsonb_objects_and_text(monkeypatch, ri
         def execute(self, sql, params=None):
             low = " ".join(sql.strip().lower().split())
             if low.startswith("select scan_id, created_at, node_count, edge_count, risk_summary, analysis_status"):
-                return _FakeCursor(
-                    [("scan-json", "2026-07-17T00:00:00Z", 3, 2, risk_summary, analysis_status, "scan", None, "")]
-                )
+                return _FakeCursor([("scan-json", "2026-07-17T00:00:00Z", 3, 2, risk_summary, analysis_status, "scan", None, "")])
             return super().execute(sql, params)
 
     store = _make_store(_SnapshotConn(), monkeypatch)

--- a/tests/test_postgres_graph_streaming.py
+++ b/tests/test_postgres_graph_streaming.py
@@ -170,7 +170,19 @@ def test_streaming_snapshot_tally_matches_nodes(monkeypatch):
 
     # graph_snapshots row: counts plus serialized analysis execution state.
     assert conn.snapshot_params is not None
-    scan, tenant, _now, node_count, edge_count, risk_summary, node_type_counts, analysis_status = conn.snapshot_params
+    (
+        scan,
+        tenant,
+        _now,
+        node_count,
+        edge_count,
+        risk_summary,
+        node_type_counts,
+        analysis_status,
+        snapshot_kind,
+        correlation_id,
+        evidence_manifest_sha256,
+    ) = conn.snapshot_params
     assert (scan, tenant, node_count, edge_count) == ("scan-2", "t1", 4, 0)
     import json
 
@@ -185,6 +197,9 @@ def test_streaming_snapshot_tally_matches_nodes(monkeypatch):
         "limits": {"max_nodes": 5000},
         "observed": {"node_count": 5001},
     }
+    assert snapshot_kind == "scan"
+    assert correlation_id is None
+    assert evidence_manifest_sha256 == ""
     # The DML-only runtime role performs one durable snapshot commit. Planner
     # maintenance runs separately under a table-owner role.
     assert conn.committed == 1
@@ -376,7 +391,9 @@ def test_snapshot_history_accepts_psycopg_jsonb_objects_and_text(monkeypatch, ri
         def execute(self, sql, params=None):
             low = " ".join(sql.strip().lower().split())
             if low.startswith("select scan_id, created_at, node_count, edge_count, risk_summary, analysis_status"):
-                return _FakeCursor([("scan-json", "2026-07-17T00:00:00Z", 3, 2, risk_summary, analysis_status)])
+                return _FakeCursor(
+                    [("scan-json", "2026-07-17T00:00:00Z", 3, 2, risk_summary, analysis_status, "scan", None, "")]
+                )
             return super().execute(sql, params)
 
     store = _make_store(_SnapshotConn(), monkeypatch)

--- a/tests/test_postgres_migrated_graph_parity.py
+++ b/tests/test_postgres_migrated_graph_parity.py
@@ -123,6 +123,48 @@ def test_attack_paths_round_trip_on_migration_owned_schema(migrated_fresh_databa
     assert [m.technique_id for m in got.technique_mappings] == ["T1078"]
 
 
+def test_graph_correlation_round_trip_on_migration_owned_schema(migrated_fresh_database):
+    from agent_bom.api.postgres_graph import PostgresGraphStore
+    from agent_bom.graph.correlation import CorrelationRunStatus, GraphCorrelationRun
+
+    store = PostgresGraphStore()
+    run = GraphCorrelationRun(
+        correlation_id="corr-migration-parity",
+        tenant_id="default",
+        idempotency_key="idem-migration-parity",
+        name="migration parity",
+        status=CorrelationRunStatus.PENDING,
+        max_age_hours=168,
+        allow_stale=False,
+        input_manifest=[{"scan_id": "scan-a"}, {"scan_id": "scan-b"}],
+        created_at="2026-08-30T00:00:00+00:00",
+    )
+
+    created, was_created = store.create_correlation_run(run)
+    replayed, replay_created = store.create_correlation_run(run)
+    running = store.update_correlation_run(
+        tenant_id="default",
+        correlation_id=run.correlation_id,
+        status=CorrelationRunStatus.RUNNING,
+        started_at="2026-08-30T00:01:00+00:00",
+    )
+    complete = store.update_correlation_run(
+        tenant_id="default",
+        correlation_id=run.correlation_id,
+        status=CorrelationRunStatus.COMPLETE,
+        manifest_sha256="sha256:" + "a" * 64,
+        output_scan_id=run.correlation_id,
+        completed_at="2026-08-30T00:02:00+00:00",
+    )
+
+    assert was_created is True
+    assert replay_created is False
+    assert replayed.correlation_id == created.correlation_id
+    assert running.status is CorrelationRunStatus.RUNNING
+    assert complete.status is CorrelationRunStatus.COMPLETE
+    assert complete.output_scan_id == run.correlation_id
+
+
 def test_audit_fork_guard_unique_index_present_after_migrate_to_head(migrated_fresh_database):
     """The hash-chain fork guard must exist in a schema built ONLY by Alembic.
 

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -38,6 +38,7 @@ RUNTIME_SCHEMA_SQL = POSTGRES_DIR / "runtime-schema.sql"
 HUB_LEDGER_SCAN_ID = VERSIONS_DIR / "20260818_01_hub_ledger_scan_id.py"
 TENANT_BINDING_AUTHORITY = VERSIONS_DIR / "20260819_01_tenant_binding_authority.py"
 HUB_OVERVIEW_REVISION = VERSIONS_DIR / "20260827_01_hub_overview_revision.py"
+GRAPH_CORRELATIONS = VERSIONS_DIR / "20260830_01_graph_correlations.py"
 
 # The fork-guard UNIQUE index is spelled differently in its two schema sources:
 # the dedicated migration concatenates two quoted Python string literals, while
@@ -49,7 +50,7 @@ _FORK_GUARD_INDEX_CANON = "createuniqueindexifnotexistsaudit_log_team_prevsig_un
 
 # The newest migration. One place to update when a revision lands, so the
 # single-head property and the head's identity do not drift apart.
-ALEMBIC_HEAD = "20260827_01"
+ALEMBIC_HEAD = "20260830_01"
 
 
 def _canonical_sql(text: str) -> str:
@@ -86,6 +87,21 @@ def test_hub_overview_revision_is_durable_chained_and_tenant_isolated() -> None:
     assert "tenant_id = public.abom_current_tenant()" in sql
     assert "GRANT SELECT, INSERT, UPDATE, DELETE ON hub_overview_revisions TO agent_bom_app" in sql
     assert "VALUES ('compliance_hub', 2, now())" in sql
+
+
+def test_graph_correlation_migration_is_additive_chained_and_tenant_isolated() -> None:
+    sql = GRAPH_CORRELATIONS.read_text()
+    assert re.search(r'revision\s*=\s*"20260830_01"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260827_01"', sql)
+    assert "CREATE TABLE IF NOT EXISTS graph_correlation_runs" in sql
+    assert "UNIQUE (tenant_id, idempotency_key)" in sql
+    assert "ADD COLUMN IF NOT EXISTS snapshot_kind" in sql
+    assert "ADD COLUMN IF NOT EXISTS correlation_id" in sql
+    assert "ADD COLUMN IF NOT EXISTS evidence_manifest_sha256" in sql
+    assert "ENABLE ROW LEVEL SECURITY" in sql
+    assert "FORCE ROW LEVEL SECURITY" in sql
+    assert "graph_correlation_runs_tenant_isolation" in sql
+    assert "VALUES ('graph', 2, now())" in sql
 
 
 def test_managed_trial_invitation_migration_is_chained_and_secret_minimal() -> None:

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -104,6 +104,13 @@ def test_graph_correlation_migration_is_additive_chained_and_tenant_isolated() -
     assert "VALUES ('graph', 2, now())" in sql
 
 
+def test_graph_correlation_migration_tolerates_legacy_schema_without_graph_snapshots() -> None:
+    """Legacy checkpoints may predate the optional graph persistence tables."""
+
+    sql = GRAPH_CORRELATIONS.read_text()
+    assert "to_regclass('public.graph_snapshots') IS NOT NULL" in sql
+
+
 def test_managed_trial_invitation_migration_is_chained_and_secret_minimal() -> None:
     sql = MANAGED_TRIAL_INVITATIONS.read_text()
     assert re.search(r'revision\s*=\s*"20260724_03"', sql)


### PR DESCRIPTION
## Summary

- add deterministic, provenance-preserving graph correlation with exact PURL, OCI digest, and repository commit/path identity boundaries
- add immutable tenant-scoped correlation-run receipts and correlated-snapshot metadata for SQLite and Postgres, including additive Alembic/RLS migration coverage
- enforce idempotent replay, monotonic terminal states, sanitized failure codes, retention behavior, and an explicit unsupported boundary for experimental Neptune persistence

## Verification

- UV_CACHE_DIR=/tmp/agent-bom-correlation-uv-cache make lint
- UV_CACHE_DIR=/tmp/agent-bom-correlation-uv-cache make preflight
- PYTHONPATH=src /Users/mohamedsaad/repos/Agent-Bom/.venv/bin/pytest -q tests/test_graph_correlation_foundation.py tests/test_graph_correlation_store.py tests/test_postgres_graph_correlation.py tests/test_graph_store_streamed_persistence.py tests/test_postgres_graph_streaming.py tests/test_postgres_migrations.py tests/test_postgres_schema_parity_gate.py tests/test_postgres_migrated_graph_parity.py tests/test_postgres_connection_parity.py tests/test_postgres_rls_backstop_parity.py tests/test_neptune_graph_store.py
- PYTHONPATH=src /Users/mohamedsaad/repos/Agent-Bom/.venv/bin/python scripts/check-counts.py
- PYTHONPATH=src /Users/mohamedsaad/repos/Agent-Bom/.venv/bin/python scripts/check_public_docs_hygiene.py
- git diff --check

## Notes

- Focused suite: 112 passed, 3 skipped because live Postgres credentials were not configured.
- Correlation persistence is supported by SQLite and Postgres. The experimental Neptune adapter fails explicitly for this new surface.
- This PR is foundation only; asynchronous execution, path fusion/runtime facts, API/CLI/MCP/UI, the reference lab, and captured visuals remain in the serial follow-up PRs.