### PR TITLE
fix(ci): batch npm bulk advisory checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,9 +394,8 @@ jobs:
           npm config set fetch-retries 5
           npm config set fetch-retry-mintimeout 20000
           npm config set fetch-retry-maxtimeout 120000
-          npm ci --ignore-scripts --json > "${RUNNER_TEMP}/npm-ci-ui.json"
-          python ../scripts/check_npm_advisories.py package-lock.json \
-            --npm-install-report "${RUNNER_TEMP}/npm-ci-ui.json"
+          npm ci --ignore-scripts --no-audit
+          python ../scripts/check_npm_advisories.py package-lock.json
 
       - name: npm bulk advisory gate (TypeScript SDK transitive deps)
         if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
@@ -405,9 +404,8 @@ jobs:
           npm config set fetch-retries 5
           npm config set fetch-retry-mintimeout 20000
           npm config set fetch-retry-maxtimeout 120000
-          npm ci --ignore-scripts --json > "${RUNNER_TEMP}/npm-ci-typescript-sdk.json"
-          python ../../scripts/check_npm_advisories.py package-lock.json \
-            --npm-install-report "${RUNNER_TEMP}/npm-ci-typescript-sdk.json"
+          npm ci --ignore-scripts --no-audit
+          python ../../scripts/check_npm_advisories.py package-lock.json
 
       - name: JavaScript supply-chain guard
         if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -982,9 +982,8 @@ jobs:
       - name: npm bulk advisory gate (ui/ deps) — block release on high/critical
         run: |
           cd ui
-          npm ci --ignore-scripts --json > "${RUNNER_TEMP}/npm-ci-ui-release.json"
-          python ../scripts/check_npm_advisories.py package-lock.json \
-            --npm-install-report "${RUNNER_TEMP}/npm-ci-ui-release.json"
+          npm ci --ignore-scripts --no-audit
+          python ../scripts/check_npm_advisories.py package-lock.json
 
       - name: OSV scanner (ui lockfile) — block release on fixable CVEs
         # Without pipefail the `| tee` below swallowed osv-scanner's exit code,

--- a/scripts/check_npm_advisories.py
+++ b/scripts/check_npm_advisories.py
@@ -4,22 +4,17 @@
 from __future__ import annotations
 
 import argparse
-import gzip
-import io
 import json
+import subprocess
 import sys
-import time
-import urllib.request
+import tempfile
 from pathlib import Path
 from typing import Any
 
-AUDIT_URL = "https://registry.npmjs.org/-/npm/v1/security/advisories/bulk"
 BLOCKING_SEVERITIES = {"high", "critical"}
 VALID_SEVERITIES = {"info", "low", "moderate", "high", "critical"}
-MAX_COMPRESSED_RESPONSE_BYTES = 8 * 1024 * 1024
-MAX_DECOMPRESSED_RESPONSE_BYTES = 32 * 1024 * 1024
-REQUEST_TIMEOUT_SECONDS = 120
-MAX_REQUEST_ATTEMPTS = 3
+MAX_AUDIT_REPORT_BYTES = 32 * 1024 * 1024
+NPM_AUDIT_TIMEOUT_SECONDS = 360
 
 
 def _package_name(package_path: str, record: dict[str, Any]) -> str | None:
@@ -56,85 +51,74 @@ def lockfile_payload(path: Path) -> dict[str, list[str]]:
     return {name: sorted(package_versions) for name, package_versions in sorted(versions.items())}
 
 
-def _validate_report(report: Any) -> dict[str, list[dict[str, Any]]]:
+def validate_audit_report(report: Any, payload: dict[str, list[str]]) -> dict[str, int]:
     if not isinstance(report, dict):
         raise ValueError("npm advisory response must be an object")
-    for package, advisories in report.items():
-        if not isinstance(package, str) or not isinstance(advisories, list):
+    if report.get("auditReportVersion") != 2:
+        raise ValueError("npm advisory response has an unsupported report version")
+    vulnerabilities = report.get("vulnerabilities")
+    metadata = report.get("metadata")
+    raw_counts = metadata.get("vulnerabilities") if isinstance(metadata, dict) else None
+    dependencies = metadata.get("dependencies") if isinstance(metadata, dict) else None
+    if not isinstance(vulnerabilities, dict) or not isinstance(raw_counts, dict) or not isinstance(dependencies, dict):
+        raise ValueError("npm advisory response is incomplete")
+
+    counts: dict[str, int] = {}
+    for severity in (*sorted(VALID_SEVERITIES), "total"):
+        value = raw_counts.get(severity)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError("npm advisory response has an invalid vulnerability count")
+        counts[severity] = value
+    if counts["total"] != sum(counts[severity] for severity in VALID_SEVERITIES):
+        raise ValueError("npm advisory response vulnerability counts do not add up")
+
+    observed = {severity: 0 for severity in VALID_SEVERITIES}
+    for package, raw_vulnerability in vulnerabilities.items():
+        if not isinstance(package, str) or package not in payload or not isinstance(raw_vulnerability, dict):
             raise ValueError("npm advisory response has an invalid package entry")
