### PR TITLE
fix(sast): expose partial JS and TS coverage

### DIFF
--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -911,6 +911,13 @@ def _ast_result_for_symbol_reach(paths: Iterable[str]) -> Any | None:
                 merged.application_entrypoints.extend(result.application_entrypoints)
             if result.dependency_symbol_reach:
                 merged.dependency_symbol_reach.extend(result.dependency_symbol_reach)
+            merged.files_analyzed += result.files_analyzed
+            merged.analysis_coverage.eligible_files += result.analysis_coverage.eligible_files
+            merged.analysis_coverage.analyzed_files += result.analysis_coverage.analyzed_files
+            if result.analysis_coverage.status == "partial":
+                merged.analysis_coverage.status = "partial"
+                merged.analysis_coverage.partial_files.extend(result.analysis_coverage.partial_files)
+            merged.warnings.extend(result.warnings)
     return merged
 
 
@@ -1422,12 +1429,15 @@ def _run_scan_sync(job: ScanJob) -> None:
             outcome = ScanOutcome.FAILED if coverage_warning_messages and not has_usable_evidence else ScanOutcome.COMPLETE
             return ScanRun(outcome=outcome, issues=issues)
 
+        _ast_only_result = None
         if not agents:
+            _ast_only_result = _ast_result_for_symbol_reach(_project_paths_for_symbol_reach(req, extra_paths=extra_symbol_paths))
             if (
                 skill_audit_data is not None
                 or iac_findings_data is not None
                 or repo_ai_inventory_data is not None
                 or repo_sast_data is not None
+                or _ast_only_result is not None
             ):
                 pipeline.skip_step("extraction", "No agents to extract")
                 pipeline.skip_step("scanning", "No packages to scan")
@@ -1455,11 +1465,17 @@ def _run_scan_sync(job: ScanJob) -> None:
                 if repo_ai_inventory_data is not None:
                     report.ai_inventory_data = repo_ai_inventory_data
                     _promote_repo_dependency_inventory(report, repo_ai_inventory_data)
+                if _ast_only_result is not None:
+                    report.ai_inventory_data = report.ai_inventory_data or {}
+                    report.ai_inventory_data["ast_analysis"] = _ast_only_result.to_dict()
                 if repo_sast_data is not None:
                     report.sast_data = repo_sast_data
                 if repo_trust_data is not None:
                     report.repo_trust_data = repo_trust_data
                 report.codeowners = dict(repo_codeowners)
+                from agent_bom.scanners import consume_coverage_warnings
+
+                report.coverage_warnings = consume_coverage_warnings()
                 _apply_tenant_workflow_metadata(report, tenant_id=job.tenant_id or "default")
                 report_json = to_json(report)
                 report_json["status"] = "findings_only"
@@ -1633,6 +1649,7 @@ def _run_scan_sync(job: ScanJob) -> None:
             _min = _sev_order.get(req.min_severity.lower(), 0)
             blast_radii = [br for br in blast_radii if _sev_order.get(br.vulnerability.severity.value.lower(), 0) >= _min]
 
+        _ast_for_reach = None
         try:
             from agent_bom.api.stores import _get_exception_store
             from agent_bom.suppression_rules import apply_tenant_suppression_rules
@@ -1705,6 +1722,9 @@ def _run_scan_sync(job: ScanJob) -> None:
             scan_id=job.job_id,
             scan_run=_build_scan_run(has_usable_evidence=True),
         )
+        if _ast_for_reach is not None:
+            report.ai_inventory_data = report.ai_inventory_data or {}
+            report.ai_inventory_data["ast_analysis"] = _ast_for_reach.to_dict()
         if skill_audit_data is not None:
             report.skill_audit_data = skill_audit_data
             from agent_bom.parsers.skill_audit import replace_skill_findings

--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -50,6 +50,7 @@ from agent_bom.ast_java import scan_java_file as _scan_java_file
 from agent_bom.ast_models import (
     ApplicationEntrypoint,
     ASTAnalysisResult,
+    ASTCoverageGap,
     CallEdge,
     DependencySymbolReach,
     _CSharpMethodAnalysis,
@@ -329,6 +330,7 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
         kotlin_files,
     ) = tuple([path for path in group if path in selected] for group in file_groups)
     if eligible_count > len(selected):
