### PR TITLE
test(docs): align storefront contracts

### DIFF
--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -215,7 +215,7 @@ def test_readme_links_end_to_end_workflow_before_persona_detail() -> None:
     persona_heading = readme.index("## Value by role")
     assert workflow_heading < workflow_link < persona_heading
     assert "[Control-plane architecture](docs/ARCHITECTURE.md)" in readme[workflow_heading:persona_heading]
-    assert "raw data, credentials, findings, and policy decisions" in readme[:workflow_heading].lower()
+    assert "Start with a local repository, image, SBOM, or MCP configuration" not in readme[:workflow_heading]
     workflow = readme[workflow_heading:persona_heading]
     normalized_workflow = " ".join(workflow.split())
     assert "### Product proof: independent evidence, one verifiable path" in workflow

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -205,12 +205,9 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert "MCP tools · no account required" not in hero
     assert '<a href="#quick-start"><b>Quick start</b></a>' in hero
     assert '<a href="https://msaad00.github.io/agent-bom/">Docs</a>' in hero
-    # The hero links the live demo. This project operates that Cloud Run service
-    # itself (`.github/workflows/demo-deploy-cloudrun.yml`), so its uptime is ours
-    # to own, and trying the product is the first thing the README's personas —
-    # AppSec, GRC, security leadership, and the engineers who remediate — need to
-    # do. Keep the link in the hero and keep it pointed at the deployed service.
-    assert '<a href="https://agent-bom-demo-82102570041.us-central1.run.app">Live demo</a>' in hero
+    # Keep the hero limited to durable first-run and documentation actions. The
+    # product proof immediately below carries the interactive UI evidence.
+    assert "Live demo" not in hero
     # `demo.agent-bom.com` is not currently mapped to that service. Until a Cloud
     # Run domain mapping exists, the README must not send anyone to a hostname
     # that resolves to nothing.


### PR DESCRIPTION
## Summary
- align README contract tests with the intentionally compact storefront
- retain the requested removal of duplicate local-source copy and the retired live-demo hero CTA

## Verification
- `uv run pytest -q tests/test_doc_architecture_svgs.py tests/test_public_docs_cli_alignment.py` (37 passed)
- `uv run ruff check tests/test_doc_architecture_svgs.py tests/test_public_docs_cli_alignment.py`
- `uv run ruff format --check tests/test_doc_architecture_svgs.py tests/test_public_docs_cli_alignment.py`
- `git diff --check`

## Notes
- Fixes the two exact assertions failing in current-main full correctness on Python 3.11, 3.13, and 3.14. No README or product behavior changes.