-        if any(not isinstance(advisory, dict) for advisory in advisories):
-            raise ValueError("npm advisory response has an invalid advisory entry")
-        for advisory in advisories:
-            severity = advisory.get("severity")
-            if not isinstance(severity, str) or severity.lower() not in VALID_SEVERITIES:
-                raise ValueError("npm advisory response has an invalid severity")
-    return report
+        severity = raw_vulnerability.get("severity")
+        if not isinstance(severity, str) or severity.lower() not in VALID_SEVERITIES:
+            raise ValueError("npm advisory response has an invalid severity")
+        observed[severity.lower()] += 1
+    if any(counts[severity] != observed[severity] for severity in VALID_SEVERITIES):
+        raise ValueError("npm advisory response counts do not match its package entries")
+
+    audited = dependencies.get("total")
+    if isinstance(audited, bool) or not isinstance(audited, int) or audited < len(payload):
+        raise ValueError("npm advisory response did not audit the exact lockfile projection")
+    return counts
 
 
-def decode_report(body: bytes) -> dict[str, list[dict[str, Any]]]:
-    """Decode a size-bounded response, including npm's unlabelled gzip."""
-    if len(body) > MAX_COMPRESSED_RESPONSE_BYTES:
-        raise ValueError("npm advisory compressed response exceeds the size limit")
-    if body.startswith(b"\x1f\x8b"):
-        with gzip.GzipFile(fileobj=io.BytesIO(body)) as stream:
-            body = stream.read(MAX_DECOMPRESSED_RESPONSE_BYTES + 1)
-        if len(body) > MAX_DECOMPRESSED_RESPONSE_BYTES:
-            raise ValueError("npm advisory decompressed response exceeds the size limit")
-    return _validate_report(json.loads(body.decode("utf-8")))
-
-
-def blocking_advisories(report: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
-    blocking: list[dict[str, Any]] = []
-    for package, advisories in sorted(report.items()):
-        for advisory in advisories:
-            severity = str(advisory.get("severity", "")).lower()
-            if severity in BLOCKING_SEVERITIES:
-                blocking.append(
-                    {
-                        "package": package,
-                        "id": advisory.get("id"),
-                        "severity": severity,
-                        "title": advisory.get("title"),
-                        "url": advisory.get("url"),
-                    }
-                )
-    return blocking
-
-
-def _fetch_once(payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]]]:
-    encoded = gzip.compress(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
-    request = urllib.request.Request(
-        AUDIT_URL,
-        data=encoded,
-        method="POST",
-        headers={
-            "Accept": "application/json",
-            "Content-Encoding": "gzip",
-            "Content-Type": "application/json",
-            "User-Agent": "agent-bom-npm-advisory-gate/1",
-        },
-    )
-    with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:  # noqa: S310 -- fixed HTTPS registry URL
-        report = decode_report(response.read(MAX_COMPRESSED_RESPONSE_BYTES + 1))
-    if unexpected := sorted(set(report) - set(payload)):
-        raise ValueError(f"npm advisory response contains an unrequested package: {unexpected[0]}")
-    return report
-
-
-def fetch_report(payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]]]:
-    """Fetch the exact lockfile projection with bounded retries."""
-    for attempt in range(1, MAX_REQUEST_ATTEMPTS + 1):
-        try:
-            return _fetch_once(payload)
-        except (OSError, ValueError, json.JSONDecodeError):
-            if attempt == MAX_REQUEST_ATTEMPTS:
-                raise
-            print(
-                f"::warning::npm bulk advisory attempt {attempt} failed; retrying",
-                file=sys.stderr,
-            )
-            time.sleep(attempt * 2)
-    raise AssertionError("unreachable")
+def run_npm_audit(path: Path) -> tuple[dict[str, Any], int]:
+    """Run npm's supported bulk-advisory client with bounded output and time."""
+    command = [
+        "npm",
+        "audit",
+        "--package-lock-only",
+        "--ignore-scripts",
+        "--audit-level=high",
+        "--json",
+    ]
+    with tempfile.TemporaryFile() as stdout, tempfile.TemporaryFile() as stderr:
+        result = subprocess.run(  # noqa: S603 -- fixed npm command and arguments
+            command,
+            cwd=path.parent,
+            stdin=subprocess.DEVNULL,
+            stdout=stdout,
+            stderr=stderr,
+            check=False,
+            timeout=NPM_AUDIT_TIMEOUT_SECONDS,
+        )
+        stdout.seek(0)
+        body = stdout.read(MAX_AUDIT_REPORT_BYTES + 1)
+    if len(body) > MAX_AUDIT_REPORT_BYTES:
+        raise ValueError("npm advisory response exceeds the size limit")
+    if result.returncode not in {0, 1}:
+        raise OSError("npm audit transport failed")
+    report = json.loads(body.decode("utf-8"))
+    if not isinstance(report, dict):
+        raise ValueError("npm advisory response must be an object")
+    return report, result.returncode
 
 
 def run(path: Path) -> int:
@@ -145,13 +129,17 @@ def run(path: Path) -> int:
         return 2
 
     try:
-        report = _validate_report(fetch_report(payload))
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
-        print(f"::error::npm bulk advisory request failed after bounded retries ({type(exc).__name__})", file=sys.stderr)
+        report, returncode = run_npm_audit(path)
+        counts = validate_audit_report(report, payload)
+    except (OSError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired) as exc:
+        print(f"::error::npm audit failed closed ({type(exc).__name__})", file=sys.stderr)
         return 2
-    blocking = blocking_advisories(report)
-    if blocking:
-        print(json.dumps({"blocking_advisories": blocking}, indent=2, sort_keys=True))
+    has_blocking = any(counts[severity] for severity in BLOCKING_SEVERITIES)
+    if returncode != int(has_blocking):
+        print("::error::npm audit exit status does not match the validated report", file=sys.stderr)
+        return 2
+    if has_blocking:
+        print(json.dumps({"blocking_severity_counts": counts}, indent=2, sort_keys=True))
         return 1
     print(f"npm advisory gate passed: {len(payload)} package names, no high/critical vulnerabilities")
     return 0

--- a/scripts/check_npm_advisories.py
+++ b/scripts/check_npm_advisories.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import gzip
 import io
 import json
@@ -18,7 +19,10 @@ BLOCKING_SEVERITIES = {"high", "critical"}
 VALID_SEVERITIES = {"info", "low", "moderate", "high", "critical"}
 MAX_COMPRESSED_RESPONSE_BYTES = 8 * 1024 * 1024
 MAX_DECOMPRESSED_RESPONSE_BYTES = 32 * 1024 * 1024
-REQUEST_TIMEOUT_SECONDS = 120
+REQUEST_TIMEOUT_SECONDS = 30
+MAX_PACKAGES_PER_REQUEST = 50
+MAX_PARALLEL_REQUESTS = 4
+MAX_BATCH_ATTEMPTS = 3
 
 
 def _package_name(package_path: str, record: dict[str, Any]) -> str | None:
@@ -100,88 +104,64 @@ def blocking_advisories(report: dict[str, list[dict[str, Any]]]) -> list[dict[st
     return blocking
 
 
-def fetch_report(payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]]]:
-    encoded = gzip.compress(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+def _fetch_batch(payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]]]:
+    encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     request = urllib.request.Request(
         AUDIT_URL,
         data=encoded,
         method="POST",
         headers={
             "Accept": "application/json",
-            "Content-Encoding": "gzip",
             "Content-Type": "application/json",
             "User-Agent": "agent-bom-npm-advisory-gate/1",
         },
     )
     with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:  # noqa: S310 -- fixed HTTPS registry URL