+        result.analysis_coverage.status = "partial"
         warning = f"AST analysis stopped at {len(selected)} of {eligible_count} eligible source files"
         result.warnings.append(warning)
         from agent_bom.scanners.state import record_coverage_warning
@@ -355,6 +357,8 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
         + len(swift_files)
         + len(kotlin_files)
     )
+    result.analysis_coverage.eligible_files = eligible_count
+    result.analysis_coverage.analyzed_files = result.files_analyzed
     selected_source_files = [path for group in file_groups for path in group if path in selected]
     result.application_entrypoints = detect_application_entrypoints(project, selected_source_files)
     function_analyses: list[_FunctionAnalysis] = []
@@ -412,6 +416,16 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
         result.flow_findings.extend(flow_findings)
         result.frameworks_detected.extend(frameworks)
         result.call_edges.extend(js_ts_call_edges)
+        if js_ts_analysis is None:
+            result.analysis_coverage.status = "partial"
+            result.analysis_coverage.partial_files.append(
+                ASTCoverageGap(
+                    file_path=rel,
+                    language="typescript" if js_ts_file.suffix.lower() in {".ts", ".tsx"} else "javascript",
+                    reason="structured_analysis_unavailable",
+                )
+            )
+            result.warnings.append(f"Partial JS/TS structured analysis for {rel}; fallback findings were retained")
         if js_ts_analysis is not None:
             for js_ts_function in js_ts_analysis.functions.values():
                 js_ts_functions[_js_ts_function_key(js_ts_function.module_name, js_ts_function.name)] = js_ts_function

--- a/src/agent_bom/ast_models.py
+++ b/src/agent_bom/ast_models.py
@@ -118,6 +118,40 @@ class ApplicationEntrypoint:
     provenance: str
 
 
+@dataclass(frozen=True)
+class ASTCoverageGap:
+    """One source file without complete structured AST evidence."""
+
+    file_path: str
+    language: str
+    reason: str
+
+    def to_dict(self) -> dict:
+        return {
+            "file": self.file_path,
+            "language": self.language,
+            "reason": self.reason,
+        }
+
+
+@dataclass
+class ASTAnalysisCoverage:
+    """Structured completeness receipt for native source analysis."""
+
+    status: str = "complete"
+    eligible_files: int = 0
+    analyzed_files: int = 0
+    partial_files: list[ASTCoverageGap] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "status": self.status,
+            "eligible_files": self.eligible_files,
+            "analyzed_files": self.analyzed_files,
+            "partial_files": [item.to_dict() for item in self.partial_files],
+        }
+
+
 @dataclass
 class ASTAnalysisResult:
     """Complete AST analysis result for a project."""
@@ -133,6 +167,7 @@ class ASTAnalysisResult:
     frameworks_detected: list[str] = field(default_factory=list)
     files_analyzed: int = 0
     warnings: list[str] = field(default_factory=list)
+    analysis_coverage: ASTAnalysisCoverage = field(default_factory=ASTAnalysisCoverage)
 
     def to_dict(self) -> dict:
         """Serialize for JSON output / AIBOMReport."""
@@ -256,6 +291,7 @@ class ASTAnalysisResult:
             "frameworks": self.frameworks_detected,
             "files_analyzed": self.files_analyzed,
             "warnings": self.warnings,
