### PR TITLE
fix(cli): make first-run control plane durable

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -61,7 +61,7 @@ agent-bom check flask@2.2.0 --ecosystem pypi     # Pre-install package verdict
 agent-bom image nginx:latest                     # Container image scan
 agent-bom scan -p . --remediate remediation.md # Fix-first remediation plan
 pip install 'agent-bom[ui]'                      # once, if you want the dashboard
-agent-bom serve                                  # API + dashboard + graph explorer
+agent-bom serve --persist ~/.agent-bom/control-plane.db  # restart-safe local control plane
 ```
 
 The base wheel is the scanner/CLI path. Install optional surfaces explicitly:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ and a separate strict opt-in block before the remediation handoff.
 | Developer / AI engineer | `agent-bom scan .` | See dependencies, secrets, IaC, agents, MCP, and whether Click, Flask, or FastAPI entry points can reach vulnerable packages before shipping |
 | AppSec / product security | `agent-bom agents --gha . --offline` | Inventory remote actions and reusable workflows with their refs, source provenance, and CI-hardening findings |
 | Cloud security | Add a read-only connection, then run a scan | Build scoped cloud, identity, and posture inventory with explicit coverage and provenance |
-| Platform / DevOps | `pip install 'agent-bom[ui]' && agent-bom serve` | Schedule scans, centralize evidence, assign owners and SLAs, and verify remediation |
+| Platform / DevOps | `pip install 'agent-bom[ui]' && agent-bom serve --persist ~/.agent-bom/control-plane.db` | Schedule scans, centralize evidence, assign owners and SLAs, and verify remediation |
 | GRC / audit | `agent-bom report compliance-narrative scan.json` | Export mapped evidence while preserving unavailable, partial, and not-assessed states |
 | CISO / engineering leader | Open **Architecture** in the self-hosted graph | Compare observed **Current** state with modeled **Proposed** and **Difference** views; proposals remain labeled as not observed or deployed |
 
@@ -131,13 +131,18 @@ alias for `--project`.
 
 Use this path when the source is an account or platform rather than a local
 target. Start the customer-controlled control plane, open **Connections**, add
-the provider's read-only grant, and run the first scan. Connections default to
-auto-scan on creation; scheduled scans are an explicit operator opt-in.
+the provider's read-only grant, and run the first scan. The browser flow
+defaults to an explicit first scan after verification; scheduled scans are an
+explicit operator opt-in.
 
 ```bash
 pip install 'agent-bom[ui]'
-agent-bom serve
+agent-bom serve --persist ~/.agent-bom/control-plane.db
 ```
+
+The explicit SQLite path keeps scan jobs, findings, compliance history, and
+graph inventory available together after a restart. Omit `--persist` only for
+an intentionally ephemeral process.
 
 For headless onboarding, `agent-bom connect <provider>` prints the exact grant,
 credential boundary, verification step, and next scan command. The
@@ -243,7 +248,7 @@ Start the loopback evaluation profile:
 
 ```bash
 pip install 'agent-bom[ui]'
-agent-bom serve
+agent-bom serve --persist ~/.agent-bom/control-plane.db
 ```
 
 Then open **Connections** to add a source or **New Scan** to target a repository,

--- a/docs/FIRST_RUN.md
+++ b/docs/FIRST_RUN.md
@@ -150,8 +150,12 @@ fixture dependencies:
 
 ```bash
 pip install 'agent-bom[ui]'
-agent-bom serve
+agent-bom serve --persist ~/.agent-bom/control-plane.db
 ```
+
+That SQLite path keeps scan history, findings, compliance posture, and graph
+inventory available after the local process restarts. A bare `agent-bom serve`
+remains available for an intentionally ephemeral session.
 
 For the curated dashboard demo:
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -40,7 +40,7 @@ You want the API, dashboard, gateway, and a deployment you own.
 
 ```bash
 pip install 'agent-bom[ui]'
