### PR TITLE
fix(graph): honor non-traversable campaign edges

### DIFF
--- a/src/agent_bom/graph/attack_path_campaigns.py
+++ b/src/agent_bom/graph/attack_path_campaigns.py
@@ -284,7 +284,7 @@ def _explore_partition(
             return
 
         for edge in graph.adjacency.get(node_id, []):
-            if _rel(edge) not in _TRAVERSABLE_RELS:
+            if not edge.traversable or _rel(edge) not in _TRAVERSABLE_RELS:
                 continue
             nxt = edge.target
             if nxt in prefix_set or nxt in hops:

--- a/tests/test_attack_path_campaigns.py
+++ b/tests/test_attack_path_campaigns.py
@@ -112,6 +112,27 @@ def test_no_jewel_yields_no_campaigns() -> None:
     assert result.campaigns == []
 
 
+def test_non_traversable_edge_never_yields_partitioned_path() -> None:
+    """Large-estate fusion must honor the same edge gate as small graphs."""
+    g = UnifiedGraph(scan_id="s", tenant_id="tenant-alpha")
+    g.add_node(_entry("entry", "acct-a"))
+    g.add_node(_jewel("ds:crown", "acct-a"))
+    g.add_edge(
+        UnifiedEdge(
+            source="entry",
+            target="ds:crown",
+            relationship=RelationshipType.CAN_ACCESS,
+            traversable=False,
+        )
+    )
+    _pad(g, _MAX_NODES + 10, account="acct-a")
+
+    result = compute_partitioned_campaigns(g)
+
+    assert result.paths == []
+    assert result.campaigns == []
+
+
 def test_cross_partition_path_is_reconciled() -> None:
     """Entry in account A -> (cross-account ASSUMES) -> crown jewel in account B.
 


### PR DESCRIPTION
Summary:
- Require edge.traversable before following allowed relationships in partitioned attack-path campaigns.
- Prevent false-positive paths through explicitly non-traversable edges.

Verification:
- Red regression reproduced a CAN_ACCESS edge false path with composite risk 36.0.
- 13 campaign tests passed.
- Non-traversable fusion and campaign parity tests passed.
- Ruff and git diff --check passed.

Notes:
- Signed commit ad9a8b30ab7a03d17d6237606e2b3ecdc9a72e29.
- Independent of release PR #5079.