### PR TITLE
fix(ui): pluralize inventory counts explicitly

### DIFF
--- a/ui/components/inventory/inventory-index.tsx
+++ b/ui/components/inventory/inventory-index.tsx
@@ -158,7 +158,7 @@ export function InventoryIndex() {
                     {total.toLocaleString()}
                   </span>
                   <span className="ml-1 text-[11px] text-[color:var(--text-tertiary)]">
-                    {empty ? "none yet" : total === 1 ? kind.singular : `${kind.singular}s`}
+                    {empty ? "none yet" : total === 1 ? kind.singular : kind.plural}
                   </span>
                 </div>
                 <span className="text-[10px] uppercase tracking-[0.1em] text-[color:var(--text-tertiary)]">whole-query facet</span>

--- a/ui/components/inventory/inventory-index.tsx
+++ b/ui/components/inventory/inventory-index.tsx
@@ -158,7 +158,7 @@ export function InventoryIndex() {
                     {total.toLocaleString()}
                   </span>
                   <span className="ml-1 text-[11px] text-[color:var(--text-tertiary)]">
-                    {empty ? "none yet" : total === 1 ? kind.singular : kind.plural}
+                    {empty ? "none yet" : total === 1 ? kind.singular : (kind.countPlural ?? kind.label)}
                   </span>
                 </div>
                 <span className="text-[10px] uppercase tracking-[0.1em] text-[color:var(--text-tertiary)]">whole-query facet</span>

--- a/ui/lib/inventory.ts
+++ b/ui/lib/inventory.ts
@@ -42,8 +42,8 @@ export interface AssetKindConfig {
   label: string;
   /** Singular, e.g. "package". */
   singular: string;
-  /** Explicit plural, e.g. "identities". */
-  plural: string;
+  /** Count-specific plural when the plural display label includes qualifiers. */
+  countPlural?: string;
   /** One-line description of what this page lists. */
   description: string;
   /** Canonical graph entity_type values that roll up into this kind. */
@@ -70,7 +70,6 @@ export const ASSET_KINDS: readonly AssetKindConfig[] = [
     id: "packages",
     label: "Packages",
     singular: "package",
-    plural: "packages",
     description:
       "Open-source dependencies discovered across your agents, images, and repositories (SBOM / SCA).",
     entityTypes: ["package"],
@@ -84,7 +83,6 @@ export const ASSET_KINDS: readonly AssetKindConfig[] = [
     id: "servers",
     label: "MCP servers",
     singular: "MCP server",
-    plural: "MCP servers",
     description:
       "Model Context Protocol servers your agents connect to, with transport, tools, and correlated findings.",
     entityTypes: ["server", "tool", "tool_call"],
@@ -98,7 +96,6 @@ export const ASSET_KINDS: readonly AssetKindConfig[] = [
     id: "agents",
     label: "AI agents",
     singular: "agent",
-    plural: "agents",
     description:
       "AI agents and clients discovered in the estate, correlated to the servers, credentials, and findings they touch.",
     entityTypes: ["agent", "model", "framework", "dataset"],
@@ -112,7 +109,6 @@ export const ASSET_KINDS: readonly AssetKindConfig[] = [
     id: "cloud",
     label: "Cloud resources",
     singular: "cloud resource",
-    plural: "cloud resources",
     description:
       "Compute, storage, databases, and network resources from connected cloud accounts (CSPM inventory).",
     entityTypes: [
@@ -137,7 +133,7 @@ export const ASSET_KINDS: readonly AssetKindConfig[] = [
     id: "identities",
     label: "Identities & credentials",
     singular: "identity",
-    plural: "identities",
+    countPlural: "identities",
     description:
       "Human and non-human identities, credentials, roles, and access policies (NHI) linked to your estate.",
     entityTypes: [
@@ -164,7 +160,6 @@ export const ASSET_KINDS: readonly AssetKindConfig[] = [
     id: "containers",
     label: "Container images",
     singular: "container image",
-    plural: "container images",
     description:
       "Container images scanned for vulnerable layers and packages, correlated to the agents that run them.",
     entityTypes: ["container"],
@@ -178,7 +173,6 @@ export const ASSET_KINDS: readonly AssetKindConfig[] = [
     id: "code",
     label: "Code & repositories",
     singular: "code asset",
-    plural: "code assets",
     description:
       "Applications, source modules, config files, and CI jobs from scanned repositories (SAST / IaC surface).",
     entityTypes: [

--- a/ui/lib/inventory.ts
+++ b/ui/lib/inventory.ts
@@ -42,6 +42,8 @@ export interface AssetKindConfig {
   label: string;
   /** Singular, e.g. "package". */
   singular: string;
+  /** Explicit plural, e.g. "identities". */
+  plural: string;
   /** One-line description of what this page lists. */
   description: string;
   /** Canonical graph entity_type values that roll up into this kind. */
@@ -68,6 +70,7 @@ export const ASSET_KINDS: readonly AssetKindConfig[] = [
     id: "packages",
     label: "Packages",
     singular: "package",
+    plural: "packages",
     description:
       "Open-source dependencies discovered across your agents, images, and repositories (SBOM / SCA).",
     entityTypes: ["package"],
@@ -81,6 +84,7 @@ export const ASSET_KINDS: readonly AssetKindConfig[] = [
     id: "servers",
     label: "MCP servers",
     singular: "MCP server",
+    plural: "MCP servers",
     description:
       "Model Context Protocol servers your agents connect to, with transport, tools, and correlated findings.",
     entityTypes: ["server", "tool", "tool_call"],
@@ -94,6 +98,7 @@ export const ASSET_KINDS: readonly AssetKindConfig[] = [
     id: "agents",
     label: "AI agents",
     singular: "agent",
+    plural: "agents",
     description:
       "AI agents and clients discovered in the estate, correlated to the servers, credentials, and findings they touch.",
     entityTypes: ["agent", "model", "framework", "dataset"],
@@ -107,6 +112,7 @@ export const ASSET_KINDS: readonly AssetKindConfig[] = [
     id: "cloud",
     label: "Cloud resources",
     singular: "cloud resource",
+    plural: "cloud resources",
     description:
       "Compute, storage, databases, and network resources from connected cloud accounts (CSPM inventory).",
     entityTypes: [
@@ -131,6 +137,7 @@ export const ASSET_KINDS: readonly AssetKindConfig[] = [
     id: "identities",
     label: "Identities & credentials",
     singular: "identity",
+    plural: "identities",
     description:
       "Human and non-human identities, credentials, roles, and access policies (NHI) linked to your estate.",
     entityTypes: [
@@ -157,6 +164,7 @@ export const ASSET_KINDS: readonly AssetKindConfig[] = [
     id: "containers",
     label: "Container images",
     singular: "container image",
+    plural: "container images",
     description:
       "Container images scanned for vulnerable layers and packages, correlated to the agents that run them.",
     entityTypes: ["container"],
@@ -170,6 +178,7 @@ export const ASSET_KINDS: readonly AssetKindConfig[] = [
     id: "code",
     label: "Code & repositories",
     singular: "code asset",
+    plural: "code assets",
     description:
       "Applications, source modules, config files, and CI jobs from scanned repositories (SAST / IaC surface).",
     entityTypes: [

--- a/ui/tests/inventory-view.test.tsx
+++ b/ui/tests/inventory-view.test.tsx
@@ -219,4 +219,39 @@ describe("InventoryIndex whole-query truth", () => {
     expect(screen.getByRole("link", { name: /^AI agents/ })).toHaveAttribute("href", "/inventory/agents");
     expect(api.getGraph).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { count: 0, expected: "none yet", theme: "light" },
+    { count: 1, expected: "identity", theme: "dark" },
+    { count: 396, expected: "identities", theme: "light" },
+    { count: 396, expected: "identities", theme: "dark" },
+  ])("renders the identity inventory count for $count in $theme theme", async ({ count, expected, theme }) => {
+    document.documentElement.dataset.theme = theme;
+    const identityFacets = facets();
+    identityFacets.type.buckets.push({ value: "user", count });
+    vi.mocked(api.getInventorySummary).mockResolvedValue(
+      summary({
+        total_assets: 1000 + count,
+        facets: identityFacets,
+      }),
+    );
+    vi.mocked(api.getInventoryAssets).mockResolvedValue(
+      page([], {
+        facets: identityFacets,
+        pagination: { total: 1000 + count, offset: 0, limit: 100, next_cursor: "", has_more: false, facet_filtered: false },
+      }),
+    );
+
+    render(
+      <InventoryProvider>
+        <InventoryIndex />
+      </InventoryProvider>,
+    );
+
+    const identities = await screen.findByRole("link", { name: /^Identities & credentials/ });
+    expect(within(identities).getByText(count.toLocaleString())).toBeInTheDocument();
+    expect(within(identities).getByText(expected)).toBeInTheDocument();
+    expect(within(identities).queryByText("identitys")).not.toBeInTheDocument();
+    delete document.documentElement.dataset.theme;
+  });
 });


### PR DESCRIPTION
## Summary

- replace inventory suffix guessing with explicit singular and plural labels
- render identity and identities correctly for singular and plural counts
- cover zero, one, and many identity counts in light and dark themes

## Verification

- focused inventory UI suite: 9 passed
- UI lint passed
- Node 24.18.0 and npm 10.9.7 toolchain contract passed
- UI typecheck passed
- production build passed with 52 generated pages
- git diff check passed

## Notes

Closes #5019