### PR TITLE
fix(graph): preserve correlation evidence truth

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -199,6 +199,13 @@ class GraphStoreProtocol(Protocol):
 
     def get_correlation_run(self, *, tenant_id: str, correlation_id: str) -> GraphCorrelationRun | None: ...
 
+    def get_correlation_run_by_idempotency_key(
+        self,
+        *,
+        tenant_id: str,
+        idempotency_key: str,
+    ) -> GraphCorrelationRun | None: ...
+
     def list_correlation_runs(self, *, tenant_id: str, limit: int = 100) -> list[GraphCorrelationRun]: ...
 
     def update_correlation_run(
@@ -1834,6 +1841,24 @@ class SQLiteGraphStore:
             return None
         try:
             return sqlite_graph_store.get_correlation_run(conn, tenant_id=tenant_id, correlation_id=correlation_id)
+        finally:
+            conn.close()
+
+    def get_correlation_run_by_idempotency_key(
+        self,
+        *,
+        tenant_id: str,
+        idempotency_key: str,
+    ) -> GraphCorrelationRun | None:
+        conn = self._open_ro_conn()
+        if conn is None:
+            return None
+        try:
+            return sqlite_graph_store.get_correlation_run_by_idempotency_key(
+                conn,
+                tenant_id=tenant_id,
+                idempotency_key=idempotency_key,
+            )
         finally:
             conn.close()
 

--- a/src/agent_bom/api/neptune_graph.py
+++ b/src/agent_bom/api/neptune_graph.py
@@ -348,6 +348,14 @@ class NeptuneGraphStore:
     def get_correlation_run(self, *, tenant_id: str, correlation_id: str) -> "GraphCorrelationRun | None":
         self._unsupported("get_correlation_run")
 
+    def get_correlation_run_by_idempotency_key(
+        self,
+        *,
+        tenant_id: str,
+        idempotency_key: str,
+    ) -> "GraphCorrelationRun | None":
+        self._unsupported("get_correlation_run_by_idempotency_key")
+
     def complete_correlation_run(
         self,
         graph: UnifiedGraph,

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -2439,6 +2439,20 @@ class PostgresGraphStore:
             ).fetchone()
         return _correlation_run_from_row(row) if row is not None else None
 
+    def get_correlation_run_by_idempotency_key(
+        self,
+        *,
+        tenant_id: str,
+        idempotency_key: str,
+    ) -> GraphCorrelationRun | None:
+        tenant = normalize_graph_tenant_id(tenant_id)
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                f"SELECT {_CORRELATION_RUN_COLUMNS} FROM graph_correlation_runs WHERE tenant_id = %s AND idempotency_key = %s",  # nosec B608 - static internal column list
+                (tenant, idempotency_key),
+            ).fetchone()
+        return _correlation_run_from_row(row) if row is not None else None
+
     def complete_correlation_run(
         self,
         graph: UnifiedGraph,

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -1864,6 +1864,20 @@ def get_correlation_run(
     return _correlation_run_from_row(row) if row is not None else None
 
 
+def get_correlation_run_by_idempotency_key(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    idempotency_key: str,
+) -> GraphCorrelationRun | None:
+    tenant = normalize_graph_tenant_id(tenant_id)
+    row = conn.execute(
+        "SELECT * FROM graph_correlation_runs WHERE tenant_id = ? AND idempotency_key = ?",
+        (tenant, idempotency_key),
+    ).fetchone()
+    return _correlation_run_from_row(row) if row is not None else None
+
+
 def create_correlation_run(
     conn: sqlite3.Connection,
     run: GraphCorrelationRun,

--- a/src/agent_bom/graph/correlation.py
+++ b/src/agent_bom/graph/correlation.py
@@ -13,8 +13,11 @@ import json
 import re
 from copy import deepcopy
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Iterable, Mapping, Sequence
+
+from packageurl import PackageURL
 
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
@@ -75,6 +78,30 @@ _RUNTIME_ENTITY_TYPES = frozenset(
 def _digest(value: Any) -> str:
     payload = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
     return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _timestamp_instant(value: str) -> datetime:
+    """Parse one evidence timestamp into a comparable UTC instant."""
+
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("correlation timestamps must be valid ISO-8601 values") from exc
+    if parsed.tzinfo is None:
+        raise ValueError("correlation timestamps must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _timestamp_sort_key(value: str) -> tuple[datetime, str]:
+    return _timestamp_instant(value), value
+
+
+def _oldest_timestamp(values: Sequence[str]) -> str:
+    return min(values, key=_timestamp_sort_key)
+
+
+def _newest_timestamp(values: Sequence[str]) -> str:
+    return max(values, key=_timestamp_sort_key)
 
 
 def correlation_manifest_digest(value: Mapping[str, Any]) -> str:
@@ -207,7 +234,11 @@ def correlation_identity(node: UnifiedNode, *, scan_id: str) -> tuple[str, str, 
     if entity_type == EntityType.PACKAGE.value:
         purl = node.attributes.get("purl")
         if isinstance(purl, str) and purl.strip():
-            return entity_type, purl.strip().lower(), "purl"
+            try:
+                canonical_purl = PackageURL.from_string(purl.strip()).to_string()
+            except ValueError:
+                return _snapshot_scoped_identity(node, scan_id=scan_id)
+            return entity_type, canonical_purl, "purl"
         return _snapshot_scoped_identity(node, scan_id=scan_id)
 
     if entity_type in _REPOSITORY_ENTITY_TYPES:
@@ -515,7 +546,10 @@ def _node_observation_receipt(observation: _NodeObservation) -> dict[str, Any]:
 
 
 def _merge_node(observations: Sequence[_NodeObservation]) -> UnifiedNode:
-    ordered = sorted(observations, key=lambda item: (item.snapshot.created_at, item.snapshot.scan_id, item.node.id))
+    ordered = sorted(
+        observations,
+        key=lambda item: (_timestamp_instant(item.snapshot.created_at), item.snapshot.scan_id, item.node.id),
+    )
     newest = ordered[-1].node
     attributes = _project_mapping(item.node.attributes for item in ordered)
     source_scan_ids = sorted({item.snapshot.scan_id for item in ordered})
@@ -530,7 +564,11 @@ def _merge_node(observations: Sequence[_NodeObservation]) -> UnifiedNode:
 
     severity_source = max(
         ordered,
-        key=lambda item: (SEVERITY_RANK.get((item.node.severity or "").lower(), 0), item.node.risk_score, item.snapshot.created_at),
+        key=lambda item: (
+            SEVERITY_RANK.get((item.node.severity or "").lower(), 0),
+            item.node.risk_score,
+            _timestamp_instant(item.snapshot.created_at),
+        ),
     ).node
     dimensions = NodeDimensions()
     for item in ordered:
@@ -549,8 +587,8 @@ def _merge_node(observations: Sequence[_NodeObservation]) -> UnifiedNode:
         risk_score=max(float(item.node.risk_score) for item in ordered),
         severity=severity_source.severity,
         severity_id=severity_source.severity_id,
-        first_seen=min(first_seen_values) if first_seen_values else "",
-        last_seen=max(last_seen_values) if last_seen_values else "",
+        first_seen=_oldest_timestamp(first_seen_values) if first_seen_values else "",
+        last_seen=_newest_timestamp(last_seen_values) if last_seen_values else "",
         attributes=attributes,
         compliance_tags=sorted({tag for item in ordered for tag in item.node.compliance_tags}),
         data_sources=sorted({source for item in ordered for source in item.node.data_sources}),
@@ -578,7 +616,10 @@ def _merge_edge(
     target_id: str,
     correlation_id: str,
 ) -> UnifiedEdge:
-    ordered = sorted(observations, key=lambda item: (item.snapshot.created_at, item.snapshot.scan_id, item.edge.id))
+    ordered = sorted(
+        observations,
+        key=lambda item: (_timestamp_instant(item.snapshot.created_at), item.snapshot.scan_id, item.edge.id),
+    )
     newest = ordered[-1].edge
     first_seen_values = [item.edge.first_seen for item in ordered if item.edge.first_seen]
     last_seen_values = [item.edge.last_seen for item in ordered if item.edge.last_seen]
@@ -604,9 +645,11 @@ def _merge_edge(
         direction="bidirectional" if all(item.edge.direction == "bidirectional" for item in ordered) else "directed",
         weight=max(float(item.edge.weight) for item in ordered),
         traversable=all(bool(item.edge.traversable) for item in ordered),
-        first_seen=min(first_seen_values) if first_seen_values else "",
-        last_seen=max(last_seen_values) if last_seen_values else "",
-        valid_from=min((item.edge.valid_from for item in ordered if item.edge.valid_from), default=""),
+        first_seen=_oldest_timestamp(first_seen_values) if first_seen_values else "",
+        last_seen=_newest_timestamp(last_seen_values) if last_seen_values else "",
+        valid_from=_oldest_timestamp([item.edge.valid_from for item in ordered if item.edge.valid_from])
+        if any(item.edge.valid_from for item in ordered)
+        else "",
         valid_to=newest.valid_to,
         source_scan_id=correlation_id,
         source_run_id=correlation_id,
@@ -637,7 +680,7 @@ def merge_graph_snapshots(
     if any(not snapshot.graph.nodes for snapshot in snapshots):
         raise ValueError("Correlation inputs must be non-empty graph snapshots")
 
-    ordered_snapshots = sorted(snapshots, key=lambda item: (item.created_at, item.scan_id))
+    ordered_snapshots = sorted(snapshots, key=lambda item: (_timestamp_instant(item.created_at), item.scan_id))
     node_groups: dict[tuple[str, str], list[_NodeObservation]] = {}
     source_to_key: dict[tuple[str, str], tuple[str, str]] = {}
     for snapshot in ordered_snapshots:

--- a/src/agent_bom/graph/correlation_service.py
+++ b/src/agent_bom/graph/correlation_service.py
@@ -141,6 +141,21 @@ class GraphCorrelationService:
         self._reconciled_tenants.clear()
 
     async def submit(self, request: CorrelationRequest) -> GraphCorrelationRun:
+        replay = await asyncio.to_thread(
+            self._store.get_correlation_run_by_idempotency_key,
+            tenant_id=request.tenant_id,
+            idempotency_key=request.idempotency_key,
+        )
+        if replay is not None:
+            replay_scan_ids = tuple(sorted(str(item.get("scan_id") or "") for item in replay.input_manifest))
+            if (
+                replay.name != request.name
+                or replay.max_age_hours != request.max_age_hours
+                or replay.allow_stale is not request.allow_stale
+                or replay_scan_ids != tuple(sorted(request.scan_ids))
+            ):
+                raise ValueError("idempotency key was already used for a different correlation request")
+            return replay
         manifest = await self._validate_inputs(request)
         now = self._now().astimezone(timezone.utc).isoformat()
         run = GraphCorrelationRun(

--- a/src/agent_bom/graph/correlation_service.py
+++ b/src/agent_bom/graph/correlation_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Callable, Sequence
 
 from agent_bom.api.graph_store import GraphStoreProtocol
@@ -23,6 +23,8 @@ from agent_bom.graph.correlation import (
 
 logger = logging.getLogger(__name__)
 
+_MAX_FUTURE_SNAPSHOT_SKEW = timedelta(minutes=5)
+
 _shared_service: GraphCorrelationService | None = None
 _shared_service_store: object | None = None
 _shared_service_loop: asyncio.AbstractEventLoop | None = None
@@ -36,6 +38,31 @@ def _timestamp(value: str) -> datetime:
     if parsed.tzinfo is None:
         raise CorrelationServiceError("invalid_snapshot_timestamp")
     return parsed.astimezone(timezone.utc)
+
+
+def _manifest_with_current_freshness(
+    manifest: Sequence[dict[str, object]],
+    *,
+    now: datetime,
+    max_age_hours: int,
+    allow_stale: bool,
+) -> list[dict[str, object]]:
+    """Recompute freshness at the decision point without changing receipts."""
+
+    refreshed: list[dict[str, object]] = []
+    for item in manifest:
+        created_at = _timestamp(str(item.get("created_at") or ""))
+        if created_at - now > _MAX_FUTURE_SNAPSHOT_SKEW:
+            raise CorrelationServiceError("input_snapshot_in_future")
+        age_hours = max(0.0, (now - created_at).total_seconds() / 3600.0)
+        freshness = "fresh" if age_hours <= max_age_hours else "stale_allowed"
+        if freshness != "fresh" and not allow_stale:
+            raise CorrelationServiceError("stale_input")
+        receipt = dict(item)
+        receipt["freshness"] = freshness
+        receipt["age_hours"] = round(age_hours, 6)
+        refreshed.append(receipt)
+    return refreshed
 
 
 @dataclass(frozen=True, slots=True)
@@ -184,11 +211,6 @@ class GraphCorrelationService:
             if int(row.get("node_count") or 0) < 1:
                 raise CorrelationServiceError("empty_input_snapshot")
             created_at = str(row.get("created_at") or "")
-            age_hours = max(0.0, (now - _timestamp(created_at)).total_seconds() / 3600.0)
-            freshness = "fresh" if age_hours <= request.max_age_hours else "stale_allowed"
-            if freshness != "fresh" and not request.allow_stale:
-                raise CorrelationServiceError("stale_input")
-
             graph = await asyncio.to_thread(
                 self._store.load_graph,
                 tenant_id=request.tenant_id,
@@ -203,11 +225,14 @@ class GraphCorrelationService:
                     "node_count": len(graph.nodes),
                     "edge_count": len(graph.edges),
                     "source_kinds": sorted({source for node in graph.nodes.values() for source in node.data_sources}),
-                    "freshness": freshness,
-                    "age_hours": round(age_hours, 6),
                 }
             )
-        return manifest
+        return _manifest_with_current_freshness(
+            manifest,
+            now=now,
+            max_age_hours=request.max_age_hours,
+            allow_stale=request.allow_stale,
+        )
 
     async def _enqueue(self, tenant_id: str, correlation_id: str, *, wait_for_capacity: bool = False) -> None:
         key = (tenant_id, correlation_id)
@@ -270,6 +295,12 @@ class GraphCorrelationService:
                 if snapshot.digest != str(item.get("digest") or ""):
                     raise CorrelationServiceError("input_snapshot_changed")
                 snapshots.append(snapshot)
+            execution_manifest = _manifest_with_current_freshness(
+                run.input_manifest,
+                now=self._now().astimezone(timezone.utc),
+                max_age_hours=run.max_age_hours,
+                allow_stale=run.allow_stale,
+            )
             merged = await asyncio.to_thread(
                 merge_graph_snapshots,
                 correlation_id=correlation_id,
@@ -279,7 +310,7 @@ class GraphCorrelationService:
             )
             if len(merged.graph.nodes) > self._max_output_nodes or len(merged.graph.edges) > self._max_output_edges:
                 raise CorrelationServiceError("correlation_budget_exceeded")
-            freshness_by_scan = {str(item["scan_id"]): str(item["freshness"]) for item in run.input_manifest}
+            freshness_by_scan = {str(item["scan_id"]): str(item["freshness"]) for item in execution_manifest}
             for edge in merged.graph.edges:
                 correlation = edge.provenance.get("correlation")
                 if not isinstance(correlation, dict):
@@ -304,7 +335,7 @@ class GraphCorrelationService:
                     "max_age_hours": run.max_age_hours,
                     "allow_stale": run.allow_stale,
                 },
-                "input_snapshots": run.input_manifest,
+                "input_snapshots": execution_manifest,
                 "correlation_merge": {
                     "node_conflict_count": node_conflicts,
                     "edge_conflict_count": edge_conflicts,

--- a/src/agent_bom/graph/path_evidence.py
+++ b/src/agent_bom/graph/path_evidence.py
@@ -140,6 +140,7 @@ def annotate_attack_path_evidence(path: AttackPath, graph: UnifiedGraph) -> Atta
                 "traversable": bool(edge.traversable),
                 "complete": bool(
                     edge.traversable
+                    and edge.direction == "directed"
                     and source_ids
                     and _has_relationship_provenance(edge)
                     and edge.source == source
@@ -160,15 +161,20 @@ def annotate_attack_path_evidence(path: AttackPath, graph: UnifiedGraph) -> Atta
     # A path must contain at least one relationship. Without this guard a
     # single-node structural finding satisfies ``all([])`` and is promoted to
     # confirmed despite having no directed, provenance-backed hop.
-    all_complete = bool(receipts) and len(receipts) == max(len(path.hops) - 1, 0) and all(receipt["complete"] for receipt in receipts)
+    all_complete = (
+        bool(receipts)
+        and len(receipts) == max(len(path.hops) - 1, 0)
+        and all(receipt["complete"] and not receipt["truncated"] for receipt in receipts)
+    )
     stale = any(str(receipt["freshness"]).startswith("stale") for receipt in receipts)
     if not all_complete and path.reachability != "unlikely":
         path.reachability = "unknown"
         path.composite_risk = min(path.composite_risk, 39.0)
         if "incomplete_hop_evidence" not in path.reachability_basis:
             path.reachability_basis.append("incomplete_hop_evidence")
-    elif stale and path.reachability == "confirmed":
-        path.reachability = "likely"
+    elif stale:
+        if path.reachability == "confirmed":
+            path.reachability = "likely"
         if "stale_evidence_allowed" not in path.reachability_basis:
             path.reachability_basis.append("stale_evidence_allowed")
     elif all_complete and path.reachability in {"unknown", "likely"}:

--- a/src/agent_bom/runtime/correlation_facts.py
+++ b/src/agent_bom/runtime/correlation_facts.py
@@ -293,6 +293,13 @@ def _reachability_from_correlation_graph(graph: Any) -> tuple[ReachabilityMap, d
     by_agent: dict[str, AgentReachability] = {}
     limit_reasons: set[str] = set()
     max_visited = 0
+
+    def directed_evidence_edge(edge: Any) -> bool:
+        correlation = edge.provenance.get("correlation") if isinstance(edge.provenance, dict) else None
+        source_ids = correlation.get("source_scan_ids") if isinstance(correlation, dict) else None
+        has_provenance = bool(source_ids or edge.source_scan_id or graph.scan_id)
+        return bool(edge.traversable and edge.direction == "directed" and has_provenance)
+
     for agent in sorted(graph.nodes.values(), key=lambda node: node.id):
         if agent.entity_type is not EntityType.AGENT:
             continue
@@ -314,16 +321,13 @@ def _reachability_from_correlation_graph(graph: Any) -> tuple[ReachabilityMap, d
             source, depth = queue.popleft()
             if depth >= _DEPTH_LIMIT:
                 if any(
-                    edge.traversable and edge.target not in visited and edge.target in graph.nodes
+                    directed_evidence_edge(edge) and edge.target not in visited and edge.target in graph.nodes
                     for edge in graph.adjacency.get(source, [])
                 ):
                     limit_reasons.add("depth_cap_reached")
                 continue
             for edge in graph.adjacency.get(source, []):
-                correlation = edge.provenance.get("correlation") if isinstance(edge.provenance, dict) else None
-                source_ids = correlation.get("source_scan_ids") if isinstance(correlation, dict) else None
-                has_provenance = bool(source_ids or edge.source_scan_id or graph.scan_id)
-                if not edge.traversable or not has_provenance or edge.target in visited:
+                if not directed_evidence_edge(edge) or edge.target in visited:
                     continue
                 if len(visited) >= _VISITED_NODE_LIMIT:
                     limit_reasons.add("visited_node_cap_reached")

--- a/src/agent_bom/runtime/correlation_facts.py
+++ b/src/agent_bom/runtime/correlation_facts.py
@@ -208,6 +208,18 @@ def _validated_input_freshness(
     return normalized, "stale_allowed" if stale else "fresh", fresh_until
 
 
+def _immutable_input_receipts(value: object) -> list[dict[str, Any]] | None:
+    """Project source-bound fields while allowing execution-time freshness."""
+
+    if not isinstance(value, list) or any(not isinstance(item, Mapping) for item in value):
+        return None
+    return [
+        {str(key): item[key] for key in sorted(item) if key not in {"age_hours", "freshness"}}
+        for item in value
+        if isinstance(item, Mapping)
+    ]
+
+
 def create_runtime_facts_bundle(
     *,
     correlation_id: str,
@@ -396,7 +408,7 @@ def create_runtime_facts_bundle_from_correlation(
     if (
         freshness_policy.get("max_age_hours") != run.max_age_hours
         or freshness_policy.get("allow_stale") is not run.allow_stale
-        or input_snapshots != run.input_manifest
+        or _immutable_input_receipts(input_snapshots) != _immutable_input_receipts(run.input_manifest)
     ):
         raise RuntimeFactsBundleError("correlation_manifest_mismatch")
     input_freshness = {

--- a/tests/test_graph_correlation_foundation.py
+++ b/tests/test_graph_correlation_foundation.py
@@ -189,6 +189,100 @@ def test_packages_without_exact_purl_remain_snapshot_scoped() -> None:
     assert len(merged.graph.nodes) == 2
 
 
+def test_case_sensitive_purl_components_do_not_create_a_cross_snapshot_bridge() -> None:
+    left = _graph("scan-1")
+    right = _graph("scan-2")
+    left.add_node(UnifiedNode(id="service:public", entity_type=EntityType.SERVER, label="public service"))
+    left.add_node(
+        UnifiedNode(
+            id="package:alpha",
+            entity_type=EntityType.PACKAGE,
+            label="foo@1.0.0-Alpha",
+            attributes={"purl": "pkg:npm/foo@1.0.0-Alpha"},
+        )
+    )
+    left.add_edge(UnifiedEdge(source="service:public", target="package:alpha", relationship=RelationshipType.CONTAINS))
+    right.add_node(
+        UnifiedNode(
+            id="package:lower",
+            entity_type=EntityType.PACKAGE,
+            label="foo@1.0.0-alpha",
+            attributes={"purl": "pkg:npm/foo@1.0.0-alpha"},
+        )
+    )
+    right.add_node(UnifiedNode(id="vuln:CVE-2026-1", entity_type=EntityType.VULNERABILITY, label="CVE-2026-1"))
+    right.add_edge(UnifiedEdge(source="package:lower", target="vuln:CVE-2026-1", relationship=RelationshipType.VULNERABLE_TO))
+
+    merged = merge_graph_snapshots(
+        correlation_id="corr-case-sensitive-purl",
+        tenant_id="acme",
+        snapshots=[CorrelationSnapshot.from_graph(left), CorrelationSnapshot.from_graph(right)],
+    ).graph
+
+    package_nodes = [node for node in merged.nodes.values() if node.entity_type == EntityType.PACKAGE]
+    assert len(package_nodes) == 2
+    assert merged.shortest_path("service:public", "vuln:CVE-2026-1") is None
+
+
+def test_invalid_purls_remain_snapshot_scoped() -> None:
+    left = _graph("scan-1")
+    right = _graph("scan-2")
+    for graph in (left, right):
+        graph.add_node(
+            UnifiedNode(
+                id="package:invalid",
+                entity_type=EntityType.PACKAGE,
+                label="invalid package reference",
+                attributes={"purl": "not-a-purl"},
+            )
+        )
+
+    merged = merge_graph_snapshots(
+        correlation_id="corr-invalid-purl",
+        tenant_id="acme",
+        snapshots=[CorrelationSnapshot.from_graph(left), CorrelationSnapshot.from_graph(right)],
+    )
+
+    assert len(merged.graph.nodes) == 2
+
+
+def test_merge_orders_offset_timestamps_by_utc_instant() -> None:
+    older = UnifiedGraph(scan_id="scan-older", tenant_id="acme", created_at="2026-09-01T00:30:00+02:00")
+    newer = UnifiedGraph(scan_id="scan-newer", tenant_id="acme", created_at="2026-08-31T23:00:00+00:00")
+    older.add_node(
+        UnifiedNode(
+            id="package:older",
+            entity_type=EntityType.PACKAGE,
+            label="older projection",
+            first_seen="2026-09-01T00:20:00+02:00",
+            last_seen="2026-09-01T00:30:00+02:00",
+            attributes={"purl": "pkg:pypi/pillow@9.0.0", "owner": "older"},
+        )
+    )
+    newer.add_node(
+        UnifiedNode(
+            id="package:newer",
+            entity_type=EntityType.PACKAGE,
+            label="newer projection",
+            first_seen="2026-08-31T22:50:00+00:00",
+            last_seen="2026-08-31T23:10:00+00:00",
+            attributes={"purl": "pkg:pypi/pillow@9.0.0", "owner": "newer"},
+        )
+    )
+
+    merged = merge_graph_snapshots(
+        correlation_id="corr-offset-order",
+        tenant_id="acme",
+        snapshots=[CorrelationSnapshot.from_graph(newer), CorrelationSnapshot.from_graph(older)],
+    )
+    node = next(iter(merged.graph.nodes.values()))
+
+    assert node.label == "newer projection"
+    assert node.attributes["owner"] == "newer"
+    assert node.first_seen == "2026-09-01T00:20:00+02:00"
+    assert node.last_seen == "2026-08-31T23:10:00+00:00"
+
+
 def test_repository_nodes_require_exact_commit_and_path_identity() -> None:
     left = _graph("scan-1")
     right = _graph("scan-2")

--- a/tests/test_graph_correlation_mechanical.py
+++ b/tests/test_graph_correlation_mechanical.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from agent_bom.api.graph_store import SQLiteGraphStore
 from agent_bom.api.routes.graph import _derived_attack_paths
+from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
 from agent_bom.graph.attack_path_fusion import apply_attack_path_fusion, compute_fused_attack_paths
 from agent_bom.graph.container import AttackPath, UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
@@ -202,6 +203,104 @@ def test_zero_hop_structural_candidate_cannot_be_confirmed() -> None:
     annotate_attack_path_evidence(path, graph)
 
     assert path.hop_evidence == []
+    assert path.reachability == "unknown"
+    assert path.composite_risk <= 39.0
+    assert "incomplete_hop_evidence" in path.reachability_basis
+
+
+def test_bidirectional_hop_remains_structural_not_confirmed() -> None:
+    graph = UnifiedGraph(scan_id="scan-a", tenant_id="tenant-a")
+    graph.add_node(UnifiedNode(id="workload:public", entity_type=EntityType.CLOUD_RESOURCE, label="public workload"))
+    graph.add_node(UnifiedNode(id="data_store:crown", entity_type=EntityType.DATA_STORE, label="crown jewel"))
+    graph.add_edge(
+        UnifiedEdge(
+            source="workload:public",
+            target="data_store:crown",
+            relationship=RelationshipType.CAN_ACCESS,
+            direction="bidirectional",
+            traversable=True,
+            source_scan_id="scan-a",
+            provenance={"source": "modeled_policy"},
+        )
+    )
+    path = AttackPath(
+        source="workload:public",
+        target="data_store:crown",
+        hops=["workload:public", "data_store:crown"],
+        edges=[RelationshipType.CAN_ACCESS.value],
+        composite_risk=90.0,
+        reachability="likely",
+    )
+
+    annotate_attack_path_evidence(path, graph)
+
+    assert path.hop_evidence[0]["direction"] == "bidirectional"
+    assert path.hop_evidence[0]["complete"] is False
+    assert path.reachability == "unknown"
+    assert path.composite_risk <= 39.0
+
+
+def test_stale_allowed_hop_cannot_be_promoted_to_confirmed() -> None:
+    graph = UnifiedGraph(scan_id="corr-stale", tenant_id="tenant-a")
+    graph.add_node(UnifiedNode(id="workload:public", entity_type=EntityType.CLOUD_RESOURCE, label="public workload"))
+    graph.add_node(UnifiedNode(id="data_store:crown", entity_type=EntityType.DATA_STORE, label="crown jewel"))
+    graph.add_edge(
+        UnifiedEdge(
+            source="workload:public",
+            target="data_store:crown",
+            relationship=RelationshipType.CAN_ACCESS,
+            source_scan_id="corr-stale",
+            provenance={"correlation": {"source_scan_ids": ["scan-a"], "freshness": "stale_allowed"}},
+        )
+    )
+    path = AttackPath(
+        source="workload:public",
+        target="data_store:crown",
+        hops=["workload:public", "data_store:crown"],
+        edges=[RelationshipType.CAN_ACCESS.value],
+        composite_risk=80.0,
+        reachability="likely",
+    )
+
+    annotate_attack_path_evidence(path, graph)
+
+    assert path.hop_evidence[0]["complete"] is True
+    assert path.reachability == "likely"
+    assert "stale_evidence_allowed" in path.reachability_basis
+    assert "directed_provenance_backed_hops" not in path.reachability_basis
+
+
+def test_bounded_analysis_cannot_promote_a_path_to_confirmed() -> None:
+    graph = UnifiedGraph(scan_id="corr-limited", tenant_id="tenant-a")
+    graph.analysis_status["attack_path_fusion"] = GraphAnalysisStatus(
+        status=GraphAnalysisState.LIMITED,
+        reason_codes=("path_limit_reached",),
+        limits={"path_limit": 1},
+        observed={"path_count": 1},
+    )
+    graph.add_node(UnifiedNode(id="workload:public", entity_type=EntityType.CLOUD_RESOURCE, label="public workload"))
+    graph.add_node(UnifiedNode(id="data_store:crown", entity_type=EntityType.DATA_STORE, label="crown jewel"))
+    graph.add_edge(
+        UnifiedEdge(
+            source="workload:public",
+            target="data_store:crown",
+            relationship=RelationshipType.CAN_ACCESS,
+            source_scan_id="corr-limited",
+            provenance={"source": "modeled_policy"},
+        )
+    )
+    path = AttackPath(
+        source="workload:public",
+        target="data_store:crown",
+        hops=["workload:public", "data_store:crown"],
+        edges=[RelationshipType.CAN_ACCESS.value],
+        composite_risk=80.0,
+        reachability="likely",
+    )
+
+    annotate_attack_path_evidence(path, graph)
+
+    assert path.hop_evidence[0]["truncated"] is True
     assert path.reachability == "unknown"
     assert path.composite_risk <= 39.0
     assert "incomplete_hop_evidence" in path.reachability_basis

--- a/tests/test_graph_correlation_service.py
+++ b/tests/test_graph_correlation_service.py
@@ -354,6 +354,43 @@ async def test_idempotent_replay_does_not_duplicate_run(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_idempotent_replay_does_not_revalidate_aged_inputs(tmp_path: Path) -> None:
+    store = SQLiteGraphStore(tmp_path / "graph.db")
+    created_at = (NOW - timedelta(minutes=30)).isoformat()
+    store.save_graph(_graph("repo", created_at))
+    store.save_graph(_graph("image", created_at))
+    clock = {"now": NOW}
+    service = GraphCorrelationService(store, now=lambda: clock["now"], queue_capacity=2)
+    request = CorrelationRequest(
+        correlation_id="corr-replay-aged",
+        tenant_id="tenant-a",
+        idempotency_key="idem-replay-aged",
+        name="replay aged",
+        scan_ids=("repo", "image"),
+        max_age_hours=1,
+    )
+
+    first = await service.submit(request)
+    clock["now"] = NOW + timedelta(hours=2)
+    replay = await service.submit(request)
+
+    assert replay == first
+    assert replay.status is CorrelationRunStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_idempotent_replay_rejects_changed_immutable_request(tmp_path: Path) -> None:
+    store = SQLiteGraphStore(tmp_path / "graph.db")
+    store.save_graph(_graph("repo", "2026-08-30T10:00:00+00:00"))
+    store.save_graph(_graph("image", "2026-08-30T11:00:00+00:00"))
+    service = GraphCorrelationService(store, now=lambda: NOW, queue_capacity=2)
+    await service.submit(CorrelationRequest("corr-replay-conflict", "tenant-a", "idem-conflict", "first", ("repo", "image"), 24))
+
+    with pytest.raises(ValueError, match="different correlation request"):
+        await service.submit(CorrelationRequest("corr-replay-conflict-new", "tenant-a", "idem-conflict", "changed", ("repo", "image"), 24))
+
+
+@pytest.mark.asyncio
 async def test_queue_backpressure_fails_second_run_without_output(tmp_path: Path) -> None:
     store = SQLiteGraphStore(tmp_path / "graph.db")
     store.save_graph(_graph("repo", "2026-08-30T10:00:00+00:00"))

--- a/tests/test_graph_correlation_service.py
+++ b/tests/test_graph_correlation_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -139,6 +139,73 @@ async def test_allowed_stale_input_remains_visibly_stale(tmp_path: Path) -> None
     assert {item["freshness"] for item in completed.result_manifest["input_snapshots"]} == {"fresh", "stale_allowed"}
     output = store.load_graph(tenant_id="tenant-a", scan_id="corr-stale-allowed")
     assert output.edges[0].provenance["correlation"]["freshness"] == "stale_allowed"
+
+
+@pytest.mark.asyncio
+async def test_restart_revalidates_inputs_that_expired_while_queued(tmp_path: Path) -> None:
+    store = SQLiteGraphStore(tmp_path / "graph.db")
+    created_at = (NOW - timedelta(minutes=30)).isoformat()
+    store.save_graph(_graph("repo", created_at))
+    store.save_graph(_graph("image", created_at))
+    dormant = GraphCorrelationService(store, now=lambda: NOW)
+    await dormant.submit(CorrelationRequest("corr-expired-in-queue", "tenant-a", "idem-expired-in-queue", "queued", ("repo", "image"), 1))
+
+    resumed = GraphCorrelationService(store, now=lambda: NOW + timedelta(hours=2))
+    await resumed.start(tenants=["tenant-a"])
+    try:
+        failed = await resumed.wait("tenant-a", "corr-expired-in-queue", timeout_seconds=5)
+    finally:
+        await resumed.stop()
+
+    assert failed.status is CorrelationRunStatus.FAILED
+    assert failed.failure_code == "stale_input"
+    assert store.load_graph(tenant_id="tenant-a", scan_id="corr-expired-in-queue").nodes == {}
+
+
+@pytest.mark.asyncio
+async def test_restart_relabels_expired_inputs_when_stale_is_allowed(tmp_path: Path) -> None:
+    store = SQLiteGraphStore(tmp_path / "graph.db")
+    created_at = (NOW - timedelta(minutes=30)).isoformat()
+    store.save_graph(_graph("repo", created_at))
+    store.save_graph(_graph("image", created_at))
+    dormant = GraphCorrelationService(store, now=lambda: NOW)
+    await dormant.submit(
+        CorrelationRequest(
+            "corr-expired-allowed",
+            "tenant-a",
+            "idem-expired-allowed",
+            "queued stale allowed",
+            ("repo", "image"),
+            1,
+            allow_stale=True,
+        )
+    )
+
+    resumed = GraphCorrelationService(store, now=lambda: NOW + timedelta(hours=2))
+    await resumed.start(tenants=["tenant-a"])
+    try:
+        completed = await resumed.wait("tenant-a", "corr-expired-allowed", timeout_seconds=5)
+    finally:
+        await resumed.stop()
+
+    assert completed.status is CorrelationRunStatus.COMPLETE
+    assert {item["freshness"] for item in completed.result_manifest["input_snapshots"]} == {"stale_allowed"}
+    output = store.load_graph(tenant_id="tenant-a", scan_id="corr-expired-allowed")
+    assert {edge.provenance["correlation"]["freshness"] for edge in output.edges} == {"stale_allowed"}
+
+
+@pytest.mark.asyncio
+async def test_service_rejects_input_beyond_runtime_clock_skew(tmp_path: Path) -> None:
+    store = SQLiteGraphStore(tmp_path / "graph.db")
+    future = (NOW + timedelta(minutes=6)).isoformat()
+    store.save_graph(_graph("future", future))
+    store.save_graph(_graph("current", NOW.isoformat()))
+    service = GraphCorrelationService(store, now=lambda: NOW)
+
+    with pytest.raises(CorrelationServiceError, match="input_snapshot_in_future"):
+        await service.submit(CorrelationRequest("corr-future", "tenant-a", "idem-future", "future rejected", ("future", "current"), 1))
+
+    assert store.get_correlation_run(tenant_id="tenant-a", correlation_id="corr-future") is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_graph_reachability_runtime.py
+++ b/tests/test_graph_reachability_runtime.py
@@ -340,6 +340,51 @@ def test_signed_bundle_blocks_first_jsonrpc_tool_call():
     assert blocked["evidence_freshness"] == "fresh"
 
 
+def test_runtime_facts_ignore_bidirectional_structural_hops() -> None:
+    from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
+    from agent_bom.graph.container import AttackPath
+    from agent_bom.graph.path_evidence import annotate_attack_path_evidence
+    from agent_bom.runtime.correlation_facts import _reachability_from_correlation_graph
+
+    graph = UnifiedGraph(scan_id="corr-bidirectional", tenant_id="default")
+    graph.add_node(
+        UnifiedNode(
+            id="agent:runtime",
+            entity_type=EntityType.AGENT,
+            label="runtime",
+            attributes={"runtime_id": "agent-a"},
+        )
+    )
+    graph.add_node(UnifiedNode(id="tool:delete-db", entity_type=EntityType.TOOL, label="delete_db"))
+    graph.add_edge(
+        UnifiedEdge(
+            source="agent:runtime",
+            target="tool:delete-db",
+            relationship=RelationshipType.REACHES_TOOL,
+            direction="bidirectional",
+            traversable=True,
+            source_scan_id="source-a",
+            provenance={"correlation": {"source_scan_ids": ["source-a"]}},
+        )
+    )
+    path = AttackPath(
+        source="agent:runtime",
+        target="tool:delete-db",
+        hops=["agent:runtime", "tool:delete-db"],
+        edges=[RelationshipType.REACHES_TOOL.value],
+        reachability="likely",
+        composite_risk=80.0,
+    )
+
+    annotate_attack_path_evidence(path, graph)
+    reachability, analysis = _reachability_from_correlation_graph(graph)
+
+    assert path.reachability == "unknown"
+    assert path.hop_evidence[0]["complete"] is False
+    assert reachability.reaches_privileged("agent-a", "delete_db") is None
+    assert analysis["complete"] is True
+
+
 def test_bundle_hot_refresh_replaces_reachability_without_restart():
     calls = 0
 

--- a/tests/test_postgres_graph_correlation.py
+++ b/tests/test_postgres_graph_correlation.py
@@ -153,6 +153,8 @@ def test_postgres_correlation_create_replay_list_and_update(monkeypatch) -> None
     assert replay_created is False
     assert replay.correlation_id == created.correlation_id == "corr-1"
     assert store.get_correlation_run(tenant_id="other", correlation_id="corr-1") is None
+    assert store.get_correlation_run_by_idempotency_key(tenant_id="acme", idempotency_key="idem-1") == created
+    assert store.get_correlation_run_by_idempotency_key(tenant_id="other", idempotency_key="idem-1") is None
     assert [run.correlation_id for run in store.list_correlation_runs(tenant_id="acme")] == ["corr-1"]
 
     running = store.update_correlation_run(


### PR DESCRIPTION
## Summary
- canonicalize package URLs without collapsing case-sensitive PURL components or merging invalid references
- revalidate correlation freshness at execution, reject excessive future skew, and compare evidence timestamps by UTC instant
- keep bidirectional, stale-allowed, and bounded-analysis paths out of confirmed reachability
- preserve tenant-scoped idempotency replay and runtime-facts binding while allowing execution-time freshness receipts

## Verification
- `pytest` correlation, path-fusion, runtime-facts, Postgres-correlation, and retained-observation integration matrix (235 passed)
- targeted Ruff check and format check
- targeted mypy (4 source files)
- `python scripts/check_exception_sanitization.py`
- `make preflight`
- `git diff --check`

## Notes
- The branch is rebased onto the merged Postgres retained-partition fix in #5054; its prior Postgres contract failure is resolved by that base change.
- Red regressions reproduced the PURL identity, UTC ordering, queue-time freshness, stale relabeling, future skew, bidirectional confirmation, stale/bounded path promotion, replay, and runtime-facts defects before implementation.
- No release tag or publication action is included.
