### PR TITLE
fix(registry): automate catalog reconciliation

### DIFF
--- a/.github/workflows/deployment-freshness.yml
+++ b/.github/workflows/deployment-freshness.yml
@@ -109,9 +109,10 @@ jobs:
         continue-on-error: true
         env:
           SMITHERY_SERVER_QUALIFIED_NAME: ${{ vars.SMITHERY_SERVER_QUALIFIED_NAME }}
+          EXPECTED_TOOL_COUNT: ${{ steps.expected.outputs.tool_count }}
         run: |
           QUALIFIED_NAME="${SMITHERY_SERVER_QUALIFIED_NAME:-agent-bom/agent-bom}"
-          RESPONSE=$(python3 - <<'PY'
+          RESPONSE=$(EXPECTED_TOOL_COUNT="$EXPECTED_TOOL_COUNT" python3 - <<'PY'
           import json
           import os
           import sys
@@ -153,11 +154,13 @@ jobs:
             echo "::warning::Could not verify Smithery catalog listing"
             exit 0
           }
-          STATE=$(echo "$RESPONSE" | EXPECTED_QUALIFIED_NAME="$QUALIFIED_NAME" python3 -c "
+          STATE=$(echo "$RESPONSE" | EXPECTED_QUALIFIED_NAME="$QUALIFIED_NAME" EXPECTED_TOOL_COUNT="$EXPECTED_TOOL_COUNT" python3 -c "
           import json, os, sys
           data = json.load(sys.stdin)
           if data.get('qualified_name') != os.environ['EXPECTED_QUALIFIED_NAME'] or not data.get('remote') or not data.get('deployment_url') or int(data.get('tool_count') or 0) < 1:
               print('invalid')
+          elif int(data.get('tool_count') or 0) != int(os.environ['EXPECTED_TOOL_COUNT']):
+              print('tool_count_drift')
           else:
               print('catalog_live')
           ")
@@ -171,7 +174,10 @@ jobs:
           echo "Smithery catalog state: $STATE"
           echo "Smithery deployment URL: $DEPLOY_URL"
           echo "Smithery tool count: $TOOL_COUNT"
-          if [ "$STATE" != "catalog_live" ]; then
+          if [ "$STATE" = "tool_count_drift" ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Smithery catalog tool inventory differs from the published release contract (${TOOL_COUNT}/${EXPECTED_TOOL_COUNT})"
+          elif [ "$STATE" != "catalog_live" ]; then
             echo "probe_failed=true" >> "$GITHUB_OUTPUT"
             echo "::warning::Smithery catalog listing is missing remote deployment metadata or tools"
           fi

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -1,6 +1,8 @@
 name: Publish to Registries
 
-# Auto-publishes to Smithery and ClawHub after a successful Release workflow.
+# Publishes to Smithery and ClawHub after a successful Release workflow, and
+# reconciles the provider-managed Smithery and Glama directories every six
+# hours until their public catalogs match the latest release contract.
 # Secrets needed (add via Settings → Secrets):
 #   SMITHERY_API_TOKEN  — Smithery service token (smithery.ai → API tokens)
 #   CLAWHUB_TOKEN       — ClawHub auth token (clawhub.ai → Settings)
@@ -11,24 +13,13 @@ name: Publish to Registries
 # release is only fresh when the catalog converges to the released tool count.
 # Optional vars:
 #   SMITHERY_MCP_URL    — Public Streamable HTTP MCP endpoint for Smithery
-# Optional secret:
-#   GLAMA_WEBHOOK_URL   — Glama rebuild webhook (POST JSON: ref, commit, version, dockerfile)
-
 on:
+  schedule:
+    - cron: "17 */6 * * *"
   workflow_run:
     workflows: ["Release"]
     types: [completed]
   workflow_dispatch:
-    inputs:
-      glama_repair:
-        description: >-
-          Fail the run if the Glama rebuild cannot be triggered. Opt in only when
-          repairing the Glama listing is the point of this run; an ordinary
-          re-publish should leave this off so an unconfigured third-party
-          webhook cannot block the other registries.
-        type: boolean
-        required: false
-        default: false
 
 permissions:
   contents: read
@@ -40,7 +31,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
       version: ${{ steps.release.outputs.version }}
       release_ref: ${{ steps.release.outputs.release_ref }}
@@ -67,10 +58,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            # Manual repair always targets the latest published release. This
-            # workflow fans out to multiple registries, so accepting an older
-            # tag here could downgrade Smithery or ClawHub as a side effect.
+          if [ "$EVENT_NAME" != "workflow_run" ]; then
+            # Manual and scheduled reconciliation always target the latest
+            # published release. Accepting an older tag here could downgrade a
+            # registry as a side effect.
             RELEASE_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest")
             RELEASE_TAG=$(echo "$RELEASE_JSON" | jq -er '.tag_name')
             if [ "$(echo "$RELEASE_JSON" | jq -r '.draft != false')" = "true" ]; then
@@ -96,7 +87,7 @@ jobs:
           git fetch --force --no-tags origin \
             "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
           RELEASE_SHA=$(git rev-list -n 1 "refs/tags/${RELEASE_TAG}")
-          if [ "$EVENT_NAME" != "workflow_dispatch" ] && [ "$RELEASE_SHA" != "$HEAD_SHA" ]; then
+          if [ "$EVENT_NAME" = "workflow_run" ] && [ "$RELEASE_SHA" != "$HEAD_SHA" ]; then
             echo "::error::Release tag and successful workflow commit do not match"
             exit 1
           fi
@@ -144,7 +135,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -262,6 +253,14 @@ jobs:
           echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
           echo "Reusing matching Smithery release ${RELEASE_ID} (${RELEASE_STATUS})"
           if [ "$RELEASE_STATUS" = "AUTH_REQUIRED" ]; then
+            curl -fsS --connect-timeout 10 --max-time 30 \
+              "https://api.smithery.ai/servers/${QUALIFIED_NAME}/releases/${RELEASE_ID}" \
+              -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" \
+              -o /tmp/smithery-release.json
+            echo "Complete Smithery scan authorization for the pending release"
+            python scripts/authorize_smithery_release.py \
+              --release-json /tmp/smithery-release.json \
+              --upstream-url "$SMITHERY_MCP_URL"
             HTTP_STATUS=$(curl -sS --connect-timeout 10 --max-time 30 \
               -o /tmp/smithery-resume-response.json -w "%{http_code}" \
               -X POST "https://api.smithery.ai/servers/${QUALIFIED_NAME}/releases/${RELEASE_ID}/resume" \
@@ -325,13 +324,17 @@ jobs:
         if: steps.smithery_config.outputs.enabled == 'true' && steps.smithery_catalog.outputs.fresh != 'true'
         env:
           SMITHERY_API_TOKEN: ${{ secrets.SMITHERY_API_TOKEN }}
+          SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
           RELEASE_ID: ${{ steps.smithery_pending.outputs.release_id || steps.smithery_publish.outputs.release_id }}
         run: |
           set -euo pipefail
+          AUTHORIZATION_ATTEMPTED=false
           for ATTEMPT in $(seq 1 90); do
-            STATUS=$(curl -fsS --connect-timeout 10 --max-time 30 \
+            curl -fsS --connect-timeout 10 --max-time 30 \
               "https://api.smithery.ai/servers/agent-bom%2Fagent-bom/releases/${RELEASE_ID}" \
-              -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" | jq -er '.status')
+              -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" \
+              -o /tmp/smithery-release.json
+            STATUS=$(jq -er '.status' /tmp/smithery-release.json)
             echo "Smithery release attempt ${ATTEMPT}/90 — ${STATUS}"
             case "$STATUS" in
               SUCCESS)
@@ -339,7 +342,23 @@ jobs:
                 exit 0
                 ;;
               AUTH_REQUIRED)
-                echo "::notice::Smithery is waiting for publisher authorization; authorize the pending release in the Smithery UI"
+                if [ "$AUTHORIZATION_ATTEMPTED" = "true" ]; then
+                  echo "::error::Smithery authorization remained required after the bounded recovery attempt"
+                  exit 1
+                fi
+                echo "Complete Smithery scan authorization for the new release"
+                python scripts/authorize_smithery_release.py \
+                  --release-json /tmp/smithery-release.json \
+                  --upstream-url "$SMITHERY_MCP_URL"
+                HTTP_STATUS=$(curl -sS --connect-timeout 10 --max-time 30 \
+                  -o /tmp/smithery-resume-response.json -w "%{http_code}" \
+                  -X POST "https://api.smithery.ai/servers/agent-bom%2Fagent-bom/releases/${RELEASE_ID}/resume" \
+                  -H "Authorization: Bearer ${SMITHERY_API_TOKEN}")
+                if [ "$HTTP_STATUS" != "202" ]; then
+                  echo "::error::Smithery release could not be resumed after scan authorization (HTTP ${HTTP_STATUS})"
+                  exit 1
+                fi
+                AUTHORIZATION_ATTEMPTED=true
                 ;;
               FAILURE|FAILURE_SCAN|AUTH_TIMEOUT|CANCELLED|INTERNAL_ERROR)
                 echo "::error::Smithery release did not complete successfully (${STATUS})"
@@ -348,7 +367,7 @@ jobs:
             esac
             sleep 10
           done
-          echo "::error::Smithery release did not finish within 15 minutes; authorize the pending release in the Smithery UI and re-run this workflow"
+          echo "::error::Smithery release did not finish within 15 minutes after bounded automatic recovery"
           exit 1
 
       - name: Verify Smithery catalog inventory
@@ -379,14 +398,13 @@ jobs:
           exit 1
 
   glama:
-    name: Trigger Glama Rebuild
+    name: Verify Glama Directory
     needs: release
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      actions: read
       contents: read
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -401,69 +419,21 @@ jobs:
       - name: Verify Glama build manifest
         run: python scripts/check_glama_listing.py --verify-manifest --git-ref "${{ needs.release.outputs.release_sha }}"
 
-      - name: Trigger Glama rebuild
-        id: glama_trigger
-        env:
-          GLAMA_WEBHOOK_URL: ${{ secrets.GLAMA_WEBHOOK_URL }}
-          GLAMA_REPAIR: ${{ inputs.glama_repair }}
-          REGISTRY_PUBLISH_REQUIRED: ${{ github.event_name == 'workflow_run' }}
-          RELEASE_REF: ${{ needs.release.outputs.release_ref }}
-          RELEASE_SHA: ${{ needs.release.outputs.release_sha }}
-          VERSION: ${{ needs.release.outputs.version }}
-          GLAMA_DOCKERFILE: integrations/glama/Dockerfile
-        run: |
-          set -u
-
-          fail_or_warn() {
-            local message="$1"
-            echo "rebuild_triggered=false" >> "$GITHUB_OUTPUT"
-            if [ "$REGISTRY_PUBLISH_REQUIRED" = "true" ] || [ "$GLAMA_REPAIR" = "true" ]; then
-              echo "::error::Required Glama publication ${message}"
-              return 1
-            fi
-            echo "::warning::Automatic Glama rebuild ${message}; the freshness issue will remain open"
-            return 0
-          }
-
-          if [ -z "$GLAMA_WEBHOOK_URL" ]; then
-            echo "Release pin for Glama: ${RELEASE_REF} (${RELEASE_SHA:0:7}) dockerfile=${GLAMA_DOCKERFILE}"
-            echo "To enable instant rebuild, set GLAMA_WEBHOOK_URL as a repository Actions secret"
-            fail_or_warn "failed because GLAMA_WEBHOOK_URL is not configured. No Glama rebuild was triggered"
-            exit $?
-          fi
-          PAYLOAD=$(jq -n \
-            --arg ref "$RELEASE_REF" \
-            --arg commit "$RELEASE_SHA" \
-            --arg version "$VERSION" \
-            --arg dockerfile "$GLAMA_DOCKERFILE" \
-            '{ref: $ref, commit: $commit, version: $version, dockerfile: $dockerfile}')
-          echo "Triggering Glama rebuild for ${RELEASE_REF} (${RELEASE_SHA:0:7}) using ${GLAMA_DOCKERFILE}"
-          if ! HTTP_STATUS=$(curl -s --connect-timeout 10 --max-time 30 \
-              -o /dev/null -w "%{http_code}" \
-              -H "Content-Type: application/json" \
-              -d "$PAYLOAD" \
-              -X POST "$GLAMA_WEBHOOK_URL"); then
-            fail_or_warn "request failed before an HTTP response was received"
-            exit $?
-          fi
-          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
-            echo "rebuild_triggered=true" >> "$GITHUB_OUTPUT"
-            echo "Glama rebuild triggered successfully"
-          else
-            fail_or_warn "returned HTTP ${HTTP_STATUS}"
-            exit $?
-          fi
-
       - name: Verify Glama listing freshness
         env:
           EXPECTED_VERSION: ${{ needs.release.outputs.version }}
           EXPECTED_TOOL_COUNT: ${{ needs.release.outputs.tool_count }}
         run: |
-          python scripts/check_glama_listing.py \
-            --expected "$EXPECTED_VERSION" \
-            --expected-tool-count "$EXPECTED_TOOL_COUNT" \
-            --retries 6 \
-            --delay-seconds 30
+          set -euo pipefail
+          if python scripts/check_glama_listing.py \
+              --expected "$EXPECTED_VERSION" \
+              --expected-tool-count "$EXPECTED_TOOL_COUNT" \
+              --retries 6 \
+              --delay-seconds 30; then
+            exit 0
+          fi
+          echo "::error::Glama has not synchronized the exact released catalog yet. Glama syncs linked GitHub repositories automatically at least daily; this workflow retries every six hours. For an immediate provider-side refresh, use Sync Server in the Glama admin interface, then rerun this verification."
+          exit 1
 
   clawhub:
     name: Publish to ClawHub

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -1,8 +1,9 @@
 name: Publish to Registries
 
-# Publishes to Smithery and ClawHub after a successful Release workflow, and
-# reconciles the provider-managed Smithery and Glama directories every six
-# hours until their public catalogs match the latest release contract.
+# Publishes after a successful Release workflow and reconciles every
+# idempotent registry every six hours until the public surfaces match the
+# latest release contract. Scheduled ClawHub retries also recover a release
+# event displaced from GitHub's single pending concurrency slot.
 # Secrets needed (add via Settings → Secrets):
 #   SMITHERY_API_TOKEN  — Smithery service token (smithery.ai → API tokens)
 #   CLAWHUB_TOKEN       — ClawHub auth token (clawhub.ai → Settings)
@@ -219,6 +220,8 @@ jobs:
                 /tmp/smithery-server-card.json >/dev/null; then
               jq -S '[.tools[].name] | sort' /tmp/smithery-server-card.json > /tmp/smithery-actual-server-card-tool-names.json
               if cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-server-card-tool-names.json; then
+                jq -S '[.tools[] | {name, inputSchema}] | sort_by(.name)' \
+                  /tmp/smithery-server-card.json > /tmp/smithery-expected-tool-contract.json
                 echo "Smithery server card matches the immutable v${VERSION} contract with ${EXPECTED_TOOL_COUNT} live tool schemas"
                 exit 0
               fi
@@ -244,21 +247,36 @@ jobs:
             echo "::error::Smithery catalog is unavailable; refusing to create a potentially duplicate release"
             exit 1
           fi
-          curl -fsS --connect-timeout 10 --max-time 30 \
-            -X GET "https://api.smithery.ai/servers/agent-bom%2Fagent-bom/releases?page=1&pageSize=100" \
-            -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" \
-            -o /tmp/smithery-latest-releases.json
-          jq -e '(.releases | type == "array") and (.pagination.currentPage == 1)' \
-            /tmp/smithery-latest-releases.json >/dev/null
-          LATEST_SUCCESS_UPSTREAM=$(jq -r \
-            '[.releases[] | select(.type == "external_shttp" and .status == "SUCCESS")] | first | .upstreamUrl // empty' \
-            /tmp/smithery-latest-releases.json)
+          MAX_RELEASE_PAGES=20
+          : > /tmp/smithery-success-releases.jsonl
+          for PAGE in $(seq 1 "$MAX_RELEASE_PAGES"); do
+            curl -fsS --connect-timeout 10 --max-time 30 \
+              -X GET "https://api.smithery.ai/servers/agent-bom%2Fagent-bom/releases?page=${PAGE}&pageSize=100" \
+              -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" \
+              -o /tmp/smithery-latest-releases.json
+            jq -e \
+              --argjson page "$PAGE" \
+              --argjson max_pages "$MAX_RELEASE_PAGES" \
+              '(.releases | type == "array") and (.pagination.currentPage == $page) and (.pagination.totalPages | type == "number") and (.pagination.totalPages >= 0) and (.pagination.totalPages <= $max_pages)' \
+              /tmp/smithery-latest-releases.json >/dev/null
+            jq -c \
+              '.releases[] | select(.type == "external_shttp" and .status == "SUCCESS")' \
+              /tmp/smithery-latest-releases.json >> /tmp/smithery-success-releases.jsonl
+            TOTAL_PAGES=$(jq -er '.pagination.totalPages' /tmp/smithery-latest-releases.json)
+            if [ "$PAGE" -ge "$TOTAL_PAGES" ]; then
+              break
+            fi
+          done
+          LATEST_SUCCESS_UPSTREAM=$(jq -sr 'first | .upstreamUrl // empty' /tmp/smithery-success-releases.jsonl)
           jq -S '[.tools[].name] | sort' /tmp/smithery-catalog.json > /tmp/smithery-actual-tool-names.json
+          jq -S '[.tools[] | {name, inputSchema}] | sort_by(.name)' \
+            /tmp/smithery-catalog.json > /tmp/smithery-actual-tool-contract.json
           if cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-tool-names.json && \
+            cmp -s /tmp/smithery-expected-tool-contract.json /tmp/smithery-actual-tool-contract.json && \
             [ "$LATEST_SUCCESS_UPSTREAM" = "$SMITHERY_MCP_URL" ]; then
             TOOL_COUNT=$(jq -r '.tools | length' /tmp/smithery-catalog.json)
             echo "fresh=true" >> "$GITHUB_OUTPUT"
-            echo "Smithery already exposes the released ${TOOL_COUNT}-tool catalog; skipping a duplicate deployment"
+            echo "Smithery already exposes the released ${TOOL_COUNT}-tool name and input-schema contract; skipping a duplicate deployment"
           else
             EXPECTED=$(jq -r 'length' /tmp/smithery-expected-tool-names.json)
             ACTUAL=$(jq -r 'length' /tmp/smithery-actual-tool-names.json)
@@ -437,13 +455,16 @@ jobs:
                 "https://api.smithery.ai/servers/agent-bom/agent-bom" \
                 -o /tmp/smithery-catalog.json; then
               jq -S '[.tools[].name] | sort' /tmp/smithery-catalog.json > /tmp/smithery-actual-tool-names.json
+              jq -S '[.tools[] | {name, inputSchema}] | sort_by(.name)' \
+                /tmp/smithery-catalog.json > /tmp/smithery-actual-tool-contract.json
               ACTUAL=$(jq -r 'length' /tmp/smithery-actual-tool-names.json)
             else
               ACTUAL=unavailable
             fi
             if [ "$ACTUAL" = "$EXPECTED_TOOL_COUNT" ] && \
-              cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-tool-names.json; then
-              echo "Smithery catalog exposes all ${ACTUAL} tools for v${VERSION}"
+              cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-tool-names.json && \
+              cmp -s /tmp/smithery-expected-tool-contract.json /tmp/smithery-actual-tool-contract.json; then
+              echo "Smithery catalog exposes all ${ACTUAL} tools and exact input schemas for v${VERSION}"
               exit 0
             fi
             echo "Smithery catalog attempt ${ATTEMPT}/12 does not match the released ${EXPECTED_TOOL_COUNT}-tool name set (actual=${ACTUAL})"
@@ -502,6 +523,8 @@ jobs:
                 /tmp/glama-server-card.json >/dev/null; then
               jq -S '[.tools[].name] | sort' /tmp/glama-server-card.json > /tmp/glama-actual-server-card-tool-names.json
               if cmp -s /tmp/glama-expected-tool-names.json /tmp/glama-actual-server-card-tool-names.json; then
+                jq -S '[.tools[] | {name, inputSchema}] | sort_by(.name)' \
+                  /tmp/glama-server-card.json > /tmp/glama-expected-tool-contract.json
                 echo "Public server card matches the immutable v${EXPECTED_VERSION} tool contract"
                 exit 0
               fi
@@ -522,6 +545,7 @@ jobs:
               --expected "$EXPECTED_VERSION" \
               --expected-tool-count "$EXPECTED_TOOL_COUNT" \
               --expected-tool-names-file /tmp/glama-expected-tool-names.json \
+              --expected-tool-contract-file /tmp/glama-expected-tool-contract.json \
               --retries 6 \
               --delay-seconds 30; then
             exit 0
@@ -536,7 +560,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-    if: ${{ needs.release.outputs.publish_current == 'true' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') }}
+    if: ${{ needs.release.outputs.publish_current == 'true' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.workflow_run.conclusion == 'success') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -234,9 +234,48 @@ jobs:
             echo "Smithery catalog differs from the released contract (${ACTUAL}/${EXPECTED} tools); publishing a new deployment"
           fi
 
+      - name: List resumable Smithery releases
+        id: smithery_pending
+        if: steps.smithery_config.outputs.enabled == 'true' && steps.smithery_catalog.outputs.fresh != 'true'
+        env:
+          SMITHERY_API_TOKEN: ${{ secrets.SMITHERY_API_TOKEN }}
+          SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
+        run: |
+          set -euo pipefail
+          QUALIFIED_NAME="agent-bom%2Fagent-bom"
+          echo "release_id=" >> "$GITHUB_OUTPUT"
+          if ! curl -fsS --connect-timeout 10 --max-time 30 \
+              -X GET "https://api.smithery.ai/servers/${QUALIFIED_NAME}/releases" \
+              -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" \
+              -o /tmp/smithery-releases.json; then
+            echo "::notice::Smithery release history is unavailable; creating a new release"
+            exit 0
+          fi
+          RELEASE=$(jq -cer --arg upstream "$SMITHERY_MCP_URL" \
+            '[.[] | select(.type == "external_shttp" and .upstreamUrl == $upstream) | select(.status == "AUTH_REQUIRED" or .status == "QUEUED" or .status == "WORKING")] | first // empty' \
+            /tmp/smithery-releases.json) || true
+          if [ -z "$RELEASE" ]; then
+            exit 0
+          fi
+          RELEASE_ID=$(echo "$RELEASE" | jq -er '.id')
+          RELEASE_STATUS=$(echo "$RELEASE" | jq -er '.status')
+          echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+          echo "Reusing matching Smithery release ${RELEASE_ID} (${RELEASE_STATUS})"
+          if [ "$RELEASE_STATUS" = "AUTH_REQUIRED" ]; then
+            HTTP_STATUS=$(curl -sS --connect-timeout 10 --max-time 30 \
+              -o /tmp/smithery-resume-response.json -w "%{http_code}" \
+              -X POST "https://api.smithery.ai/servers/${QUALIFIED_NAME}/releases/${RELEASE_ID}/resume" \
+              -H "Authorization: Bearer ${SMITHERY_API_TOKEN}")
+            if [ "$HTTP_STATUS" != "202" ]; then
+              echo "::error::Matching Smithery release could not be resumed (HTTP ${HTTP_STATUS}); authorize it with the publisher identity, then retry"
+              exit 1
+            fi
+            echo "Smithery accepted resume for release ${RELEASE_ID}"
+          fi
+
       - name: Publish to Smithery
         id: smithery_publish
-        if: steps.smithery_config.outputs.enabled == 'true' && steps.smithery_catalog.outputs.fresh != 'true'
+        if: steps.smithery_config.outputs.enabled == 'true' && steps.smithery_catalog.outputs.fresh != 'true' && steps.smithery_pending.outputs.release_id == ''
         env:
           SMITHERY_API_TOKEN: ${{ secrets.SMITHERY_API_TOKEN }}
           SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
@@ -286,7 +325,7 @@ jobs:
         if: steps.smithery_config.outputs.enabled == 'true' && steps.smithery_catalog.outputs.fresh != 'true'
         env:
           SMITHERY_API_TOKEN: ${{ secrets.SMITHERY_API_TOKEN }}
-          RELEASE_ID: ${{ steps.smithery_publish.outputs.release_id }}
+          RELEASE_ID: ${{ steps.smithery_pending.outputs.release_id || steps.smithery_publish.outputs.release_id }}
         run: |
           set -euo pipefail
           for ATTEMPT in $(seq 1 90); do

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -24,6 +24,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: publish-registries
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Resolve published release
@@ -38,6 +42,7 @@ jobs:
       release_sha: ${{ steps.release.outputs.release_sha }}
       tool_count: ${{ steps.release.outputs.tool_count }}
       smithery_oauth_ready: ${{ steps.release.outputs.smithery_oauth_ready }}
+      publish_current: ${{ steps.release.outputs.publish_current }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -82,6 +87,12 @@ jobs:
               echo "::error::Successful Release workflow did not report a release commit"
               exit 1
             fi
+            LATEST_RELEASE_TAG=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)
+            if [ "$LATEST_RELEASE_TAG" != "$RELEASE_TAG" ]; then
+              echo "publish_current=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::Skipping delayed ${RELEASE_TAG} registry event because ${LATEST_RELEASE_TAG} is already the latest published release"
+              exit 0
+            fi
           fi
 
           git fetch --force --no-tags origin \
@@ -121,6 +132,7 @@ jobs:
             SMITHERY_OAUTH_READY=false
           fi
           {
+            echo "publish_current=true"
             echo "version=$VERSION"
             echo "release_ref=refs/tags/${RELEASE_TAG}"
             echo "release_sha=$RELEASE_SHA"
@@ -135,7 +147,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ needs.release.outputs.publish_current == 'true' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.workflow_run.conclusion == 'success') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -176,6 +188,19 @@ jobs:
           fi
           echo "enabled=true" >> "$GITHUB_OUTPUT"
 
+      - name: Fetch release commit for Smithery contract verification
+        if: steps.smithery_config.outputs.enabled == 'true'
+        env:
+          RELEASE_SHA: ${{ needs.release.outputs.release_sha }}
+        run: git fetch --no-tags --depth=1 origin "$RELEASE_SHA"
+
+      - name: Extract immutable Smithery release tool contract
+        if: steps.smithery_config.outputs.enabled == 'true'
+        run: >-
+          python scripts/check_glama_listing.py
+          --write-tool-names /tmp/smithery-expected-tool-names.json
+          --git-ref "${{ needs.release.outputs.release_sha }}"
+
       - name: Validate Smithery public server card
         if: steps.smithery_config.outputs.enabled == 'true'
         env:
@@ -192,8 +217,11 @@ jobs:
                 --argjson tool_count "$EXPECTED_TOOL_COUNT" \
                 '.serverInfo.version == $version and (.authentication.required == true) and (.authentication.schemes | index("oauth2") != null) and (.tools | length) == $tool_count and all(.tools[]; (.name | type == "string") and (.inputSchema | type == "object"))' \
                 /tmp/smithery-server-card.json >/dev/null; then
-              echo "Smithery server card matches v${VERSION} with ${EXPECTED_TOOL_COUNT} live tool schemas"
-              exit 0
+              jq -S '[.tools[].name] | sort' /tmp/smithery-server-card.json > /tmp/smithery-actual-server-card-tool-names.json
+              if cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-server-card-tool-names.json; then
+                echo "Smithery server card matches the immutable v${VERSION} contract with ${EXPECTED_TOOL_COUNT} live tool schemas"
+                exit 0
+              fi
             fi
             echo "Smithery server card attempt ${ATTEMPT}/12 has not reached the released contract"
             sleep 10
@@ -204,25 +232,41 @@ jobs:
       - name: Check Smithery catalog parity
         id: smithery_catalog
         if: steps.smithery_config.outputs.enabled == 'true'
+        env:
+          SMITHERY_API_TOKEN: ${{ secrets.SMITHERY_API_TOKEN }}
+          SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
         run: |
           set -euo pipefail
           echo "fresh=false" >> "$GITHUB_OUTPUT"
           if ! curl -fsS --connect-timeout 10 --max-time 30 \
               "https://api.smithery.ai/servers/agent-bom/agent-bom" \
               -o /tmp/smithery-catalog.json; then
-            echo "::notice::Smithery catalog could not be read before publication; creating a release"
-            exit 0
+            echo "::error::Smithery catalog is unavailable; refusing to create a potentially duplicate release"
+            exit 1
           fi
-          jq -S '[.tools[].name] | sort' /tmp/smithery-server-card.json > /tmp/smithery-expected-tool-names.json
+          curl -fsS --connect-timeout 10 --max-time 30 \
+            -X GET "https://api.smithery.ai/servers/agent-bom%2Fagent-bom/releases?page=1&pageSize=100" \
+            -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" \
+            -o /tmp/smithery-latest-releases.json
+          jq -e '(.releases | type == "array") and (.pagination.currentPage == 1)' \
+            /tmp/smithery-latest-releases.json >/dev/null
+          LATEST_SUCCESS_UPSTREAM=$(jq -r \
+            '[.releases[] | select(.type == "external_shttp" and .status == "SUCCESS")] | first | .upstreamUrl // empty' \
+            /tmp/smithery-latest-releases.json)
           jq -S '[.tools[].name] | sort' /tmp/smithery-catalog.json > /tmp/smithery-actual-tool-names.json
-          if cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-tool-names.json; then
+          if cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-tool-names.json && \
+            [ "$LATEST_SUCCESS_UPSTREAM" = "$SMITHERY_MCP_URL" ]; then
             TOOL_COUNT=$(jq -r '.tools | length' /tmp/smithery-catalog.json)
             echo "fresh=true" >> "$GITHUB_OUTPUT"
             echo "Smithery already exposes the released ${TOOL_COUNT}-tool catalog; skipping a duplicate deployment"
           else
             EXPECTED=$(jq -r 'length' /tmp/smithery-expected-tool-names.json)
             ACTUAL=$(jq -r 'length' /tmp/smithery-actual-tool-names.json)
-            echo "Smithery catalog differs from the released contract (${ACTUAL}/${EXPECTED} tools); publishing a new deployment"
+            if [ "$LATEST_SUCCESS_UPSTREAM" != "$SMITHERY_MCP_URL" ]; then
+              echo "Smithery tool catalog matches but the successful release upstream differs; publishing a new deployment"
+            else
+              echo "Smithery catalog differs from the released contract (${ACTUAL}/${EXPECTED} tools); publishing a new deployment"
+            fi
           fi
 
       - name: List resumable Smithery releases
@@ -235,16 +279,27 @@ jobs:
           set -euo pipefail
           QUALIFIED_NAME="agent-bom%2Fagent-bom"
           echo "release_id=" >> "$GITHUB_OUTPUT"
-          if ! curl -fsS --connect-timeout 10 --max-time 30 \
-              -X GET "https://api.smithery.ai/servers/${QUALIFIED_NAME}/releases" \
+          MAX_RELEASE_PAGES=20
+          : > /tmp/smithery-active-releases.jsonl
+          for PAGE in $(seq 1 "$MAX_RELEASE_PAGES"); do
+            curl -fsS --connect-timeout 10 --max-time 30 \
+              -X GET "https://api.smithery.ai/servers/${QUALIFIED_NAME}/releases?page=${PAGE}&pageSize=100" \
               -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" \
-              -o /tmp/smithery-releases.json; then
-            echo "::notice::Smithery release history is unavailable; creating a new release"
-            exit 0
-          fi
-          RELEASE=$(jq -cer --arg upstream "$SMITHERY_MCP_URL" \
-            '[.[] | select(.type == "external_shttp" and .upstreamUrl == $upstream) | select(.status == "AUTH_REQUIRED" or .status == "QUEUED" or .status == "WORKING")] | first // empty' \
-            /tmp/smithery-releases.json) || true
+              -o /tmp/smithery-releases.json
+            jq -e \
+              --argjson page "$PAGE" \
+              --argjson max_pages "$MAX_RELEASE_PAGES" \
+              '(.releases | type == "array") and (.pagination.currentPage == $page) and (.pagination.totalPages | type == "number") and (.pagination.totalPages >= 0) and (.pagination.totalPages <= $max_pages)' \
+              /tmp/smithery-releases.json >/dev/null
+            jq -c --arg upstream "$SMITHERY_MCP_URL" \
+              '.releases[] | select(.type == "external_shttp" and .upstreamUrl == $upstream) | select(.status == "AUTH_REQUIRED" or .status == "QUEUED" or .status == "WORKING")' \
+              /tmp/smithery-releases.json >> /tmp/smithery-active-releases.jsonl
+            TOTAL_PAGES=$(jq -er '.pagination.totalPages' /tmp/smithery-releases.json)
+            if [ "$PAGE" -ge "$TOTAL_PAGES" ]; then
+              break
+            fi
+          done
+          RELEASE=$(jq -sc 'first // empty' /tmp/smithery-active-releases.jsonl)
           if [ -z "$RELEASE" ]; then
             exit 0
           fi
@@ -404,7 +459,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ needs.release.outputs.publish_current == 'true' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.workflow_run.conclusion == 'success') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -419,6 +474,44 @@ jobs:
       - name: Verify Glama build manifest
         run: python scripts/check_glama_listing.py --verify-manifest --git-ref "${{ needs.release.outputs.release_sha }}"
 
+      - name: Extract immutable release tool contract
+        run: >-
+          python scripts/check_glama_listing.py
+          --write-tool-names /tmp/glama-expected-tool-names.json
+          --git-ref "${{ needs.release.outputs.release_sha }}"
+
+      - name: Validate released public server card for Glama
+        env:
+          MCP_SERVER_URL: ${{ vars.SMITHERY_MCP_URL }}
+          EXPECTED_TOOL_COUNT: ${{ needs.release.outputs.tool_count }}
+          EXPECTED_VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MCP_SERVER_URL:-}" ]; then
+            echo "::error::SMITHERY_MCP_URL is required to verify the public server card"
+            exit 1
+          fi
+          SERVER_CARD_URL=$(python3 -c 'import sys; from urllib.parse import urlsplit, urlunsplit; p=urlsplit(sys.argv[1]); assert p.scheme == "https" and p.netloc; print(urlunsplit((p.scheme, p.netloc, "/.well-known/mcp/server-card.json", "", "")))' "$MCP_SERVER_URL")
+          for ATTEMPT in $(seq 1 6); do
+            if curl -fsS --connect-timeout 10 --max-time 30 \
+                "$SERVER_CARD_URL" -o /tmp/glama-server-card.json && \
+              jq -e \
+                --arg version "$EXPECTED_VERSION" \
+                --argjson tool_count "$EXPECTED_TOOL_COUNT" \
+                '.serverInfo.version == $version and (.tools | length) == $tool_count and all(.tools[]; (.name | type == "string") and (.name | length > 0) and (.inputSchema | type == "object")) and (([.tools[].name] | unique | length) == $tool_count)' \
+                /tmp/glama-server-card.json >/dev/null; then
+              jq -S '[.tools[].name] | sort' /tmp/glama-server-card.json > /tmp/glama-actual-server-card-tool-names.json
+              if cmp -s /tmp/glama-expected-tool-names.json /tmp/glama-actual-server-card-tool-names.json; then
+                echo "Public server card matches the immutable v${EXPECTED_VERSION} tool contract"
+                exit 0
+              fi
+            fi
+            echo "Public server card attempt ${ATTEMPT}/6 has not reached the immutable release contract"
+            sleep 10
+          done
+          echo "::error::Public server card does not match the immutable released tool-name contract"
+          exit 1
+
       - name: Verify Glama listing freshness
         env:
           EXPECTED_VERSION: ${{ needs.release.outputs.version }}
@@ -428,6 +521,7 @@ jobs:
           if python scripts/check_glama_listing.py \
               --expected "$EXPECTED_VERSION" \
               --expected-tool-count "$EXPECTED_TOOL_COUNT" \
+              --expected-tool-names-file /tmp/glama-expected-tool-names.json \
               --retries 6 \
               --delay-seconds 30; then
             exit 0
@@ -442,7 +536,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ needs.release.outputs.publish_current == 'true' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/surface-freshness.yml
+++ b/.github/workflows/surface-freshness.yml
@@ -124,7 +124,7 @@ jobs:
               rows,
               "",
               "**Statuses**",
-              "- `stale` — surface published a different version; re-run the publish workflow.",
+              "- `stale` — surface published a different version; use that provider's supported publish or sync path, then re-run verification.",
               "- `unmonitored (misconfigured)` — a required repo variable is unset, so this surface is NOT being watched. Set the named variable.",
               "- `unreachable` — the surface URL is configured but the probe failed (network / HTTP / parse).",
               "",

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -46,10 +46,11 @@ remote deployment metadata, and non-empty tools.
 **Option B — Automated**:
 The `publish-registries.yml` workflow parses the static server-card tool names
 from the immutable release commit, then compares that contract with both the
-live server card and Smithery's public catalog before publishing. If they
-already match and the latest successful release is bound to the configured
-upstream URL, the workflow skips a duplicate deployment. If capabilities or
-the upstream changed, it creates an external release using:
+live server card and Smithery's public catalog before publishing. It also
+compares the catalog's input schemas with the live release-bound server card.
+If names, schemas, and the latest successful upstream URL already match, the
+workflow skips a duplicate deployment. If capabilities or the upstream
+changed, it creates an external release using:
 - `SMITHERY_API_TOKEN`
 
 `SMITHERY_MCP_URL` is retained only for the external-upstream publish mode. It
@@ -105,7 +106,10 @@ Search for "agent-bom" at: https://registry.modelcontextprotocol.io
 
 ## 3. ClawHub / OpenClaw
 
-Automated via `publish-registries.yml` using `CLAWHUB_TOKEN`.
+Automated via `publish-registries.yml` using `CLAWHUB_TOKEN`. The exact
+release version is retried every six hours, and ClawHub's already-published
+response is treated as an idempotent success. This also recovers publication
+when GitHub replaces an older pending workflow run in its concurrency queue.
 
 The public ClawHub surface is intentionally curated. Release automation publishes only:
 - `agent-bom-scan`
@@ -151,7 +155,10 @@ For an immediate provider-side refresh, open the server's admin page and use
 **Sync Server**, then dispatch **Publish to Registries** again. Verification
 requires both the released version marker and the exact MCP tool-name set
 parsed from the immutable release commit; the live server card is checked
-independently against the same contract.
+independently against the same contract. When Glama's machine inventory is
+reachable, its input schemas must also match the live release-bound server
+card. A user-visible Schema page match with an unreachable machine inventory
+is reported as degraded rather than full parity.
 
 A Glama hosted release is separate from directory synchronization. Creating
 one remains a maintainer action in Glama: configure the Dockerfile build,

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -55,11 +55,14 @@ must never point at Smithery's hosted proxy URL. Freshness monitoring no longer
 depends on that variable; it uses the Smithery catalog API directly.
 
 Do not add the upstream bearer token to Smithery `configSchema`. Smithery
-reserves the `Authorization` header for OAuth. A new authenticated capability
-scan can pause as `AUTH_REQUIRED`; authorize that pending release in Smithery's
-**Releases** UI. The workflow waits up to 15 minutes and otherwise fails
-honestly. After authorization, re-running the workflow verifies catalog parity
-without creating another deployment.
+reserves the `Authorization` header for OAuth. If a capability scan pauses as
+`AUTH_REQUIRED`, the workflow reads the release through Smithery's authenticated
+API, accepts only an authorization URL on the configured Agent-Bom origin,
+follows the bounded machine-to-machine PKCE callback without logging its OAuth
+state, and resumes the same release. It never creates a duplicate while a
+matching release remains active. The workflow retries every six hours and
+fails honestly if the provider still requires authorization or the exact
+catalog does not converge.
 
 ### Verification
 
@@ -135,13 +138,20 @@ clawhub install agent-bom-scan
 ## 4. Glama
 
 Glama indexes the repository README and builds the MCP schema from
-`integrations/glama/Dockerfile`. Automatic forward releases require the
-`GLAMA_WEBHOOK_URL` Actions secret; a missing webhook or a stale public listing
-fails the registry workflow rather than reporting a green publication.
+`integrations/glama/Dockerfile`. Glama synchronizes linked GitHub repositories
+automatically at least daily. `publish-registries.yml` verifies the exact
+released version and MCP tool set immediately after a release and every six
+hours; it does not call an undocumented provider endpoint or report stale data
+as published.
 
-For a manual repair, open the server's **Admin → Repository** page and run
-**Sync**, then dispatch **Publish to Registries** again. Verification requires
-both the released version marker and the exact released MCP tool count.
+For an immediate provider-side refresh, open the server's admin page and use
+**Sync Server**, then dispatch **Publish to Registries** again. Verification
+requires both the released version marker and the exact released MCP tool
+count.
+
+A Glama hosted release is separate from directory synchronization. Creating
+one remains a maintainer action in Glama: configure the Dockerfile build,
+deploy and pass the build test, then create and publish the Glama release.
 
 ```bash
 python scripts/check_glama_listing.py \
@@ -233,6 +243,7 @@ For dependency-heavy or security-driven releases, also verify:
 | **GHCR (stdio)** | `Dockerfile.mcp` | publish-mcp.yml | workflow_run |
 | **GHCR (SSE)** | `deploy/docker/Dockerfile.sse` | publish-mcp.yml | workflow_run |
 | **Smithery** | workflow API | publish-registries.yml | workflow_run |
+| **Glama directory** | `glama.json` + `integrations/glama/Dockerfile` | provider sync + strict verification | provider daily sync / publish-registries.yml every 6 hours |
 | **ClawHub** | curated `integrations/openclaw/*/SKILL.md` set | publish-registries.yml | workflow_run |
 | **MCP Registry** | `integrations/mcp-registry/server.json` | publish-mcp-registry.yml | workflow_run |
 | **Railway** | `deploy/docker/Dockerfile.sse` | deploy-mcp-sse.yml | release workflow_call / workflow_dispatch |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -145,8 +145,7 @@ both the released version marker and the exact released MCP tool count.
 
 ```bash
 python scripts/check_glama_listing.py \
-  --expected 0.103.2 \
-  --expected-tool-count 84
+  --expected 0.103.2
 ```
 
 ---

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -44,10 +44,12 @@ remote deployment metadata, and non-empty tools.
 5. Click **Continue**
 
 **Option B — Automated**:
-The `publish-registries.yml` workflow compares the released server-card tool
-names with Smithery's public catalog before publishing. If they already match,
-the workflow skips a duplicate deployment. If capabilities changed, it creates
-an external release using:
+The `publish-registries.yml` workflow parses the static server-card tool names
+from the immutable release commit, then compares that contract with both the
+live server card and Smithery's public catalog before publishing. If they
+already match and the latest successful release is bound to the configured
+upstream URL, the workflow skips a duplicate deployment. If capabilities or
+the upstream changed, it creates an external release using:
 - `SMITHERY_API_TOKEN`
 
 `SMITHERY_MCP_URL` is retained only for the external-upstream publish mode. It
@@ -59,10 +61,11 @@ reserves the `Authorization` header for OAuth. If a capability scan pauses as
 `AUTH_REQUIRED`, the workflow reads the release through Smithery's authenticated
 API, accepts only an authorization URL on the configured Agent-Bom origin,
 follows the bounded machine-to-machine PKCE callback without logging its OAuth
-state, and resumes the same release. It never creates a duplicate while a
-matching release remains active. The workflow retries every six hours and
-fails honestly if the provider still requires authorization or the exact
-catalog does not converge.
+state. The only permitted redirect is the configured authorization endpoint to
+Smithery's exact HTTPS callback; a second redirect or alternate host, port, or
+path fails closed. The workflow never creates a duplicate while a matching
+release remains active, retries every six hours, and fails honestly if the
+provider still requires authorization or the exact catalog does not converge.
 
 ### Verification
 
@@ -146,8 +149,9 @@ as published.
 
 For an immediate provider-side refresh, open the server's admin page and use
 **Sync Server**, then dispatch **Publish to Registries** again. Verification
-requires both the released version marker and the exact released MCP tool
-count.
+requires both the released version marker and the exact MCP tool-name set
+parsed from the immutable release commit; the live server card is checked
+independently against the same contract.
 
 A Glama hosted release is separate from directory synchronization. Creating
 one remains a maintainer action in Glama: configure the Dockerfile build,

--- a/scripts/authorize_smithery_release.py
+++ b/scripts/authorize_smithery_release.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Complete a Smithery scan authorization against the trusted MCP origin.
+
+Smithery pauses authenticated external-server scans and records the OAuth
+authorization URL in the release log. Agent-Bom's broker authorization endpoint
+is deliberately machine-to-machine: a valid registered PKCE client is granted
+and redirected immediately. This helper follows that one bounded flow without
+printing the URL, whose query contains ephemeral OAuth state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+_AUTH_PATH = "/oauth/authorize"
+_MAX_RELEASE_BYTES = 2 * 1024 * 1024
+_URL_RE = re.compile(r"https?://[^\s<>\"']+")
+
+
+def _strings(value: Any) -> Iterator[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _strings(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _strings(item)
+
+
+def _origin(parts: Any) -> tuple[str, str, int | None]:
+    return parts.scheme.lower(), (parts.hostname or "").lower(), parts.port
+
+
+def extract_authorization_url(release: Any, upstream_url: str) -> str | None:
+    """Return the first exact-origin Agent-Bom authorization URL in release logs."""
+    upstream = urlsplit(upstream_url)
+    if upstream.scheme.lower() != "https" or not upstream.hostname:
+        raise ValueError("Smithery upstream must be an HTTPS URL")
+
+    for text in _strings(release):
+        for raw in _URL_RE.findall(text):
+            candidate = raw.rstrip(".,;:)]}")
+            parsed = urlsplit(candidate)
+            if _origin(parsed) == _origin(upstream) and parsed.path == _AUTH_PATH and parsed.query:
+                return candidate
+    return None
+
+
+class _BoundedRedirectHandler(HTTPRedirectHandler):
+    max_redirections = 5
+    max_repeats = 2
+
+
+def _default_opener(request: Request, *, timeout: float):
+    return build_opener(_BoundedRedirectHandler()).open(request, timeout=timeout)
+
+
+def complete_authorization(
+    authorization_url: str,
+    *,
+    opener: Callable[..., Any] = _default_opener,
+) -> None:
+    """Follow the registered PKCE authorization callback with strict bounds."""
+    request = Request(
+        authorization_url,
+        headers={"User-Agent": "agent-bom-registry-reconciler/1"},
+        method="GET",
+    )
+    with opener(request, timeout=30.0) as response:
+        status = int(getattr(response, "status", 200))
+        response.read(4096)
+    if status >= 400:
+        raise RuntimeError("Smithery scan authorization callback failed")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--release-json", type=Path, required=True)
+    parser.add_argument("--upstream-url", required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        if args.release_json.stat().st_size > _MAX_RELEASE_BYTES:
+            raise ValueError("release response exceeds the bounded input size")
+        release = json.loads(args.release_json.read_text(encoding="utf-8"))
+        authorization_url = extract_authorization_url(release, args.upstream_url)
+        if authorization_url is None:
+            print("Smithery release did not expose a trusted Agent-Bom authorization URL", file=sys.stderr)
+            return 2
+        complete_authorization(authorization_url)
+    except Exception:  # noqa: BLE001 - OAuth state and provider responses must not reach CI logs
+        print("Smithery scan authorization could not be completed safely", file=sys.stderr)
+        return 1
+
+    print("Smithery scan authorization callback completed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/authorize_smithery_release.py
+++ b/scripts/authorize_smithery_release.py
@@ -17,10 +17,12 @@ import sys
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import parse_qs, urlsplit
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 _AUTH_PATH = "/oauth/authorize"
+_SMITHERY_CALLBACK_HOST = "server.smithery.ai"
+_SMITHERY_CALLBACK_PATH = "/oauth/callback"
 _MAX_RELEASE_BYTES = 2 * 1024 * 1024
 _URL_RE = re.compile(r"https?://[^\s<>\"']+")
 
@@ -37,7 +39,45 @@ def _strings(value: Any) -> Iterator[str]:
 
 
 def _origin(parts: Any) -> tuple[str, str, int | None]:
-    return parts.scheme.lower(), (parts.hostname or "").lower(), parts.port
+    scheme = parts.scheme.lower()
+    port = parts.port
+    if port is None and scheme == "https":
+        port = 443
+    return scheme, (parts.hostname or "").lower(), port
+
+
+def _endpoint(parts: Any) -> tuple[str, str, int | None, str]:
+    return (*_origin(parts), parts.path)
+
+
+def _authorization_callback_url(authorization_url: str) -> str:
+    authorization = urlsplit(authorization_url)
+    if (
+        authorization.scheme.lower() != "https"
+        or not authorization.hostname
+        or authorization.username
+        or authorization.password
+        or authorization.path != _AUTH_PATH
+    ):
+        raise ValueError("authorization URL must use the trusted HTTPS endpoint")
+
+    redirect_values = parse_qs(authorization.query, keep_blank_values=True).get("redirect_uri", [])
+    if len(redirect_values) != 1:
+        raise ValueError("authorization URL must contain one Smithery redirect_uri")
+    callback = urlsplit(redirect_values[0])
+    if (
+        callback.scheme.lower() != "https"
+        or not callback.hostname
+        or callback.hostname.lower().rstrip(".") != _SMITHERY_CALLBACK_HOST
+        or _origin(callback)[2] != 443
+        or callback.path != _SMITHERY_CALLBACK_PATH
+        or callback.username
+        or callback.password
+        or callback.query
+        or callback.fragment
+    ):
+        raise ValueError("Smithery redirect_uri must use a trusted HTTPS origin")
+    return redirect_values[0]
 
 
 def extract_authorization_url(release: Any, upstream_url: str) -> str | None:
@@ -59,9 +99,30 @@ class _BoundedRedirectHandler(HTTPRedirectHandler):
     max_redirections = 5
     max_repeats = 2
 
+    def __init__(self, *, authorization_url: str, callback_url: str) -> None:
+        super().__init__()
+        self._authorization_endpoint = _endpoint(urlsplit(authorization_url))
+        self._callback_endpoint = _endpoint(urlsplit(callback_url))
+        self.allowed_origins = {
+            _origin(urlsplit(authorization_url)),
+            _origin(urlsplit(callback_url)),
+        }
 
-def _default_opener(request: Request, *, timeout: float):
-    return build_opener(_BoundedRedirectHandler()).open(request, timeout=timeout)
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001, ANN201
+        destination = urlsplit(newurl)
+        if (
+            _endpoint(urlsplit(req.full_url)) != self._authorization_endpoint
+            or destination.scheme.lower() != "https"
+            or destination.username
+            or destination.password
+            or _endpoint(destination) != self._callback_endpoint
+        ):
+            raise ValueError("authorization redirect must use one exact callback on a trusted HTTPS origin")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _default_opener(request: Request, *, timeout: float, redirect_handler: _BoundedRedirectHandler):
+    return build_opener(redirect_handler).open(request, timeout=timeout)
 
 
 def complete_authorization(
@@ -70,15 +131,18 @@ def complete_authorization(
     opener: Callable[..., Any] = _default_opener,
 ) -> None:
     """Follow the registered PKCE authorization callback with strict bounds."""
+    callback_url = _authorization_callback_url(authorization_url)
+    redirect_handler = _BoundedRedirectHandler(authorization_url=authorization_url, callback_url=callback_url)
     request = Request(
         authorization_url,
         headers={"User-Agent": "agent-bom-registry-reconciler/1"},
         method="GET",
     )
-    with opener(request, timeout=30.0) as response:
+    with opener(request, timeout=30.0, redirect_handler=redirect_handler) as response:
         status = int(getattr(response, "status", 200))
         response.read(4096)
-    if status >= 400:
+        final_url = response.geturl()
+    if status >= 400 or _endpoint(urlsplit(final_url)) != _endpoint(urlsplit(callback_url)):
         raise RuntimeError("Smithery scan authorization callback failed")
 
 

--- a/scripts/check_glama_listing.py
+++ b/scripts/check_glama_listing.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import html
 import json
 import os
@@ -22,6 +23,7 @@ README = ROOT / "README.md"
 DEFAULT_URL = "https://glama.ai/mcp/servers/msaad00/agent-bom"
 DEFAULT_API_URL = "https://glama.ai/api/mcp/v1/servers/msaad00/agent-bom"
 DEFAULT_SCHEMA_URL = f"{DEFAULT_URL}/schema"
+_MAX_TOOL_NAMES_BYTES = 2 * 1024 * 1024
 
 
 def _env_or(name: str, default: str) -> str:
@@ -36,6 +38,7 @@ def _env_or(name: str, default: str) -> str:
 
 GLAMA_DOCKERFILE = "integrations/glama/Dockerfile"
 GLAMA_MANIFESTS = (ROOT / "glama.json", ROOT / "integrations" / "glama" / "server.json")
+MCP_SERVER_METADATA = "src/agent_bom/mcp_server_metadata.py"
 
 
 def _is_current_checkout_ref(git_ref: str) -> bool:
@@ -77,6 +80,56 @@ def _load_readme_tool_count() -> str:
     if not match:
         raise SystemExit("README.md MCP tool count sentence not found")
     return match.group(1)
+
+
+def _load_expected_tool_names(path: Path) -> list[str]:
+    if path.stat().st_size > _MAX_TOOL_NAMES_BYTES:
+        raise ValueError("expected tool-name contract exceeds the bounded input size")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list) or not payload:
+        raise ValueError("expected tool-name contract must be a non-empty JSON list")
+    if any(not isinstance(name, str) or not name or name != name.strip() for name in payload):
+        raise ValueError("expected tool-name contract contains an invalid name")
+    normalized = sorted(payload)
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("expected tool-name contract contains duplicate names")
+    return normalized
+
+
+def _tool_set_failures(actual: list[str], expected: list[str]) -> list[str]:
+    actual_set = set(actual)
+    expected_set = set(expected)
+    failures: list[str] = []
+    missing = sorted(expected_set - actual_set)
+    unexpected = sorted(actual_set - expected_set)
+    if missing:
+        failures.append(f"missing expected tools: {', '.join(missing[:10])}")
+    if unexpected:
+        failures.append(f"unexpected tools: {', '.join(unexpected[:10])}")
+    return failures
+
+
+def _release_tool_names(git_ref: str | None) -> list[str]:
+    """Parse the release's static server-card tool list without executing it."""
+
+    tree = ast.parse(_read_repo_file(MCP_SERVER_METADATA, git_ref=git_ref), filename=MCP_SERVER_METADATA)
+    raw_tools: object | None = None
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if any(isinstance(target, ast.Name) and target.id == "_SERVER_CARD_TOOLS" for target in targets):
+            raw_tools = ast.literal_eval(node.value)
+            break
+    if not isinstance(raw_tools, list) or not raw_tools:
+        raise ValueError("release metadata does not contain a non-empty static MCP tool list")
+    names = [tool.get("name") for tool in raw_tools if isinstance(tool, dict)]
+    if len(names) != len(raw_tools) or any(not isinstance(name, str) or not name or name != name.strip() for name in names):
+        raise ValueError("release metadata contains an invalid MCP tool name")
+    normalized = sorted(names)
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("release metadata contains duplicate MCP tool names")
+    return normalized
 
 
 def verify_build_manifest(git_ref: str | None = None) -> list[str]:
@@ -210,6 +263,12 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Expected public API tool count; defaults to the current README contract.",
     )
+    parser.add_argument(
+        "--expected-tool-names-file",
+        type=Path,
+        default=None,
+        help="JSON list of exact released tool names required from the public inventory.",
+    )
     parser.add_argument("--json", action="store_true", help="Emit a machine-readable freshness result.")
     parser.add_argument("--timeout", type=int, default=20)
     parser.add_argument("--retries", type=int, default=1)
@@ -224,7 +283,19 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Read manifest files from this git ref/SHA while running trusted checker code.",
     )
+    parser.add_argument(
+        "--write-tool-names",
+        type=Path,
+        default=None,
+        help="Write the exact static MCP tool-name list parsed from --git-ref, then exit.",
+    )
     args = parser.parse_args(argv)
+
+    if args.write_tool_names:
+        names = _release_tool_names(args.git_ref)
+        args.write_tool_names.write_text(json.dumps(names, indent=2) + "\n", encoding="utf-8")
+        print(f"Wrote {len(names)} release-bound MCP tool names")
+        return 0
 
     if args.verify_manifest:
         failures = verify_build_manifest(args.git_ref)
@@ -238,17 +309,22 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     version = (args.expected or _load_version()).lstrip("v").strip()
+    expected_tool_names = _load_expected_tool_names(args.expected_tool_names_file) if args.expected_tool_names_file else None
     tool_count = args.expected_tool_count if args.expected_tool_count is not None else int(_load_readme_tool_count())
     if tool_count < 1:
         raise SystemExit("expected Glama tool count must be positive")
+    if expected_tool_names is not None and len(expected_tool_names) != tool_count:
+        raise SystemExit("expected Glama tool-name contract and tool count do not match")
     last_error = ""
     listing_version = "unknown"
     actual_tool_count: int | None = None
     inventory_source: str | None = None
+    exact_tool_set: bool | None = None
     last_probe_unreachable = False
     for attempt in range(1, max(1, args.retries) + 1):
         actual_tool_count = None
         inventory_source = None
+        exact_tool_set = None
         last_probe_unreachable = False
         try:
             page = _fetch(args.url, args.timeout)
@@ -271,6 +347,10 @@ def main(argv: list[str] | None = None) -> int:
                 actual_tool_count = len(schema_tools)
                 if actual_tool_count != tool_count:
                     failures.append(f"Glama public Schema exposes {actual_tool_count} tools; expected {tool_count}")
+                if expected_tool_names is not None:
+                    tool_set_failures = _tool_set_failures(schema_tools, expected_tool_names)
+                    failures.extend(tool_set_failures)
+                    exact_tool_set = not tool_set_failures
             else:
                 inventory_source = "api"
                 try:
@@ -279,13 +359,25 @@ def main(argv: list[str] | None = None) -> int:
                     if not isinstance(tools, list):
                         raise ValueError("Glama public API tools field is not a list")
                     actual_tool_count = len(tools)
-                    tool_names = [tool.get("name") for tool in tools if isinstance(tool, dict)]
-                    if len(tool_names) != actual_tool_count or any(not isinstance(name, str) or not name.strip() for name in tool_names):
+                    raw_tool_names = [tool.get("name") for tool in tools if isinstance(tool, dict)]
+                    valid_tool_names = len(raw_tool_names) == actual_tool_count and all(
+                        isinstance(name, str) and bool(name) and name == name.strip() for name in raw_tool_names
+                    )
+                    if not valid_tool_names:
                         failures.append("Glama public API inventory contains a tool without a name")
-                    elif len(set(tool_names)) != actual_tool_count:
-                        failures.append("Glama public API inventory contains duplicate tool names")
+                        exact_tool_set = False
+                        tool_names: list[str] = []
+                    else:
+                        tool_names = [name for name in raw_tool_names if isinstance(name, str)]
+                        if len(set(tool_names)) != actual_tool_count:
+                            failures.append("Glama public API inventory contains duplicate tool names")
+                            exact_tool_set = False
                     if actual_tool_count != tool_count:
                         failures.append(f"Glama public API exposes {actual_tool_count} tools; expected {tool_count}")
+                    if expected_tool_names is not None and valid_tool_names and len(set(tool_names)) == actual_tool_count:
+                        tool_set_failures = _tool_set_failures(tool_names, expected_tool_names)
+                        failures.extend(tool_set_failures)
+                        exact_tool_set = not tool_set_failures
                 except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
                     failures.append(f"failed to verify Glama public API tool inventory: {exc}")
                     last_probe_unreachable = True
@@ -301,6 +393,7 @@ def main(argv: list[str] | None = None) -> int:
                                 "tool_count": actual_tool_count,
                                 "expected_tool_count": tool_count,
                                 "inventory_source": inventory_source,
+                                "exact_tool_set": exact_tool_set,
                             },
                             separators=(",", ":"),
                         )
@@ -325,6 +418,7 @@ def main(argv: list[str] | None = None) -> int:
                     "tool_count": actual_tool_count,
                     "expected_tool_count": tool_count,
                     "inventory_source": inventory_source,
+                    "exact_tool_set": exact_tool_set,
                     "error": last_error,
                 },
                 separators=(",", ":"),

--- a/scripts/check_glama_listing.py
+++ b/scripts/check_glama_listing.py
@@ -96,6 +96,28 @@ def _load_expected_tool_names(path: Path) -> list[str]:
     return normalized
 
 
+def _load_expected_tool_contract(path: Path) -> list[dict[str, object]]:
+    if path.stat().st_size > _MAX_TOOL_NAMES_BYTES:
+        raise ValueError("expected tool contract exceeds the bounded input size")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list) or not payload:
+        raise ValueError("expected tool contract must be a non-empty JSON list")
+    normalized: list[dict[str, object]] = []
+    for tool in payload:
+        if not isinstance(tool, dict):
+            raise ValueError("expected tool contract contains a non-object tool")
+        name = tool.get("name")
+        input_schema = tool.get("inputSchema")
+        if not isinstance(name, str) or not name or name != name.strip() or not isinstance(input_schema, dict):
+            raise ValueError("expected tool contract contains an invalid name or input schema")
+        normalized.append({"name": name, "inputSchema": input_schema})
+    normalized.sort(key=lambda tool: str(tool["name"]))
+    names = [str(tool["name"]) for tool in normalized]
+    if len(set(names)) != len(names):
+        raise ValueError("expected tool contract contains duplicate names")
+    return normalized
+
+
 def _tool_set_failures(actual: list[str], expected: list[str]) -> list[str]:
     actual_set = set(actual)
     expected_set = set(expected)
@@ -107,6 +129,53 @@ def _tool_set_failures(actual: list[str], expected: list[str]) -> list[str]:
     if unexpected:
         failures.append(f"unexpected tools: {', '.join(unexpected[:10])}")
     return failures
+
+
+def _api_inventory_result(
+    tools: object,
+    *,
+    tool_count: int,
+    expected_tool_names: list[str] | None,
+    expected_tool_contract: list[dict[str, object]] | None,
+) -> tuple[int, list[str], bool | None, bool | None]:
+    if not isinstance(tools, list):
+        raise ValueError("Glama public API tools field is not a list")
+    failures: list[str] = []
+    actual_tool_count = len(tools)
+    raw_tool_names = [tool.get("name") for tool in tools if isinstance(tool, dict)]
+    valid_tool_names = len(raw_tool_names) == actual_tool_count and all(
+        isinstance(name, str) and bool(name) and name == name.strip() for name in raw_tool_names
+    )
+    exact_tool_set: bool | None = None
+    exact_input_schemas: bool | None = None
+    tool_names: list[str] = []
+    if not valid_tool_names:
+        failures.append("Glama public API inventory contains a tool without a name")
+        exact_tool_set = False
+    else:
+        tool_names = [name for name in raw_tool_names if isinstance(name, str)]
+        if len(set(tool_names)) != actual_tool_count:
+            failures.append("Glama public API inventory contains duplicate tool names")
+            exact_tool_set = False
+    if actual_tool_count != tool_count:
+        failures.append(f"Glama public API exposes {actual_tool_count} tools; expected {tool_count}")
+    if expected_tool_names is not None and valid_tool_names and len(set(tool_names)) == actual_tool_count:
+        tool_set_failures = _tool_set_failures(tool_names, expected_tool_names)
+        failures.extend(tool_set_failures)
+        exact_tool_set = not tool_set_failures
+    if expected_tool_contract is not None:
+        actual_by_name = {
+            str(tool["name"]): tool for tool in tools if isinstance(tool, dict) and isinstance(tool.get("name"), str)
+        }
+        schema_failures: list[str] = []
+        for expected_tool in expected_tool_contract:
+            name = str(expected_tool["name"])
+            actual_tool = actual_by_name.get(name)
+            if actual_tool is None or actual_tool.get("inputSchema") != expected_tool["inputSchema"]:
+                schema_failures.append(f"input schema differs for tool: {name}")
+        failures.extend(schema_failures)
+        exact_input_schemas = not schema_failures and len(actual_by_name) == len(expected_tool_contract)
+    return actual_tool_count, failures, exact_tool_set, exact_input_schemas
 
 
 def _release_tool_names(git_ref: str | None) -> list[str]:
@@ -269,6 +338,12 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="JSON list of exact released tool names required from the public inventory.",
     )
+    parser.add_argument(
+        "--expected-tool-contract-file",
+        type=Path,
+        default=None,
+        help="JSON list of name/inputSchema objects required from a reachable public machine inventory.",
+    )
     parser.add_argument("--json", action="store_true", help="Emit a machine-readable freshness result.")
     parser.add_argument("--timeout", type=int, default=20)
     parser.add_argument("--retries", type=int, default=1)
@@ -310,6 +385,14 @@ def main(argv: list[str] | None = None) -> int:
 
     version = (args.expected or _load_version()).lstrip("v").strip()
     expected_tool_names = _load_expected_tool_names(args.expected_tool_names_file) if args.expected_tool_names_file else None
+    expected_tool_contract = (
+        _load_expected_tool_contract(args.expected_tool_contract_file) if args.expected_tool_contract_file else None
+    )
+    if expected_tool_contract is not None:
+        contract_names = [str(tool["name"]) for tool in expected_tool_contract]
+        if expected_tool_names is not None and contract_names != expected_tool_names:
+            raise SystemExit("expected Glama tool-name and input-schema contracts do not match")
+        expected_tool_names = contract_names
     tool_count = args.expected_tool_count if args.expected_tool_count is not None else int(_load_readme_tool_count())
     if tool_count < 1:
         raise SystemExit("expected Glama tool count must be positive")
@@ -320,11 +403,15 @@ def main(argv: list[str] | None = None) -> int:
     actual_tool_count: int | None = None
     inventory_source: str | None = None
     exact_tool_set: bool | None = None
+    exact_input_schemas: bool | None = None
+    degraded_reason: str | None = None
     last_probe_unreachable = False
     for attempt in range(1, max(1, args.retries) + 1):
         actual_tool_count = None
         inventory_source = None
         exact_tool_set = None
+        exact_input_schemas = None
+        degraded_reason = None
         last_probe_unreachable = False
         try:
             page = _fetch(args.url, args.timeout)
@@ -342,8 +429,21 @@ def main(argv: list[str] | None = None) -> int:
                 # Schema page cannot be fetched or has not populated yet.
                 pass
 
+            api_result: tuple[int, list[str], bool | None, bool | None] | None = None
+            api_error: Exception | None = None
+            try:
+                api_payload = _fetch_json(args.api_url, args.timeout)
+                api_result = _api_inventory_result(
+                    api_payload.get("tools"),
+                    tool_count=tool_count,
+                    expected_tool_names=expected_tool_names,
+                    expected_tool_contract=expected_tool_contract,
+                )
+            except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
+                api_error = exc
+
             if schema_tools:
-                inventory_source = "schema"
+                inventory_source = "schema+api" if api_result is not None else "schema"
                 actual_tool_count = len(schema_tools)
                 if actual_tool_count != tool_count:
                     failures.append(f"Glama public Schema exposes {actual_tool_count} tools; expected {tool_count}")
@@ -351,55 +451,46 @@ def main(argv: list[str] | None = None) -> int:
                     tool_set_failures = _tool_set_failures(schema_tools, expected_tool_names)
                     failures.extend(tool_set_failures)
                     exact_tool_set = not tool_set_failures
+                if api_result is None:
+                    degraded_reason = "Glama public API inventory was unreachable"
+                else:
+                    api_count, api_failures, api_exact_set, api_exact_schemas = api_result
+                    actual_tool_count = api_count
+                    failures.extend(api_failures)
+                    if api_exact_set is not None:
+                        exact_tool_set = bool(exact_tool_set is not False and api_exact_set)
+                    exact_input_schemas = api_exact_schemas
+            elif api_result is not None:
+                inventory_source = "api"
+                actual_tool_count, api_failures, exact_tool_set, exact_input_schemas = api_result
+                failures.extend(api_failures)
             else:
                 inventory_source = "api"
-                try:
-                    api_payload = _fetch_json(args.api_url, args.timeout)
-                    tools = api_payload.get("tools")
-                    if not isinstance(tools, list):
-                        raise ValueError("Glama public API tools field is not a list")
-                    actual_tool_count = len(tools)
-                    raw_tool_names = [tool.get("name") for tool in tools if isinstance(tool, dict)]
-                    valid_tool_names = len(raw_tool_names) == actual_tool_count and all(
-                        isinstance(name, str) and bool(name) and name == name.strip() for name in raw_tool_names
-                    )
-                    if not valid_tool_names:
-                        failures.append("Glama public API inventory contains a tool without a name")
-                        exact_tool_set = False
-                        tool_names: list[str] = []
-                    else:
-                        tool_names = [name for name in raw_tool_names if isinstance(name, str)]
-                        if len(set(tool_names)) != actual_tool_count:
-                            failures.append("Glama public API inventory contains duplicate tool names")
-                            exact_tool_set = False
-                    if actual_tool_count != tool_count:
-                        failures.append(f"Glama public API exposes {actual_tool_count} tools; expected {tool_count}")
-                    if expected_tool_names is not None and valid_tool_names and len(set(tool_names)) == actual_tool_count:
-                        tool_set_failures = _tool_set_failures(tool_names, expected_tool_names)
-                        failures.extend(tool_set_failures)
-                        exact_tool_set = not tool_set_failures
-                except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
-                    failures.append(f"failed to verify Glama public API tool inventory: {exc}")
-                    last_probe_unreachable = True
+                failures.append(f"failed to verify Glama public API tool inventory: {api_error}")
+                last_probe_unreachable = True
             if not failures:
+                status = "fresh_degraded" if degraded_reason else "fresh"
                 if args.json:
                     print(
                         json.dumps(
                             {
                                 "surface": "Glama",
-                                "status": "fresh",
+                                "status": status,
                                 "expected": version,
                                 "listing_version": listing_version,
                                 "tool_count": actual_tool_count,
                                 "expected_tool_count": tool_count,
                                 "inventory_source": inventory_source,
                                 "exact_tool_set": exact_tool_set,
+                                "exact_input_schemas": exact_input_schemas,
+                                "degraded_reason": degraded_reason,
                             },
                             separators=(",", ":"),
                         )
                     )
                     return 0
-                print(f"Glama listing is fresh for agent-bom v{version} with {actual_tool_count} MCP tools")
+                suffix = f" ({degraded_reason})" if degraded_reason else ""
+                print(f"Glama listing is {status} for agent-bom v{version} with {actual_tool_count} MCP tools{suffix}")
                 return 0
             last_error = "\n".join(failures)
 
@@ -419,6 +510,8 @@ def main(argv: list[str] | None = None) -> int:
                     "expected_tool_count": tool_count,
                     "inventory_source": inventory_source,
                     "exact_tool_set": exact_tool_set,
+                    "exact_input_schemas": exact_input_schemas,
+                    "degraded_reason": degraded_reason,
                     "error": last_error,
                 },
                 separators=(",", ":"),

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -558,6 +558,23 @@ def test_deployment_freshness_targets_exact_published_server_card_contract():
     assert "steps.railway.outputs.probe_failed == 'true'" in workflow
 
 
+def test_deployment_freshness_marks_smithery_tool_count_drift() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "deployment-freshness.yml").read_text()
+
+    assert "EXPECTED_TOOL_COUNT: ${{ steps.expected.outputs.tool_count }}" in workflow
+    assert 'EXPECTED_TOOL_COUNT="$EXPECTED_TOOL_COUNT"' in workflow
+    assert "int(data.get('tool_count') or 0) != int(os.environ['EXPECTED_TOOL_COUNT'])" in workflow
+    assert 'echo "stale=true" >> "$GITHUB_OUTPUT"' in workflow
+    assert "Smithery catalog tool inventory differs from the published release contract" in workflow
+
+
+def test_publishing_guide_does_not_pin_a_stale_mcp_tool_count() -> None:
+    guide = (ROOT / "docs" / "PUBLISHING.md").read_text()
+
+    assert "--expected-tool-count 84" not in guide
+    assert "--expected-tool-count 86" not in guide
+
+
 def test_deployment_freshness_uses_a_version_stable_issue_identity():
     """A clean release must close deployment alerts opened by an older version."""
     workflow = (ROOT / ".github" / "workflows" / "deployment-freshness.yml").read_text()

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -722,9 +722,7 @@ def test_publish_registries_workflow_validates_registry_gates_and_curated_clawhu
     assert 'git merge-base --is-ancestor "$RELEASE_SHA" "origin/$DEFAULT_BRANCH"' in workflow
     assert "Release workflow must be a same-repository tag push" in workflow
     assert "workflow_run.head_sha || github.ref" not in workflow
-    assert "actions: read" in workflow
-    assert "jq -n" in workflow
-    assert "dockerfile: $dockerfile" in workflow
+    assert "actions: write" not in workflow
 
 
 def test_publish_registries_manual_repair_resolves_latest_release_only():
@@ -756,25 +754,21 @@ def test_publish_registries_uses_release_metrics_for_glama_and_clawhub_assets():
     assert 'git archive --format=tar "$RELEASE_SHA" -- integrations/openclaw' in workflow
 
 
-def test_glama_rebuild_webhook_is_secret_and_missing_secret_is_honest():
-    """A missing webhook must not leak a URL or claim a rebuild happened."""
+def test_glama_publication_uses_supported_provider_sync_and_strict_verification():
+    """Glama directory publication is provider-managed and release-verified."""
     workflow = (ROOT / ".github" / "workflows" / "publish-registries.yml").read_text()
 
-    assert "GLAMA_WEBHOOK_URL: ${{ secrets.GLAMA_WEBHOOK_URL }}" in workflow
-    assert "GLAMA_WEBHOOK_URL: ${{ vars.GLAMA_WEBHOOK_URL }}" not in workflow
-    assert "id: glama_trigger" in workflow
-    assert 'echo "rebuild_triggered=false" >> "$GITHUB_OUTPUT"' in workflow
-    assert "No Glama rebuild was triggered" in workflow
-    assert "set GLAMA_WEBHOOK_URL as a repository Actions secret" in workflow
-    assert 'HTTP_STATUS" -lt 300' in workflow
-    assert 'HTTP_STATUS" -lt 400' not in workflow
-    assert "REGISTRY_PUBLISH_REQUIRED: ${{ github.event_name == 'workflow_run' }}" in workflow
-    assert "GLAMA_REPAIR: ${{ inputs.glama_repair }}" in workflow
-    assert 'if [ "$REGISTRY_PUBLISH_REQUIRED" = "true" ] || [ "$GLAMA_REPAIR" = "true" ]; then' in workflow
-    assert "::error::Required Glama publication" in workflow
     glama_job = workflow.split("  glama:\n", 1)[1].split("  clawhub:\n", 1)[0]
+    assert "GLAMA_WEBHOOK_URL" not in glama_job
+    assert "glama_repair" not in workflow
+    assert "Trigger Glama rebuild" not in glama_job
+    assert "-X POST" not in glama_job
     assert "continue-on-error: true" not in glama_job
-    assert "python scripts/check_glama_listing.py" in glama_job
+    assert 'check_glama_listing.py --verify-manifest --git-ref "${{ needs.release.outputs.release_sha }}"' in glama_job
+    assert '--expected "$EXPECTED_VERSION"' in glama_job
+    assert '--expected-tool-count "$EXPECTED_TOOL_COUNT"' in glama_job
+    assert "Glama syncs linked GitHub repositories automatically at least daily" in glama_job
+    assert "Sync Server" in glama_job
     assert "exit 1" in workflow
 
 

--- a/tests/test_publish_registries_glama_gate.py
+++ b/tests/test_publish_registries_glama_gate.py
@@ -28,14 +28,15 @@ def test_dispatch_does_not_expose_an_unsupported_glama_trigger() -> None:
     assert "glama_repair" not in inputs
 
 
-def test_registry_reconciliation_retries_automatically_without_republishing_clawhub() -> None:
+def test_registry_reconciliation_retries_every_idempotent_registry_automatically() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
     triggers = _workflow()[True]
 
     assert triggers["schedule"] == [{"cron": "17 */6 * * *"}]
-    assert text.count("github.event_name == 'schedule'") == 3
+    assert text.count("github.event_name == 'schedule'") == 4
     clawhub = text.split("  clawhub:\n", 1)[1]
-    assert "github.event_name == 'schedule'" not in clawhub
+    assert "github.event_name == 'schedule'" in clawhub
+    assert "already published" in clawhub
 
 
 def test_glama_job_verifies_provider_managed_sync_without_inventing_an_api() -> None:
@@ -54,6 +55,8 @@ def test_glama_job_verifies_provider_managed_sync_without_inventing_an_api() -> 
     assert "--expected-tool-names-file /tmp/glama-expected-tool-names.json" in job
     assert "glama-actual-server-card-tool-names.json" in job
     assert "cmp -s /tmp/glama-expected-tool-names.json /tmp/glama-actual-server-card-tool-names.json" in job
+    assert "glama-expected-tool-contract.json" in job
+    assert "--expected-tool-contract-file /tmp/glama-expected-tool-contract.json" in job
 
 
 def test_stale_glama_directory_fails_with_supported_recovery_guidance() -> None:

--- a/tests/test_publish_registries_glama_gate.py
+++ b/tests/test_publish_registries_glama_gate.py
@@ -47,6 +47,13 @@ def test_glama_job_verifies_provider_managed_sync_without_inventing_an_api() -> 
     assert "--verify-manifest --git-ref" in job
     assert '--expected "$EXPECTED_VERSION"' in job
     assert '--expected-tool-count "$EXPECTED_TOOL_COUNT"' in job
+    assert "--write-tool-names /tmp/glama-expected-tool-names.json" in job
+    assert '--git-ref "${{ needs.release.outputs.release_sha }}"' in job
+    assert "Validate released public server card for Glama" in job
+    assert "glama-expected-tool-names.json" in job
+    assert "--expected-tool-names-file /tmp/glama-expected-tool-names.json" in job
+    assert "glama-actual-server-card-tool-names.json" in job
+    assert "cmp -s /tmp/glama-expected-tool-names.json /tmp/glama-actual-server-card-tool-names.json" in job
 
 
 def test_stale_glama_directory_fails_with_supported_recovery_guidance() -> None:

--- a/tests/test_publish_registries_glama_gate.py
+++ b/tests/test_publish_registries_glama_gate.py
@@ -1,14 +1,4 @@
-"""An unconfigured optional integration must not fail the whole publish.
-
-`Publish to Registries` pushes PyPI, Docker, Smithery and Glama. The Glama step
-failed the entire workflow when `GLAMA_WEBHOOK_URL` was unset, on the reasoning
-that a *manual repair* which cannot do what was asked should fail loudly. That
-intent is right, but `workflow_dispatch` carried no inputs, so an ordinary
-re-run of the publish was indistinguishable from an explicit Glama repair — and
-a third-party webhook nobody had configured became a release blocker (#4651).
-
-The operator now says which one they meant.
-"""
+"""Glama publication must use provider-supported automatic synchronization."""
 
 from __future__ import annotations
 
@@ -19,11 +9,10 @@ import yaml
 WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "publish-registries.yml"
 
 
-def _glama_step_text() -> str:
-    """Just the Glama step. The release job legitimately branches on event_name."""
+def _glama_job_text() -> str:
+    """Return the Glama job without unrelated registry implementation text."""
     text = WORKFLOW.read_text(encoding="utf-8")
-    start = text.index("Trigger Glama rebuild")
-    return text[start:]
+    return text.split("  glama:\n", 1)[1].split("  clawhub:\n", 1)[0]
 
 
 def _workflow() -> dict:
@@ -32,27 +21,38 @@ def _workflow() -> dict:
     return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
 
 
-def test_dispatch_exposes_an_explicit_glama_repair_input() -> None:
+def test_dispatch_does_not_expose_an_unsupported_glama_trigger() -> None:
     triggers = _workflow()[True]
-    inputs = triggers["workflow_dispatch"]["inputs"]
+    inputs = (triggers["workflow_dispatch"] or {}).get("inputs", {})
 
-    assert "glama_repair" in inputs, "an operator cannot signal a Glama repair without an input"
-    assert inputs["glama_repair"]["type"] == "boolean"
-    assert inputs["glama_repair"]["default"] is False, "repair must be opt-in, never the default for a re-run"
+    assert "glama_repair" not in inputs
 
 
-def test_a_missing_webhook_only_fails_an_explicit_repair() -> None:
-    """The gate must read the intent input, not merely that the run was dispatched."""
-    step = _glama_step_text()
-
-    assert "GLAMA_REPAIR: ${{ inputs.glama_repair }}" in step
-    assert '[ "$EVENT_NAME" = "workflow_dispatch" ]' not in step, "gating on event_name treats every manual re-run as a repair request"
-    assert '[ "$GLAMA_REPAIR" = "true" ]' in step
-
-
-def test_the_unconfigured_path_still_reports_and_leaves_the_issue_open() -> None:
-    """Warning quietly is how a stale listing survives for months — say it out loud."""
+def test_registry_reconciliation_retries_automatically_without_republishing_clawhub() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
+    triggers = _workflow()[True]
 
-    assert "rebuild_triggered=false" in text
-    assert "the freshness issue will remain open" in text
+    assert triggers["schedule"] == [{"cron": "17 */6 * * *"}]
+    assert text.count("github.event_name == 'schedule'") == 3
+    clawhub = text.split("  clawhub:\n", 1)[1]
+    assert "github.event_name == 'schedule'" not in clawhub
+
+
+def test_glama_job_verifies_provider_managed_sync_without_inventing_an_api() -> None:
+    job = _glama_job_text()
+
+    assert "GLAMA_WEBHOOK_URL" not in job
+    assert "Trigger Glama rebuild" not in job
+    assert "-X POST" not in job
+    assert "--verify-manifest --git-ref" in job
+    assert '--expected "$EXPECTED_VERSION"' in job
+    assert '--expected-tool-count "$EXPECTED_TOOL_COUNT"' in job
+
+
+def test_stale_glama_directory_fails_with_supported_recovery_guidance() -> None:
+    """A stale provider directory stays visible without a fictitious trigger claim."""
+    job = _glama_job_text()
+
+    assert "Glama syncs linked GitHub repositories automatically at least daily" in job
+    assert "Sync Server" in job
+    assert "exit 1" in job

--- a/tests/test_publish_registries_release_auth_gate.py
+++ b/tests/test_publish_registries_release_auth_gate.py
@@ -33,8 +33,13 @@ def test_smithery_publication_is_idempotent_and_bounds_authorization_recovery() 
     assert "--write-tool-names /tmp/smithery-expected-tool-names.json" in workflow
     assert "smithery-actual-server-card-tool-names.json" in workflow
     assert "cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-server-card-tool-names.json" in workflow
+    assert "smithery-expected-tool-contract.json" in workflow
+    assert "smithery-actual-tool-contract.json" in workflow
+    assert "cmp -s /tmp/smithery-expected-tool-contract.json /tmp/smithery-actual-tool-contract.json" in workflow
     assert "LATEST_SUCCESS_UPSTREAM" in workflow
     assert 'select(.type == "external_shttp" and .status == "SUCCESS")' in workflow
+    assert ": > /tmp/smithery-success-releases.jsonl" in workflow
+    assert 'GET "https://api.smithery.ai/servers/agent-bom%2Fagent-bom/releases?page=${PAGE}&pageSize=100"' in workflow
     assert '"$LATEST_SUCCESS_UPSTREAM" = "$SMITHERY_MCP_URL"' in workflow
     assert "tool catalog matches but the successful release upstream differs" in workflow
     assert "smithery_catalog.outputs.fresh != 'true'" in workflow
@@ -91,6 +96,7 @@ def test_registry_publication_runs_are_serialized() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
     assert "concurrency:\n  group: publish-registries\n  cancel-in-progress: false" in workflow
+    assert "github.event_name == 'schedule'" in workflow.split("  clawhub:\n", 1)[1]
 
 
 def test_delayed_release_event_cannot_republish_an_older_version_as_latest() -> None:

--- a/tests/test_publish_registries_release_auth_gate.py
+++ b/tests/test_publish_registries_release_auth_gate.py
@@ -36,6 +36,17 @@ def test_smithery_publication_is_idempotent_and_waits_for_publisher_authorizatio
     assert "within 15 minutes" in workflow
 
 
+def test_smithery_publication_reuses_matching_pending_release() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "List resumable Smithery releases" in workflow
+    assert 'GET "https://api.smithery.ai/servers/${QUALIFIED_NAME}/releases"' in workflow
+    assert 'select(.type == "external_shttp" and .upstreamUrl == $upstream)' in workflow
+    assert 'select(.status == "AUTH_REQUIRED" or .status == "QUEUED" or .status == "WORKING")' in workflow
+    assert 'POST "https://api.smithery.ai/servers/${QUALIFIED_NAME}/releases/${RELEASE_ID}/resume"' in workflow
+    assert "Reusing matching Smithery release" in workflow
+
+
 def test_surface_freshness_rechecks_immediately_after_registry_publication() -> None:
     workflow = (ROOT / ".github/workflows/surface-freshness.yml").read_text(encoding="utf-8")
     assert 'workflows: ["Publish to Registries"]' in workflow

--- a/tests/test_publish_registries_release_auth_gate.py
+++ b/tests/test_publish_registries_release_auth_gate.py
@@ -23,7 +23,7 @@ def test_automatic_forward_release_cannot_report_success_when_smithery_is_skippe
     assert "Smithery publication is required for an automatic forward release" in workflow
 
 
-def test_smithery_publication_is_idempotent_and_waits_for_publisher_authorization() -> None:
+def test_smithery_publication_is_idempotent_and_bounds_authorization_recovery() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
     assert "Check Smithery catalog parity" in workflow
@@ -32,7 +32,7 @@ def test_smithery_publication_is_idempotent_and_waits_for_publisher_authorizatio
     assert "skipping a duplicate deployment" in workflow
     assert "for ATTEMPT in $(seq 1 90)" in workflow
     assert "AUTH_REQUIRED)" in workflow
-    assert "authorize the pending release in the Smithery UI" in workflow
+    assert "bounded recovery attempt" in workflow
     assert "within 15 minutes" in workflow
 
 
@@ -45,6 +45,15 @@ def test_smithery_publication_reuses_matching_pending_release() -> None:
     assert 'select(.status == "AUTH_REQUIRED" or .status == "QUEUED" or .status == "WORKING")' in workflow
     assert 'POST "https://api.smithery.ai/servers/${QUALIFIED_NAME}/releases/${RELEASE_ID}/resume"' in workflow
     assert "Reusing matching Smithery release" in workflow
+
+
+def test_new_smithery_release_completes_machine_authorization_before_resume() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "authorize_smithery_release.py" in workflow
+    assert "Complete Smithery scan authorization" in workflow
+    assert "AUTHORIZATION_ATTEMPTED" in workflow
+    assert "Smithery authorization remained required after the bounded recovery attempt" in workflow
 
 
 def test_surface_freshness_rechecks_immediately_after_registry_publication() -> None:

--- a/tests/test_publish_registries_release_auth_gate.py
+++ b/tests/test_publish_registries_release_auth_gate.py
@@ -1,5 +1,7 @@
 """Registry repair must evaluate Smithery auth from the published release."""
 
+import json
+import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -27,9 +29,18 @@ def test_smithery_publication_is_idempotent_and_bounds_authorization_recovery() 
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
     assert "Check Smithery catalog parity" in workflow
+    assert "Extract immutable Smithery release tool contract" in workflow
+    assert "--write-tool-names /tmp/smithery-expected-tool-names.json" in workflow
+    assert "smithery-actual-server-card-tool-names.json" in workflow
+    assert "cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-server-card-tool-names.json" in workflow
+    assert "LATEST_SUCCESS_UPSTREAM" in workflow
+    assert 'select(.type == "external_shttp" and .status == "SUCCESS")' in workflow
+    assert '"$LATEST_SUCCESS_UPSTREAM" = "$SMITHERY_MCP_URL"' in workflow
+    assert "tool catalog matches but the successful release upstream differs" in workflow
     assert "smithery_catalog.outputs.fresh != 'true'" in workflow
     assert "smithery-expected-tool-names.json" in workflow
     assert "skipping a duplicate deployment" in workflow
+    assert "Smithery catalog is unavailable; refusing to create a potentially duplicate release" in workflow
     assert "for ATTEMPT in $(seq 1 90)" in workflow
     assert "AUTH_REQUIRED)" in workflow
     assert "bounded recovery attempt" in workflow
@@ -40,11 +51,56 @@ def test_smithery_publication_reuses_matching_pending_release() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
     assert "List resumable Smithery releases" in workflow
-    assert 'GET "https://api.smithery.ai/servers/${QUALIFIED_NAME}/releases"' in workflow
+    assert 'GET "https://api.smithery.ai/servers/${QUALIFIED_NAME}/releases?page=${PAGE}&pageSize=100"' in workflow
+    assert ".releases[]" in workflow
+    assert ".pagination.currentPage" in workflow
+    assert ".pagination.totalPages" in workflow
+    assert "MAX_RELEASE_PAGES=20" in workflow
     assert 'select(.type == "external_shttp" and .upstreamUrl == $upstream)' in workflow
     assert 'select(.status == "AUTH_REQUIRED" or .status == "QUEUED" or .status == "WORKING")' in workflow
     assert 'POST "https://api.smithery.ai/servers/${QUALIFIED_NAME}/releases/${RELEASE_ID}/resume"' in workflow
     assert "Reusing matching Smithery release" in workflow
+
+
+def test_smithery_release_selector_accepts_documented_envelope_shape() -> None:
+    payload = {
+        "releases": [
+            {"id": "other", "type": "external_shttp", "upstreamUrl": "https://other.example/mcp", "status": "WORKING"},
+            {"id": "wanted", "type": "external_shttp", "upstreamUrl": "https://mcp.example.test/mcp", "status": "AUTH_REQUIRED"},
+        ],
+        "pagination": {"currentPage": 1, "pageSize": 100, "totalCount": 2, "totalPages": 1},
+    }
+    selector = (
+        '[.releases[] | select(.type == "external_shttp" and .upstreamUrl == $upstream) '
+        '| select(.status == "AUTH_REQUIRED" or .status == "QUEUED" or .status == "WORKING")] '
+        "| first // empty"
+    )
+
+    result = subprocess.run(
+        ["jq", "-c", "--arg", "upstream", "https://mcp.example.test/mcp", selector],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert json.loads(result.stdout) == payload["releases"][1]
+
+
+def test_registry_publication_runs_are_serialized() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "concurrency:\n  group: publish-registries\n  cancel-in-progress: false" in workflow
+
+
+def test_delayed_release_event_cannot_republish_an_older_version_as_latest() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "publish_current: ${{ steps.release.outputs.publish_current }}" in workflow
+    assert 'LATEST_RELEASE_TAG=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)' in workflow
+    assert 'if [ "$LATEST_RELEASE_TAG" != "$RELEASE_TAG" ]; then' in workflow
+    assert "publish_current=false" in workflow
+    assert workflow.count("needs.release.outputs.publish_current == 'true'") == 3
 
 
 def test_new_smithery_release_completes_machine_authorization_before_resume() -> None:

--- a/tests/test_smithery_release_authorization.py
+++ b/tests/test_smithery_release_authorization.py
@@ -1,0 +1,80 @@
+"""Bounded Smithery scan authorization recovery."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "authorize_smithery_release.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("authorize_smithery_release", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extracts_only_the_expected_upstream_authorization_endpoint() -> None:
+    module = _load_script()
+    payload = {
+        "logs": [
+            {"message": "ignore https://evil.example/oauth/authorize?state=bad"},
+            {
+                "message": (
+                    "Authorization required: "
+                    "https://mcp.example.test/oauth/authorize?client_id=abc&state=opaque&response_type=code"
+                )
+            },
+        ]
+    }
+
+    assert module.extract_authorization_url(payload, "https://mcp.example.test/mcp") == (
+        "https://mcp.example.test/oauth/authorize?client_id=abc&state=opaque&response_type=code"
+    )
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        "http://mcp.example.test/oauth/authorize?state=x",
+        "https://evil.example/oauth/authorize?state=x",
+        "https://mcp.example.test/other?state=x",
+        "https://mcp.example.test.evil.invalid/oauth/authorize?state=x",
+    ],
+)
+def test_rejects_untrusted_authorization_urls(candidate: str) -> None:
+    module = _load_script()
+
+    assert module.extract_authorization_url({"logs": [{"message": candidate}]}, "https://mcp.example.test/mcp") is None
+
+
+def test_authorization_follows_a_bounded_redirect_without_printing_the_url(capsys) -> None:
+    module = _load_script()
+    seen: list[tuple[str, float]] = []
+
+    class _Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self, _limit: int) -> bytes:
+            return b"ok"
+
+    def opener(request, *, timeout):
+        seen.append((request.full_url, timeout))
+        return _Response()
+
+    secret_url = "https://mcp.example.test/oauth/authorize?state=sensitive&response_type=code"
+    module.complete_authorization(secret_url, opener=opener)
+
+    assert seen == [(secret_url, 30.0)]
+    assert "sensitive" not in capsys.readouterr().out

--- a/tests/test_smithery_release_authorization.py
+++ b/tests/test_smithery_release_authorization.py
@@ -24,12 +24,7 @@ def test_extracts_only_the_expected_upstream_authorization_endpoint() -> None:
     payload = {
         "logs": [
             {"message": "ignore https://evil.example/oauth/authorize?state=bad"},
-            {
-                "message": (
-                    "Authorization required: "
-                    "https://mcp.example.test/oauth/authorize?client_id=abc&state=opaque&response_type=code"
-                )
-            },
+            {"message": ("Authorization required: https://mcp.example.test/oauth/authorize?client_id=abc&state=opaque&response_type=code")},
         ]
     }
 

--- a/tests/test_smithery_release_authorization.py
+++ b/tests/test_smithery_release_authorization.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from urllib.request import Request
 
 import pytest
 
@@ -24,12 +25,19 @@ def test_extracts_only_the_expected_upstream_authorization_endpoint() -> None:
     payload = {
         "logs": [
             {"message": "ignore https://evil.example/oauth/authorize?state=bad"},
-            {"message": ("Authorization required: https://mcp.example.test/oauth/authorize?client_id=abc&state=opaque&response_type=code")},
+            {
+                "message": (
+                    "Authorization required: https://mcp.example.test/oauth/authorize?"
+                    "client_id=abc&state=opaque&response_type=code&"
+                    "redirect_uri=https%3A%2F%2Fserver.smithery.ai%2Foauth%2Fcallback"
+                )
+            },
         ]
     }
 
     assert module.extract_authorization_url(payload, "https://mcp.example.test/mcp") == (
-        "https://mcp.example.test/oauth/authorize?client_id=abc&state=opaque&response_type=code"
+        "https://mcp.example.test/oauth/authorize?client_id=abc&state=opaque&response_type=code&"
+        "redirect_uri=https%3A%2F%2Fserver.smithery.ai%2Foauth%2Fcallback"
     )
 
 
@@ -64,12 +72,113 @@ def test_authorization_follows_a_bounded_redirect_without_printing_the_url(capsy
         def read(self, _limit: int) -> bytes:
             return b"ok"
 
-    def opener(request, *, timeout):
+        def geturl(self) -> str:
+            return "https://server.smithery.ai/oauth/callback?code=opaque"
+
+    def opener(request, *, timeout, redirect_handler):
         seen.append((request.full_url, timeout))
+        assert redirect_handler.allowed_origins == {
+            ("https", "mcp.example.test", 443),
+            ("https", "server.smithery.ai", 443),
+        }
         return _Response()
 
-    secret_url = "https://mcp.example.test/oauth/authorize?state=sensitive&response_type=code"
+    secret_url = (
+        "https://mcp.example.test/oauth/authorize?state=sensitive&response_type=code&"
+        "redirect_uri=https%3A%2F%2Fserver.smithery.ai%2Foauth%2Fcallback"
+    )
     module.complete_authorization(secret_url, opener=opener)
 
     assert seen == [(secret_url, 30.0)]
     assert "sensitive" not in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "redirect_url",
+    [
+        "http://server.smithery.ai/oauth/callback?code=secret",
+        "https://evil.example/oauth/callback?code=secret",
+        "https://127.0.0.1/oauth/callback?code=secret",
+        "https://foo.smithery.ai/oauth/callback?code=secret",
+        "https://server.smithery.ai:444/oauth/callback?code=secret",
+        "https://server.smithery.ai/arbitrary?code=secret",
+        "https://server.smithery.ai.evil.example/oauth/callback?code=secret",
+    ],
+)
+def test_redirect_handler_rejects_cross_origin_and_insecure_redirects(redirect_url: str) -> None:
+    module = _load_script()
+    handler = module._BoundedRedirectHandler(
+        authorization_url="https://mcp.example.test/oauth/authorize?state=opaque",
+        callback_url="https://server.smithery.ai/oauth/callback",
+    )
+
+    with pytest.raises(ValueError, match="trusted HTTPS origin"):
+        handler.redirect_request(
+            Request("https://mcp.example.test/oauth/authorize?state=opaque"),
+            None,
+            302,
+            "Found",
+            {},
+            redirect_url,
+        )
+
+
+def test_authorization_requires_a_smithery_https_callback() -> None:
+    module = _load_script()
+
+    with pytest.raises(ValueError, match="Smithery redirect_uri"):
+        module.complete_authorization("https://mcp.example.test/oauth/authorize?state=x&redirect_uri=https%3A%2F%2Fevil.example%2Fcallback")
+
+    with pytest.raises(ValueError, match="Smithery redirect_uri"):
+        module.complete_authorization(
+            "https://mcp.example.test/oauth/authorize?state=x&"
+            "redirect_uri=https%3A%2F%2Fserver.smithery.ai%2Foauth%2Fcallback%3Fnext%3Dopaque"
+        )
+
+
+def test_authorization_rejects_a_200_response_that_never_reaches_the_callback() -> None:
+    module = _load_script()
+    authorization_url = (
+        "https://mcp.example.test/oauth/authorize?state=sensitive&redirect_uri=https%3A%2F%2Fserver.smithery.ai%2Foauth%2Fcallback"
+    )
+
+    class _Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self, _limit: int) -> bytes:
+            return b"login required"
+
+        def geturl(self) -> str:
+            return authorization_url
+
+    def opener(_request, *, timeout, redirect_handler):
+        assert timeout == 30.0
+        assert redirect_handler.allowed_origins
+        return _Response()
+
+    with pytest.raises(RuntimeError, match="callback failed"):
+        module.complete_authorization(authorization_url, opener=opener)
+
+
+def test_authorization_rejects_a_redirect_after_the_exact_callback() -> None:
+    module = _load_script()
+    handler = module._BoundedRedirectHandler(
+        authorization_url="https://mcp.example.test/oauth/authorize?state=opaque",
+        callback_url="https://server.smithery.ai/oauth/callback",
+    )
+
+    with pytest.raises(ValueError, match="one exact callback"):
+        handler.redirect_request(
+            Request("https://server.smithery.ai/oauth/callback?code=opaque"),
+            None,
+            302,
+            "Found",
+            {},
+            "https://server.smithery.ai/oauth/success",
+        )

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -167,8 +167,8 @@ def test_glama_tool_names_are_extracted_inertly_from_the_release_ref(tmp_path):
     assert "graph_correlation_status" in names
 
 
-def test_glama_listing_accepts_exact_public_schema_when_directory_api_is_empty(monkeypatch, capsys):
-    """The rendered Schema inventory is evidence even when the directory API lags."""
+def test_glama_listing_rejects_exact_public_schema_when_directory_api_is_stale(monkeypatch, capsys):
+    """One fresh public surface must not hide a reachable stale machine API."""
     script = _load_script("check_glama_listing.py")
     current_page = "v0.98.3 MCP server mode exposes 77 MCP tools"
     schema_page = "".join(f'<a href="/mcp/servers/msaad00/agent-bom/tools/tool_{index}">tool_{index}</a>' for index in range(77))
@@ -179,11 +179,72 @@ def test_glama_listing_accepts_exact_public_schema_when_directory_api_is_empty(m
     monkeypatch.setattr(script, "_fetch", fetch)
     monkeypatch.setattr(script, "_fetch_json", lambda _url, _timeout: {"tools": []})
 
-    assert script.main(["--expected", "0.98.3", "--expected-tool-count", "77", "--json", "--retries", "1"]) == 0
+    assert script.main(["--expected", "0.98.3", "--expected-tool-count", "77", "--json", "--retries", "1"]) == 1
     payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
-    assert payload["status"] == "fresh"
-    assert payload["tool_count"] == 77
+    assert payload["status"] == "stale"
+    assert payload["inventory_source"] == "schema+api"
+    assert "public API exposes 0 tools; expected 77" in payload["error"]
+
+
+def test_glama_listing_marks_schema_only_success_as_degraded(monkeypatch, capsys):
+    script = _load_script("check_glama_listing.py")
+    current_page = "v0.98.3 MCP server mode exposes 2 MCP tools"
+    schema_page = "".join(
+        f'<a href="/mcp/servers/msaad00/agent-bom/tools/tool_{index}">tool_{index}</a>' for index in range(2)
+    )
+
+    def fetch(url, _timeout):
+        return schema_page if url.endswith("/schema") else current_page
+
+    monkeypatch.setattr(script, "_fetch", fetch)
+    monkeypatch.setattr(script, "_fetch_json", lambda _url, _timeout: (_ for _ in ()).throw(urllib.error.URLError("401")))
+
+    assert script.main(["--expected", "0.98.3", "--expected-tool-count", "2", "--json", "--retries", "1"]) == 0
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["status"] == "fresh_degraded"
     assert payload["inventory_source"] == "schema"
+    assert payload["degraded_reason"] == "Glama public API inventory was unreachable"
+
+
+def test_glama_listing_rejects_stale_input_schema_from_reachable_api(monkeypatch, capsys, tmp_path):
+    script = _load_script("check_glama_listing.py")
+    expected_contract = [
+        {"name": "scan", "inputSchema": {"type": "object", "additionalProperties": False}},
+        {"name": "check", "inputSchema": {"type": "object", "required": ["package"]}},
+    ]
+    contract_file = tmp_path / "expected-contract.json"
+    contract_file.write_text(json.dumps(expected_contract), encoding="utf-8")
+    current_page = "v0.103.2 MCP server mode exposes 2 MCP tools"
+
+    monkeypatch.setattr(script, "_fetch", lambda _url, _timeout: current_page)
+    monkeypatch.setattr(
+        script,
+        "_fetch_json",
+        lambda _url, _timeout: {
+            "tools": [expected_contract[0], {"name": "check", "inputSchema": {"type": "object"}}]
+        },
+    )
+
+    assert (
+        script.main(
+            [
+                "--expected",
+                "0.103.2",
+                "--expected-tool-count",
+                "2",
+                "--expected-tool-contract-file",
+                str(contract_file),
+                "--json",
+                "--retries",
+                "1",
+            ]
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["status"] == "stale"
+    assert payload["exact_input_schemas"] is False
+    assert "input schema differs for tool: check" in payload["error"]
 
 
 def test_glama_listing_checks_visible_copy_not_hidden_stale_metadata(monkeypatch, capsys):

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -9,6 +9,8 @@ import urllib.error
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -81,6 +83,88 @@ def test_glama_listing_accepts_exact_public_api_tool_inventory(monkeypatch, caps
     assert payload["status"] == "fresh"
     assert payload["tool_count"] == 77
     assert payload["expected_tool_count"] == 77
+
+
+def test_glama_listing_rejects_same_count_with_a_different_tool(monkeypatch, capsys, tmp_path):
+    script = _load_script("check_glama_listing.py")
+    expected_names = ["graph_correlate", "graph_correlation_status"]
+    names_file = tmp_path / "expected-tools.json"
+    names_file.write_text(json.dumps(expected_names), encoding="utf-8")
+    current_page = "v0.103.2 MCP server mode exposes 2 MCP tools"
+
+    monkeypatch.setattr(script, "_fetch", lambda _url, _timeout: current_page)
+    monkeypatch.setattr(
+        script,
+        "_fetch_json",
+        lambda _url, _timeout: {"tools": [{"name": "graph_correlate"}, {"name": "unrelated_tool"}]},
+    )
+
+    assert (
+        script.main(
+            [
+                "--expected",
+                "0.103.2",
+                "--expected-tool-count",
+                "2",
+                "--expected-tool-names-file",
+                str(names_file),
+                "--json",
+                "--retries",
+                "1",
+            ]
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["status"] == "stale"
+    assert payload["exact_tool_set"] is False
+    assert "missing expected tools: graph_correlation_status" in payload["error"]
+    assert "unexpected tools: unrelated_tool" in payload["error"]
+
+
+@pytest.mark.parametrize("bad_name", [None, ["nested"], {"nested": "value"}, " scan "])
+def test_glama_listing_reports_malformed_tool_names_as_stale(monkeypatch, capsys, tmp_path, bad_name):
+    script = _load_script("check_glama_listing.py")
+    names_file = tmp_path / "expected-tools.json"
+    names_file.write_text(json.dumps(["scan", "check"]), encoding="utf-8")
+    current_page = "v0.103.2 MCP server mode exposes 2 MCP tools"
+
+    monkeypatch.setattr(script, "_fetch", lambda _url, _timeout: current_page)
+    monkeypatch.setattr(script, "_fetch_json", lambda _url, _timeout: {"tools": [{"name": "scan"}, {"name": bad_name}]})
+
+    assert (
+        script.main(
+            [
+                "--expected",
+                "0.103.2",
+                "--expected-tool-count",
+                "2",
+                "--expected-tool-names-file",
+                str(names_file),
+                "--json",
+                "--retries",
+                "1",
+            ]
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["status"] == "stale"
+    assert payload["exact_tool_set"] is False
+    assert "tool without a name" in payload["error"]
+
+
+def test_glama_tool_names_are_extracted_inertly_from_the_release_ref(tmp_path):
+    script = _load_script("check_glama_listing.py")
+    destination = tmp_path / "tool-names.json"
+
+    assert script.main(["--write-tool-names", str(destination), "--git-ref", "HEAD"]) == 0
+    names = json.loads(destination.read_text(encoding="utf-8"))
+
+    assert names == sorted(names)
+    assert len(names) == len(set(names)) == 86
+    assert "graph_correlate" in names
+    assert "graph_correlation_status" in names
 
 
 def test_glama_listing_accepts_exact_public_schema_when_directory_api_is_empty(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- reconcile Smithery, Glama, and idempotent ClawHub publication every six hours against the latest published release
- require immutable tool-name parity plus live release-bound input-schema parity, cross-check Glama surfaces when both are reachable, and report schema-only proof as degraded
- safely reuse fully paginated Smithery releases, bind freshness to the configured upstream, recover displaced release events, and prevent obsolete delayed events from publishing
- complete Smithery scan authorization through one exact HTTPS callback and fail closed on cross-origin, extra-redirect, malformed, or unavailable provider evidence

## Verification
- uv run pytest -q tests/test_deployment.py tests/test_surface_freshness.py tests/test_publish_registries_glama_gate.py tests/test_publish_registries_release_auth_gate.py tests/test_smithery_release_authorization.py (129 passed)
- make lint
- make preflight
- actionlint .github/workflows/publish-registries.yml
- python scripts/check_ci_pipefail.py
- python scripts/check_public_docs_hygiene.py
- git diff --check
- release-bound v0.103.2 metadata produced 86 unique tools and matched the live public server card exactly
- live Glama probe truthfully reported 84/86 tools and identified graph_correlate and graph_correlation_status as missing

## Notes
- Glama directory synchronization is provider-managed; this workflow retries verification automatically without inventing an undocumented mutation endpoint.
- A Glama hosted release remains a separate maintainer operation in the provider UI.