+            "analysis_coverage": self.analysis_coverage.to_dict(),
             "stats": {
                 "total_prompts": len(self.prompts),
                 "total_guardrails": len(self.guardrails),

--- a/tests/api/test_api_scan_discovery_scope.py
+++ b/tests/api/test_api_scan_discovery_scope.py
@@ -76,3 +76,22 @@ def test_scan_opts_into_host_discovery_explicitly(monkeypatch):
     _run(store, ScanRequest(offline=True, enrich=False, discover_host=True))
 
     assert None in calls, "discover_host=True must run ambient host-wide discovery"
+
+
+def test_api_scan_projects_partial_js_ts_coverage_into_result(monkeypatch, tmp_path):
+    store = InMemoryJobStore()
+    _record_discovery(monkeypatch, store)
+    project = tmp_path / "tenant-project"
+    project.mkdir()
+    (project / "server.ts").write_text(
+        'import * as cp from "node:child_process";\nserver.tool("run", "Run", async () => cp.execSync("id"));\nfunction unfinished(\n',
+        encoding="utf-8",
+    )
+
+    job = _run(store, ScanRequest(agent_projects=[str(project)], offline=True, enrich=False))
+
+    assert job is not None
+    assert job.result is not None
+    assert job.result["ai_inventory"]["ast_analysis"]["analysis_coverage"]["status"] == "partial"
+    assert job.result["scan_run"]["outcome"] == "partial"
+    assert any(issue["source"] == "ast-js-ts" for issue in job.result["scan_run"]["issues"])

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -1305,6 +1305,29 @@ def test_analyze_project_resolves_cross_file_module_alias_when_names_are_ambiguo
     )
 
 
+def test_analyze_project_reports_partial_typescript_coverage_without_dropping_fallback_findings(tmp_path: Path):
+    (tmp_path / "server.ts").write_text(
+        'import * as cp from "node:child_process";\nserver.tool("run", "Run", async () => cp.execSync("id"));\nfunction unfinished(\n',
+        encoding="utf-8",
+    )
+
+    result = analyze_project(tmp_path)
+
+    assert result.flow_findings
+    assert result.analysis_coverage.to_dict() == {
+        "status": "partial",
+        "eligible_files": 1,
+        "analyzed_files": 1,
+        "partial_files": [
+            {
+                "file": "server.ts",
+                "language": "typescript",
+                "reason": "structured_analysis_unavailable",
+            }
+        ],
+    }
+
+
 def test_code_command_json_includes_ai_component_inventory(tmp_path: Path):
     (tmp_path / "index.js").write_text('import OpenAI from "openai";\n')
     runner = CliRunner()

--- a/tests/test_ast_source_coverage.py
+++ b/tests/test_ast_source_coverage.py
@@ -19,6 +19,9 @@ from agent_bom.ast_rust import scan_rust_file
 from agent_bom.ast_swift import scan_swift_file
 from agent_bom.evidence.scan_run import ScanOutcome, effective_scan_run, vulnerability_coverage_incomplete
 from agent_bom.models import AIBOMReport
+from agent_bom.output.html import to_html
+from agent_bom.output.json_fmt import to_json
+from agent_bom.output.sarif import to_sarif
 from agent_bom.scanners.state import consume_coverage_warnings, reset_scan_warnings
 
 _MAX_AST_SOURCE_SIZE = 512 * 1024
@@ -156,6 +159,32 @@ def test_ast_warning_marks_run_partial_without_invalidating_vulnerability_covera
     assert vulnerability_coverage_incomplete(report) is False
 
 