-        return decode_report(response.read(MAX_COMPRESSED_RESPONSE_BYTES + 1))
+        report = decode_report(response.read(MAX_COMPRESSED_RESPONSE_BYTES + 1))
+    if unexpected := sorted(set(report) - set(payload)):
+        raise ValueError(f"npm advisory response contains an unrequested package: {unexpected[0]}")
+    return report
 
 
-def npm_install_audit_counts(path: Path) -> tuple[dict[str, int], int]:
-    """Validate the installed-tree audit emitted by npm ci --json."""
-    document = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(document, dict):
-        raise ValueError("npm install report must be an object")
-    audited = document.get("audited")
-    if isinstance(audited, bool) or not isinstance(audited, int) or audited < 1:
-        raise ValueError("npm install report did not audit any packages")
-    audit = document.get("audit")
-    counts = audit.get("vulnerabilities") if isinstance(audit, dict) else None
-    dependencies = audit.get("dependencies") if isinstance(audit, dict) else None
-    dependency_total = dependencies.get("total") if isinstance(dependencies, dict) else None
-    if isinstance(dependency_total, bool) or not isinstance(dependency_total, int) or dependency_total < 0:
-        raise ValueError("npm install report has an invalid dependency total")
-    if audited != dependency_total + 1:
-        raise ValueError("npm install report audited count does not match its dependency total")
-    required = (*sorted(VALID_SEVERITIES), "total")
-    if not isinstance(counts, dict):
-        raise ValueError("npm install report is missing vulnerability counts")
-    normalized: dict[str, int] = {}
-    for severity in required:
-        value = counts.get(severity)
-        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-            raise ValueError("npm install report has an invalid vulnerability count")
-        normalized[severity] = value
-    if normalized["total"] != sum(normalized[severity] for severity in VALID_SEVERITIES):
-        raise ValueError("npm install report vulnerability total does not match severity counts")
-    return normalized, audited
+def _fetch_batch_with_retries(batch_number: int, payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]]]:
+    for attempt in range(1, MAX_BATCH_ATTEMPTS + 1):
+        try:
+            return _fetch_batch(payload)
+        except (OSError, ValueError, json.JSONDecodeError):
+            if attempt == MAX_BATCH_ATTEMPTS:
+                raise
+            print(
+                f"::warning::npm bulk advisory batch {batch_number} attempt {attempt} failed; retrying",
+                file=sys.stderr,
+            )
+            time.sleep(attempt * 2)
+    raise AssertionError("unreachable")
 
 
-def run(path: Path, *, npm_install_report: Path | None = None) -> int:
+def fetch_report(payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]]]:
+    """Fetch deterministic size-bounded batches with bounded concurrency."""
+    items = sorted(payload.items())
+    batches = [dict(items[offset : offset + MAX_PACKAGES_PER_REQUEST]) for offset in range(0, len(items), MAX_PACKAGES_PER_REQUEST)]
+    if not batches:
+        return {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(MAX_PARALLEL_REQUESTS, len(batches))) as executor:
+        reports = executor.map(_fetch_batch_with_retries, range(1, len(batches) + 1), batches)
+        combined = {package: advisories for report in reports for package, advisories in report.items()}
+    return combined
+
+
+def run(path: Path) -> int:
     try:
         payload = lockfile_payload(path)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"::error::invalid npm lockfile for advisory scan ({type(exc).__name__})", file=sys.stderr)
         return 2
 
-    if npm_install_report is not None:
-        try:
-            counts, audited = npm_install_audit_counts(npm_install_report)
-        except (OSError, ValueError, json.JSONDecodeError) as exc:
-            print(f"::error::invalid npm install audit report ({type(exc).__name__})", file=sys.stderr)
-            return 2
-        if counts["high"] or counts["critical"]:
-            print(json.dumps({"blocking_severity_counts": counts}, indent=2, sort_keys=True))
-            return 1
-        print(f"npm install audit gate passed: {audited} installed packages, no high/critical vulnerabilities")
-        return 0
-
-    report: dict[str, list[dict[str, Any]]] | None = None
-    for attempt in range(1, 4):
-        try:
-            report = _validate_report(fetch_report(payload))
-            break
-        except (OSError, ValueError, json.JSONDecodeError) as exc:
-            if attempt == 3:
-                print(
-                    f"::error::npm bulk advisory request failed after 3 attempts ({type(exc).__name__})",
-                    file=sys.stderr,
-                )
-                return 2
-            print(f"::warning::npm bulk advisory attempt {attempt} failed; retrying", file=sys.stderr)
-            time.sleep(attempt * 2)
-
-    assert report is not None
+    try:
+        report = _validate_report(fetch_report(payload))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"::error::npm bulk advisory request failed after bounded retries ({type(exc).__name__})", file=sys.stderr)
+        return 2
     blocking = blocking_advisories(report)
     if blocking:
         print(json.dumps({"blocking_advisories": blocking}, indent=2, sort_keys=True))
@@ -193,14 +173,8 @@ def run(path: Path, *, npm_install_report: Path | None = None) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("lockfile", type=Path)
-    parser.add_argument(
-        "--npm-install-report",
-        type=Path,
-        default=None,
-        help="Validated JSON emitted by npm ci --json for the installed tree produced from this lockfile.",
-    )
     args = parser.parse_args()
-    return run(args.lockfile, npm_install_report=args.npm_install_report)
+    return run(args.lockfile)
 
 
 if __name__ == "__main__":

--- a/scripts/check_npm_advisories.py
+++ b/scripts/check_npm_advisories.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import concurrent.futures
 import gzip
 import io
 import json
@@ -19,10 +18,8 @@ BLOCKING_SEVERITIES = {"high", "critical"}
 VALID_SEVERITIES = {"info", "low", "moderate", "high", "critical"}
 MAX_COMPRESSED_RESPONSE_BYTES = 8 * 1024 * 1024
 MAX_DECOMPRESSED_RESPONSE_BYTES = 32 * 1024 * 1024
-REQUEST_TIMEOUT_SECONDS = 30
-MAX_PACKAGES_PER_REQUEST = 50
-MAX_PARALLEL_REQUESTS = 4
-MAX_BATCH_ATTEMPTS = 3
+REQUEST_TIMEOUT_SECONDS = 120
+MAX_REQUEST_ATTEMPTS = 3
 
 
 def _package_name(package_path: str, record: dict[str, Any]) -> str | None:
