### PR TITLE
fix(deploy): supersede stale demo approvals

### DIFF
--- a/.github/workflows/demo-deploy-cloudrun.yml
+++ b/.github/workflows/demo-deploy-cloudrun.yml
@@ -36,9 +36,11 @@ on:
 permissions: {} # all permissions denied by default; the job declares only what it needs
 
 concurrency:
-  # Never let two deploys race on the same Cloud Run service.
+  # Only the newest release is useful. Supersede an obsolete run even when it
+  # is waiting for protected-environment approval so it cannot block the
+  # current release indefinitely.
   group: demo-deploy-cloudrun
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -65,6 +65,16 @@ def test_enterprise_demo_contract_is_gated_and_packaged() -> None:
     assert "rate_limited_after_page_2" in deploy_workflow
 
 
+def test_demo_deploy_new_release_supersedes_stale_approval_wait() -> None:
+    """An obsolete protected-environment wait must not block a newer release."""
+    workflow = yaml.safe_load((ROOT / ".github" / "workflows" / "demo-deploy-cloudrun.yml").read_text(encoding="utf-8"))
+
+    assert workflow["concurrency"] == {
+        "group": "demo-deploy-cloudrun",
+        "cancel-in-progress": True,
+    }
+
+
 def test_dependency_security_skips_only_proven_docs_only_changes() -> None:
     workflow_path = ROOT / ".github" / "workflows" / "pr-security-gate.yml"
     workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- let the newest release cancel an obsolete Cloud Run demo run that is still waiting for protected-environment approval
- retain single-run deployment serialization while preventing stale approvals from blocking current releases indefinitely
- add a regression contract for the concurrency policy

## Verification

- `uv run pytest -q tests/test_ci_workflow_contract.py`
- `uv run pytest -q tests/test_compose_secrets_healthcheck.py -k cloud_run_demo tests/test_deploy_topology_docs.py tests/test_documented_images_are_published.py`
- `uv run ruff check tests/test_ci_workflow_contract.py`
- `uv run ruff format --check tests/test_ci_workflow_contract.py`
- `uv run python scripts/lint_release_workflow.py .github/workflows/demo-deploy-cloudrun.yml`
- `uv run python scripts/check_ci_pipefail.py .github/workflows/demo-deploy-cloudrun.yml`
- `uv run python scripts/check_workflow_timeouts.py`
- `actionlint .github/workflows/demo-deploy-cloudrun.yml`
- `git diff --check`

## Notes

The v0.103.2 deploy reached the current protected environment after the obsolete August 24 run was cancelled, then failed closed because the environment still contains retired AWS configuration and lacks the required GCP Cloud Run variables and secrets. This PR fixes the queueing defect only; it does not invent deployment credentials.