+def test_partial_js_ts_metadata_and_warning_project_to_json_sarif_and_html(tmp_path: Path) -> None:
+    from agent_bom.ast_analyzer import analyze_project
+
+    (tmp_path / "server.ts").write_text(
+        'import * as cp from "node:child_process";\nserver.tool("run", "Run", async () => cp.execSync("id"));\nfunction unfinished(\n',
+        encoding="utf-8",
+    )
+    result = analyze_project(tmp_path)
+    report = AIBOMReport(
+        ai_inventory_data={"ast_analysis": result.to_dict()},
+        coverage_warnings=consume_coverage_warnings(),
+    )
+
+    json_report = to_json(report)
+    sarif_run = to_sarif(report)["runs"][0]
+    html = to_html(report, [])
+
+    assert json_report["ai_inventory"]["ast_analysis"]["analysis_coverage"]["status"] == "partial"
+    assert json_report["scan_run"]["outcome"] == "partial"
+    notification = sarif_run["invocations"][0]["toolExecutionNotifications"][0]
+    assert notification["descriptor"]["id"] == "scanner_coverage_gap"
+    assert sarif_run["properties"]["scan_outcome"] == "partial"
+    assert "PARTIAL COVERAGE" in html
+    assert "CLEAN" not in html
+
+
 def test_project_file_budget_prioritizes_entrypoints_and_records_partial_coverage(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -178,6 +207,7 @@ def test_project_file_budget_prioritizes_entrypoints_and_records_partial_coverag
     result = ast_analyzer.analyze_project(tmp_path)
 
     assert result.files_analyzed == 2
+    assert result.analysis_coverage.status == "partial"
     assert any(tool.name == "late_tool" and tool.file_path == "zzzz/mcp_server.py" for tool in result.tools)
     assert result.warnings == ["AST analysis stopped at 2 of 4 eligible source files"]
     assert consume_coverage_warnings() == [

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1727,6 +1727,39 @@ def test_zero_finding_partial_secret_scan_is_preserved_and_fails_closed(monkeypa
     ]
 
 
+def test_partially_parseable_typescript_retains_findings_and_marks_cli_json_partial(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "server.ts").write_text(
+        'import * as cp from "node:child_process";\nserver.tool("run", "Run", async () => cp.execSync("id"));\nfunction unfinished(\n',
+        encoding="utf-8",
+    )
+    output = tmp_path / "partial-ast.json"
+
+    result = _run(
+        [
+            "scan",
+            str(project),
+            "--no-scan",
+            "--offline",
+            "--no-auto-update-db",
+            "--format",
+            "json",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    ast_analysis = payload["ai_inventory"]["ast_analysis"]
+    assert ast_analysis["flow_findings"]
+    assert ast_analysis["analysis_coverage"]["status"] == "partial"
+    assert payload["scan_run"]["outcome"] == "partial"
+    assert any(issue["source"] == "ast-js-ts" for issue in payload["scan_run"]["issues"])
+    assert "CLEAN" not in result.output
+
+
 def test_model_scan_refusal_is_preserved_and_fails_closed(tmp_path):
     output = tmp_path / "model-refusal.json"
 

--- a/ui/tests/job-pipeline-panel.test.tsx
+++ b/ui/tests/job-pipeline-panel.test.tsx
@@ -66,10 +66,10 @@ describe("JobPipelinePanel evidence explainability", () => {
           outcome: "partial",
           issues: [
             {
-              code: "collector_permission_denied",
+              code: "scanner_coverage_gap",
               stage: "scanning",
-              source: "gcp-iam",
-              message: "Collector could not enumerate service accounts",
+              source: "ast-js-ts",
+              message: "Structured JS/TS analysis did not complete; regex fallback coverage is partial.",
               severity: "warning",
               affects_coverage: true,
             },
@@ -96,9 +96,9 @@ describe("JobPipelinePanel evidence explainability", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Select scanning stage" }));
     expect(screen.getByText("9 vulnerabilities")).toBeInTheDocument();
-    expect(screen.getByText("gcp-iam")).toBeInTheDocument();
-    expect(screen.getByText("collector_permission_denied")).toBeInTheDocument();
-    expect(screen.getByText("Collector could not enumerate service accounts")).toBeInTheDocument();
+    expect(screen.getByText("ast-js-ts")).toBeInTheDocument();
+    expect(screen.getByText("scanner_coverage_gap")).toBeInTheDocument();
+    expect(screen.getByText("Structured JS/TS analysis did not complete; regex fallback coverage is partial.")).toBeInTheDocument();
     expect(screen.getByText("Coverage affected")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- represent incomplete JavaScript and TypeScript AST analysis as structured coverage metadata
- retain fallback findings while marking scan outcomes and warnings partial
- propagate the completeness receipt through JSON, SARIF, HTML, CLI, API, and UI surfaces

## Verification

- focused Python suite: 238 passed
- focused UI suite: 1 passed
- Node 24.18.0 and npm 10.9.7 toolchain contract passed
- UI typecheck passed
- focused Ruff and full mypy passed
- make preflight passed

## Notes

Closes #5012