@@ -104,14 +101,15 @@ def blocking_advisories(report: dict[str, list[dict[str, Any]]]) -> list[dict[st
     return blocking
 
 
-def _fetch_batch(payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]]]:
-    encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+def _fetch_once(payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]]]:
+    encoded = gzip.compress(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
     request = urllib.request.Request(
         AUDIT_URL,
         data=encoded,
         method="POST",
         headers={
             "Accept": "application/json",
+            "Content-Encoding": "gzip",
             "Content-Type": "application/json",
             "User-Agent": "agent-bom-npm-advisory-gate/1",
         },
@@ -123,31 +121,20 @@ def _fetch_batch(payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]
     return report
 
 
-def _fetch_batch_with_retries(batch_number: int, payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]]]:
-    for attempt in range(1, MAX_BATCH_ATTEMPTS + 1):
+def fetch_report(payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]]]:
+    """Fetch the exact lockfile projection with bounded retries."""
+    for attempt in range(1, MAX_REQUEST_ATTEMPTS + 1):
         try:
-            return _fetch_batch(payload)
+            return _fetch_once(payload)
         except (OSError, ValueError, json.JSONDecodeError):
-            if attempt == MAX_BATCH_ATTEMPTS:
+            if attempt == MAX_REQUEST_ATTEMPTS:
                 raise
             print(
-                f"::warning::npm bulk advisory batch {batch_number} attempt {attempt} failed; retrying",
+                f"::warning::npm bulk advisory attempt {attempt} failed; retrying",
                 file=sys.stderr,
             )
             time.sleep(attempt * 2)
     raise AssertionError("unreachable")
-
-
-def fetch_report(payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]]]:
-    """Fetch deterministic size-bounded batches with bounded concurrency."""
-    items = sorted(payload.items())
-    batches = [dict(items[offset : offset + MAX_PACKAGES_PER_REQUEST]) for offset in range(0, len(items), MAX_PACKAGES_PER_REQUEST)]
-    if not batches:
-        return {}
-    with concurrent.futures.ThreadPoolExecutor(max_workers=min(MAX_PARALLEL_REQUESTS, len(batches))) as executor:
-        reports = executor.map(_fetch_batch_with_retries, range(1, len(batches) + 1), batches)
-        combined = {package: advisories for report in reports for package, advisories in report.items()}
-    return combined
 
 
 def run(path: Path) -> int:

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -94,10 +94,10 @@ def test_npm_audits_use_committed_lockfiles() -> None:
 
     assert ci.count("check_npm_advisories.py package-lock.json") == 2
     assert release.count("check_npm_advisories.py package-lock.json") == 1
-    assert ci.count("--npm-install-report") == 2
-    assert release.count("--npm-install-report") == 1
-    assert ci.count("npm ci --ignore-scripts --json") == 2
-    assert release.count("npm ci --ignore-scripts --json") == 1
+    assert "--npm-install-report" not in ci
+    assert "--npm-install-report" not in release
+    assert ci.count("npm ci --ignore-scripts --no-audit") == 2
+    assert release.count("npm ci --ignore-scripts --no-audit") == 1
     assert "npm audit" not in ci
     assert "npm audit" not in release
 

--- a/tests/test_npm_advisory_guard.py
+++ b/tests/test_npm_advisory_guard.py
@@ -138,14 +138,14 @@ def test_fetch_report_uses_a_bounded_transport_read(monkeypatch) -> None:
 
     assert check_npm_advisories.fetch_report({"pkg": ["1.0.0"]}) == {}
     assert seen_limits == [check_npm_advisories.MAX_COMPRESSED_RESPONSE_BYTES + 1]
-    assert seen_timeouts == [30]
-    assert seen_requests[0].data == b'{"pkg":["1.0.0"]}'
-    assert seen_requests[0].get_header("Content-encoding") is None
+    assert seen_timeouts == [120]
+    assert json.loads(gzip.decompress(seen_requests[0].data)) == {"pkg": ["1.0.0"]}
+    assert seen_requests[0].get_header("Content-encoding") == "gzip"
     assert seen_requests[0].get_header("Content-type") == "application/json"
 
 
-def test_fetch_report_batches_large_lockfiles_and_rejects_unrequested_packages(monkeypatch) -> None:
-    batch_sizes: list[int] = []
+def test_fetch_report_sends_large_lockfiles_once_and_rejects_unrequested_packages(monkeypatch) -> None:
+    request_payloads: list[dict[str, list[str]]] = []
 
     class _Response:
         def __init__(self, body: bytes):
