### PR TITLE
fix(postgres): provision retained observation partitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ while advancing the maintained dependency and MCP-registry baseline.
 
 ### Fixed
 
+- Postgres observation migrations provision the full retained-history window as
+  well as the future runway, so backdated connector evidence no longer attempts
+  partition DDL through the least-privilege application role; stale deployments
+  receive a sanitized retryable response instead of a raw database failure.
 - MCP runtime introspection now rejects security-blocked servers before any
   transport is opened, keeps stdio process launch disabled by default, and
   requires both explicit opt-in and authenticated operator authority before a

--- a/deploy/supabase/postgres/alembic/versions/20260901_01_observation_partition_retention_window.py
+++ b/deploy/supabase/postgres/alembic/versions/20260901_01_observation_partition_retention_window.py
@@ -1,0 +1,41 @@
+"""Provision the retained observation window under the migration owner.
+
+Runtime Postgres roles are DML-only. Historical evidence inside the configured
+retention horizon therefore needs migration-owned child partitions just like
+current and future evidence. This revision applies the expanded bounded window
+to existing deployments; the Alembic post-upgrade hook keeps it topped up.
+
+Revision ID: 20260901_01
+Revises: 20260830_03
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from alembic import op
+
+revision = "20260901_01"
+down_revision = "20260830_03"
+branch_labels = None
+depends_on = None
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from agent_bom.api.hub_observations_partition import (  # noqa: E402
+    provision_observation_partition_runway,
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    provision_observation_partition_runway(bind.connection.driver_connection)
+
+
+def downgrade() -> None:
+    # Forward-only: a child may already contain retained observation evidence.
+    return

--- a/src/agent_bom/api/hub_observations_partition.py
+++ b/src/agent_bom/api/hub_observations_partition.py
@@ -229,17 +229,27 @@ def provision_observation_partition_runway(
     now: datetime | None = None,
     months_ahead: int = OBSERVATION_PARTITION_RUNWAY_MONTHS,
 ) -> int:
-    """Top the partition runway up to *months_ahead* months past *now*.
+    """Provision retained history plus *months_ahead* months past *now*.
 
     The deploy-time entry point, run by the migration owner (the only principal
     that may create a child and force RLS on it). Idempotent: re-running in the
     same month creates nothing, and a later run fills only the new gap, so it is
     safe to call on every ``alembic upgrade``.
 
-    ``months_behind=0`` so a top-up never resurrects a month that retention has
-    already detached and dropped.
+    Historical connector evidence is valid anywhere inside the configured
+    retention horizon. Provisioning that whole bounded window keeps runtime
+    roles DML-only while allowing those backfills; retention later drops only
+    children wholly outside the same horizon.
     """
-    return ensure_observation_partitions(conn, now=now, months_ahead=months_ahead, months_behind=0)
+    anchor = (now or _utc_now()).date()
+    oldest = anchor - timedelta(days=max(0, HUB_OBSERVATIONS_RETENTION_DAYS))
+    months_behind = max(0, _month_index(anchor) - _month_index(oldest))
+    return ensure_observation_partitions(
+        conn,
+        now=now,
+        months_ahead=months_ahead,
+        months_behind=months_behind,
+    )
 
 
 def observation_runway_end(conn: Any) -> date | None:
@@ -281,6 +291,14 @@ class ObservationPartitionRangeError(ValueError):
         )
 
 
+class ObservationPartitionUnavailableError(RuntimeError):
+    """A migration-owned child partition is missing for an in-range timestamp."""
+
+    def __init__(self, partition: str) -> None:
+        self.partition = partition
+        super().__init__("observation_partition_unavailable")
+
+
 def _month_index(value: date) -> int:
     return value.year * 12 + (value.month - 1)
 
@@ -311,14 +329,12 @@ def ensure_observation_partition_for(
 ) -> bool:
     """Ensure the monthly partition covering *observed_at* exists.
 
-    Returns ``True`` when a partition was created. Bulk/connector ingest with an
-    ``observed_at`` older than the pre-provisioned window (behind=1) previously
-    raised a raw ``CheckViolation`` -> 500. This creates the covering partition
-    on demand within a bounded window so historical backfills succeed, and raises
-    :class:`ObservationPartitionRangeError` (mapped to 4xx by the route) for
-    values so far past/future they are almost certainly bad data. Unparseable or
-    non-partitioned tables are a no-op (the legacy single table has no partition
-    constraint, and downstream normalisation owns bad timestamps).
+    Returns ``False`` when the partition exists. Runtime roles are DML-only, so
+    this function never attempts DDL. A missing in-range child raises
+    :class:`ObservationPartitionUnavailableError` (mapped to a sanitized 503),
+    while values far outside the bounded window raise
+    :class:`ObservationPartitionRangeError` (mapped to 4xx). Unparseable or
+    non-partitioned tables remain a no-op.
     """
     if not is_observations_partitioned(conn):
         return False