-agent-bom serve                           # local API + bundled dashboard
+agent-bom serve --persist ~/.agent-bom/control-plane.db  # restart-safe local API + dashboard
 # or a self-hosted pilot:
 docker compose -f deploy/docker-compose.pilot.yml up -d
 ```

--- a/src/agent_bom/cli/_quickstart.py
+++ b/src/agent_bom/cli/_quickstart.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -14,6 +15,7 @@ import click
 from agent_bom.samples import write_first_run_sample
 
 QUICKSTART_SCAN_TIMEOUT_SECONDS = 300
+DURABLE_LOCAL_CONTROL_PLANE_DB = Path.home() / ".agent-bom" / "control-plane.db"
 
 
 @click.command("quickstart")
@@ -104,7 +106,7 @@ def quickstart_cmd(
     click.echo("")
     click.echo("Local API/UI:")
     click.echo("  pip install 'agent-bom[ui]'")
-    click.echo(f"  agent-bom serve --host 127.0.0.1 --port {port} --allow-insecure-no-auth")
+    click.echo(f"  agent-bom serve --persist ~/.agent-bom/control-plane.db --host 127.0.0.1 --port {port} --allow-insecure-no-auth")
     click.echo("  # loopback demo runs unauthenticated so the cockpit can load; on a shared host drop")
     click.echo("  # --allow-insecure-no-auth and pass --api-key <key> (send it as a Bearer / X-API-Key header).")
     click.echo(f"  API docs: http://127.0.0.1:{port}/docs")
@@ -145,8 +147,8 @@ def _run_quickstart(
             "Could not locate the 'agent-bom' executable to run the scan. "
             f"Run it manually: {_sample_scan_command(sample_dir, offline=offline)}"
         )
-    # --context-graph triggers persistence of the unified graph to the local
-    # control-plane store (~/.agent-bom/db/graph.db) that `agent-bom serve` reads,
+    # --context-graph triggers persistence of the unified graph to the same
+    # local control-plane store that the printed durable `serve` command reads,
     # so the security-graph cockpit is populated on first run.
     report_path = sample_dir / "agent-bom-report.json"
     scan_args = [
@@ -170,9 +172,14 @@ def _run_quickstart(
     else:
         scan_args.append("--enrich")
     click.echo(f"[2/3] Scanning sample stack: {' '.join(scan_args[1:])}")
+    scan_env = os.environ.copy()
+    # Preserve an operator's explicit database override; otherwise align the
+    # generated scan and serve handoff on the documented restart-safe path.
+    scan_env.setdefault("AGENT_BOM_DB", str(DURABLE_LOCAL_CONTROL_PLANE_DB))
     result = subprocess.run(  # noqa: S603 - args built from validated inputs
         scan_args,
         check=False,
+        env=scan_env,
         timeout=QUICKSTART_SCAN_TIMEOUT_SECONDS,
     )
     if result.returncode != 0:
@@ -192,7 +199,7 @@ def _run_quickstart(
     click.echo("Onboarding complete. The security graph is now populated locally.")
     click.echo("")
     click.echo("Open the cockpit:")
-    click.echo(f"  agent-bom serve --host 127.0.0.1 --port {port} --allow-insecure-no-auth")
+    click.echo(f"  agent-bom serve --persist ~/.agent-bom/control-plane.db --host 127.0.0.1 --port {port} --allow-insecure-no-auth")
     click.echo("  # loopback demo runs unauthenticated so the cockpit can load; on a shared host drop")
     click.echo("  # --allow-insecure-no-auth and pass --api-key <key> (send it as a Bearer / X-API-Key header).")
     click.echo(f"  Security graph: http://127.0.0.1:{port}/security-graph")

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -538,7 +538,12 @@ def _analytics_summary_rows(
     help="Host to bind to (non-loopback requires --api-key / OIDC or --allow-insecure-no-auth).",
 )
 @click.option("--port", default=8422, show_default=True, type=LISTEN_PORT_RANGE, help="API server port")
-@click.option("--persist", default=None, metavar="DB_PATH", help="Enable persistent job storage via SQLite (e.g. --persist jobs.db).")
+@click.option(
+    "--persist",
+    default=None,
+    metavar="DB_PATH",
+    help="Enable persistent job storage via SQLite (for example ~/.agent-bom/control-plane.db).",
+)
 @click.option("--cors-allow-all", is_flag=True, default=False, help="Allow all CORS origins (dev mode).")
 @click.option(
     "--api-key",
@@ -660,7 +665,7 @@ def serve_cmd(
       Remote with auth:
         agent-bom serve --host 0.0.0.0 --api-key <key>
       Persistent jobs:
-        agent-bom serve --port 8422 --persist jobs.db
+        agent-bom serve --persist ~/.agent-bom/control-plane.db --port 8422
     """
     from agent_bom.logging_config import setup_logging
 
@@ -676,8 +681,9 @@ def serve_cmd(
 
     if demo_estate:
         _os.environ["AGENT_BOM_DEMO_ESTATE"] = "1"
-    if persist:
-        _os.environ["AGENT_BOM_DB"] = str(Path(persist).resolve())
+    persist_path = str(Path(persist).expanduser().resolve()) if persist else None
+    if persist_path:
+        _os.environ["AGENT_BOM_DB"] = persist_path
     if cors_allow_all:
         _os.environ["AGENT_BOM_CORS_ALL"] = "1"
     # REST-only mode: signal the API app (imported below) to skip mounting the
@@ -711,7 +717,7 @@ def serve_cmd(
         else None
     )
 
-    from agent_bom.api.server import configure_api, set_dev_api_key
+    from agent_bom.api.server import configure_api, set_dev_api_key, set_job_store
 
     configure_api(
         cors_allow_all=cors_allow_all,
@@ -719,6 +725,13 @@ def serve_cmd(
         allow_unauthenticated=allow_insecure_no_auth,
     )
     set_dev_api_key(dev_api_key)
+    if persist_path:
+        # Do not rely only on the server module's first-import environment
+        # selection. Embedded callers and tests can import the app before the
+        # CLI command runs; an explicit flag must still select durable jobs.
+        from agent_bom.api.store import SQLiteJobStore
+
+        set_job_store(SQLiteJobStore(db_path=persist_path))
 
     _ui_dist = Path(__file__).resolve().parents[1] / "ui_dist"
     rows = [
@@ -741,7 +754,7 @@ def serve_cmd(
             ),
         ),
         ("TLS", "app-native mTLS" if tls_kwargs.get("ssl_ca_certs") else ("server TLS" if tls_kwargs else "delegated/none")),
-        ("Storage", _storage_summary(persist=persist)),
+        ("Storage", _storage_summary(persist=persist_path)),
         *_analytics_summary_rows(
             resolved_backend=resolved_backend,
             resolved_url=resolved_url,

--- a/tests/test_public_frontdoor_contract.py
+++ b/tests/test_public_frontdoor_contract.py
@@ -9,6 +9,7 @@ from scripts.render_release_highlights import render_highlights
 from scripts.render_social_preview_svg import render as render_social_preview
 
 ROOT = Path(__file__).resolve().parents[1]
+DURABLE_LOCAL_CONTROL_PLANE = "agent-bom serve --persist ~/.agent-bom/control-plane.db"
 
 
 def test_social_preview_is_portable_and_evidence_focused() -> None:
@@ -172,9 +173,36 @@ def test_persona_routes_start_with_their_actual_work() -> None:
     assert "| Developer / AI engineer | `agent-bom scan .`" in personas
     assert "| AppSec / product security | `agent-bom agents --gha . --offline`" in personas
     assert "| Cloud security | Add a read-only connection, then run a scan" in personas
-    assert "| Platform / DevOps | `pip install 'agent-bom[ui]' && agent-bom serve`" in personas
+    assert f"| Platform / DevOps | `pip install 'agent-bom[ui]' && {DURABLE_LOCAL_CONTROL_PLANE}`" in personas
     assert "| CISO / engineering leader | Open **Architecture** in the self-hosted graph" in personas
     assert "owners and slas" in personas.lower()
+
+
+def test_primary_local_control_plane_first_runs_use_one_durable_sqlite_path() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    pypi = (ROOT / "PYPI_README.md").read_text(encoding="utf-8")
+    start_here = (ROOT / "docs" / "START_HERE.md").read_text(encoding="utf-8")
+    first_run = (ROOT / "docs" / "FIRST_RUN.md").read_text(encoding="utf-8")
+
+    personas = readme.split("## Value by role", 1)[1].split("\n## ", 1)[0]
+    path_b = readme.split("### Path B — connect a source, then scan", 1)[1].split("\n### ", 1)[0]
+    self_host = readme.split("## Self-host", 1)[1].split("\n## ", 1)[0]
+    pypi_starts = pypi.split("## Recommended starting points", 1)[1].split("\n## ", 1)[0]
+    platform_start = start_here.split("## Platform / SRE", 1)[1].split("\n## ", 1)[0]
+    dashboard_start = first_run.split("## 3. Open the Dashboard", 1)[1].split("\n## ", 1)[0]
+
+    for surface in (personas, path_b, self_host, pypi_starts, platform_start, dashboard_start):
+        assert DURABLE_LOCAL_CONTROL_PLANE in surface
+
+    assert readme.count(DURABLE_LOCAL_CONTROL_PLANE) == 3
+
+
+def test_readme_connection_first_run_requires_an_explicit_scan_after_verification() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    path_b = readme.split("### Path B — connect a source, then scan", 1)[1].split("\n### ", 1)[0]
+
+    assert "explicit first scan after verification" in path_b
+    assert "Connections default to auto-scan on creation" not in path_b
 
 
 def test_cloud_connect_leads_with_wheel_safe_emit_before_optional_terraform() -> None:

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -13,15 +13,25 @@ from click.testing import CliRunner
 from agent_bom.cli import main
 
 ROOT = Path(__file__).resolve().parents[1]
+DURABLE_LOCAL_CONTROL_PLANE = "agent-bom serve --persist ~/.agent-bom/control-plane.db"
 
 
 @pytest.fixture()
 def _fake_scan(monkeypatch):
     """Capture the scan subprocess instead of running a real scan."""
-    calls: list[list[str]] = []
+
+    class CapturedScanCalls(list[list[str]]):
+        environments: list[dict[str, str] | None]
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.environments = []
+
+    calls = CapturedScanCalls()
 
     def fake_run(args, check=False, **kwargs):  # noqa: ANN001, ANN003
         calls.append(list(args))
+        calls.environments.append(kwargs.get("env"))
         return subprocess.CompletedProcess(args, 0)
 
     monkeypatch.setattr("agent_bom.cli._quickstart._resolve_agent_bom", lambda: "agent-bom")
@@ -37,7 +47,7 @@ def test_quickstart_dry_run_offline_prints_local_next_steps():
     assert "agent-bom scan --demo --offline" in result.output
     assert "agent-bom quickstart --write-sample --sample-dir agent-bom-first-run" in result.output
     assert "agent-bom scan --inventory agent-bom-first-run/inventory.json -p agent-bom-first-run --offline" in result.output
-    assert "agent-bom serve --host 127.0.0.1 --port 8422" in result.output
+    assert f"{DURABLE_LOCAL_CONTROL_PLANE} --host 127.0.0.1 --port 8422" in result.output
     assert "http://127.0.0.1:8422/docs" in result.output
     assert "agent-bom[all]" in result.output
     assert "MLflow remains separate" in result.output
@@ -68,8 +78,9 @@ def test_quickstart_rejects_dry_run_with_run():
     assert "--dry-run cannot be combined with --run" in result.output
 
 
-def test_quickstart_run_scans_with_context_graph_and_seeds_policy(tmp_path, _fake_scan):
+def test_quickstart_run_scans_with_context_graph_and_seeds_policy(tmp_path, _fake_scan, monkeypatch):
     sample_dir = tmp_path / "stack"
+    monkeypatch.delenv("AGENT_BOM_DB", raising=False)
 
     result = CliRunner().invoke(main, ["quickstart", "--run", "--offline", "--sample-dir", str(sample_dir)])
 
@@ -86,6 +97,9 @@ def test_quickstart_run_scans_with_context_graph_and_seeds_policy(tmp_path, _fak
     assert "-o" in scan_args
     assert str(sample_dir / "agent-bom-report.json") in scan_args
     assert str(sample_dir / "inventory.json") in scan_args
+    scan_env = _fake_scan.environments[0]
+    assert scan_env is not None
+    assert scan_env["AGENT_BOM_DB"] == str(Path.home() / ".agent-bom" / "control-plane.db")
     # secure-by-default gateway baseline seeded and valid
     policy_path = sample_dir / "gateway-baseline-policy.json"
     assert policy_path.exists()
@@ -96,7 +110,7 @@ def test_quickstart_run_scans_with_context_graph_and_seeds_policy(tmp_path, _fak
     assert "Onboarding complete" in result.output
     assert "/security-graph" in result.output
     # cockpit handoff must pass a flag that actually lets /v1/overview load on loopback
-    assert "agent-bom serve --host 127.0.0.1 --port 8422 --allow-insecure-no-auth" in result.output
+    assert f"{DURABLE_LOCAL_CONTROL_PLANE} --host 127.0.0.1 --port 8422 --allow-insecure-no-auth" in result.output
     assert "--api-key <key>" in result.output
 
 

--- a/tests/test_serve_command.py
+++ b/tests/test_serve_command.py
@@ -8,6 +8,50 @@ from click.testing import CliRunner
 from agent_bom.cli import main
 
 
+def test_serve_persist_rehydrates_completed_scan_history_after_restart(monkeypatch, tmp_path):
+    """The durable first-run flag must select a restart-safe scan job store."""
+    import uvicorn
+
+    from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+    from agent_bom.api.server import set_job_store
+    from agent_bom.api.store import InMemoryJobStore, SQLiteJobStore
+    from agent_bom.api.stores import _get_store
+
+    database = tmp_path / "control-plane.db"
+    args = ["serve", "--no-ui", "--persist", str(database)]
+    monkeypatch.setattr(uvicorn, "run", lambda *args, **kwargs: None)
+    monkeypatch.setenv("AGENT_BOM_DB", str(database))
+
+    try:
+        first = CliRunner().invoke(main, args)
+        assert first.exit_code == 0, first.output
+        first_store = _get_store()
+        assert isinstance(first_store, SQLiteJobStore)
+        first_store.put(
+            ScanJob(
+                job_id="first-run-scan",
+                tenant_id="default",
+                status=JobStatus.DONE,
+                created_at="2026-08-30T19:59:59+00:00",
+                completed_at="2026-08-30T20:00:00+00:00",
+                request=ScanRequest(offline=True),
+                result={"findings": [{"id": "finding-1", "severity": "high"}]},
+            )
+        )
+
+        restarted = CliRunner().invoke(main, args)
+        assert restarted.exit_code == 0, restarted.output
+        restarted_store = _get_store()
+        persisted = restarted_store.get("first-run-scan", tenant_id="default")
+
+        assert isinstance(restarted_store, SQLiteJobStore)
+        assert persisted is not None
+        assert persisted.status is JobStatus.DONE
+        assert persisted.result == {"findings": [{"id": "finding-1", "severity": "high"}]}
+    finally:
+        set_job_store(InMemoryJobStore())
+
+
 def test_serve_requires_uvicorn(monkeypatch):
     """serve exits with error when uvicorn is not installed."""
     runner = CliRunner()


### PR DESCRIPTION
## Summary

- make the documented first-run control plane persist jobs, findings, compliance, scan history, and graph evidence in one SQLite database
- select the SQLite job store explicitly for `serve --persist`, including when API modules were imported earlier
- keep bare `agent-bom serve` intentionally ephemeral and make browser onboarding require an explicit first scan

## Verification

- red: 6 failed, 25 passed in the initial front-door/quickstart/serve contract suite
- red: 1 focused failure for quickstart graph-database alignment
- green: 219 passed in the targeted product suite
- green: 31 passed in the final focused rerun
- `uv run ruff check` and format checks
- `make preflight`
- `uv run python scripts/check_public_docs_hygiene.py` (785 files)
- stale-command search across primary public surfaces
- `git diff --check`

## Notes

The restart regression proves a completed scan result is rehydrated after a second `serve --persist` invocation. Omitting `--persist` remains an explicit ephemeral mode.