### PR TITLE
fix(cli): verify quickstart runtime handoff

### DIFF
--- a/src/agent_bom/cli/_quickstart.py
+++ b/src/agent_bom/cli/_quickstart.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import cast
+from typing import TypedDict, cast
 
 import click
 
@@ -16,6 +18,12 @@ from agent_bom.samples import write_first_run_sample
 
 QUICKSTART_SCAN_TIMEOUT_SECONDS = 300
 DURABLE_LOCAL_CONTROL_PLANE_DB = Path.home() / ".agent-bom" / "control-plane.db"
+
+
+class _GraphReceipt(TypedDict):
+    scan_id: str
+    nodes: int
+    edges: int
 
 
 @click.command("quickstart")
@@ -150,9 +158,13 @@ def _run_quickstart(
             "Could not locate the 'agent-bom' executable to run the scan. "
             f"Run it manually: {_sample_scan_command(sample_dir, offline=offline)}"
         )
-    # --context-graph triggers persistence of the unified graph to the same
-    # local control-plane store that the printed durable `serve` command reads,
-    # so the security-graph cockpit is populated on first run.
+    # --context-graph triggers persistence of the unified graph. Resolve both
+    # database paths before launching the child process so the readback and the
+    # printed control-plane command use the exact same configuration.
+    scan_env = os.environ.copy()
+    control_plane_db, graph_db = _resolve_quickstart_databases(scan_env)
+    scan_env["AGENT_BOM_DB"] = str(control_plane_db)
+    scan_env["AGENT_BOM_GRAPH_DB"] = str(graph_db)
     report_path = sample_dir / "agent-bom-report.json"
     scan_args = [
         executable,
@@ -179,10 +191,7 @@ def _run_quickstart(
     else:
         scan_args.append("--enrich")
     click.echo(f"[2/3] Scanning sample stack: {' '.join(scan_args[1:])}")
-    scan_env = os.environ.copy()
-    # Preserve an operator's explicit database override; otherwise align the
-    # generated scan and serve handoff on the documented restart-safe path.
-    scan_env.setdefault("AGENT_BOM_DB", str(DURABLE_LOCAL_CONTROL_PLANE_DB))
+    scan_started_at = datetime.now(timezone.utc)
     result = subprocess.run(  # noqa: S603 - args built from validated inputs
         scan_args,
         check=False,
@@ -191,6 +200,15 @@ def _run_quickstart(
     )
     if result.returncode != 0:
         raise click.ClickException(f"Scan exited with status {result.returncode}. The cockpit graph may be incomplete.")
+    graph_receipt = _verify_persisted_graph(
+        report_path=report_path,
+        graph_db=graph_db,
+        scan_started_at=scan_started_at,
+    )
+    click.echo(
+        f"      Verified persisted graph: {graph_receipt['nodes']} nodes, "
+        f"{graph_receipt['edges']} edges (scan {graph_receipt['scan_id'][:8]}…)"
+    )
 
     # 3. Secure-by-default gateway policy ----------------------------------
     policy_path: Path | None = None
@@ -203,21 +221,91 @@ def _run_quickstart(
 
     # Handoff ---------------------------------------------------------------
     click.echo("")
-    click.echo("Onboarding complete. The security graph is now populated locally.")
+    click.echo("Onboarding complete. The security graph was read back from the configured local database.")
     click.echo("")
     click.echo("Open the cockpit:")
-    click.echo(
-        f"  AGENT_BOM_NO_AUTH_ROLE=analyst agent-bom serve --persist ~/.agent-bom/control-plane.db"
-        f" --host 127.0.0.1 --port {port} --allow-insecure-no-auth"
-    )
+    click.echo(f"  {_control_plane_command(control_plane_db=control_plane_db, graph_db=graph_db, port=port)}")
     click.echo("  # the explicit local analyst role permits scans in this loopback-only workflow;")
     click.echo("  # on a shared host use --api-key <key> or configure OIDC authentication instead.")
     click.echo(f"  Security graph: http://127.0.0.1:{port}/security-graph")
     click.echo(f"  Dashboard:      http://127.0.0.1:{port}/")
     if policy_path is not None:
         click.echo("")
-        click.echo("Enforce the gateway baseline:")
-        click.echo(f"  agent-bom gateway serve --policy {policy_path} --upstreams upstreams.yaml")
+        click.echo(f"Run the gateway baseline ({gateway_mode.lower()}):")
+        click.echo(
+            f"  agent-bom gateway serve --policy {shlex.quote(str(policy_path))} "
+            f"--from-control-plane http://127.0.0.1:{port} --bind 127.0.0.1:8090"
+        )
+
+
+def _resolve_quickstart_databases(environment: dict[str, str]) -> tuple[Path, Path]:
+    """Resolve the child scan and printed control-plane database paths."""
+
+    control_plane_db = _durable_sqlite_path(environment.get("AGENT_BOM_DB") or str(DURABLE_LOCAL_CONTROL_PLANE_DB))
+    graph_db = _durable_sqlite_path(environment.get("AGENT_BOM_GRAPH_DB") or str(control_plane_db))
+    return control_plane_db, graph_db
+
+
+def _durable_sqlite_path(value: str) -> Path:
+    """Normalize one restart-safe local SQLite path for the quickstart."""
+
+    raw = value.strip()
+    if raw == ":memory:" or "://" in raw:
+        raise click.ClickException(
+            "agent-bom quickstart --run requires a durable local SQLite path in AGENT_BOM_DB and AGENT_BOM_GRAPH_DB."
+        )
+    return Path(raw).expanduser().resolve()
+
+
+def _verify_persisted_graph(
+    *,
+    report_path: Path,
+    graph_db: Path,
+    scan_started_at: datetime,
+) -> _GraphReceipt:
+    """Read back the exact scan snapshot before claiming onboarding success."""
+
+    try:
+        payload = json.loads(report_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise click.ClickException("Persisted graph could not be verified because the scan report is unavailable.") from exc
+
+    scan_run = payload.get("scan_run")
+    scan_id = str(payload.get("scan_id") or (scan_run.get("scan_id") if isinstance(scan_run, dict) else "") or "")
+    outcome = str(scan_run.get("outcome") or "") if isinstance(scan_run, dict) else ""
+    if not scan_id or outcome != "complete" or not graph_db.is_file():
+        raise click.ClickException("Persisted graph could not be verified in the configured graph database.")
+
+    try:
+        from agent_bom.cli._tenant import resolve_cli_tenant_id
+        from agent_bom.db.graph_store import load_graph, open_graph_db
+
+        with open_graph_db(graph_db) as connection:
+            graph = load_graph(connection, tenant_id=resolve_cli_tenant_id(), scan_id=scan_id)
+        created_at = datetime.fromisoformat(graph.created_at.replace("Z", "+00:00"))
+    except Exception as exc:  # noqa: BLE001 - every storage/read/schema failure means verification failed
+        raise click.ClickException("Persisted graph could not be verified in the configured graph database.") from exc
+
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+    if graph.scan_id != scan_id or not graph.nodes or not graph.edges or created_at < scan_started_at:
+        raise click.ClickException("Persisted graph could not be verified in the configured graph database.")
+    return {"scan_id": scan_id, "nodes": len(graph.nodes), "edges": len(graph.edges)}
+
+
+def _control_plane_command(*, control_plane_db: Path, graph_db: Path, port: int) -> str:
+    """Render a shell-safe command that opens the database just verified."""
+
+    environment = []
+    if graph_db != control_plane_db:
+        environment.append(f"AGENT_BOM_GRAPH_DB={shlex.quote(str(graph_db))}")
+    environment.append("AGENT_BOM_NO_AUTH_ROLE=analyst")
+    persisted = (
+        "~/.agent-bom/control-plane.db"
+        if control_plane_db == DURABLE_LOCAL_CONTROL_PLANE_DB.expanduser().resolve()
+        else shlex.quote(str(control_plane_db))
+    )
+    return f"{' '.join(environment)} agent-bom serve --persist {persisted} --host 127.0.0.1 --port {port} --allow-insecure-no-auth"
 
 
 def _write_gateway_baseline(output_path: Path, *, mode: str) -> None:

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -37,6 +37,10 @@ def _fake_scan(monkeypatch):
 
     monkeypatch.setattr("agent_bom.cli._quickstart._resolve_agent_bom", lambda: "agent-bom")
     monkeypatch.setattr("agent_bom.cli._quickstart.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "agent_bom.cli._quickstart._verify_persisted_graph",
+        lambda **kwargs: {"scan_id": "fake-scan-id", "nodes": 3, "edges": 2},
+    )
     return calls
 
 
@@ -113,6 +117,37 @@ def test_quickstart_run_scans_with_context_graph_and_seeds_policy(tmp_path, _fak
     # cockpit handoff must pass a flag that actually lets /v1/overview load on loopback
     assert f"{LOCAL_ANALYST_CONTROL_PLANE} --host 127.0.0.1 --port 8422 --allow-insecure-no-auth" in result.output
     assert "--api-key <key>" in result.output
+    assert "--from-control-plane http://127.0.0.1:8422" in result.output
+    assert "upstreams.yaml" not in result.output
+    assert "Run the gateway baseline (audit):" in result.output
+
+
+def test_quickstart_run_prints_the_configured_control_plane_database(tmp_path, _fake_scan, monkeypatch):
+    sample_dir = tmp_path / "stack"
+    control_plane_db = tmp_path / "configured-control-plane.db"
+    monkeypatch.setenv("AGENT_BOM_DB", str(control_plane_db))
+
+    result = CliRunner().invoke(main, ["quickstart", "--run", "--offline", "--sample-dir", str(sample_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert f"agent-bom serve --persist {control_plane_db}" in result.output
+    assert "--persist ~/.agent-bom/control-plane.db" not in result.output
+
+
+def test_quickstart_run_preserves_a_separate_configured_graph_database(tmp_path, _fake_scan, monkeypatch):
+    sample_dir = tmp_path / "stack"
+    control_plane_db = tmp_path / "control-plane.db"
+    graph_db = tmp_path / "graphs.db"
+    monkeypatch.setenv("AGENT_BOM_DB", str(control_plane_db))
+    monkeypatch.setenv("AGENT_BOM_GRAPH_DB", str(graph_db))
+
+    result = CliRunner().invoke(main, ["quickstart", "--run", "--offline", "--sample-dir", str(sample_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert _fake_scan.environments[0]["AGENT_BOM_DB"] == str(control_plane_db)
+    assert _fake_scan.environments[0]["AGENT_BOM_GRAPH_DB"] == str(graph_db)
+    assert f"AGENT_BOM_GRAPH_DB={graph_db}" in result.output
+    assert f"agent-bom serve --persist {control_plane_db}" in result.output
 
 
 def test_quickstart_run_offline_succeeds_with_empty_vulnerability_db(tmp_path, monkeypatch):
@@ -171,6 +206,10 @@ def test_quickstart_run_treats_a_critical_verdict_as_completed_evidence(tmp_path
 
     monkeypatch.setattr("agent_bom.cli._quickstart._resolve_agent_bom", lambda: "agent-bom")
     monkeypatch.setattr("agent_bom.cli._quickstart.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "agent_bom.cli._quickstart._verify_persisted_graph",
+        lambda **kwargs: {"scan_id": "fake-scan-id", "nodes": 3, "edges": 2},
+    )
 
     result = CliRunner().invoke(main, ["quickstart", "--run", "--offline", "--sample-dir", str(sample_dir)])
 
@@ -193,6 +232,23 @@ def test_quickstart_run_surfaces_scan_failure(tmp_path, monkeypatch):
 
     assert result.exit_code != 0
     assert "Scan exited with status 2" in result.output
+
+
+def test_quickstart_run_rejects_a_success_exit_without_persisted_graph(tmp_path, monkeypatch):
+    sample_dir = tmp_path / "stack"
+    graph_db = tmp_path / "missing-graph.db"
+    monkeypatch.setenv("AGENT_BOM_DB", str(graph_db))
+    monkeypatch.setattr("agent_bom.cli._quickstart._resolve_agent_bom", lambda: "agent-bom")
+    monkeypatch.setattr(
+        "agent_bom.cli._quickstart.subprocess.run",
+        lambda args, check=False, **kwargs: subprocess.CompletedProcess(args, 0),
+    )
+
+    result = CliRunner().invoke(main, ["quickstart", "--run", "--offline", "--sample-dir", str(sample_dir)])
+
+    assert result.exit_code != 0
+    assert "persisted graph could not be verified" in result.output.lower()
+    assert "Onboarding complete" not in result.output
 
 
 def test_all_extra_composes_first_run_extras_without_mlflow():


### PR DESCRIPTION
## Summary
- read back the exact fresh, non-empty graph snapshot before quickstart reports success
- preserve configured control-plane and graph database paths in both the child scan and printed serve command
- replace the nonexistent upstreams.yaml handoff with loopback control-plane discovery and label audit mode accurately

## Verification
- red first: four focused quickstart contracts failed on the missing gateway handoff, fixed database copy, separate graph-database handoff, and child exit 0 without a persisted graph
- `UV_CACHE_DIR=/private/tmp/agent-bom-uv-cache uv run pytest -q tests/test_quickstart.py tests/test_first_run_sample.py tests/test_cli_canonical_verbs.py tests/test_public_docs_cli_alignment.py` (60 passed)
- `UV_CACHE_DIR=/private/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/cli/_quickstart.py`
- `UV_CACHE_DIR=/private/tmp/agent-bom-uv-cache uv run ruff check src/agent_bom/cli/_quickstart.py tests/test_quickstart.py`
- `UV_CACHE_DIR=/private/tmp/agent-bom-uv-cache uv run ruff format --check src/agent_bom/cli/_quickstart.py tests/test_quickstart.py`
- `git diff --check`
- real offline quickstart: verified 32 persisted nodes and 43 edges for scan `1aadf9b6-291f-5c3d-a533-103070283f5e`
- loopback smoke: `/health` returned 0.103.2, `/v1/graph/snapshots` returned that exact snapshot, and the printed gateway command discovered upstreams then started successfully

## Notes
- Base: `a5fd939c503b1f7533c7c710153a88301ff44a12`
- Head: `9127b49256aba80e7e8b57168526bbc88624ae71`
- Preflight was not required because no API route, model, schema, or generated artifact changed.
- No tag, release, registry publication, deployment, or issue state is changed.