@@ -342,8 +358,7 @@ def ensure_observation_partition_for(
     ).fetchone()
     if exists:
         return False
-    _create_observation_partition(conn, month.year, month.month)
-    return True
+    raise ObservationPartitionUnavailableError(child)
 
 
 def _partition_end_date(partition_name: str) -> date | None:

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -1121,10 +1121,9 @@ class PostgresComplianceHubStore:
         if not clean:
             return
         now = _now_utc_iso()
-        # observed_at is batch-level: ensure its monthly partition exists once
-        # per batch so a backdated bulk import (older than the pre-provisioned
-        # behind=1 window) does not raise a raw CheckViolation -> 500. Out of
-        # the bounded window raises ObservationPartitionRangeError -> 4xx.
+        # observed_at is batch-level: verify its migration-owned monthly child
+        # once per batch. Runtime roles are intentionally DML-only; a stale
+        # deploy returns a sanitized 503 instead of attempting schema DDL.
         from agent_bom.api.hub_observations_partition import ensure_observation_partition_for
 
         ensure_observation_partition_for(conn, observed_at)

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -2609,7 +2609,10 @@ async def ingest_compliance_findings(request: Request) -> dict:
     # (mirrors the bulk ingest and read paths). See ``hub_ingest_store_writes`` /
     # ``hub_store_call``.
     from agent_bom.api.hub_ingest import hub_ingest_store_writes, hub_store_call
-    from agent_bom.api.hub_observations_partition import ObservationPartitionRangeError
+    from agent_bom.api.hub_observations_partition import (
+        ObservationPartitionRangeError,
+        ObservationPartitionUnavailableError,
+    )
 
     try:
         store_result = await hub_store_call(
@@ -2627,6 +2630,11 @@ async def ingest_compliance_findings(request: Request) -> dict:
         # clean 422 instead of a raw partition CheckViolation 500 (mirrors the
         # bulk ingest route).
         raise HTTPException(status_code=422, detail=sanitize_error(exc)) from exc
+    except ObservationPartitionUnavailableError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Observation storage is not provisioned for this timestamp; run database migrations.",
+        ) from exc
     new_total = store_result["new_total"]
     reconciled = store_result["reconciled"]
     delta_results = store_result["delta_results"]

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -3922,7 +3922,10 @@ async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> d
     # upsert + reconcile + delta emission) to a worker thread so concurrent bulk
     # ingest cannot freeze the event loop and unrelated requests (mirrors the
     # read path). See ``_bulk_ingest_store_writes`` / ``_hub_store_call``.
-    from agent_bom.api.hub_observations_partition import ObservationPartitionRangeError
+    from agent_bom.api.hub_observations_partition import (
+        ObservationPartitionRangeError,
+        ObservationPartitionUnavailableError,
+    )
 
     try:
         store_result = await _hub_store_call(
@@ -3939,6 +3942,11 @@ async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> d
         # observed_at is so far past/future it is almost certainly bad data — a
         # clean 4xx instead of a raw partition CheckViolation 500.
         raise HTTPException(status_code=422, detail=sanitize_error(exc)) from exc
+    except ObservationPartitionUnavailableError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Observation storage is not provisioned for this timestamp; run database migrations.",
+        ) from exc
     new_total = store_result["new_total"]
     reconciled = store_result["reconciled"]
     delta_results = store_result["delta_results"]

--- a/tests/test_bulk_ingest_offload.py
+++ b/tests/test_bulk_ingest_offload.py
@@ -88,3 +88,25 @@ def test_bulk_ingest_out_of_range_observed_at_returns_422(monkeypatch) -> None:
     )
 
     assert resp.status_code == 422, resp.text
+
+
+def test_bulk_ingest_missing_partition_returns_sanitized_503(monkeypatch) -> None:
+    from agent_bom.api.hub_observations_partition import ObservationPartitionUnavailableError
+
+    client = TestClient(app, raise_server_exceptions=False)
+    client.headers.update(proxy_headers(role="analyst", tenant=f"partition-{uuid4().hex}"))
+
+    def _raise_unavailable(*args, **kwargs):
+        raise ObservationPartitionUnavailableError("hub_findings_current_observations_y2026m07")
+
+    monkeypatch.setattr(scan_routes, "_bulk_ingest_store_writes", _raise_unavailable)
+    resp = client.post(
+        "/v1/findings/bulk",
+        json={"source": "agent-runtime", "findings": [{"id": "f-1", "title": "one", "severity": "high"}]},
+    )
+
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["detail"] == "Observation storage is not provisioned for this timestamp; run database migrations."
+    assert body["error"]["details"] == body["detail"]
+    assert "y2026m07" not in resp.text