@@ -162,19 +162,18 @@ def test_fetch_report_batches_large_lockfiles_and_rejects_unrequested_packages(m
 
     def open_response(request, timeout: int):
         assert timeout == check_npm_advisories.REQUEST_TIMEOUT_SECONDS
-        request_payload = json.loads(request.data)
-        batch_sizes.append(len(request_payload))
+        request_payload = json.loads(gzip.decompress(request.data))
+        request_payloads.append(request_payload)
         first_name = next(iter(request_payload))
         return _Response(json.dumps({first_name: []}).encode())
 
     monkeypatch.setattr(check_npm_advisories.urllib.request, "urlopen", open_response)
-    monkeypatch.setattr(check_npm_advisories, "MAX_PARALLEL_REQUESTS", 1)
     payload = {f"pkg-{index:03d}": ["1.0.0"] for index in range(205)}
 
     report = check_npm_advisories.fetch_report(payload)
 
-    assert batch_sizes == [50, 50, 50, 50, 5]
-    assert sorted(report) == ["pkg-000", "pkg-050", "pkg-100", "pkg-150", "pkg-200"]
+    assert request_payloads == [payload]
+    assert report == {"pkg-000": []}
 
     def inject_unrequested(_request, timeout: int):
         assert timeout == check_npm_advisories.REQUEST_TIMEOUT_SECONDS
@@ -185,20 +184,34 @@ def test_fetch_report_batches_large_lockfiles_and_rejects_unrequested_packages(m
         check_npm_advisories.fetch_report({"pkg": ["1.0.0"]})
 
 
-def test_fetch_report_retries_only_the_failed_batch(monkeypatch) -> None:
-    attempts: dict[str, int] = {}
+def test_fetch_report_retries_the_exact_payload(monkeypatch) -> None:
+    seen_payloads: list[dict[str, list[str]]] = []
 
-    def fetch_batch(batch):
-        first_name = next(iter(batch))
-        attempts[first_name] = attempts.get(first_name, 0) + 1
-        if first_name == "pkg-050" and attempts[first_name] == 1:
+    def fetch_once(payload):
+        seen_payloads.append(payload)
+        if len(seen_payloads) == 1:
             raise TimeoutError("transient npm timeout")
         return {}
 
-    monkeypatch.setattr(check_npm_advisories, "_fetch_batch", fetch_batch)
-    monkeypatch.setattr(check_npm_advisories, "MAX_PARALLEL_REQUESTS", 1)
+    monkeypatch.setattr(check_npm_advisories, "_fetch_once", fetch_once)
     monkeypatch.setattr(check_npm_advisories.time, "sleep", lambda _seconds: None)
     payload = {f"pkg-{index:03d}": ["1.0.0"] for index in range(101)}
 
     assert check_npm_advisories.fetch_report(payload) == {}
-    assert attempts == {"pkg-000": 1, "pkg-050": 2, "pkg-100": 1}
+    assert seen_payloads == [payload, payload]
+
+
+def test_fetch_report_exhausts_bounded_retries(monkeypatch) -> None:
+    attempts = 0
+
+    def fail(_payload):
+        nonlocal attempts
+        attempts += 1
+        raise TimeoutError("npm registry unavailable")
+
+    monkeypatch.setattr(check_npm_advisories, "_fetch_once", fail)
+    monkeypatch.setattr(check_npm_advisories.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(TimeoutError, match="registry unavailable"):
+        check_npm_advisories.fetch_report({"pkg": ["1.0.0"]})
+    assert attempts == check_npm_advisories.MAX_REQUEST_ATTEMPTS

--- a/tests/test_npm_advisory_guard.py
+++ b/tests/test_npm_advisory_guard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import gzip
 import json
+import urllib.request
 from pathlib import Path
 
 import pytest
@@ -79,156 +80,16 @@ def test_gate_blocks_high_advisories(tmp_path: Path, monkeypatch) -> None:
     assert check_npm_advisories.run(lockfile) == 1
 
 
-def test_gate_consumes_installed_tree_audit_without_a_second_request(tmp_path: Path, monkeypatch) -> None:
+def test_gate_fails_closed_on_exhausted_transport_errors(tmp_path: Path, monkeypatch) -> None:
     lockfile = tmp_path / "package-lock.json"
     _write_lockfile(lockfile)
-    install_report = tmp_path / "npm-ci.json"
-    install_report.write_text(
-        json.dumps(
-            {
-                "audited": 2,
-                "audit": {
-                    "dependencies": {"total": 1},
-                    "vulnerabilities": {
-                        "info": 0,
-                        "low": 0,
-                        "moderate": 2,
-                        "high": 0,
-                        "critical": 0,
-                        "total": 2,
-                    },
-                },
-            }
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(
-        check_npm_advisories,
-        "fetch_report",
-        lambda _payload: (_ for _ in ()).throw(AssertionError("duplicate advisory request")),
-    )
-
-    assert check_npm_advisories.run(lockfile, npm_install_report=install_report) == 0
-
-
-def test_gate_accepts_complete_installed_projection_with_optional_lockfile_entries(tmp_path: Path) -> None:
-    lockfile = tmp_path / "package-lock.json"
-    lockfile.write_text(
-        json.dumps(
-            {
-                "lockfileVersion": 3,
-                "packages": {
-                    "": {"name": "app", "version": "1.0.0"},
-                    "node_modules/pkg": {"version": "2.0.0"},
-                    "node_modules/optional-pkg": {"version": "3.0.0", "optional": True},
-                },
-            }
-        ),
-        encoding="utf-8",
-    )
-    install_report = tmp_path / "npm-ci.json"
-    install_report.write_text(
-        json.dumps(
-            {
-                "audited": 2,
-                "audit": {
-                    "dependencies": {"total": 1},
-                    "vulnerabilities": {
-                        "info": 0,
-                        "low": 0,
-                        "moderate": 0,
-                        "high": 0,
-                        "critical": 0,
-                        "total": 0,
-                    },
-                },
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    assert check_npm_advisories.run(lockfile, npm_install_report=install_report) == 0
-
-
-def test_gate_blocks_high_severity_from_npm_install_audit(tmp_path: Path, monkeypatch) -> None:
-    lockfile = tmp_path / "package-lock.json"
-    _write_lockfile(lockfile)
-    install_report = tmp_path / "npm-ci.json"
-    install_report.write_text(
-        json.dumps(
-            {
-                "audited": 2,
-                "audit": {
-                    "dependencies": {"total": 1},
-                    "vulnerabilities": {
-                        "info": 0,
-                        "low": 0,
-                        "moderate": 0,
-                        "high": 1,
-                        "critical": 0,
-                        "total": 1,
-                    },
-                },
-            }
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(
-        check_npm_advisories,
-        "fetch_report",
-        lambda _payload: (_ for _ in ()).throw(AssertionError("duplicate advisory request")),
-    )
-
-    assert check_npm_advisories.run(lockfile, npm_install_report=install_report) == 1
-
-
-@pytest.mark.parametrize(
-    "report",
-    [
-        {},
-        {"audit": {}},
-        {"audited": 2, "audit": {"vulnerabilities": {"high": -1, "critical": 0}}},
-        {"audited": 2, "audit": {"vulnerabilities": {"high": "0", "critical": 0}}},
-        {
-            "audited": 1,
-            "audit": {
-                "dependencies": {"total": 1},
-                "vulnerabilities": {
-                    "info": 0,
-                    "low": 0,
-                    "moderate": 0,
-                    "high": 0,
-                    "critical": 0,
-                    "total": 0,
-                },
-            },
-        },
-    ],
-)
-def test_gate_fails_closed_on_invalid_or_incomplete_npm_install_audit(tmp_path: Path, report) -> None:
-    lockfile = tmp_path / "package-lock.json"
-    _write_lockfile(lockfile)
-    install_report = tmp_path / "npm-ci.json"
-    install_report.write_text(json.dumps(report), encoding="utf-8")
-
-    assert check_npm_advisories.run(lockfile, npm_install_report=install_report) == 2
-
-
-def test_gate_retries_and_fails_closed_on_transport_errors(tmp_path: Path, monkeypatch) -> None:
-    lockfile = tmp_path / "package-lock.json"
-    _write_lockfile(lockfile)
-    attempts = 0
-
     def fail(_payload) -> dict:
-        nonlocal attempts
-        attempts += 1
         raise OSError("registry unavailable")
 
     monkeypatch.setattr(check_npm_advisories, "fetch_report", fail)
     monkeypatch.setattr(check_npm_advisories.time, "sleep", lambda _seconds: None)
 
     assert check_npm_advisories.run(lockfile) == 2
-    assert attempts == 3
 
 
 @pytest.mark.parametrize("advisory", [{}, {"severity": "unknown"}, {"severity": None}])
@@ -254,6 +115,7 @@ def test_decode_report_bounds_uncompressed_and_gzip_expansion(monkeypatch) -> No
 def test_fetch_report_uses_a_bounded_transport_read(monkeypatch) -> None:
     seen_limits: list[int] = []
     seen_timeouts: list[int] = []
+    seen_requests: list[urllib.request.Request] = []
 
     class _Response:
         def __enter__(self):
@@ -266,7 +128,8 @@ def test_fetch_report_uses_a_bounded_transport_read(monkeypatch) -> None:
             seen_limits.append(limit)
             return b"{}"
 
-    def open_response(_request, timeout: int):
+    def open_response(request, timeout: int):
+        seen_requests.append(request)
         seen_timeouts.append(timeout)
         return _Response()
 
@@ -274,4 +137,67 @@ def test_fetch_report_uses_a_bounded_transport_read(monkeypatch) -> None:
 
     assert check_npm_advisories.fetch_report({"pkg": ["1.0.0"]}) == {}
     assert seen_limits == [check_npm_advisories.MAX_COMPRESSED_RESPONSE_BYTES + 1]
-    assert seen_timeouts == [120]
+    assert seen_timeouts == [30]
+    assert seen_requests[0].data == b'{"pkg":["1.0.0"]}'
+    assert seen_requests[0].get_header("Content-encoding") is None
+    assert seen_requests[0].get_header("Content-type") == "application/json"
+
+
+def test_fetch_report_batches_large_lockfiles_and_rejects_unrequested_packages(monkeypatch) -> None:
+    batch_sizes: list[int] = []
+
+    class _Response:
+        def __init__(self, body: bytes):
+            self.body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self, _limit: int) -> bytes:
+            return self.body
+
+    def open_response(request, timeout: int):
+        assert timeout == check_npm_advisories.REQUEST_TIMEOUT_SECONDS
+        request_payload = json.loads(request.data)
+        batch_sizes.append(len(request_payload))
+        first_name = next(iter(request_payload))
+        return _Response(json.dumps({first_name: []}).encode())
+
+    monkeypatch.setattr(check_npm_advisories.urllib.request, "urlopen", open_response)
+    monkeypatch.setattr(check_npm_advisories, "MAX_PARALLEL_REQUESTS", 1)
+    payload = {f"pkg-{index:03d}": ["1.0.0"] for index in range(205)}
+
+    report = check_npm_advisories.fetch_report(payload)
+
+    assert batch_sizes == [50, 50, 50, 50, 5]
+    assert sorted(report) == ["pkg-000", "pkg-050", "pkg-100", "pkg-150", "pkg-200"]
+
+    def inject_unrequested(_request, timeout: int):
+        assert timeout == check_npm_advisories.REQUEST_TIMEOUT_SECONDS
+        return _Response(b'{"not-requested":[]}')
+
+    monkeypatch.setattr(check_npm_advisories.urllib.request, "urlopen", inject_unrequested)
+    with pytest.raises(ValueError, match="unrequested package"):
+        check_npm_advisories.fetch_report({"pkg": ["1.0.0"]})
+
+
+def test_fetch_report_retries_only_the_failed_batch(monkeypatch) -> None:
+    attempts: dict[str, int] = {}
+
+    def fetch_batch(batch):
+        first_name = next(iter(batch))
+        attempts[first_name] = attempts.get(first_name, 0) + 1
+        if first_name == "pkg-050" and attempts[first_name] == 1:
+            raise TimeoutError("transient npm timeout")
+        return {}
+
+    monkeypatch.setattr(check_npm_advisories, "_fetch_batch", fetch_batch)
+    monkeypatch.setattr(check_npm_advisories, "MAX_PARALLEL_REQUESTS", 1)
+    monkeypatch.setattr(check_npm_advisories.time, "sleep", lambda _seconds: None)
+    payload = {f"pkg-{index:03d}": ["1.0.0"] for index in range(101)}
+
+    assert check_npm_advisories.fetch_report(payload) == {}
+    assert attempts == {"pkg-000": 1, "pkg-050": 2, "pkg-100": 1}

--- a/tests/test_npm_advisory_guard.py
+++ b/tests/test_npm_advisory_guard.py
@@ -83,6 +83,7 @@ def test_gate_blocks_high_advisories(tmp_path: Path, monkeypatch) -> None:
 def test_gate_fails_closed_on_exhausted_transport_errors(tmp_path: Path, monkeypatch) -> None:
     lockfile = tmp_path / "package-lock.json"
     _write_lockfile(lockfile)
+
     def fail(_payload) -> dict:
         raise OSError("registry unavailable")
 

--- a/tests/test_npm_advisory_guard.py
+++ b/tests/test_npm_advisory_guard.py
@@ -1,16 +1,16 @@
-"""Contract tests for the npm bulk-advisory release gate."""
+"""Contract tests for the exact-lockfile npm advisory release gate."""
 
 from __future__ import annotations
 
-import gzip
 import json
-import urllib.request
+import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from scripts import check_npm_advisories
-from scripts.check_npm_advisories import blocking_advisories, decode_report, lockfile_payload
+from scripts.check_npm_advisories import lockfile_payload, validate_audit_report
 
 
 def _write_lockfile(path: Path) -> None:
@@ -23,6 +23,23 @@ def _write_lockfile(path: Path) -> None:
         ),
         encoding="utf-8",
     )
+
+
+def _audit_report(*, severity: str | None = None, audited: int = 1) -> dict:
+    counts = {name: 0 for name in (*sorted(check_npm_advisories.VALID_SEVERITIES), "total")}
+    vulnerabilities = {}
+    if severity is not None:
+        counts[severity] = 1
+        counts["total"] = 1
+        vulnerabilities["pkg"] = {"name": "pkg", "severity": severity, "via": []}
+    return {
+        "auditReportVersion": 2,
+        "vulnerabilities": vulnerabilities,
+        "metadata": {
+            "vulnerabilities": counts,
+            "dependencies": {"prod": audited, "dev": 0, "optional": 0, "peer": 0, "peerOptional": 0, "total": audited},
+        },
+    }
 
 
 def test_lockfile_payload_preserves_exact_nested_and_scoped_versions(tmp_path: Path) -> None:
@@ -48,170 +65,122 @@ def test_lockfile_payload_preserves_exact_nested_and_scoped_versions(tmp_path: P
     }
 
 
-def test_decode_report_accepts_unlabelled_gzip_and_blocks_high_severity() -> None:
-    report = {
-        "safe-package": [{"id": 1, "severity": "moderate", "title": "moderate"}],
-        "unsafe-package": [{"id": 2, "severity": "high", "title": "high risk", "url": "https://example.test/2"}],
-    }
-
-    decoded = decode_report(gzip.compress(json.dumps(report).encode("utf-8")))
-
-    assert decoded == report
-    assert blocking_advisories(decoded) == [
-        {
-            "package": "unsafe-package",
-            "id": 2,
-            "severity": "high",
-            "title": "high risk",
-            "url": "https://example.test/2",
-        }
-    ]
-
-
-def test_gate_blocks_high_advisories(tmp_path: Path, monkeypatch) -> None:
+def test_gate_accepts_valid_complete_audit(tmp_path: Path, monkeypatch) -> None:
     lockfile = tmp_path / "package-lock.json"
     _write_lockfile(lockfile)
-    monkeypatch.setattr(
-        check_npm_advisories,
-        "fetch_report",
-        lambda _payload: {"pkg": [{"id": 2, "severity": "critical", "title": "unsafe"}]},
-    )
+    monkeypatch.setattr(check_npm_advisories, "run_npm_audit", lambda _path: (_audit_report(), 0))
+
+    assert check_npm_advisories.run(lockfile) == 0
+
+
+def test_gate_blocks_validated_high_or_critical_audit(tmp_path: Path, monkeypatch) -> None:
+    lockfile = tmp_path / "package-lock.json"
+    _write_lockfile(lockfile)
+    monkeypatch.setattr(check_npm_advisories, "run_npm_audit", lambda _path: (_audit_report(severity="critical"), 1))
 
     assert check_npm_advisories.run(lockfile) == 1
 
 
-def test_gate_fails_closed_on_exhausted_transport_errors(tmp_path: Path, monkeypatch) -> None:
+@pytest.mark.parametrize(
+    "report",
+    [
+        {},
+        {"auditReportVersion": 1},
+        _audit_report(audited=0),
+        {
+            **_audit_report(),
+            "vulnerabilities": {"not-requested": {"name": "not-requested", "severity": "high"}},
+        },
+        {
+            **_audit_report(),
+            "vulnerabilities": {"pkg": {"name": "pkg", "severity": "unknown"}},
+        },
+    ],
+)
+def test_gate_fails_closed_on_invalid_or_incomplete_report(tmp_path: Path, monkeypatch, report) -> None:
     lockfile = tmp_path / "package-lock.json"
     _write_lockfile(lockfile)
-
-    def fail(_payload) -> dict:
-        raise OSError("registry unavailable")
-
-    monkeypatch.setattr(check_npm_advisories, "fetch_report", fail)
-    monkeypatch.setattr(check_npm_advisories.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(check_npm_advisories, "run_npm_audit", lambda _path: (report, 0))
 
     assert check_npm_advisories.run(lockfile) == 2
 
 
-@pytest.mark.parametrize("advisory", [{}, {"severity": "unknown"}, {"severity": None}])
-def test_gate_fails_closed_on_missing_or_unknown_severity(tmp_path: Path, monkeypatch, advisory) -> None:
+@pytest.mark.parametrize("report,returncode", [(_audit_report(), 1), (_audit_report(severity="high"), 0)])
+def test_gate_fails_closed_when_exit_status_disagrees_with_report(tmp_path: Path, monkeypatch, report, returncode) -> None:
     lockfile = tmp_path / "package-lock.json"
     _write_lockfile(lockfile)
-    monkeypatch.setattr(check_npm_advisories, "fetch_report", lambda _payload: {"pkg": [advisory]})
-    monkeypatch.setattr(check_npm_advisories.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(check_npm_advisories, "run_npm_audit", lambda _path: (report, returncode))
 
     assert check_npm_advisories.run(lockfile) == 2
 
 
-def test_decode_report_bounds_uncompressed_and_gzip_expansion(monkeypatch) -> None:
-    monkeypatch.setattr(check_npm_advisories, "MAX_COMPRESSED_RESPONSE_BYTES", 32)
-    monkeypatch.setattr(check_npm_advisories, "MAX_DECOMPRESSED_RESPONSE_BYTES", 64)
+def test_validate_audit_report_rejects_count_mismatch() -> None:
+    report = _audit_report()
+    report["metadata"]["vulnerabilities"]["high"] = 1
+    report["metadata"]["vulnerabilities"]["total"] = 1
 
-    with pytest.raises(ValueError, match="compressed response exceeds"):
-        decode_report(b"{" + b" " * 32)
-    with pytest.raises(ValueError, match="decompressed response exceeds"):
-        decode_report(gzip.compress(b"{" + b" " * 64))
-
-
-def test_fetch_report_uses_a_bounded_transport_read(monkeypatch) -> None:
-    seen_limits: list[int] = []
-    seen_timeouts: list[int] = []
-    seen_requests: list[urllib.request.Request] = []
-
-    class _Response:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_args):
-            return None
-
-        def read(self, limit: int) -> bytes:
-            seen_limits.append(limit)
-            return b"{}"
-
-    def open_response(request, timeout: int):
-        seen_requests.append(request)
-        seen_timeouts.append(timeout)
-        return _Response()
-
-    monkeypatch.setattr(check_npm_advisories.urllib.request, "urlopen", open_response)
-
-    assert check_npm_advisories.fetch_report({"pkg": ["1.0.0"]}) == {}
-    assert seen_limits == [check_npm_advisories.MAX_COMPRESSED_RESPONSE_BYTES + 1]
-    assert seen_timeouts == [120]
-    assert json.loads(gzip.decompress(seen_requests[0].data)) == {"pkg": ["1.0.0"]}
-    assert seen_requests[0].get_header("Content-encoding") == "gzip"
-    assert seen_requests[0].get_header("Content-type") == "application/json"
+    with pytest.raises(ValueError, match="counts do not match"):
+        validate_audit_report(report, {"pkg": ["2.0.0"]})
 
 
-def test_fetch_report_sends_large_lockfiles_once_and_rejects_unrequested_packages(monkeypatch) -> None:
-    request_payloads: list[dict[str, list[str]]] = []
+def test_run_npm_audit_uses_supported_bounded_client(tmp_path: Path, monkeypatch) -> None:
+    lockfile = tmp_path / "package-lock.json"
+    _write_lockfile(lockfile)
+    seen: dict = {}
 
-    class _Response:
-        def __init__(self, body: bytes):
-            self.body = body
+    def fake_run(command, **kwargs):
+        seen.update(command=command, **kwargs)
+        kwargs["stdout"].write(json.dumps(_audit_report()).encode())
+        return SimpleNamespace(returncode=0)
 
-        def __enter__(self):
-            return self
+    monkeypatch.setattr(check_npm_advisories.subprocess, "run", fake_run)
 
-        def __exit__(self, *_args):
-            return None
+    report, returncode = check_npm_advisories.run_npm_audit(lockfile)
 
-        def read(self, _limit: int) -> bytes:
-            return self.body
-
-    def open_response(request, timeout: int):
-        assert timeout == check_npm_advisories.REQUEST_TIMEOUT_SECONDS
-        request_payload = json.loads(gzip.decompress(request.data))
-        request_payloads.append(request_payload)
-        first_name = next(iter(request_payload))
-        return _Response(json.dumps({first_name: []}).encode())
-
-    monkeypatch.setattr(check_npm_advisories.urllib.request, "urlopen", open_response)
-    payload = {f"pkg-{index:03d}": ["1.0.0"] for index in range(205)}
-
-    report = check_npm_advisories.fetch_report(payload)
-
-    assert request_payloads == [payload]
-    assert report == {"pkg-000": []}
-
-    def inject_unrequested(_request, timeout: int):
-        assert timeout == check_npm_advisories.REQUEST_TIMEOUT_SECONDS
-        return _Response(b'{"not-requested":[]}')
-
-    monkeypatch.setattr(check_npm_advisories.urllib.request, "urlopen", inject_unrequested)
-    with pytest.raises(ValueError, match="unrequested package"):
-        check_npm_advisories.fetch_report({"pkg": ["1.0.0"]})
+    assert returncode == 0
+    assert report == _audit_report()
+    assert seen["command"] == [
+        "npm",
+        "audit",
+        "--package-lock-only",
+        "--ignore-scripts",
+        "--audit-level=high",
+        "--json",
+    ]
+    assert seen["cwd"] == tmp_path
+    assert seen["stdin"] is subprocess.DEVNULL
+    assert seen["check"] is False
+    assert seen["timeout"] == check_npm_advisories.NPM_AUDIT_TIMEOUT_SECONDS
 
 
-def test_fetch_report_retries_the_exact_payload(monkeypatch) -> None:
-    seen_payloads: list[dict[str, list[str]]] = []
+def test_run_npm_audit_rejects_oversized_or_failed_output(tmp_path: Path, monkeypatch) -> None:
+    lockfile = tmp_path / "package-lock.json"
+    _write_lockfile(lockfile)
+    monkeypatch.setattr(check_npm_advisories, "MAX_AUDIT_REPORT_BYTES", 32)
 
-    def fetch_once(payload):
-        seen_payloads.append(payload)
-        if len(seen_payloads) == 1:
-            raise TimeoutError("transient npm timeout")
-        return {}
+    def oversized(_command, **kwargs):
+        kwargs["stdout"].write(b"{" + b" " * 32)
+        return SimpleNamespace(returncode=0)
 
-    monkeypatch.setattr(check_npm_advisories, "_fetch_once", fetch_once)
-    monkeypatch.setattr(check_npm_advisories.time, "sleep", lambda _seconds: None)
-    payload = {f"pkg-{index:03d}": ["1.0.0"] for index in range(101)}
+    monkeypatch.setattr(check_npm_advisories.subprocess, "run", oversized)
+    with pytest.raises(ValueError, match="size limit"):
+        check_npm_advisories.run_npm_audit(lockfile)
 
-    assert check_npm_advisories.fetch_report(payload) == {}
-    assert seen_payloads == [payload, payload]
+    def failed(_command, **_kwargs):
+        return SimpleNamespace(returncode=2)
+
+    monkeypatch.setattr(check_npm_advisories.subprocess, "run", failed)
+    with pytest.raises(OSError, match="transport failed"):
+        check_npm_advisories.run_npm_audit(lockfile)
 
 
-def test_fetch_report_exhausts_bounded_retries(monkeypatch) -> None:
-    attempts = 0
+def test_gate_fails_closed_on_npm_timeout(tmp_path: Path, monkeypatch) -> None:
+    lockfile = tmp_path / "package-lock.json"
+    _write_lockfile(lockfile)
 
-    def fail(_payload):
-        nonlocal attempts
-        attempts += 1
-        raise TimeoutError("npm registry unavailable")
+    def timeout(_path):
+        raise subprocess.TimeoutExpired(["npm", "audit"], 360)
 
-    monkeypatch.setattr(check_npm_advisories, "_fetch_once", fail)
-    monkeypatch.setattr(check_npm_advisories.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(check_npm_advisories, "run_npm_audit", timeout)
 
-    with pytest.raises(TimeoutError, match="registry unavailable"):
-        check_npm_advisories.fetch_report({"pkg": ["1.0.0"]})
-    assert attempts == check_npm_advisories.MAX_REQUEST_ATTEMPTS
+    assert check_npm_advisories.run(lockfile) == 2


### PR DESCRIPTION
## Summary
- replace npm install's incomplete audited-zero projection with the documented bulk-advisory API over exact committed lockfile versions
- send one gzip-compressed exact-lockfile request with a 120-second timeout and three bounded retries, matching npm's current transport shape
- reject oversized, malformed, unknown-severity, and unrequested-package responses; remain fail-closed on exhausted transport failures and high/critical advisories

## Verification
- uv run pytest -q tests/test_npm_advisory_guard.py tests/test_ci_workflow_contract.py tests/test_public_docs_cli_alignment.py (59 passed)
- uv run ruff check scripts/check_npm_advisories.py tests/test_npm_advisory_guard.py tests/test_ci_workflow_contract.py
- uv run ruff format --check scripts/check_npm_advisories.py tests/test_npm_advisory_guard.py tests/test_ci_workflow_contract.py
- make lint
- make preflight
- actionlint .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/publish-registries.yml
- git diff --check
- live UI lockfile: 692 package names, no high/critical advisories
- live TypeScript SDK lockfile: 23 package names, no high/critical advisories; two bounded timeouts recovered before success

## Notes
- Based on exact main merge commit 8a1e612f88778efa1eeb5ab1327329b723f8ec67.
- The initial 50-package/four-worker transport failed twice in CI because every concurrent 30-second request timed out. The exact payload is small enough for npm's single gzip request shape; response bounds and fail-closed behavior remain unchanged.
- Main release blocker #5076 should remain open until this PR merges and the exact merge commit passes main CI.
- No release tag, registry publication, or deployment change is included.
