### PR TITLE
fix(cli): make first-run evidence resilient

### DIFF
--- a/src/agent_bom/cli/_quickstart.py
+++ b/src/agent_bom/cli/_quickstart.py
@@ -162,6 +162,10 @@ def _run_quickstart(
         "-p",
         str(sample_dir),
         "--context-graph",
+        # The sample is intentionally vulnerable. A severity verdict is still
+        # useful completed evidence and must not abort policy/UI onboarding;
+        # --exit-zero does not suppress incomplete, malicious, or policy exits.
+        "--exit-zero",
         "-o",
         str(report_path),
     ]

--- a/src/agent_bom/resolver.py
+++ b/src/agent_bom/resolver.py
@@ -267,6 +267,10 @@ async def _get_npm_latest_doc(package_name: str, client: httpx.AsyncClient) -> d
     except Exception as exc:
         if not inflight.done():
             inflight.set_exception(exc)
+            # The owner also raises directly. Mark its coordination future as
+            # observed so a no-waiter outage cannot emit an asyncio traceback;
+            # concurrent waiters still receive the stored exception.
+            inflight.exception()
         raise
     finally:
         with _RESOLVER_STATE_LOCK:
@@ -315,6 +319,9 @@ async def _get_pypi_info_doc(package_name: str, client: httpx.AsyncClient) -> di
     except Exception as exc:
         if not inflight.done():
             inflight.set_exception(exc)
+            # See the npm path above: the owner raises directly, while this
+            # retrieval prevents an orphaned-future traceback with no waiter.
+            inflight.exception()
         raise
     finally:
         with _RESOLVER_STATE_LOCK:

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -161,6 +161,26 @@ def test_quickstart_run_no_gateway_policy_skips_file(tmp_path, _fake_scan):
     assert "Skipped gateway baseline policy" in result.output
 
 
+def test_quickstart_run_treats_a_critical_verdict_as_completed_evidence(tmp_path, monkeypatch):
+    sample_dir = tmp_path / "stack"
+    calls: list[list[str]] = []
+
+    def fake_run(args, check=False, **kwargs):  # noqa: ANN001, ANN003
+        calls.append(list(args))
+        return subprocess.CompletedProcess(args, 0 if "--exit-zero" in args else 1)
+
+    monkeypatch.setattr("agent_bom.cli._quickstart._resolve_agent_bom", lambda: "agent-bom")
+    monkeypatch.setattr("agent_bom.cli._quickstart.subprocess.run", fake_run)
+
+    result = CliRunner().invoke(main, ["quickstart", "--run", "--offline", "--sample-dir", str(sample_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert len(calls) == 1
+    assert "--exit-zero" in calls[0]
+    assert (sample_dir / "gateway-baseline-policy.json").is_file()
+    assert "Onboarding complete" in result.output
+
+
 def test_quickstart_run_surfaces_scan_failure(tmp_path, monkeypatch):
     sample_dir = tmp_path / "stack"
     monkeypatch.setattr("agent_bom.cli._quickstart._resolve_agent_bom", lambda: "agent-bom")

--- a/tests/test_resolver_cov.py
+++ b/tests/test_resolver_cov.py
@@ -155,6 +155,40 @@ class TestResolveNpmMetadata:
         assert mock_request.call_count == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("lookup", "package_name"),
+        [
+            (_get_npm_latest_doc, "unavailable-npm-package"),
+            (_get_pypi_info_doc, "unavailable-pypi-package"),
+        ],
+    )
+    async def test_registry_failure_does_not_leave_an_unhandled_inflight_future(self, lookup, package_name):
+        loop = asyncio.get_running_loop()
+        created: list[asyncio.Future] = []
+
+        class LoopProxy:
+            def create_future(self):
+                future = loop.create_future()
+                created.append(future)
+                return future
+
+        exception_was_retrieved = False
+        try:
+            with (
+                patch("agent_bom.resolver.asyncio.get_running_loop", return_value=LoopProxy()),
+                patch("agent_bom.resolver.request_with_retry", side_effect=RuntimeError("registry unavailable")),
+            ):
+                with pytest.raises(RuntimeError, match="registry unavailable"):
+                    await lookup(package_name, AsyncMock())
+            exception_was_retrieved = not created[0]._log_traceback
+        finally:
+            if created and created[0].done():
+                created[0].exception()
+
+        assert len(created) == 1
+        assert exception_was_retrieved
+
+    @pytest.mark.asyncio
     async def test_concurrent_pypi_info_requests_share_inflight_lookup(self):
         mock_response = MagicMock()
         mock_response.status_code = 200


### PR DESCRIPTION
## Summary
- let the intentionally vulnerable quickstart sample complete onboarding after a critical severity verdict while preserving incomplete, malicious-package, and policy failure exits
- consume owner-side registry coordination exceptions so routine npm/PyPI outages do not emit orphaned asyncio tracebacks
- add regressions for both npm and PyPI outage paths and the complete quickstart handoff

## Verification
- `UV_CACHE_DIR=/private/tmp/agent-bom-uv-cache uv run pytest -q tests/test_resolver_cov.py tests/test_quickstart.py` (47 passed)
- `UV_CACHE_DIR=/private/tmp/agent-bom-uv-cache uv run ruff check src/agent_bom/resolver.py src/agent_bom/cli/_quickstart.py tests/test_resolver_cov.py tests/test_quickstart.py`
- `UV_CACHE_DIR=/private/tmp/agent-bom-uv-cache uv run ruff format --check src/agent_bom/resolver.py src/agent_bom/cli/_quickstart.py tests/test_resolver_cov.py tests/test_quickstart.py`
- `git diff --check`

## Notes
- No release, tag, registry, API, UI, or deployment behavior is changed by this PR.