--- a/tests/test_compliance_ingest_offload.py
+++ b/tests/test_compliance_ingest_offload.py
@@ -122,6 +122,25 @@ def test_compliance_ingest_out_of_range_observed_at_returns_422(monkeypatch) -> 
     assert resp.status_code == 422, resp.text
 
 
+def test_compliance_ingest_missing_partition_returns_sanitized_503(monkeypatch) -> None:
+    from agent_bom.api.hub_observations_partition import ObservationPartitionUnavailableError
+
+    client = TestClient(app, raise_server_exceptions=False)
+    client.headers.update(proxy_headers(role="admin", tenant=f"cmpl-partition-{uuid4().hex}"))
+
+    def _raise_unavailable(*args, **kwargs):
+        raise ObservationPartitionUnavailableError("hub_findings_current_observations_y2026m07")
+
+    monkeypatch.setattr(hub_ingest_mod, "hub_ingest_store_writes", _raise_unavailable)
+    resp = client.post("/v1/compliance/ingest", json={"format": "sarif", "content": _sarif_content()})
+
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["detail"] == "Observation storage is not provisioned for this timestamp; run database migrations."
+    assert body["error"]["details"] == body["detail"]
+    assert "y2026m07" not in resp.text
+
+
 @pytest.mark.asyncio
 async def test_hub_store_call_keeps_event_loop_responsive() -> None:
     """The off-loop seam must run blocking work in a worker thread.

--- a/tests/test_hub_observation_partition_ondemand.py
+++ b/tests/test_hub_observation_partition_ondemand.py
@@ -1,10 +1,8 @@
-"""On-demand observation partition creation for backdated bulk ingest.
+"""Observation partition admission for backdated bulk ingest.
 
-``hub_findings_current_observations`` pre-provisioned only ``months_behind=1``
-partitions, so bulk/connector ingest with an ``observed_at`` older than ~1 month
-raised a raw ``CheckViolation`` -> 500. The partition covering ``observed_at`` is
-now created on demand within a bounded window; values far outside the window
-raise :class:`ObservationPartitionRangeError` (mapped to a clean 4xx).
+Runtime roles are DML-only, so the write path may verify a migration-owned
+partition but must never issue DDL. Missing in-range children raise a stable
+operational error; values far outside the bounded window remain clean 4xx.
 """
 
 from __future__ import annotations
@@ -17,6 +15,7 @@ import pytest
 
 from agent_bom.api.hub_observations_partition import (
     ObservationPartitionRangeError,
+    ObservationPartitionUnavailableError,
     ensure_observation_partition_for,
 )
 
@@ -51,11 +50,12 @@ class _PartitionSpy:
 _NOW = datetime(2026, 7, 16, tzinfo=timezone.utc)
 
 
-def test_backdated_observed_at_creates_partition_on_demand():
+def test_backdated_observed_at_requires_a_migration_owned_partition():
     spy = _PartitionSpy()
-    created = ensure_observation_partition_for(spy, "2026-03-01T00:00:00Z", now=_NOW)
-    assert created is True
-    assert spy._created_partition(), "a covering partition must be created for a backdated observation"
+    with pytest.raises(ObservationPartitionUnavailableError) as raised:
+        ensure_observation_partition_for(spy, "2026-03-01T00:00:00Z", now=_NOW)
+    assert raised.value.partition == "hub_findings_current_observations_y2026m03"
+    assert not spy._created_partition(), "a DML-only ingest path must never issue partition DDL"
 
 
 def test_far_future_observed_at_raises_range_error():
@@ -77,65 +77,6 @@ def test_non_partitioned_table_is_noop():
             return _FakeCursor(row=None)  # relkind query -> not partitioned
 
     assert ensure_observation_partition_for(_Unpartitioned(), "2020-01-01T00:00:00Z", now=_NOW) is False
