### PR TITLE
fix(release): sign refreshed latest images

### DIFF
--- a/.github/workflows/refresh-latest-container.yml
+++ b/.github/workflows/refresh-latest-container.yml
@@ -140,6 +140,19 @@ jobs:
             org.opencontainers.image.created=${{ github.run_id }}
             org.opencontainers.image.revision=${{ steps.release.outputs.tag }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign refreshed API latest
+        run: cosign sign --yes "agentbom/agent-bom@${{ steps.build-push.outputs.digest }}"
+
+      - name: Verify refreshed API latest signature
+        run: |
+          cosign verify \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/refresh-latest-container.yml@${{ github.ref }}" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "agentbom/agent-bom@${{ steps.build-push.outputs.digest }}"
+
       - name: Sync Docker Hub README
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -316,6 +329,19 @@ jobs:
             org.opencontainers.image.created=${{ github.run_id }}
             org.opencontainers.image.revision=${{ steps.release.outputs.tag }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign refreshed UI latest
+        run: cosign sign --yes "agentbom/agent-bom-ui@${{ steps.build-push-ui.outputs.digest }}"
+
+      - name: Verify refreshed UI latest signature
+        run: |
+          cosign verify \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/refresh-latest-container.yml@${{ github.ref }}" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "agentbom/agent-bom-ui@${{ steps.build-push-ui.outputs.digest }}"
+
       - name: Sync UI Docker Hub README
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -452,3 +478,16 @@ jobs:
             org.opencontainers.image.description=Read-only cloud collector — ships boto3/azure/google/snowflake SDKs independently of the control-plane release. No external MCP in the scan path.
             org.opencontainers.image.created=${{ github.run_id }}
             org.opencontainers.image.revision=${{ steps.release.outputs.tag }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign refreshed collector latest
+        run: cosign sign --yes "agentbom/agent-bom-collector@${{ steps.build-push.outputs.digest }}"
+
+      - name: Verify refreshed collector latest signature
+        run: |
+          cosign verify \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/refresh-latest-container.yml@${{ github.ref }}" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "agentbom/agent-bom-collector@${{ steps.build-push.outputs.digest }}"

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ and runtime integrations for the other deployment profiles.
 | Surface | Get it |
 |---|---|
 | Python package | `pip install agent-bom` — [PyPI](https://pypi.org/project/agent-bom/) |
-| Container | `docker pull agentbom/agent-bom` — [Docker Hub](https://hub.docker.com/r/agentbom/agent-bom) |
+| Container | `docker pull agentbom/agent-bom:0.103.2` — signed release image on [Docker Hub](https://hub.docker.com/r/agentbom/agent-bom) |
 | Kubernetes | `helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom` |
 | GitHub Action | [`msaad00/agent-bom`](action.yml) |
 | MCP server | `pip install 'agent-bom[mcp-server]' && agent-bom mcp server` |

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -822,6 +822,41 @@ def test_refresh_latest_container_has_publish_budget_and_buildkit_cache():
     assert "cache-to: type=gha,mode=max,scope=refresh-ui-latest" in workflow
 
 
+def test_refresh_latest_keyless_signs_and_verifies_every_published_digest():
+    """A scheduled rebuild must not replace signed ``latest`` tags with unsigned digests."""
+    workflow = (ROOT / ".github" / "workflows" / "refresh-latest-container.yml").read_text()
+    jobs = (
+        (
+            workflow.split("  refresh-latest:\n", 1)[1].split("  refresh-ui-latest:\n", 1)[0],
+            "build-push",
+            "agentbom/agent-bom",
+        ),
+        (
+            workflow.split("  refresh-ui-latest:\n", 1)[1].split("  refresh-collector-latest:\n", 1)[0],
+            "build-push-ui",
+            "agentbom/agent-bom-ui",
+        ),
+        (
+            workflow.split("  refresh-collector-latest:\n", 1)[1],
+            "build-push",
+            "agentbom/agent-bom-collector",
+        ),
+    )
+
+    for job, build_step, image in jobs:
+        digest_ref = f'"{image}@${{{{ steps.{build_step}.outputs.digest }}}}"'
+        assert "sigstore/cosign-installer@" in job
+        assert f"cosign sign --yes {digest_ref}" in job
+        assert "cosign verify \\" in job
+        assert "--certificate-oidc-issuer https://token.actions.githubusercontent.com" in job
+        assert (
+            '--certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/'
+            'refresh-latest-container.yml@${{ github.ref }}"'
+        ) in job
+        assert job.count(digest_ref) >= 2
+        assert job.index("cosign sign --yes") < job.index("cosign verify")
+
+
 def test_deploy_mcp_sse_workflow_uses_bearer_token_for_health_check():
     """Post-deploy health verification should use the same auth contract as Railway."""
     workflow = (ROOT / ".github" / "workflows" / "deploy-mcp-sse.yml").read_text()


### PR DESCRIPTION
## Summary

- keyless-sign each refreshed API, UI, and collector `latest` manifest digest
- verify every signature against the exact refresh-workflow OIDC identity before the job can succeed
- pin the README container pull to the signed `0.103.2` release while the floating-tag repair is reviewed
- add a workflow contract that fails if any published refresh digest loses signing or verification

## Verification

- `/Users/mohamedsaad/repos/Agent-Bom/.venv/bin/pytest -q tests/test_deployment.py tests/test_container_supply_chain_repair.py` (71 passed)
- `/Users/mohamedsaad/repos/Agent-Bom/.venv/bin/pytest -q tests/test_ci_workflow_contract.py` (29 passed)
- `/Users/mohamedsaad/repos/Agent-Bom/.venv/bin/ruff check tests/test_deployment.py`
- `/Users/mohamedsaad/repos/Agent-Bom/.venv/bin/python scripts/check_workflow_timeouts.py`
- `actionlint -ignore SC2129 .github/workflows/refresh-latest-container.yml`
- `/Users/mohamedsaad/repos/Agent-Bom/.venv/bin/python scripts/check_release_consistency.py`
- `/Users/mohamedsaad/repos/Agent-Bom/.venv/bin/python scripts/check_public_docs_hygiene.py`
- `git diff --check`

## Notes

The live `latest` digests remain unsigned until this change is merged and the refresh workflow completes. Immutable `0.103.2` release digests remain signed. This PR does not tag, publish, deploy, or close drift issues.