### PR TITLE
fix(mcp): gate runtime introspection execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ while advancing the maintained dependency and MCP-registry baseline.
 - Private SQLite graph-build workspaces avoid durable fsync overhead while
   retaining transactional staging semantics; durable graph stores are unchanged.
 
+### Fixed
+
+- MCP runtime introspection now rejects security-blocked servers before any
+  transport is opened, keeps stdio process launch disabled by default, and
+  requires both explicit opt-in and authenticated operator authority before a
+  discovered command can run.
+
 ## [0.103.1] - 2026-08-29
 
 This patch restores Alpine arm64 API-image publication and makes the

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -245,7 +245,9 @@ live runtime traffic rather than static reachability.
 - **Read-mostly**: scanner, graph, audit, and posture tools are read-only.
   The 20 write-annotated tools cover scan-history diff, Shield, identity,
   external ingest, CWPP runtime-evidence ingest, access review, finding
-  triage and exception approval, snapshot correlation, remediation campaigns, and ticket workflows. They require an
+  triage and exception approval, snapshot correlation, remediation campaigns,
+  and ticket workflows. One process-execution tool can launch a discovered
+  local MCP server only with explicit authorization. These tools require an
   authenticated MCP operator token plus admin role, their specific write
   scope (`cloud:write`, `findings:write`, `identity:write`, `scan:write`, `shield:write`,
   or `ticketing:write`), and an audit reason; stdio cannot invoke them.

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -5,7 +5,9 @@ The server card also advertises 6 resources and 8 workflow prompts so agents can
 choose structured playbooks instead of guessing tool order.
 Most tools are read-only. 20 write-annotated tools cover scan-history
 diff, Shield, identity, external ingest, CWPP runtime-evidence ingest, access
-review, snapshot correlation, finding triage and exception approval, remediation campaigns, and ticket workflows.
+review, snapshot correlation, finding triage and exception approval,
+remediation campaigns, and ticket workflows. 1 process-execution tool can
+launch a discovered local MCP server only with explicit authorization.
 Each requires `operator_role=admin`, its tool-specific write scope, and an audit
 reason. The registered scope families are `cloud:write`, `findings:write`,
 `identity:write`, `scan:write`, `shield:write`, and `ticketing:write`.

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -5,7 +5,9 @@ runtime, and remediation. The tools are read-only by default: agent consumers
 can request evidence and deploy guidance without mutating repos, cloud
 resources, or runtime targets. 20 write-annotated tools cover scan-history
 diff, Shield, identity, external ingest, CWPP runtime-evidence ingest, access
-review, snapshot correlation, finding triage and exception approval, remediation campaigns, and ticket workflows.
+review, snapshot correlation, finding triage and exception approval,
+remediation campaigns, and ticket workflows. 1 process-execution tool can
+launch a discovered local MCP server only with explicit authorization.
 They fail closed unless a remote caller uses the operator token and supplies an
 admin role, the tool-specific write scope, and an audit reason; stdio cannot
 invoke them.

--- a/src/agent_bom/mcp_introspect.py
+++ b/src/agent_bom/mcp_introspect.py
@@ -1,6 +1,6 @@
 """MCP Runtime Introspection — connect to live MCP servers for tool/resource discovery.
 
-Read-only introspection: connects to running MCP servers via the MCP protocol,
+Protocol-read-only introspection: connects to running MCP servers via the MCP protocol,
 calls ``tools/list``, ``resources/list``, and ``prompts/list`` to discover actual runtime capabilities,
 and compares them against config-declared data to detect drift.
 
@@ -9,8 +9,10 @@ Requires ``mcp`` SDK.  Install with::
     pip install mcp
 
 Security guarantees:
-- **Read-only**: Only calls ``initialize``, ``tools/list``, ``resources/list``, and ``prompts/list``.
+- **Protocol read-only**: Only calls ``initialize``, ``tools/list``, ``resources/list``, and ``prompts/list``.
   Never calls ``tools/call``.
+- **Execution-gated**: Security-blocked servers are never connected to or launched;
+  callers can also disable stdio process execution entirely.
 - **Timeout-guarded**: Every connection attempt has a configurable timeout.
 - **Clean shutdown**: All server subprocesses are terminated on exit.
 """
@@ -32,6 +34,8 @@ logger = logging.getLogger(__name__)
 
 # Default timeout for connecting to an MCP server (seconds)
 DEFAULT_TIMEOUT = 10.0