-
-
-class _DuplicatePartitionError(Exception):
-    """Mimics psycopg's DuplicateTable (sqlstate 42P07)."""
-
-    sqlstate = "42P07"
-
-
-@dataclass
-class _RacingPartitionSpy:
-    """Reports the child absent on probe, then raises duplicate on CREATE.
-
-    Models two API workers creating the same not-yet-existing month partition:
-    both pass the existence probe, both issue ``CREATE TABLE ... PARTITION OF``,
-    and the loser hits the Postgres catalog race.
-    """
-
-    exc: Exception
-    executed: list[str] = field(default_factory=list)
-
-    def execute(self, sql: str, params: tuple | None = None) -> _FakeCursor:
-        norm = " ".join(sql.split()).lower()
-        self.executed.append(norm)
-        if "relkind" in norm:
-            return _FakeCursor(row=("p",))  # partitioned parent
-        if "partition of hub_findings_current_observations" in norm:
-            raise self.exc
-        if "from pg_class" in norm:
-            return _FakeCursor(row=None)  # child partition absent on probe
-        return _FakeCursor(row=None)
-
-
-def test_concurrent_partition_creation_duplicate_table_is_success():
-    """A racing worker's DuplicateTable must be swallowed, not surface as a 500."""
-    spy = _RacingPartitionSpy(exc=_DuplicatePartitionError("relation already exists"))
-    # Must not raise: the partition exists (the other worker created it).
-    assert ensure_observation_partition_for(spy, "2026-03-01T00:00:00Z", now=_NOW) is True
-    assert any("partition of" in s for s in spy.executed)
-
-
-def test_concurrent_partition_creation_already_exists_message_is_success():
-    """The 'already exists' message class (no sqlstate) is also treated as success."""
-
-    class _NoCodeError(Exception):
-        pass
-
-    spy = _RacingPartitionSpy(exc=_NoCodeError('relation "..._y2026m03" already exists'))
-    assert ensure_observation_partition_for(spy, "2026-03-01T00:00:00Z", now=_NOW) is True
-
-
-def test_non_duplicate_create_error_still_raises():
-    """A genuine DDL error (not a duplicate) must not be swallowed."""
-
-    class _BoomError(Exception):
-        sqlstate = "42501"  # insufficient_privilege
-
-    spy = _RacingPartitionSpy(exc=_BoomError("permission denied"))
-    with pytest.raises(_BoomError):
-        ensure_observation_partition_for(spy, "2026-03-01T00:00:00Z", now=_NOW)
 
 
 def test_current_month_partition_not_recreated_when_present(monkeypatch):

