### PR TITLE
fix(graph): stabilize workspace scale proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ while advancing the maintained dependency and MCP-registry baseline.
   verified.
 - Python, JavaScript, MCP, and CodeQL dependencies plus the bundled MCP registry
   are refreshed under their existing release and serialization contracts.
+- Private SQLite graph-build workspaces avoid durable fsync overhead while
+  retaining transactional staging semantics; durable graph stores are unchanged.
 
 ## [0.103.1] - 2026-08-29
 

--- a/src/agent_bom/graph/build_workspace.py
+++ b/src/agent_bom/graph/build_workspace.py
@@ -159,7 +159,14 @@ class _SQLiteWorkspaceBackend:
             self._path = Path(db_path)
             self._owns_file = False
         self._conn = sqlite3.connect(str(self._path))
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        # This database is a private, process-local staging workspace that is
+        # discarded after the graph is persisted.  WAL + full fsync semantics
+        # turn the producer's many bounded upserts into runner-disk latency and
+        # provide no recovery value: a crashed build is never selectable.  Keep
+        # the journal in memory and disable synchronous flushes while retaining
+        # SQLite's transactional statement semantics for the live build.
+        self._conn.execute("PRAGMA journal_mode=MEMORY")
+        self._conn.execute("PRAGMA synchronous=OFF")
         # ``entity_type`` (nodes) and ``source_id``/``target_id`` (edges) back the
         # random-access read indexes; kept in lock-step with the Postgres backend
         # (graph_build_workspace_nodes/_edges). SQLite workspace DBs are private

--- a/tests/graph/test_graph_build_workspace.py
+++ b/tests/graph/test_graph_build_workspace.py
@@ -111,6 +111,16 @@ def test_postgres_workspace_cleanup_stays_tenant_bound() -> None:
     assert all("tenant_id = %s" in sql for sql, _params in conn.executed if sql.startswith("DELETE FROM graph_build_workspace_"))
 
 
+def test_sqlite_workspace_uses_ephemeral_write_pragmas() -> None:
+    """Private build staging must not inherit durable database fsync costs."""
+    backend = _SQLiteWorkspaceBackend()
+    try:
+        assert backend._conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "memory"
+        assert backend._conn.execute("PRAGMA synchronous").fetchone()[0] == 0
+    finally:
+        backend.close()
+
+
 def _synthetic_graph(scan: str, n: int, tenant: str = "t1") -> UnifiedGraph:
     g = UnifiedGraph(scan_id=scan, tenant_id=tenant)
     for i in range(n):

--- a/tests/graph/test_store_backed_build_wiring.py
+++ b/tests/graph/test_store_backed_build_wiring.py
@@ -319,6 +319,11 @@ def test_store_backed_producer_peak_advantage_widens_with_scale() -> None:
 
     ratio_small = store_small / ram_small
     ratio_large = store_large / ram_large
+    print(
+        f"graph-scale nodes={n_small}/{n_large} "
+        f"store_peaks={store_small}/{store_large} ram_peaks={ram_small}/{ram_large} "
+        f"ratios={ratio_small:.3f}/{ratio_large:.3f}"
+    )
 
     assert ratio_small < 0.65, f"store/in-RAM producer peak too high at ~{n_small} nodes: {ratio_small:.3f}"
     assert ratio_large < 0.48, f"store/in-RAM producer peak too high at ~{n_large} nodes: {ratio_large:.3f}"


### PR DESCRIPTION
## Summary

- use in-memory journaling and disabled synchronous flushes for private throwaway SQLite graph-build workspaces
- preserve transactional staging semantics and leave durable SQLite/Postgres graph stores unchanged
- retain the 7,201/28,801-node heap-ratio proof and emit its measured counts and ratios on failure

## Verification

- `uv run pytest tests/graph/test_graph_build_workspace.py tests/graph/test_store_backed_build_wiring.py -q -m "not graph_performance"` (17 passed)
- `uv run pytest tests/graph/test_store_backed_build_wiring.py -q -s -m graph_performance -p no:randomly` (1 passed; 28,801-node large envelope; ratios 0.517/0.383)
- `make preflight`
- `make lint`
- `make format-check`
- `git diff --check`

## Notes

Exact-main CI run 33467786527 canceled the graph-performance job at its 30-minute bound; the same test passed locally before this change in 2m59s and the failed-job retry passed on GitHub in 4m37s. This change removes hosted-runner fsync variance without reducing the measured graph envelope or relaxing the timeout.