### PR TITLE
fix(auth): harden SAML algorithm and replay validation

### DIFF
--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -31,6 +31,8 @@ Endpoints:
 
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import logging
 import os
@@ -189,6 +191,21 @@ def _relay_state_digest(relay_state: str) -> str:
     return hashlib.sha256(relay_state.encode("utf-8")).hexdigest()
 
 
+def _saml_response_digest(saml_response: str) -> str:
+    """Hash the verified response bytes, independent of Base64 presentation."""
+    import hashlib
+
+    compact = "".join(saml_response.split())
+    try:
+        response_bytes = base64.b64decode(compact, validate=True)
+    except (binascii.Error, ValueError):
+        # Production reaches this helper only after python3-saml has verified
+        # the response. Keep mocked/test integrations deterministic without
+        # weakening the verification boundary.
+        response_bytes = compact.encode("utf-8")
+    return hashlib.sha256(response_bytes).hexdigest()
+
+
 def _saml_idp_initiated_allowed() -> bool:
     return os.environ.get("AGENT_BOM_SAML_ALLOW_IDP_INITIATED", "").strip().lower() in {"1", "true", "yes", "on"}
 
@@ -234,7 +251,7 @@ def _consume_saml_relay_state(relay_state: str | None) -> None:
 def _consume_saml_response_once(saml_response: str, *, ttl_seconds: int) -> None:
     from agent_bom.api.shared_auth_state import AuthStateUnavailable, get_auth_state
 
-    digest = f"saml-response:{_relay_state_digest(saml_response)}"
+    digest = f"saml-response:{_saml_response_digest(saml_response)}"
     backend = get_auth_state()
     now = int(time.time())
     try:

--- a/src/agent_bom/api/saml.py
+++ b/src/agent_bom/api/saml.py
@@ -239,6 +239,7 @@ class SAMLConfig:
                 "wantAssertionsSigned": True,
                 "wantAssertionsEncrypted": False,
                 "requestedAuthnContext": False,
+                "rejectDeprecatedAlgorithm": True,
             },
         }
 

--- a/tests/api/test_api_saml.py
+++ b/tests/api/test_api_saml.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import os
 from unittest.mock import patch
 
@@ -113,6 +114,18 @@ def test_saml_enabled_from_env_tracks_config(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setenv("AGENT_BOM_SAML_SP_ENTITY_ID", "https://agent-bom.example.com/saml/metadata")
     monkeypatch.setenv("AGENT_BOM_SAML_SP_ACS_URL", "https://agent-bom.example.com/v1/auth/saml/login")
     assert saml_enabled_from_env() is True
+
+
+def test_saml_settings_reject_deprecated_signature_algorithms() -> None:
+    cfg = SAMLConfig(
+        idp_entity_id="https://idp.example.com/metadata",
+        idp_sso_url="https://idp.example.com/sso",
+        idp_x509_cert="cert",
+        sp_entity_id="https://agent-bom.example.com/saml/metadata",
+        sp_acs_url="https://agent-bom.example.com/v1/auth/saml/login",
+    )
+
+    assert cfg.settings_dict()["security"]["rejectDeprecatedAlgorithm"] is True
 
 
 def test_saml_attribute_mapping_uses_existing_role_and_tenant_contract():
@@ -359,6 +372,36 @@ async def test_saml_login_rejects_replayed_assertion_with_fresh_relay(isolated_k
 
     with pytest.raises(HTTPException) as error:
         await enterprise.saml_login(SAMLLoginRequest(saml_response="same-assertion", relay_state=second_relay["relay_state"]))
+    assert error.value.status_code == 401
+    assert error.value.detail == "SAML assertion replay detected"
+
+
+@pytest.mark.asyncio
+async def test_saml_replay_identity_uses_decoded_response_bytes(isolated_key_store, monkeypatch, saml_runtime_enabled):
+    first_relay = await enterprise.saml_relay_state()
+    second_relay = await enterprise.saml_relay_state()
+    encoded = base64.b64encode(b'<samlp:Response ID="response-1">signed-content</samlp:Response>').decode("ascii")
+    folded = "\n".join(encoded[index : index + 16] for index in range(0, len(encoded), 16))
+
+    monkeypatch.setattr(
+        "agent_bom.api.saml.SAMLConfig.verify_response",
+        lambda self, saml_response, relay_state=None: type(
+            "Assertion",
+            (),
+            {
+                "subject": "alice@example.com",
+                "attributes": {"agent_bom_role": "admin", "tenant_id": "tenant-alpha"},
+                "role": "admin",
+                "tenant_id": "tenant-alpha",
+                "session_index": "session-1",
+            },
+        )(),
+    )
+
+    await enterprise.saml_login(SAMLLoginRequest(saml_response=encoded, relay_state=first_relay["relay_state"]))
+
+    with pytest.raises(HTTPException) as error:
+        await enterprise.saml_login(SAMLLoginRequest(saml_response=folded, relay_state=second_relay["relay_state"]))
     assert error.value.status_code == 401
     assert error.value.detail == "SAML assertion replay detected"
 


### PR DESCRIPTION
## Summary

- reject deprecated SAML signature and digest algorithms through the python3-saml security contract
- derive replay identities from decoded response bytes so equivalent Base64 encodings share one one-time nonce
- add regression coverage for both fail-closed behaviors

## Verification

- `uv run pytest -q tests/api/test_api_saml.py tests/test_shared_auth_state.py tests/test_websocket_auth_fails_closed.py tests/test_cli_serve_auth_enforce.py -p no:cacheprovider` (94 passed)
- `uv run ruff check src/agent_bom/api/saml.py src/agent_bom/api/routes/enterprise.py tests/api/test_api_saml.py`
- `uv run mypy src/agent_bom/api/saml.py src/agent_bom/api/routes/enterprise.py`
- `uv run python scripts/check_exception_sanitization.py`
- `make preflight`
- `git diff --check`

## Notes

SAML response verification still occurs before replay consumption. Invalid response text cannot reach the session-minting path; the fallback digest path only preserves deterministic behavior for mocked integrations after the verification boundary.