### PR TITLE
fix(graph): scope current snapshot selection by kind

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -158,9 +158,15 @@ _DYNAMIC_RELATIONSHIP_VALUES = {
 class GraphStoreProtocol(Protocol):
     """Shared graph store contract used by the API pipeline and routes."""
 
-    def latest_snapshot_id(self, *, tenant_id: str = "") -> str: ...
+    def latest_snapshot_id(self, *, tenant_id: str = "", snapshot_kind: str = "scan") -> str: ...
 
-    def previous_snapshot_id(self, *, tenant_id: str = "", before_scan_id: str = "") -> str: ...
+    def previous_snapshot_id(
+        self,
+        *,
+        tenant_id: str = "",
+        before_scan_id: str = "",
+        snapshot_kind: str = "scan",
+    ) -> str: ...
 
     def save_graph(self, graph: UnifiedGraph) -> None: ...
 
@@ -1542,23 +1548,34 @@ class SQLiteGraphStore:
         finally:
             conn.close()
 
-    def latest_snapshot_id(self, *, tenant_id: str = "") -> str:
+    def latest_snapshot_id(self, *, tenant_id: str = "", snapshot_kind: str = "scan") -> str:
         tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
         if conn is None:
             return ""
         try:
-            return sqlite_graph_store.latest_snapshot_id(conn, tenant_id=tenant_id)
+            return sqlite_graph_store.latest_snapshot_id(conn, tenant_id=tenant_id, snapshot_kind=snapshot_kind)
         finally:
             conn.close()
 
-    def previous_snapshot_id(self, *, tenant_id: str = "", before_scan_id: str = "") -> str:
+    def previous_snapshot_id(
+        self,
+        *,
+        tenant_id: str = "",
+        before_scan_id: str = "",
+        snapshot_kind: str = "scan",
+    ) -> str:
         tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
         if conn is None:
             return ""
         try:
-            return sqlite_graph_store.previous_snapshot_id(conn, tenant_id=tenant_id, before_scan_id=before_scan_id)
+            return sqlite_graph_store.previous_snapshot_id(
+                conn,
+                tenant_id=tenant_id,
+                before_scan_id=before_scan_id,
+                snapshot_kind=snapshot_kind,
+            )
         finally:
             conn.close()
 

--- a/src/agent_bom/api/neptune_graph.py
+++ b/src/agent_bom/api/neptune_graph.py
@@ -14,6 +14,7 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, NoReturn, Protocol, cast
 
+from agent_bom.db.graph_store import normalize_snapshot_kind
 from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
 from agent_bom.graph.analysis import GraphAnalysisStatus, analysis_status_map_from_dict, analysis_status_map_to_dict
 from agent_bom.graph.container import apply_node_budget
@@ -300,11 +301,23 @@ class NeptuneGraphStore:
         graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
         return digest_from_graph(graph)
 
-    def latest_snapshot_id(self, *, tenant_id: str = "") -> str:
+    def latest_snapshot_id(self, *, tenant_id: str = "", snapshot_kind: str = "scan") -> str:
+        snapshot_kind = normalize_snapshot_kind(snapshot_kind)
+        if snapshot_kind != "scan":
+            return ""
         snapshots = self.list_snapshots(tenant_id=tenant_id, limit=1)
         return snapshots[0]["scan_id"] if snapshots else ""
 
-    def previous_snapshot_id(self, *, tenant_id: str = "", before_scan_id: str = "") -> str:
+    def previous_snapshot_id(
+        self,
+        *,
+        tenant_id: str = "",
+        before_scan_id: str = "",
+        snapshot_kind: str = "scan",
+    ) -> str:
+        snapshot_kind = normalize_snapshot_kind(snapshot_kind)
+        if snapshot_kind != "scan":
+            return ""
         snapshots = self.list_snapshots(tenant_id=tenant_id, limit=1000)
         for index, snapshot in enumerate(snapshots):
             if snapshot["scan_id"] == before_scan_id and index + 1 < len(snapshots):

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -624,7 +624,7 @@ def _persist_graph_snapshot(
         try:
             prior_digest = None
             graph_store = _get_graph_store()
-            previous_scan_id = graph_store.latest_snapshot_id(tenant_id=tenant_id)
+            previous_scan_id = graph_store.latest_snapshot_id(tenant_id=tenant_id, snapshot_kind="scan")
             if previous_scan_id and previous_scan_id != scan_id:
                 # Bounded prior-snapshot digest instead of a second full UnifiedGraph
                 # load — keeps peak RSS decoupled from the prior graph size (#4055/#4075).

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -25,7 +25,12 @@ from agent_bom.api.graph_store import (
 )
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 from agent_bom.config import POSTGRES_GRAPH_SEARCH_TIMEOUT_MS, POSTGRES_STATEMENT_TIMEOUT_MS
-from agent_bom.db.graph_store import DEFAULT_GRAPH_TENANT_ID, graph_retention_policy, normalize_graph_tenant_id
+from agent_bom.db.graph_store import (
+    DEFAULT_GRAPH_TENANT_ID,
+    graph_retention_policy,
+    normalize_graph_tenant_id,
+    normalize_snapshot_kind,
+)
 from agent_bom.graph import EntityType, technique_mappings_from_json
 from agent_bom.graph.analysis import GraphAnalysisStatus, analysis_status_map_from_dict, analysis_status_map_to_dict
 from agent_bom.graph.completeness import (
@@ -573,18 +578,19 @@ class PostgresGraphStore:
                 conn.rollback()
                 logger.warning("Skipping optional Postgres graph trigram indexes: %s", type(exc).__name__)
 
-    def latest_snapshot_id(self, *, tenant_id: str = "") -> str:
+    def latest_snapshot_id(self, *, tenant_id: str = "", snapshot_kind: str = "scan") -> str:
         tenant_id = normalize_graph_tenant_id(tenant_id)
+        snapshot_kind = normalize_snapshot_kind(snapshot_kind)
         with _tenant_connection(self._pool) as conn:
             row = conn.execute(
                 """
                 SELECT scan_id
                 FROM graph_snapshots
-                WHERE tenant_id = %s
+                WHERE tenant_id = %s AND snapshot_kind = %s
                 ORDER BY created_at DESC, scan_id DESC
                 LIMIT 1
                 """,
-                (tenant_id,),
+                (tenant_id, snapshot_kind),
             ).fetchone()
             return str(row[0]) if row else ""
 
@@ -611,14 +617,21 @@ class PostgresGraphStore:
             dimensions=NodeDimensions.from_dict(_decode_json_object(row[15], field="node dimensions")),
         )
 
-    def previous_snapshot_id(self, *, tenant_id: str = "", before_scan_id: str = "") -> str:
+    def previous_snapshot_id(
+        self,
+        *,
+        tenant_id: str = "",
+        before_scan_id: str = "",
+        snapshot_kind: str = "scan",
+    ) -> str:
         tenant_id = normalize_graph_tenant_id(tenant_id)
+        snapshot_kind = normalize_snapshot_kind(snapshot_kind)
         if not before_scan_id:
             return ""
         with _tenant_connection(self._pool) as conn:
             current = conn.execute(
-                "SELECT created_at FROM graph_snapshots WHERE tenant_id = %s AND scan_id = %s",
-                (tenant_id, before_scan_id),
+                "SELECT created_at FROM graph_snapshots WHERE tenant_id = %s AND scan_id = %s AND snapshot_kind = %s",
+                (tenant_id, before_scan_id, snapshot_kind),
             ).fetchone()
             if not current:
                 return ""
@@ -626,11 +639,11 @@ class PostgresGraphStore:
                 """
                 SELECT scan_id
                 FROM graph_snapshots
-                WHERE tenant_id = %s AND created_at < %s
+                WHERE tenant_id = %s AND snapshot_kind = %s AND created_at < %s
                 ORDER BY created_at DESC, scan_id DESC
                 LIMIT 1
                 """,
-                (tenant_id, current[0]),
+                (tenant_id, snapshot_kind, current[0]),
             ).fetchone()
             return str(row[0]) if row else ""
 

--- a/src/agent_bom/api/routes/demo_estate.py
+++ b/src/agent_bom/api/routes/demo_estate.py
@@ -182,7 +182,7 @@ def _build_demo_estate_status(tenant_id: str) -> DemoEstateStatus:
 
     graph_store = _get_graph_store()
     bootstrap = get_demo_estate_bootstrap_status(tenant_id=tenant_id)
-    owner = str(graph_store.latest_snapshot_id(tenant_id=tenant_id) or "")
+    owner = str(graph_store.latest_snapshot_id(tenant_id=tenant_id, snapshot_kind="scan") or "")
     bootstrap_owner = str(bootstrap.get("graph_owner_scan_id") or "")
     showcase_stats = graph_store.snapshot_stats(tenant_id=tenant_id, scan_id=SHOWCASE_SCAN_ID)
     showcase_available = int(showcase_stats.get("total_nodes") or 0) > 0

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -2457,7 +2457,11 @@ async def get_scoped_graph(
 
     tenant = _tenant(request)
     graph_store = _get_graph_store_or_503()
-    if not scan_id and not await _graph_store_call(graph_store.latest_snapshot_id, tenant_id=tenant):
+    if not scan_id and not await _graph_store_call(
+        graph_store.latest_snapshot_id,
+        tenant_id=tenant,
+        snapshot_kind="scan",
+    ):
         raise HTTPException(status_code=503, detail="Graph snapshots not found. Run a scan first.")
     graph = await _load_graph_for_investigation(
         graph_store,
@@ -2512,7 +2516,11 @@ async def get_graph(
     graph_store = _get_graph_store_or_503()
     requested_scan_id = _coalesce_alias(scan_id, scan, primary_name="scan_id", alias_name="scan")
 
-    if not requested_scan_id and not await _graph_store_call(graph_store.latest_snapshot_id, tenant_id=tenant):
+    if not requested_scan_id and not await _graph_store_call(
+        graph_store.latest_snapshot_id,
+        tenant_id=tenant,
+        snapshot_kind="scan",
+    ):
         raise HTTPException(status_code=503, detail="Graph snapshots not found. Run a scan first.")
 
     et_set = _parse_entity_type_filter(entity_types)
@@ -2671,7 +2679,11 @@ async def get_fix_first_graph_view(
     graph_store = _get_graph_store_or_503()
     requested_scan_id = scan_id or ""
 
-    if not requested_scan_id and not await _graph_store_call(graph_store.latest_snapshot_id, tenant_id=tenant):
+    if not requested_scan_id and not await _graph_store_call(
+        graph_store.latest_snapshot_id,
+        tenant_id=tenant,
+        snapshot_kind="scan",
+    ):
         raise HTTPException(status_code=503, detail="Graph snapshots not found. Run a scan first.")
 
     graph = await _load_graph_for_investigation(
@@ -3200,7 +3212,11 @@ async def get_graph_clusters(
     tenant = _tenant(request)
     graph_store = _get_graph_store_or_503()
     requested_scan_id = scan_id or ""
-    if not requested_scan_id and not await _graph_store_call(graph_store.latest_snapshot_id, tenant_id=tenant):
+    if not requested_scan_id and not await _graph_store_call(
+        graph_store.latest_snapshot_id,
+        tenant_id=tenant,
+        snapshot_kind="scan",
+    ):
         raise HTTPException(status_code=503, detail="Graph snapshots not found. Run a scan first.")
 
     selected_kinds = {kind.strip() for kind in kinds.split(",") if kind.strip()} if kinds else set(SEMANTIC_CLUSTER_KINDS)
@@ -3241,7 +3257,11 @@ async def list_graph_agents(
             offset=offset,
             limit=limit,
         )
-        effective_scan_id = scan_id or await _graph_store_call(graph_store.latest_snapshot_id, tenant_id=tenant_id)
+        effective_scan_id = scan_id or await _graph_store_call(
+            graph_store.latest_snapshot_id,
+            tenant_id=tenant_id,
+            snapshot_kind="scan",
+        )
         created_at = ""
     else:
         effective_scan_id, created_at, agents, total, next_cursor = await _graph_store_call(
@@ -4365,7 +4385,11 @@ async def get_graph_rollup(
     graph_store = _get_graph_store_or_503()
     requested_scan_id = scan_id or ""
 
-    if not requested_scan_id and not await _graph_store_call(graph_store.latest_snapshot_id, tenant_id=tenant):
+    if not requested_scan_id and not await _graph_store_call(
+        graph_store.latest_snapshot_id,
+        tenant_id=tenant,
+        snapshot_kind="scan",
+    ):
         raise HTTPException(status_code=503, detail="Graph snapshots not found. Run a scan first.")
 
     if min_severity and min_severity.lower() not in SEVERITY_RANK:

--- a/src/agent_bom/api/routes/graph_scenarios.py
+++ b/src/agent_bom/api/routes/graph_scenarios.py
@@ -219,7 +219,11 @@ def _ensure_supported_graph_backend() -> Any:
 async def _snapshot_state(graph_store: Any, tenant_id: str, scan_id: str) -> tuple[bool, bool, str]:
     try:
         snapshots = await asyncio.to_thread(graph_store.list_snapshots, tenant_id=tenant_id, limit=10_000)
-        latest = await asyncio.to_thread(graph_store.latest_snapshot_id, tenant_id=tenant_id)
+        latest = await asyncio.to_thread(
+            graph_store.latest_snapshot_id,
+            tenant_id=tenant_id,
+            snapshot_kind="scan",
+        )
     except NeptuneGraphStoreUnsupportedOperationError as exc:
         raise HTTPException(status_code=501, detail=sanitize_error(exc)) from exc
     except Exception as exc:

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -53,6 +53,7 @@ logger = logging.getLogger(__name__)
 # ═══════════════════════════════════════════════════════════════════════════
 
 DEFAULT_GRAPH_TENANT_ID = "default"
+GRAPH_SNAPSHOT_KINDS = frozenset({"scan", "correlation"})
 _GRAPH_SCHEMA_VERSION = 5
 _DEFAULT_GRAPH_WRITE_BATCH_SIZE = 1000
 _DEFAULT_GRAPH_RETENTION_DAYS = 180
@@ -701,30 +702,51 @@ def open_graph_db(db_path: str | Path) -> Generator[sqlite3.Connection, None, No
         conn.close()
 
 
-def latest_snapshot_id(conn: sqlite3.Connection, *, tenant_id: str = "") -> str:
-    """Return the newest snapshot ID for a tenant, or ``""`` when absent."""
+def normalize_snapshot_kind(snapshot_kind: str) -> str:
+    """Validate the immutable snapshot product selected by a graph consumer."""
+    normalized = str(snapshot_kind or "").strip().lower()
+    if normalized not in GRAPH_SNAPSHOT_KINDS:
+        raise ValueError("snapshot_kind must be 'scan' or 'correlation'")
+    return normalized
+
+
+def latest_snapshot_id(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str = "",
+    snapshot_kind: str = "scan",
+) -> str:
+    """Return the newest same-kind snapshot ID for a tenant, or ``""``."""
     tenant_id = normalize_graph_tenant_id(tenant_id)
+    snapshot_kind = normalize_snapshot_kind(snapshot_kind)
     row = conn.execute(
         """\
         SELECT scan_id
         FROM graph_snapshots
-        WHERE tenant_id = ?
+        WHERE tenant_id = ? AND snapshot_kind = ?
         ORDER BY created_at DESC, scan_id DESC
         LIMIT 1
         """,
-        (tenant_id,),
+        (tenant_id, snapshot_kind),
     ).fetchone()
     return str(row["scan_id"]) if row else ""
 
 
-def previous_snapshot_id(conn: sqlite3.Connection, *, tenant_id: str = "", before_scan_id: str = "") -> str:
-    """Return the snapshot immediately before ``before_scan_id`` for a tenant."""
+def previous_snapshot_id(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str = "",
+    before_scan_id: str = "",
+    snapshot_kind: str = "scan",
+) -> str:
+    """Return the same-kind snapshot immediately before ``before_scan_id``."""
     tenant_id = normalize_graph_tenant_id(tenant_id)
+    snapshot_kind = normalize_snapshot_kind(snapshot_kind)
     if not before_scan_id:
         return ""
     current = conn.execute(
-        "SELECT created_at FROM graph_snapshots WHERE tenant_id = ? AND scan_id = ?",
-        (tenant_id, before_scan_id),
+        "SELECT created_at FROM graph_snapshots WHERE tenant_id = ? AND scan_id = ? AND snapshot_kind = ?",
+        (tenant_id, before_scan_id, snapshot_kind),
     ).fetchone()
     if not current:
         return ""
@@ -732,11 +754,11 @@ def previous_snapshot_id(conn: sqlite3.Connection, *, tenant_id: str = "", befor
         """\
         SELECT scan_id
         FROM graph_snapshots
-        WHERE tenant_id = ? AND created_at < ?
+        WHERE tenant_id = ? AND snapshot_kind = ? AND created_at < ?
         ORDER BY created_at DESC, scan_id DESC
         LIMIT 1
         """,
-        (tenant_id, current["created_at"]),
+        (tenant_id, snapshot_kind, current["created_at"]),
     ).fetchone()
     return str(row["scan_id"]) if row else ""
 

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -347,7 +347,7 @@ def _graph_owner_scan_id(graph_store: Any, tenant_id: str) -> str:
     try:
         latest = getattr(graph_store, "latest_snapshot_id", None)
         if callable(latest):
-            return str(latest(tenant_id=tenant_id) or "")
+            return str(latest(tenant_id=tenant_id, snapshot_kind="scan") or "")
     except Exception:  # noqa: BLE001 - never block the demo boot on a read
         _logger.debug("could not resolve graph owner scan id", exc_info=True)
     return ""

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -746,7 +746,7 @@ def _existing_snapshots(graph_store: GraphStoreProtocol, tenant_id: str) -> list
             _logger.warning("showcase seed could not list snapshots", exc_info=True)
     latest_snapshot_id = getattr(graph_store, "latest_snapshot_id", None)
     if callable(latest_snapshot_id):
-        scan_id = latest_snapshot_id(tenant_id=tenant_id)
+        scan_id = latest_snapshot_id(tenant_id=tenant_id, snapshot_kind="scan")
         if scan_id:
             return [{"scan_id": scan_id, "created_at": ""}]
     return []

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -1265,8 +1265,8 @@ class _RecordingGraphStore:
         self.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
         self.presets: dict[str, dict] = {}
 
-    def latest_snapshot_id(self, *, tenant_id: str = "") -> str:
-        self.calls.append(("latest_snapshot_id", tenant_id))
+    def latest_snapshot_id(self, *, tenant_id: str = "", snapshot_kind: str | None = None) -> str:
+        self.calls.append(("latest_snapshot_id", tenant_id, snapshot_kind))
         return self.graph.scan_id
 
     def previous_snapshot_id(self, *, tenant_id: str = "", before_scan_id: str = "") -> str:
@@ -1727,7 +1727,7 @@ class TestGraphStoreBackendSelection:
         assert body["attack_paths"][0]["exposure_path"]["severity"] == "high"
         assert body["stats"]["analysis_status"]["attack_path_fusion"]["status"] == "limited"
         assert attack_path_response.json()["stats"]["analysis_status"]["attack_path_fusion"]["status"] == "limited"
-        assert any(call[0] == "latest_snapshot_id" for call in recording_graph_store.calls)
+        assert ("latest_snapshot_id", "default", "scan") in recording_graph_store.calls
         assert any(call[0] == "page_nodes" for call in recording_graph_store.calls)
 
     def test_graph_edge_history_routes_use_pluggable_store(self, recording_graph_store):
@@ -2459,9 +2459,9 @@ class TestGraphStoreBackendSelection:
 
         original_latest_snapshot_id = recording_graph_store.latest_snapshot_id
 
-        def _slow_latest_snapshot_id(*, tenant_id: str = "") -> str:
+        def _slow_latest_snapshot_id(*, tenant_id: str = "", snapshot_kind: str | None = None) -> str:
             time.sleep(0.01)
-            return original_latest_snapshot_id(tenant_id=tenant_id)
+            return original_latest_snapshot_id(tenant_id=tenant_id, snapshot_kind=snapshot_kind)
 
         monkeypatch.setattr(recording_graph_store, "latest_snapshot_id", _slow_latest_snapshot_id)
         client = TestClient(app)

--- a/tests/test_graph_correlation_store.py
+++ b/tests/test_graph_correlation_store.py
@@ -192,6 +192,69 @@ def test_snapshot_metadata_round_trips_without_changing_legacy_defaults(tmp_path
     assert by_id["corr-1"]["evidence_manifest_sha256"] == "sha256:" + "b" * 64
 
 
+def test_latest_snapshot_selection_is_scoped_by_kind_and_tenant(tmp_path) -> None:
+    db = tmp_path / "graph.db"
+    with graph_store.open_graph_db(db) as conn:
+        prior = UnifiedGraph(
+            scan_id="scan-0",
+            tenant_id="acme",
+            created_at="2026-08-29T23:59:00+00:00",
+        )
+        prior.add_node(UnifiedNode(id="agent:prior", entity_type=EntityType.AGENT, label="prior"))
+        graph_store.save_graph(conn, prior)
+
+        scan = UnifiedGraph(
+            scan_id="scan-1",
+            tenant_id="acme",
+            created_at="2026-08-30T00:00:00+00:00",
+        )
+        scan.add_node(UnifiedNode(id="agent:scan", entity_type=EntityType.AGENT, label="scan"))
+        graph_store.save_graph(conn, scan)
+
+        correlated = UnifiedGraph(
+            scan_id="corr-1",
+            tenant_id="acme",
+            created_at="2026-08-30T00:01:00+00:00",
+        )
+        correlated.add_node(UnifiedNode(id="agent:corr", entity_type=EntityType.AGENT, label="correlation"))
+        graph_store.save_graph_streaming(
+            conn,
+            scan_id="corr-1",
+            tenant_id="acme",
+            nodes=correlated.nodes.values(),
+            edges=(),
+            created_at=correlated.created_at,
+            snapshot_kind="correlation",
+            correlation_id="corr-1",
+        )
+
+        other = UnifiedGraph(
+            scan_id="scan-other",
+            tenant_id="other",
+            created_at="2026-08-30T00:02:00+00:00",
+        )
+        other.add_node(UnifiedNode(id="agent:other", entity_type=EntityType.AGENT, label="other"))
+        graph_store.save_graph(conn, other)
+
+        assert graph_store.latest_snapshot_id(conn, tenant_id="acme") == "scan-1"
+        assert graph_store.latest_snapshot_id(conn, tenant_id="acme", snapshot_kind="scan") == "scan-1"
+        assert graph_store.latest_snapshot_id(conn, tenant_id="acme", snapshot_kind="correlation") == "corr-1"
+        assert graph_store.latest_snapshot_id(conn, tenant_id="other", snapshot_kind="correlation") == ""
+        assert graph_store.previous_snapshot_id(conn, tenant_id="acme", before_scan_id="scan-1") == "scan-0"
+        assert (
+            graph_store.previous_snapshot_id(
+                conn,
+                tenant_id="acme",
+                before_scan_id="corr-1",
+                snapshot_kind="correlation",
+            )
+            == ""
+        )
+
+        with pytest.raises(ValueError, match="snapshot_kind"):
+            graph_store.latest_snapshot_id(conn, tenant_id="acme", snapshot_kind="inventory")
+
+
 def test_completed_correlation_snapshot_cannot_be_replaced_by_a_scan_retry(tmp_path) -> None:
     db = tmp_path / "graph.db"
     with graph_store.open_graph_db(db) as conn:

--- a/tests/test_postgres_graph_correlation.py
+++ b/tests/test_postgres_graph_correlation.py
@@ -93,6 +93,34 @@ class _Pool:
         return self.conn
 
 
+class _SnapshotConn:
+    def __init__(self):
+        self.snapshots = [
+            ("scan-1", "acme", "scan", "2026-08-30T00:00:00+00:00"),
+            ("corr-1", "acme", "correlation", "2026-08-30T00:01:00+00:00"),
+            ("scan-other", "other", "scan", "2026-08-30T00:02:00+00:00"),
+        ]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def execute(self, sql, params=None):
+        low = " ".join(sql.strip().lower().split())
+        params = tuple(params or ())
+        if low.startswith("select set_config"):
+            return _Cursor()
+        if low.startswith("select scan_id") and "from graph_snapshots" in low:
+            assert "snapshot_kind = %s" in low
+            tenant_id, snapshot_kind = params
+            matches = [row for row in self.snapshots if row[1] == tenant_id and row[2] == snapshot_kind]
+            matches.sort(key=lambda row: (row[3], row[0]), reverse=True)
+            return _Cursor([(matches[0][0],)] if matches else [])
+        return _Cursor()
+
+
 def _store(monkeypatch):
     from agent_bom.api import postgres_graph
 
@@ -148,6 +176,21 @@ def test_postgres_correlation_create_replay_list_and_update(monkeypatch) -> None
     assert complete.status is CorrelationRunStatus.COMPLETE
     assert json.loads(conn.rows[("acme", "corr-1")][7]) == _run().input_manifest
     assert conn.commits == 3
+
+
+def test_postgres_latest_snapshot_selection_is_scoped_by_kind_and_tenant(monkeypatch) -> None:
+    from agent_bom.api import postgres_graph
+
+    monkeypatch.setattr(postgres_graph.PostgresGraphStore, "_init_tables", lambda self: None)
+    monkeypatch.setattr(postgres_graph.PostgresGraphStore, "_init_optional_search_indexes", lambda self: None)
+    store = postgres_graph.PostgresGraphStore(pool=_Pool(_SnapshotConn()))
+
+    assert store.latest_snapshot_id(tenant_id="acme") == "scan-1"
+    assert store.latest_snapshot_id(tenant_id="acme", snapshot_kind="correlation") == "corr-1"
+    assert store.latest_snapshot_id(tenant_id="other", snapshot_kind="correlation") == ""
+
+    with pytest.raises(ValueError, match="snapshot_kind"):
+        store.latest_snapshot_id(tenant_id="acme", snapshot_kind="inventory")
 
 
 def test_postgres_correlation_rejects_idempotency_key_reuse_for_different_request(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- scope latest and previous graph snapshot selection by tenant and immutable snapshot kind
- keep current estate/API projections on scan snapshots while correlation evidence remains explicitly selectable
- preserve SQLite, Postgres, and Neptune backend contract parity and reject unsupported kinds

Closes #5010

## Verification

- `uv run pytest tests/test_graph_correlation_store.py tests/test_postgres_graph_correlation.py tests/test_graph_api.py tests/test_neptune_graph_store.py tests/test_graph_scenario_routes.py tests/test_showcase_graph_seeding.py tests/test_demo_estate_bootstrap.py tests/api/test_api_pipeline_persist_memory.py tests/api/test_persist_graph_workspace_consumer.py tests/api/test_store_backed_build_persist.py -q --tb=short` (168 passed, 1 skipped)
- `uv run ruff check` on changed Python and test files
- `uv run ruff format --check` on changed Python and test files
- `uv run mypy src/agent_bom`
- `make preflight`
- post-rebase focused regression: 3 passed
- `git diff --check`

## Notes

The default graph product remains a scan snapshot. Correlation outputs are selected by explicit identifier or `snapshot_kind=correlation`; tenant filtering is applied before kind and recency selection.