--- a/tests/test_hub_observations_partition_runway.py
+++ b/tests/test_hub_observations_partition_runway.py
@@ -102,6 +102,20 @@ def test_provisioned_runway_reaches_at_least_twelve_months_past_today(monkeypatc
     assert OBSERVATION_PARTITION_RUNWAY_MONTHS >= 12
 
 
+def test_provisioned_window_covers_the_full_retention_horizon(monkeypatch) -> None:
+    """A deploy must provision every retained month so historical ingest stays DML-only."""
+    monkeypatch.setattr(partitions, "_ensure_observation_partition_rls", lambda *_a: None)
+    frozen_now = datetime(2026, 9, 2, tzinfo=timezone.utc)
+    conn = _FakePartitionedConn()
+
+    provision_observation_partition_runway(conn, now=frozen_now)
+
+    months = conn.created_months()
+    oldest_retained = frozen_now.date() - timedelta(days=partitions.HUB_OBSERVATIONS_RETENTION_DAYS)
+    assert months[0] == (oldest_retained.year, oldest_retained.month)
+    assert (2026, 7) in months
+
+
 @pytest.mark.parametrize(
     "frozen_now",
     [
@@ -119,7 +133,8 @@ def test_runway_crosses_year_boundaries_without_a_gap(monkeypatch, frozen_now: d
     provision_observation_partition_runway(conn, now=frozen_now)
 
     months = conn.created_months()
-    assert months[0] == (frozen_now.year, frozen_now.month)
+    oldest_retained = frozen_now.date() - timedelta(days=partitions.HUB_OBSERVATIONS_RETENTION_DAYS)
+    assert months[0] == (oldest_retained.year, oldest_retained.month)
     indexes = [year * 12 + (month - 1) for year, month in months]
     assert indexes == list(range(indexes[0], indexes[0] + len(indexes))), "gap in the provisioned month sequence"
     assert _runway_end_of(months) - frozen_now.date() >= timedelta(days=365)
@@ -131,7 +146,9 @@ def test_runway_top_up_is_idempotent_and_only_fills_the_gap(monkeypatch) -> None
     frozen_now = datetime(2026, 7, 31, tzinfo=timezone.utc)
     conn = _FakePartitionedConn()
     first = provision_observation_partition_runway(conn, now=frozen_now)
-    assert first == OBSERVATION_PARTITION_RUNWAY_MONTHS + 1
+    oldest_retained = frozen_now.date() - timedelta(days=partitions.HUB_OBSERVATIONS_RETENTION_DAYS)
+    retained_months = (frozen_now.year * 12 + frozen_now.month) - (oldest_retained.year * 12 + oldest_retained.month)
+    assert first == retained_months + OBSERVATION_PARTITION_RUNWAY_MONTHS + 1
 
     conn.statements.clear()
     assert provision_observation_partition_runway(conn, now=frozen_now) == 0
@@ -152,7 +169,9 @@ def test_every_new_partition_child_gets_forced_tenant_rls(monkeypatch) -> None:
     provision_observation_partition_runway(conn, now=datetime(2026, 7, 31, tzinfo=timezone.utc))
 
     assert protected == [partition_table_name(y, m) for y, m in conn.created_months()]
-    assert len(protected) == OBSERVATION_PARTITION_RUNWAY_MONTHS + 1
+    oldest_retained = date(2026, 7, 31) - timedelta(days=partitions.HUB_OBSERVATIONS_RETENTION_DAYS)
+    retained_months = (2026 * 12 + 7) - (oldest_retained.year * 12 + oldest_retained.month)
+    assert len(protected) == retained_months + OBSERVATION_PARTITION_RUNWAY_MONTHS + 1
 
 
 def test_provisioning_is_a_noop_on_an_unpartitioned_table() -> None:

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -41,6 +41,7 @@ HUB_OVERVIEW_REVISION = VERSIONS_DIR / "20260827_01_hub_overview_revision.py"
 GRAPH_CORRELATIONS = VERSIONS_DIR / "20260830_01_graph_correlations.py"
 ATTACK_PATH_EVIDENCE = VERSIONS_DIR / "20260830_02_graph_correlation_mechanical.py"
 CLOUD_CONNECTION_CAPABILITY_EVIDENCE = VERSIONS_DIR / "20260830_03_cloud_connection_capability_evidence.py"
+OBSERVATION_PARTITION_RETENTION_WINDOW = VERSIONS_DIR / "20260901_01_observation_partition_retention_window.py"
 
 # The fork-guard UNIQUE index is spelled differently in its two schema sources:
 # the dedicated migration concatenates two quoted Python string literals, while
@@ -52,7 +53,7 @@ _FORK_GUARD_INDEX_CANON = "createuniqueindexifnotexistsaudit_log_team_prevsig_un
 
 # The newest migration. One place to update when a revision lands, so the
 # single-head property and the head's identity do not drift apart.
-ALEMBIC_HEAD = "20260830_03"
+ALEMBIC_HEAD = "20260901_01"
 
 
 def _canonical_sql(text: str) -> str:
@@ -586,6 +587,16 @@ def test_observation_partition_runway_migration_uses_the_psycopg_driver_connecti
     module.upgrade()
 
     assert seen == [driver_connection]
+
+
+def test_observation_partition_retention_window_is_migration_owned_and_forward_only() -> None:
+    sql = OBSERVATION_PARTITION_RETENTION_WINDOW.read_text()
+    assert re.search(r'revision\s*=\s*"20260901_01"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260830_03"', sql)
+    assert "provision_observation_partition_runway" in sql
+    assert "driver_connection" in sql
+    assert "DROP TABLE" not in sql
+    assert "CREATE TABLE" not in sql
 
 
 def test_graph_edge_snapshot_key_index_is_chained_and_matches_bootstrap() -> None:


### PR DESCRIPTION
## Summary
- provision every retained observation month under the migration owner, alongside the future runway
- keep application/runtime roles DML-only and return a sanitized retryable response when deployment migrations are stale
- add the chained Alembic revision and regression coverage for retained-history ingest and API failure behavior

## Verification
- `uv run pytest -q tests/test_hub_observation_partition_ondemand.py tests/test_hub_observations_partition_runway.py tests/test_bulk_ingest_offload.py tests/test_compliance_ingest_offload.py tests/test_postgres_migrations.py` (68 passed)
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run mypy src/agent_bom/api/hub_observations_partition.py src/agent_bom/api/postgres_compliance_hub.py src/agent_bom/api/routes/scan.py src/agent_bom/api/routes/compliance.py`
- `uv run python scripts/check_exception_sanitization.py`
- `make preflight`
- `git diff --check`

## Notes
- This fixes the September date-rollover failure in the Postgres integration contract without granting schema DDL to `agent_bom_app`.
- No release tag or artifact publication is part of this PR.