### PR TITLE
fix(mcp): use streamable HTTP for introspection

### DIFF
--- a/src/agent_bom/mcp_introspect.py
+++ b/src/agent_bom/mcp_introspect.py
@@ -359,7 +359,7 @@ async def introspect_server(
     Connects via the server's configured transport, performs the MCP handshake,
     and queries tools/list + resources/list.
 
-    Only stdio and SSE transports are supported for introspection.
+    Stdio, SSE, and Streamable HTTP transports are supported for introspection.
     """
     result = ServerIntrospection(
         server_name=server.name,
@@ -387,11 +387,17 @@ async def introspect_server(
             return result
         return await _introspect_stdio(server, result, timeout)
 
-    elif server.transport in (TransportType.SSE, TransportType.STREAMABLE_HTTP):
+    elif server.transport == TransportType.SSE:
         if not server.url:
             result.error = f"No URL configured for {server.transport.value} server"
             return result
         return await _introspect_sse(server, result, timeout)
+
+    elif server.transport == TransportType.STREAMABLE_HTTP:
+        if not server.url:
+            result.error = f"No URL configured for {server.transport.value} server"
+            return result
+        return await _introspect_streamable_http(server, result, timeout)
 
     else:
         result.error = f"Unsupported transport: {server.transport.value}"
@@ -446,6 +452,36 @@ async def _introspect_sse(
     try:
         async with asyncio.timeout(timeout):
             async with sse_client(server.url) as (read, write):  # type: ignore[arg-type]
+                async with ClientSession(read, write) as session:
+                    init_result = await session.initialize()
+                    result.protocol_version = getattr(init_result, "protocolVersion", None)
+
+                    result = await _query_capabilities(session, server, result)
+
+    except TimeoutError:
+        result.error = f"Connection timed out after {timeout}s"
+    except Exception as exc:
+        result.error = _safe_runtime_text(exc)
+
+    return result
+
+
+async def _introspect_streamable_http(
+    server: MCPServer,
+    result: ServerIntrospection,
+    timeout: float,
+) -> ServerIntrospection:
+    """Introspect via MCP Streamable HTTP transport."""
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamable_http_client
+
+    if not server.url:
+        result.error = "Server URL is not set"
+        return result
+
+    try:
+        async with asyncio.timeout(timeout):
+            async with streamable_http_client(server.url) as (read, write, _get_session_id):
                 async with ClientSession(read, write) as session:
                     init_result = await session.initialize()
                     result.protocol_version = getattr(init_result, "protocolVersion", None)

--- a/tests/test_mcp_introspect.py
+++ b/tests/test_mcp_introspect.py
@@ -490,6 +490,127 @@ async def test_introspect_server_no_url():
 
 
 @pytest.mark.asyncio
+async def test_introspect_server_routes_streamable_http_to_its_client():
+    from agent_bom.mcp_introspect import ServerIntrospection, introspect_server
+
+    server = MCPServer(
+        name="streamable-server",
+        transport=TransportType.STREAMABLE_HTTP,
+        url="https://example.test/mcp",
+    )
+    expected = ServerIntrospection(server_name=server.name, success=True)
+    wrong_transport = ServerIntrospection(server_name=server.name, success=False)
+
+    with (
+        patch("agent_bom.mcp_introspect._check_mcp_sdk"),
+        patch(
+            "agent_bom.mcp_introspect._introspect_streamable_http",
+            new=AsyncMock(return_value=expected),
+        ) as streamable_http,
+        patch(
+            "agent_bom.mcp_introspect._introspect_sse",
+            new=AsyncMock(return_value=wrong_transport),
+        ) as sse,
+    ):
+        result = await introspect_server(server, timeout=1.0)
+
+    assert result is expected
+    streamable_http.assert_awaited_once()
+    sse.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_introspect_streamable_http_uses_streamable_client_and_queries_capabilities():
+    from agent_bom.mcp_introspect import ServerIntrospection, _introspect_streamable_http
+
+    server = MCPServer(
+        name="streamable-server",
+        transport=TransportType.STREAMABLE_HTTP,
+        url="https://example.test/mcp",
+    )
+    result = ServerIntrospection(server_name=server.name, success=False)
+    completed = ServerIntrospection(server_name=server.name, success=True)
+
+    transport_context = MagicMock()
+    transport_context.__aenter__ = AsyncMock(return_value=("read", "write", lambda: "session-id"))
+    transport_context.__aexit__ = AsyncMock(return_value=None)
+    session = MagicMock()
+    session.initialize = AsyncMock(return_value=SimpleNamespace(protocolVersion="2025-06-18"))
+    session_context = MagicMock()
+    session_context.__aenter__ = AsyncMock(return_value=session)
+    session_context.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "mcp.client.streamable_http.streamable_http_client",
+            return_value=transport_context,
+        ) as streamable_http_client,
+        patch("mcp.ClientSession", return_value=session_context) as client_session,
+        patch(
+            "agent_bom.mcp_introspect._query_capabilities",
+            new=AsyncMock(return_value=completed),
+        ) as query_capabilities,
+    ):
+        actual = await _introspect_streamable_http(server, result, timeout=1.0)
+
+    assert actual is completed
+    assert result.protocol_version == "2025-06-18"
+    streamable_http_client.assert_called_once_with(server.url)
+    client_session.assert_called_once_with("read", "write")
+    query_capabilities.assert_awaited_once_with(session, server, result)
+
+
+@pytest.mark.asyncio
+async def test_introspect_streamable_http_preserves_timeout_error():
+    from agent_bom.mcp_introspect import ServerIntrospection, _introspect_streamable_http
+
+    server = MCPServer(
+        name="streamable-server",
+        transport=TransportType.STREAMABLE_HTTP,
+        url="https://example.test/mcp",
+    )
+    result = ServerIntrospection(server_name=server.name, success=False)
+    transport_context = MagicMock()
+    transport_context.__aenter__ = AsyncMock(side_effect=TimeoutError)
+    transport_context.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "mcp.client.streamable_http.streamable_http_client",
+        return_value=transport_context,
+    ):
+        actual = await _introspect_streamable_http(server, result, timeout=0.25)
+
+    assert actual is result
+    assert actual.success is False
+    assert actual.error == "Connection timed out after 0.25s"
+
+
+@pytest.mark.asyncio
+async def test_introspect_streamable_http_sanitizes_transport_error():
+    from agent_bom.mcp_introspect import ServerIntrospection, _introspect_streamable_http
+
+    server = MCPServer(
+        name="streamable-server",
+        transport=TransportType.STREAMABLE_HTTP,
+        url="https://example.test/mcp",
+    )
+    result = ServerIntrospection(server_name=server.name, success=False)
+    transport_context = MagicMock()
+    transport_context.__aenter__ = AsyncMock(side_effect=RuntimeError("failed with token=super-secret"))
+    transport_context.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "mcp.client.streamable_http.streamable_http_client",
+        return_value=transport_context,
+    ):
+        actual = await _introspect_streamable_http(server, result, timeout=1.0)
+
+    assert actual is result
+    assert actual.success is False
+    assert "super-secret" not in (actual.error or "")
+
+
+@pytest.mark.asyncio
 async def test_introspect_server_rejects_security_blocked_before_transport():
     """A discovery block is an execution boundary, not advisory metadata."""
     from agent_bom.mcp_introspect import introspect_server


### PR DESCRIPTION
Summary:
- Route streamable-http MCP servers through the modern `streamable_http` client instead of the SSE client.
- Preserve shared capability discovery, timeout, sanitization, protocol capture, and completeness behavior.
- Add transport-specific routing, wiring, timeout, and sanitized-error regression tests.

Verification:
- 34 focused MCP introspection tests passed at the rebased head.
- Ruff, Ruff formatting, and mypy passed for the changed module and tests.
- `git diff --check` passed.

Notes:
- Signed head: `e72a7029f36d94f2219c6fa342b49c4883de864e`.
- Exact base main: `da63ca381411efe35befa05c012ed2137d59bc6a`.
- Independent of evidence foundation PR #5080.