+INTROSPECTION_BLOCKED_ERROR = "Introspection blocked by security policy"
+STDIO_APPROVAL_REQUIRED_ERROR = "Stdio command execution requires explicit approval"
 _PATH_HINT_RE = re.compile(r"(path|file|dir|cwd|workspace)", re.IGNORECASE)
 _URL_HINT_RE = re.compile(r"(url|uri|endpoint|host|domain|webhook)", re.IGNORECASE)
 _SHELL_HINT_RE = re.compile(r"(cmd|command|shell|exec|script)", re.IGNORECASE)
@@ -347,6 +351,8 @@ def _apply_runtime_risk(server: MCPServer, result: ServerIntrospection) -> None:
 async def introspect_server(
     server: MCPServer,
     timeout: float = DEFAULT_TIMEOUT,
+    *,
+    allow_stdio: bool = True,
 ) -> ServerIntrospection:
     """Introspect a single MCP server.
 
@@ -355,8 +361,6 @@ async def introspect_server(
 
     Only stdio and SSE transports are supported for introspection.
     """
-    _check_mcp_sdk()
-
     result = ServerIntrospection(
         server_name=server.name,
         success=False,
@@ -367,6 +371,15 @@ async def introspect_server(
         configured_resource_count=len(server.resources),
         configured_prompt_count=len(server.prompts),
     )
+
+    if server.security_blocked:
+        result.error = INTROSPECTION_BLOCKED_ERROR
+        return result
+    if server.transport == TransportType.STDIO and not allow_stdio:
+        result.error = STDIO_APPROVAL_REQUIRED_ERROR
+        return result
+
+    _check_mcp_sdk()
 
     if server.transport == TransportType.STDIO:
         if not server.command:
@@ -557,6 +570,8 @@ async def introspect_servers(
     servers: list[MCPServer],
     timeout: float = DEFAULT_TIMEOUT,
     max_concurrent: int = 5,
+    *,
+    allow_stdio: bool = True,
 ) -> IntrospectionReport:
     """Introspect multiple MCP servers with concurrency control.
 
@@ -568,19 +583,21 @@ async def introspect_servers(
     Returns:
         IntrospectionReport with all results and warnings.
     """
-    _check_mcp_sdk()
-
     report = IntrospectionReport()
     semaphore = asyncio.Semaphore(max_concurrent)
 
     async def _introspect_with_semaphore(server: MCPServer) -> ServerIntrospection:
         async with semaphore:
-            return await introspect_server(server, timeout)
+            return await introspect_server(server, timeout, allow_stdio=allow_stdio)
 
     # Only introspect servers that have enough config to connect
     introspectable = []
     for server in servers:
-        if server.transport == TransportType.STDIO and server.command:
+        if server.security_blocked:
+            report.warnings.append(f"Skipping {_safe_runtime_text(server.name, max_len=300)}: {INTROSPECTION_BLOCKED_ERROR.lower()}")
+        elif server.transport == TransportType.STDIO and server.command and not allow_stdio:
+            report.warnings.append(f"Skipping {_safe_runtime_text(server.name, max_len=300)}: {STDIO_APPROVAL_REQUIRED_ERROR.lower()}")
+        elif server.transport == TransportType.STDIO and server.command:
             introspectable.append(server)
         elif server.transport in (TransportType.SSE, TransportType.STREAMABLE_HTTP) and server.url:
             introspectable.append(server)
@@ -588,8 +605,11 @@ async def introspect_servers(
             report.warnings.append(f"Skipping {server.name}: no command/URL for {server.transport.value} transport")
 
     if not introspectable:
-        report.warnings.append("No servers eligible for introspection")
+        if not report.warnings:
+            report.warnings.append("No servers eligible for introspection")
         return report
+
+    _check_mcp_sdk()
 
     tasks = [_introspect_with_semaphore(s) for s in introspectable]
     results = await asyncio.gather(*tasks, return_exceptions=True)
@@ -613,9 +633,11 @@ async def introspect_servers(
 def introspect_servers_sync(
     servers: list[MCPServer],
     timeout: float = DEFAULT_TIMEOUT,
+    *,
+    allow_stdio: bool = True,
 ) -> IntrospectionReport:
     """Synchronous wrapper for introspect_servers."""
-    return asyncio.run(introspect_servers(servers, timeout))
+    return asyncio.run(introspect_servers(servers, timeout, allow_stdio=allow_stdio))
 
 
 # ── Health Checks ────────────────────────────────────────────────────────────
@@ -655,8 +677,6 @@ async def health_check_servers(
     """
     import time
 
-    _check_mcp_sdk()
-
     semaphore = asyncio.Semaphore(max_concurrent)
 
     async def _probe(server: MCPServer) -> HealthStatus:
@@ -673,19 +693,25 @@ async def health_check_servers(
                 error=result.error,
             )
 
+    blocked = [HealthStatus(server_name=s.name, reachable=False, error=INTROSPECTION_BLOCKED_ERROR) for s in servers if s.security_blocked]
     eligible = [
         s
         for s in servers
-        if (s.transport == TransportType.STDIO and s.command)
-        or (s.transport in (TransportType.SSE, TransportType.STREAMABLE_HTTP) and s.url)
+        if not s.security_blocked
+        and (
+            (s.transport == TransportType.STDIO and s.command)
+            or (s.transport in (TransportType.SSE, TransportType.STREAMABLE_HTTP) and s.url)
+        )
     ]
 
     if not eligible:
-        return []
+        return blocked
+
+    _check_mcp_sdk()
 
     tasks = [_probe(s) for s in eligible]
     outcomes = await asyncio.gather(*tasks, return_exceptions=True)
-    results: list[HealthStatus] = []
+    results: list[HealthStatus] = blocked
     for server, outcome in zip(eligible, outcomes, strict=False):
         if isinstance(outcome, BaseException):
             results.append(

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -493,6 +493,8 @@ async def _execute_tool_sync_async(
     /,
     *args,
     tool_timeout: float | None = None,
+    destructive: bool = False,
+    required_scope: str | None = None,
     **kwargs,
 ) -> _ToolReturn | str:
     """Run a sync MCP tool under the shared async governance envelope."""
@@ -511,6 +513,8 @@ async def _execute_tool_sync_async(
         get_tool_semaphore_fn=_get_tool_semaphore,
         sanitize_error_fn=sanitize_error,
         logger=logger,
+        destructive=destructive,
+        required_scope=required_scope,
         **kwargs,
     )
 
@@ -539,6 +543,10 @@ _WRITE_ACTION = ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempo
 # recomputes and upserts campaign status). It is a WRITE — never readOnlyHint —
 # but non-destructive and idempotent.
 _WRITE_IDEMPOTENT = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=True)
+# Runtime capability inspection is protocol-read-only, but stdio discovery may
+# launch a configured process. Advertise the host-side execution truthfully so
+# MCP clients can require approval before the explicit opt-in is accepted.
+_RUNTIME_INTROSPECTION = ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=True)
 
 
 def _check_mcp_sdk() -> None:
@@ -1400,6 +1408,7 @@ def create_mcp_server(
     _register_runtime_catalog_tools(
         mcp,
         read_only=_READ_ONLY,
+        runtime_introspection=_RUNTIME_INTROSPECTION,
         execute_tool_sync_async=_execute_tool_sync_async,
         safe_path=_safe_path,
         truncate_response=_truncate_response,

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -124,9 +124,10 @@ _SERVER_CARD_TOOLS = [
         "name": "tool_risk_assessment",
         "description": (
             "Live-introspect configured MCP servers via tools/list and score each exposed tool by capability"
-            " (filesystem, network, code execution, credential access) to rate per-tool and per-server blast radius"
+            " (filesystem, network, code execution, credential access) to rate per-tool and per-server blast radius;"
+            " launching an unblocked stdio command requires explicit opt-in"
         ),
-        "annotations": {"readOnlyHint": True},
+        "annotations": {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
     },
     {
         "name": "inventory",
@@ -470,7 +471,7 @@ _TOOL_CAPABILITY_CLASSES = {
     "inventory_summary": ["READ", "GRAPH", "INVENTORY"],
     "inventory_list": ["READ", "GRAPH", "INVENTORY"],
     "inventory_asset": ["READ", "GRAPH", "INVENTORY", "ANALYZE"],
-    "tool_risk_assessment": ["READ", "ANALYZE"],
+    "tool_risk_assessment": ["READ", "ANALYZE", "PROCESS_EXECUTION"],
     "inventory": ["READ", "LOCAL_FILE_READ"],
     "diff": ["WRITE", "READ", "LOCAL_FILE_READ", "ANALYZE", "HISTORY"],
     "marketplace_check": ["READ", "REGISTRY"],

--- a/src/agent_bom/mcp_server_runtime.py
+++ b/src/agent_bom/mcp_server_runtime.py
@@ -585,9 +585,42 @@ async def execute_tool_sync_async(
     get_tool_semaphore_fn: Callable[[], asyncio.Semaphore],
     sanitize_error_fn: Callable[[Exception], str],
     logger,
+    destructive: bool = False,
+    required_scope: str | None = None,
     **kwargs,
 ) -> _ToolReturn | str:
     request_meta = request_meta_factory()
+    if destructive:
+        authenticated_actor = request_meta.get("client_id") or request_meta.get("caller") or "mcp-operator"
+        kwargs.setdefault("_authenticated_actor", authenticated_actor)
+        auth_scopes = str(request_meta.get("auth_scopes", "") or "")
+        denial = authorize_destructive_tool(
+            tool_name,
+            operator_role=str(kwargs.get("operator_role", "") or ""),
+            operator_scopes=str(kwargs.get("operator_scopes", "") or ""),
+            auth_scopes=auth_scopes,
+            required_scope=required_scope,
+        )
+        if denial is not None:
+            log_caller = _log_value(request_meta["caller"])
+            log_actor = _log_value(str(authenticated_actor or "unset"))
+            record_tool_metric_fn(tool_name, elapsed_ms=0, success=False, error="forbidden")
+            record_tool_request_fn(
+                tool_name,
+                caller=request_meta["caller"],
+                client_id=request_meta["client_id"],
+                request_id=request_meta["request_id"],
+                status="forbidden",
+                elapsed_ms=0,
+                error="forbidden",
+            )
+            logger.warning(
+                "mcp tool forbidden: %s caller=%s actor=%r",
+                tool_name,
+                log_caller,
+                log_actor,
+            )
+            return truncate_response_fn(json.dumps(denial))
     log_caller = _log_value(request_meta["caller"])
     log_request_id = _log_value(request_meta["request_id"])
     retry_after = check_caller_rate_limit_fn(request_meta["caller"] or "local")

--- a/src/agent_bom/mcp_server_runtime_catalog.py
+++ b/src/agent_bom/mcp_server_runtime_catalog.py
@@ -11,6 +11,7 @@ def register_runtime_catalog_tools(
     mcp,
     *,
     read_only,
+    runtime_introspection,
     execute_tool_sync_async: Callable[..., Awaitable[str]],
     safe_path,
     truncate_response,
@@ -81,10 +82,14 @@ def register_runtime_catalog_tools(
             _truncate_response=truncate_response,
         )
 
-    @mcp.tool(annotations=read_only, title="Tool Capability Risk")
+    @mcp.tool(annotations=runtime_introspection, title="Tool Capability Risk")
     async def tool_risk_assessment(
         config_path: Annotated[str | None, Field(description="Path to MCP client config directory. Auto-discovers all if omitted.")] = None,
-        timeout: Annotated[float, Field(description="Per-server introspection timeout in seconds.")] = 10.0,
+        timeout: Annotated[float, Field(ge=0.1, le=60.0, description="Per-server introspection timeout in seconds.")] = 10.0,
+        allow_command_execution: Annotated[
+            bool,
+            Field(description="Explicitly allow launching unblocked stdio server commands. False only connects to HTTP/SSE servers."),
+        ] = False,
     ) -> str:
         """Live-introspect MCP servers and score each tool's capability risk.
 
@@ -98,6 +103,8 @@ def register_runtime_catalog_tools(
             config_path: MCP client config directory to read; auto-discovers all
                 supported clients when omitted.
             timeout: Per-server introspection timeout in seconds.
+            allow_command_execution: Explicit opt-in required before launching
+                discovered stdio server commands.
 
         Returns:
             JSON with per-server tool inventories, per-tool capability classes
@@ -111,5 +118,8 @@ def register_runtime_catalog_tools(
             tool_risk_assessment_impl,
             config_path=config_path,
             timeout=timeout,
+            allow_command_execution=allow_command_execution,
+            _safe_path=safe_path,
             _truncate_response=truncate_response,
+            destructive=allow_command_execution,
         )

--- a/src/agent_bom/mcp_tools/runtime.py
+++ b/src/agent_bom/mcp_tools/runtime.py
@@ -806,6 +806,9 @@ def tool_risk_assessment_impl(
     *,
     config_path: str | None = None,
     timeout: float = 10.0,
+    allow_command_execution: bool = False,
+    _authenticated_actor: str = "",
+    _safe_path,
     _truncate_response,
 ) -> str:
     """Implementation of the tool_risk_assessment tool."""
@@ -813,12 +816,13 @@ def tool_risk_assessment_impl(
         from agent_bom.discovery import discover_all
         from agent_bom.mcp_introspect import introspect_servers_sync
 
-        agents = discover_all(project_dir=config_path)
+        resolved_config_path = str(_safe_path(config_path)) if config_path else None
+        agents = discover_all(project_dir=resolved_config_path)
         servers = [s for a in agents for s in a.mcp_servers]
         if not servers:
             return json.dumps({"status": "no_servers_found", "servers": []})
 
-        report = introspect_servers_sync(servers, timeout=timeout)
+        report = introspect_servers_sync(servers, timeout=timeout, allow_stdio=allow_command_execution)
         results = [r.to_dict(include_runtime_objects=True) for r in report.results]
         summary = {
             "total_servers": report.total_servers,
@@ -826,8 +830,9 @@ def tool_risk_assessment_impl(
             "failed": report.failed,
             "critical_or_high": sum(1 for r in report.results if r.capability_risk_level in ("critical", "high")),
             "max_capability_risk_score": max((r.capability_risk_score for r in report.results), default=0.0),
+            "command_execution_allowed": allow_command_execution,
         }
-        return _truncate_response(json.dumps({"summary": summary, "servers": results}, indent=2))
+        return _truncate_response(json.dumps({"summary": summary, "servers": results, "warnings": report.warnings}, indent=2))
     except Exception as exc:
         logger.exception("MCP tool error")
         return json.dumps({"error": sanitize_error(exc)})

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -304,6 +304,7 @@ def test_server_card_tools_expose_capability_classes():
         # Assigns, tickets, and verifies persisted remediation campaigns.
         "risk_campaign_workflow",
     }
+    process_execution_tools = {"tool_risk_assessment"}
     # Writes that tear down or invalidate state advertise destructiveHint; issuing
     # an identity or granting access creates state and is non-destructive.
     # ingest_external_scan mutates the control plane (bulk-ingest + reconcile
@@ -324,6 +325,7 @@ def test_server_card_tools_expose_capability_classes():
         "approve_exception",
         "risk_campaign_workflow",
         "cloud_side_scan",
+        "tool_risk_assessment",
     }
     card = build_server_card()
     for tool in card["tools"]:
@@ -334,6 +336,10 @@ def test_server_card_tools_expose_capability_classes():
             assert "WRITE" in classes, tool["name"]
             assert tool["annotations"]["readOnlyHint"] is False
             assert tool["annotations"]["destructiveHint"] is (tool["name"] in destructive_writes), tool["name"]
+        elif tool["name"] in process_execution_tools:
+            assert "PROCESS_EXECUTION" in classes, tool["name"]
+            assert tool["annotations"]["readOnlyHint"] is False
+            assert tool["annotations"]["destructiveHint"] is True
         else:
             assert "READ" in classes, tool["name"]
             assert tool["annotations"]["readOnlyHint"] is True
@@ -379,8 +385,10 @@ def test_mcp_docs_match_resource_and_prompt_catalog():
     assert f"{len(card['tools'])} MCP tools" in docs
     assert "Most tools are read-only" in docs
     assert "AGENT_BOM_MCP_OPERATOR_TOKEN" in docs
-    write_tools = [tool["name"] for tool in card["tools"] if tool.get("annotations", {}).get("readOnlyHint") is False]
-    assert sorted(write_tools) == [
+    non_read_only_tools = [
+        tool["name"] for tool in card["tools"] if tool.get("annotations", {}).get("readOnlyHint") is False
+    ]
+    assert sorted(non_read_only_tools) == [
         "access_review",
         "approve_exception",
         "cloud_side_scan",
@@ -401,8 +409,14 @@ def test_mcp_docs_match_resource_and_prompt_catalog():
         "shield_start",
         "shield_unblock",
         "sync_ticket_status",
+        "tool_risk_assessment",
+    ]
+    write_tools = [tool["name"] for tool in card["tools"] if "WRITE" in tool.get("capability_classes", [])]
+    process_execution_tools = [
+        tool["name"] for tool in card["tools"] if "PROCESS_EXECUTION" in tool.get("capability_classes", [])
     ]
     assert f"{len(write_tools)} write-annotated tools" in docs
+    assert f"{len(process_execution_tools)} process-execution tool" in docs
     for required_scope in (
         "cloud:write",
         "findings:write",

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -385,9 +385,7 @@ def test_mcp_docs_match_resource_and_prompt_catalog():
     assert f"{len(card['tools'])} MCP tools" in docs
     assert "Most tools are read-only" in docs
     assert "AGENT_BOM_MCP_OPERATOR_TOKEN" in docs
-    non_read_only_tools = [
-        tool["name"] for tool in card["tools"] if tool.get("annotations", {}).get("readOnlyHint") is False
-    ]
+    non_read_only_tools = [tool["name"] for tool in card["tools"] if tool.get("annotations", {}).get("readOnlyHint") is False]
     assert sorted(non_read_only_tools) == [
         "access_review",
         "approve_exception",
@@ -412,9 +410,7 @@ def test_mcp_docs_match_resource_and_prompt_catalog():
         "tool_risk_assessment",
     ]
     write_tools = [tool["name"] for tool in card["tools"] if "WRITE" in tool.get("capability_classes", [])]
-    process_execution_tools = [
-        tool["name"] for tool in card["tools"] if "PROCESS_EXECUTION" in tool.get("capability_classes", [])
-    ]
+    process_execution_tools = [tool["name"] for tool in card["tools"] if "PROCESS_EXECUTION" in tool.get("capability_classes", [])]
     assert f"{len(write_tools)} write-annotated tools" in docs
     assert f"{len(process_execution_tools)} process-execution tool" in docs
     for required_scope in (

--- a/tests/test_health_checks.py
+++ b/tests/test_health_checks.py
@@ -169,6 +169,25 @@ async def test_health_check_skips_ineligible_servers():
 
 
 @pytest.mark.asyncio
+async def test_health_check_reports_security_blocked_without_probing():
+    blocked = _stdio_server("blocked")
+    blocked.security_blocked = True
+
+    with (
+        patch("agent_bom.mcp_introspect._check_mcp_sdk") as sdk_check,
+        patch("agent_bom.mcp_introspect.introspect_server") as introspect,
+    ):
+        statuses = await health_check_servers([blocked], timeout=5.0)
+
+    assert len(statuses) == 1
+    assert statuses[0].server_name == "blocked"
+    assert statuses[0].reachable is False
+    assert statuses[0].error == "Introspection blocked by security policy"
+    sdk_check.assert_not_called()
+    introspect.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_health_check_empty_list():
     with patch("agent_bom.mcp_introspect._check_mcp_sdk"):
         statuses = await health_check_servers([], timeout=5.0)

--- a/tests/test_mcp_catalog_drift.py
+++ b/tests/test_mcp_catalog_drift.py
@@ -114,3 +114,27 @@ def test_live_access_review_and_diff_annotations_are_not_read_only() -> None:
         assert annotations is not None, f"{name} should carry annotations"
         assert annotations.readOnlyHint is not True, f"{name} live annotation must not be readOnlyHint=True"
     assert tools["diff"].annotations.destructiveHint is True
+
+
+def test_tool_risk_assessment_is_labeled_as_process_execution() -> None:
+    """Runtime stdio discovery can launch a configured process and needs approval."""
+    tool = {item["name"]: item for item in build_server_card()["tools"]}["tool_risk_assessment"]
+    classes = set(tool.get("capability_classes", []))
+    annotations = tool.get("annotations", {}) or {}
+
+    assert "PROCESS_EXECUTION" in classes
+    assert annotations.get("readOnlyHint") is False
+    assert annotations.get("destructiveHint") is True
+
+
+def test_live_tool_risk_assessment_requires_opt_in_and_operator_approval() -> None:
+    pytest.importorskip("mcp", reason="mcp SDK not installed")
+    from agent_bom.mcp_server import create_mcp_server
+
+    server = create_mcp_server()
+    tool = {item.name: item for item in asyncio.run(server.list_tools())}["tool_risk_assessment"]
+    properties = tool.inputSchema["properties"]
+
+    assert tool.annotations.readOnlyHint is False
+    assert tool.annotations.destructiveHint is True
+    assert properties["allow_command_execution"]["default"] is False

--- a/tests/test_mcp_introspect.py
+++ b/tests/test_mcp_introspect.py
@@ -2,7 +2,7 @@
 
 import sys
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -487,6 +487,49 @@ async def test_introspect_server_no_url():
         result = await introspect_server(server, timeout=1.0)
     assert not result.success
     assert "No URL" in result.error
+
+
+@pytest.mark.asyncio
+async def test_introspect_server_rejects_security_blocked_before_transport():
+    """A discovery block is an execution boundary, not advisory metadata."""
+    from agent_bom.mcp_introspect import introspect_server
+
+    server = MCPServer(
+        name="blocked-server",
+        transport=TransportType.STDIO,
+        command="must-not-run",
+        security_blocked=True,
+    )
+
+    with (
+        patch("agent_bom.mcp_introspect._check_mcp_sdk") as sdk_check,
+        patch("agent_bom.mcp_introspect._introspect_stdio", new_callable=AsyncMock) as stdio,
+    ):
+        result = await introspect_server(server, timeout=1.0)
+
+    assert result.success is False
+    assert result.error == "Introspection blocked by security policy"
+    sdk_check.assert_not_called()
+    stdio.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_introspect_servers_skips_security_blocked_with_visible_warning():
+    from agent_bom.mcp_introspect import introspect_servers
+
+    blocked = MCPServer(
+        name="blocked-server",
+        transport=TransportType.STDIO,
+        command="must-not-run",
+        security_blocked=True,
+    )
+
+    with patch("agent_bom.mcp_introspect._check_mcp_sdk") as sdk_check:
+        report = await introspect_servers([blocked], timeout=1.0)
+
+    assert report.results == []
+    assert report.warnings == ["Skipping blocked-server: introspection blocked by security policy"]
+    sdk_check.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1277,6 +1277,34 @@ def test_inventory_no_agents(mock_discover):
     assert result["status"] == "no_agents_found"
 
 
+@patch("agent_bom.discovery.discover_all")
+def test_tool_risk_assessment_default_does_not_require_process_approval(mock_discover):
+    """The default protocol-read-only path remains usable without stdio launch."""
+    from agent_bom.mcp_server import create_mcp_server
+
+    mock_discover.return_value = []
+    result = _call_tool(create_mcp_server(), "tool_risk_assessment", {})
+
+    assert result["status"] == "no_servers_found"
+    mock_discover.assert_called_once_with(project_dir=None)
+
+
+@patch("agent_bom.discovery.discover_all")
+def test_tool_risk_assessment_stdio_opt_in_requires_authenticated_operator(mock_discover):
+    """A tool argument cannot self-authorize host process execution."""
+    from agent_bom.mcp_server import create_mcp_server
+
+    result = _call_tool(
+        create_mcp_server(),
+        "tool_risk_assessment",
+        {"allow_command_execution": True},
+    )
+
+    assert result["status"] == "blocked"
+    assert "authenticated operator token" in result["error"]
+    mock_discover.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Tool: diff (mocked pipeline)
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server_cov.py
+++ b/tests/test_mcp_server_cov.py
@@ -201,6 +201,52 @@ class TestToolMetrics:
         assert payload["timed_out"] is True
 
     @pytest.mark.asyncio
+    async def test_execute_tool_sync_async_blocks_destructive_without_operator(self, monkeypatch):
+        import agent_bom.mcp_server as mod
+
+        called = False
+
+        def _must_not_run():
+            nonlocal called
+            called = True
+            return "unexpected"
+
+        monkeypatch.setattr(
+            mod,
+            "_current_tool_request",
+            lambda: {
+                "caller": "read-client",
+                "client_id": "read-client",
+                "request_id": "request-1",
+                "auth_scopes": "read",
+            },
+        )
+
+        result = await _execute_tool_sync_async("runtime_process", _must_not_run, destructive=True)
+
+        assert json.loads(result)["status"] == "blocked"
+        assert called is False
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_sync_async_allows_authenticated_operator(self, monkeypatch):
+        import agent_bom.mcp_server as mod
+
+        monkeypatch.setattr(
+            mod,
+            "_current_tool_request",
+            lambda: {
+                "caller": "operator-client",
+                "client_id": "operator-client",
+                "request_id": "request-2",
+                "auth_scopes": "admin",
+            },
+        )
+
+        result = await _execute_tool_sync_async("runtime_process", lambda **_: "ok", destructive=True)
+
+        assert result == "ok"
+
+    @pytest.mark.asyncio
     async def test_execute_tool_async_returns_sanitized_error_payload(self):
         async def _boom():
             raise RuntimeError("failed token=abc123 at /tmp/private/path")

--- a/tests/test_mcp_tool_impls.py
+++ b/tests/test_mcp_tool_impls.py
@@ -1017,10 +1017,64 @@ def test_tool_risk_assessment_impl_success():
         patch("agent_bom.discovery.discover_all", return_value=[agent]),
         patch("agent_bom.mcp_introspect.introspect_servers_sync", return_value=report),
     ):
-        result = tool_risk_assessment_impl(config_path=None, timeout=5.0, _truncate_response=_trunc)
+        result = tool_risk_assessment_impl(
+            config_path=None,
+            timeout=5.0,
+            allow_command_execution=True,
+            _safe_path=lambda value: value,
+            _truncate_response=_trunc,
+        )
     data = json.loads(result)
     assert data["summary"]["total_servers"] == 1
     assert data["servers"][0]["capability_risk_level"] == "high"
+
+
+def test_tool_risk_assessment_requires_opt_in_before_stdio_execution():
+    from agent_bom.mcp_introspect import IntrospectionReport
+    from agent_bom.mcp_tools.runtime import tool_risk_assessment_impl
+
+    server = MagicMock()
+    server.name = "local-stdio"
+    server.command = "must-not-run"
+    server.transport.value = "stdio"
+    agent = MagicMock()
+    agent.mcp_servers = [server]
+
+    with (
+        patch("agent_bom.discovery.discover_all", return_value=[agent]),
+        patch("agent_bom.mcp_introspect.introspect_servers_sync", return_value=IntrospectionReport()) as introspect,
+    ):
+        result = tool_risk_assessment_impl(
+            config_path=None,
+            timeout=5.0,
+            allow_command_execution=False,
+            _safe_path=lambda value: value,
+            _truncate_response=_trunc,
+        )
+
+    data = json.loads(result)
+    assert data["summary"]["command_execution_allowed"] is False
+    introspect.assert_called_once_with([server], timeout=5.0, allow_stdio=False)
+
+
+def test_tool_risk_assessment_validates_requested_config_path_before_discovery():
+    from agent_bom.mcp_tools.runtime import tool_risk_assessment_impl
+
+    with (
+        patch("agent_bom.discovery.discover_all") as discover,
+        patch("agent_bom.mcp_introspect.introspect_servers_sync") as introspect,
+    ):
+        result = tool_risk_assessment_impl(
+            config_path="/outside/allowed/root",
+            timeout=5.0,
+            allow_command_execution=False,
+            _safe_path=MagicMock(side_effect=ValueError("path is outside allowed roots")),
+            _truncate_response=_trunc,
+        )
+
+    assert "error" in json.loads(result)
+    discover.assert_not_called()
+    introspect.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- reject security-blocked MCP servers before transport initialization and report the skipped state in batch and health results
- keep MCP-triggered stdio launch disabled by default; require explicit opt-in plus authenticated operator authorization
- validate requested config paths and align live/server-card annotations with the process-execution boundary

## Verification

- `uv run pytest -q tests/test_mcp_introspect.py tests/test_health_checks.py tests/test_mcp_tool_impls.py tests/test_mcp_catalog_drift.py tests/test_mcp_server_cov.py tests/test_mcp_server.py tests/test_introspect_cmd.py tests/test_cli_analysis.py tests/test_concurrency_failure_gaps.py tests/test_mcp_tool_output_contract.py tests/test_mcp_inventory.py tests/test_mcp_wheel_smoke.py` (441 passed, 1 skipped)
- `make lint`
- `make preflight`
- `uv run python scripts/check-counts.py`
- `uv run python scripts/check_exception_sanitization.py`
- `git diff --check`

## Notes

- direct CLI introspection retains its explicit stdio behavior
- protocol-read-only HTTP/SSE assessment remains available without process-execution approval
