### PR TITLE
feat(identity): define provider-neutral join contract

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "Python modules",
-      "value": 888,
+      "value": 889,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -16,7 +16,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 50 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 888 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 889 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/schemas/v1/IdentityResourceJoinContract.json
+++ b/docs/schemas/v1/IdentityResourceJoinContract.json
@@ -986,19 +986,12 @@
       "description": "One exact provider identifier retained for deterministic correlation.",
       "properties": {
         "account": {
-          "anyOf": [
-            {
-              "maxLength": 2048,
-              "minLength": 1,
-              "pattern": "^[^\\s]+$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Account"
+          "description": "Required provider scope: account, organization, tenant, subscription, or project identifier.",
+          "maxLength": 2048,
+          "minLength": 1,
+          "pattern": "^[^\\s]+$",
+          "title": "Account",
+          "type": "string"
         },
         "id_type": {
           "maxLength": 100,
@@ -1029,7 +1022,8 @@
         "source",
         "provider",
         "id_type",
-        "value"
+        "value",
+        "account"
       ],
       "title": "ProviderNativeId",
       "type": "object"

--- a/docs/schemas/v1/IdentityResourceJoinContract.json
+++ b/docs/schemas/v1/IdentityResourceJoinContract.json
@@ -1,7 +1,39 @@
 {
+  "$comment": "Cross-record identity, resource, relationship, freshness, and evidence-anchor invariants require IdentityResourceJoinContract.model_validate; JSON Schema alone is not sufficient.",
   "$defs": {
     "CanonicalIdentityEntity": {
       "additionalProperties": false,
+      "allOf": [
+        {
+          "properties": {
+            "status": {
+              "enum": [
+                "complete",
+                "partial"
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "partial"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "reason_codes": {
+                "minItems": 1
+              }
+            }
+          }
+        }
+      ],
       "description": "Canonical identity with one or more authoritative provider-native IDs.",
       "properties": {
         "display_name": {
@@ -80,6 +112,37 @@
     },
     "CanonicalResourceReference": {
       "additionalProperties": false,
+      "allOf": [
+        {
+          "properties": {
+            "status": {
+              "enum": [
+                "complete",
+                "partial"
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "partial"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "reason_codes": {
+                "minItems": 1
+              }
+            }
+          }
+        }
+      ],
       "description": "Bounded resource reference that an observed identity relationship targets.",
       "properties": {
         "display_name": {
@@ -446,8 +509,226 @@
       "title": "FreshnessStatus",
       "type": "string"
     },
+    "IdentityJoinMethod": {
+      "description": "Authoritative provider mechanism that established a structural join.",
+      "enum": [
+        "directory_membership",
+        "role_assignment",
+        "trust_policy",
+        "workload_binding",
+        "ownership_record"
+      ],
+      "title": "IdentityJoinMethod",
+      "type": "string"
+    },
     "IdentityRelationship": {
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "relationship_type": {
+                "const": "member_of"
+              }
+            },
+            "required": [
+              "relationship_type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "join_method": {
+                "const": "directory_membership"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "relationship_type": {
+                "const": "assumes"
+              }
+            },
+            "required": [
+              "relationship_type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "join_method": {
+                "const": "role_assignment"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "relationship_type": {
+                "const": "trusts"
+              }
+            },
+            "required": [
+              "relationship_type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "join_method": {
+                "const": "trust_policy"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "relationship_type": {
+                "const": "runs_as"
+              }
+            },
+            "required": [
+              "relationship_type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "join_method": {
+                "const": "workload_binding"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "relationship_type": {
+                "const": "owns"
+              }
+            },
+            "required": [
+              "relationship_type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "join_method": {
+                "const": "ownership_record"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "complete"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 1
+              },
+              "provider_assertion_ids": {
+                "minItems": 1
+              },
+              "source_native_id": {
+                "type": "object"
+              },
+              "source_ref": {
+                "type": "string"
+              },
+              "target_native_id": {
+                "type": "object"
+              },
+              "target_ref": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "source_ref",
+              "target_ref",
+              "evidence_refs",
+              "source_native_id",
+              "target_native_id",
+              "provider_assertion_ids"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "partial"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "anyOf": [
+              {
+                "properties": {
+                  "source_ref": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source_ref"
+                ]
+              },
+              {
+                "properties": {
+                  "target_ref": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target_ref"
+                ]
+              }
+            ],
+            "properties": {
+              "evidence_refs": {
+                "minItems": 1
+              },
+              "reason_codes": {
+                "minItems": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "enum": [
+                  "partial",
+                  "unavailable",
+                  "failed"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "reason_codes": {
+                "minItems": 1
+              }
+            }
+          }
+        }
+      ],
       "description": "One structural join assertion or an explicit incomplete join attempt.",
       "properties": {
         "evidence_refs": {
@@ -460,6 +741,21 @@
           },
           "maxItems": 50,
           "title": "Evidence Refs",
+          "type": "array"
+        },
+        "join_method": {
+          "$ref": "#/$defs/IdentityJoinMethod"
+        },
+        "provider_assertion_ids": {
+          "default": [],
+          "items": {
+            "maxLength": 200,
+            "minLength": 1,
+            "pattern": "^[^\\s]+$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Provider Assertion Ids",
           "type": "array"
         },
         "reason_codes": {
@@ -482,6 +778,17 @@
         "relationship_type": {
           "$ref": "#/$defs/IdentityRelationshipType"
         },
+        "source_native_id": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProviderNativeId"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "source_ref": {
           "anyOf": [
             {
@@ -499,6 +806,17 @@
         },
         "status": {
           "$ref": "#/$defs/EvidenceStatus"
+        },
+        "target_native_id": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProviderNativeId"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "target_ref": {
           "anyOf": [
@@ -519,6 +837,7 @@
       "required": [
         "relationship_id",
         "relationship_type",
+        "join_method",
         "status"
       ],
       "title": "IdentityRelationship",
@@ -550,6 +869,120 @@
     },
     "ProviderNativeId": {
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "source": {
+                "const": "okta"
+              }
+            },
+            "required": [
+              "source"
+            ]
+          },
+          "then": {
+            "properties": {
+              "provider": {
+                "enum": [
+                  "okta"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "source": {
+                "const": "aws"
+              }
+            },
+            "required": [
+              "source"
+            ]
+          },
+          "then": {
+            "properties": {
+              "provider": {
+                "enum": [
+                  "aws"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "source": {
+                "const": "azure"
+              }
+            },
+            "required": [
+              "source"
+            ]
+          },
+          "then": {
+            "properties": {
+              "provider": {
+                "enum": [
+                  "azure",
+                  "entra"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "source": {
+                "const": "gcp"
+              }
+            },
+            "required": [
+              "source"
+            ]
+          },
+          "then": {
+            "properties": {
+              "provider": {
+                "enum": [
+                  "gcp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "source": {
+                "const": "saas"
+              }
+            },
+            "required": [
+              "source"
+            ]
+          },
+          "then": {
+            "properties": {
+              "provider": {
+                "not": {
+                  "enum": [
+                    "aws",
+                    "azure",
+                    "entra",
+                    "gcp",
+                    "okta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ],
       "description": "One exact provider identifier retained for deterministic correlation.",
       "properties": {
         "account": {
@@ -603,10 +1036,15 @@
     }
   },
   "additionalProperties": false,
-  "description": "Public contract for evidence-backed cross-provider identity/resource joins.",
+  "description": "Public shape for evidence-backed cross-provider identity/resource joins.\n\nJSON Schema enforces local field/status constraints. Cross-record identity,\nresource, freshness, and evidence-anchor invariants require the executable\nPydantic validator inherited from the core contract.",
   "properties": {
     "completeness": {
       "$ref": "#/$defs/EvidenceCompletenessLedger"
+    },
+    "evaluated_at": {
+      "format": "date-time",
+      "title": "Evaluated At",
+      "type": "string"
     },
     "evidence": {
       "default": [],
@@ -616,6 +1054,12 @@
       "maxItems": 5000,
       "title": "Evidence",
       "type": "array"
+    },
+    "freshness_max_age_seconds": {
+      "maximum": 31536000,
+      "minimum": 1,
+      "title": "Freshness Max Age Seconds",
+      "type": "integer"
     },
     "identities": {
       "default": [],
@@ -660,6 +1104,8 @@
   },
   "required": [
     "tenant_id",
+    "evaluated_at",
+    "freshness_max_age_seconds",
     "completeness"
   ],
   "title": "IdentityResourceJoinContract",

--- a/docs/schemas/v1/IdentityResourceJoinContract.json
+++ b/docs/schemas/v1/IdentityResourceJoinContract.json
@@ -1,0 +1,667 @@
+{
+  "$defs": {
+    "CanonicalIdentityEntity": {
+      "additionalProperties": false,
+      "description": "Canonical identity with one or more authoritative provider-native IDs.",
+      "properties": {
+        "display_name": {
+          "maxLength": 300,
+          "minLength": 1,
+          "title": "Display Name",
+          "type": "string"
+        },
+        "entity_id": {
+          "maxLength": 500,
+          "minLength": 1,
+          "pattern": "^[^\\s]+$",
+          "title": "Entity Id",
+          "type": "string"
+        },
+        "entity_type": {
+          "$ref": "#/$defs/CanonicalIdentityType"
+        },
+        "evidence_refs": {
+          "items": {
+            "maxLength": 500,
+            "minLength": 1,
+            "pattern": "^[^\\s]+$",
+            "type": "string"
+          },
+          "maxItems": 50,
+          "minItems": 1,
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "native_ids": {
+          "items": {
+            "$ref": "#/$defs/ProviderNativeId"
+          },
+          "maxItems": 20,
+          "minItems": 1,
+          "title": "Native Ids",
+          "type": "array"
+        },
+        "reason_codes": {
+          "default": [],
+          "items": {
+            "pattern": "^[a-z0-9][a-z0-9_.:-]{0,63}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Reason Codes",
+          "type": "array"
+        },
+        "status": {
+          "$ref": "#/$defs/EvidenceStatus",
+          "default": "complete"
+        }
+      },
+      "required": [
+        "display_name",
+        "native_ids",
+        "evidence_refs",
+        "entity_id",
+        "entity_type"
+      ],
+      "title": "CanonicalIdentityEntity",
+      "type": "object"
+    },
+    "CanonicalIdentityType": {
+      "description": "Provider-neutral identity entities used by the join contract.",
+      "enum": [
+        "person",
+        "service_account",
+        "workload_identity",
+        "role",
+        "group"
+      ],
+      "title": "CanonicalIdentityType",
+      "type": "string"
+    },
+    "CanonicalResourceReference": {
+      "additionalProperties": false,
+      "description": "Bounded resource reference that an observed identity relationship targets.",
+      "properties": {
+        "display_name": {
+          "maxLength": 300,
+          "minLength": 1,
+          "title": "Display Name",
+          "type": "string"
+        },
+        "evidence_refs": {
+          "items": {
+            "maxLength": 500,
+            "minLength": 1,
+            "pattern": "^[^\\s]+$",
+            "type": "string"
+          },
+          "maxItems": 50,
+          "minItems": 1,
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "native_ids": {
+          "items": {
+            "$ref": "#/$defs/ProviderNativeId"
+          },
+          "maxItems": 20,
+          "minItems": 1,
+          "title": "Native Ids",
+          "type": "array"
+        },
+        "reason_codes": {
+          "default": [],
+          "items": {
+            "pattern": "^[a-z0-9][a-z0-9_.:-]{0,63}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Reason Codes",
+          "type": "array"
+        },
+        "resource_id": {
+          "maxLength": 500,
+          "minLength": 1,
+          "pattern": "^[^\\s]+$",
+          "title": "Resource Id",
+          "type": "string"
+        },
+        "resource_type": {
+          "maxLength": 100,
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9_.:-]*$",
+          "title": "Resource Type",
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/EvidenceStatus",
+          "default": "complete"
+        }
+      },
+      "required": [
+        "display_name",
+        "native_ids",
+        "evidence_refs",
+        "resource_id",
+        "resource_type"
+      ],
+      "title": "CanonicalResourceReference",
+      "type": "object"
+    },
+    "CompletenessEntry": {
+      "additionalProperties": false,
+      "description": "Completeness of one component at one processing stage.",
+      "properties": {
+        "affects_coverage": {
+          "default": true,
+          "title": "Affects Coverage",
+          "type": "boolean"
+        },
+        "component": {
+          "maxLength": 100,
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9_.:-]*$",
+          "title": "Component",
+          "type": "string"
+        },
+        "expected_count": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Expected Count"
+        },
+        "reason_codes": {
+          "default": [],
+          "items": {
+            "pattern": "^[a-z0-9][a-z0-9_.:-]{0,63}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Reason Codes",
+          "type": "array"
+        },
+        "requested": {
+          "default": true,
+          "title": "Requested",
+          "type": "boolean"
+        },
+        "returned_count": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Returned Count"
+        },
+        "stage": {
+          "$ref": "#/$defs/EvidenceStage"
+        },
+        "status": {
+          "$ref": "#/$defs/EvidenceStatus"
+        }
+      },
+      "required": [
+        "stage",
+        "component",
+        "status"
+      ],
+      "title": "CompletenessEntry",
+      "type": "object"
+    },
+    "EvidenceBasis": {
+      "description": "How an evidence record was established.",
+      "enum": [
+        "observed",
+        "runtime_observed",
+        "inferred",
+        "modeled"
+      ],
+      "title": "EvidenceBasis",
+      "type": "string"
+    },
+    "EvidenceCompletenessLedger": {
+      "additionalProperties": false,
+      "description": "Deterministic aggregation of bounded component completeness.",
+      "properties": {
+        "entries": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/CompletenessEntry"
+          },
+          "maxItems": 500,
+          "title": "Entries",
+          "type": "array"
+        },
+        "overall_status": {
+          "$ref": "#/$defs/EvidenceStatus",
+          "readOnly": true
+        },
+        "schema_version": {
+          "const": "evidence-completeness.v1",
+          "default": "evidence-completeness.v1",
+          "title": "Schema Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "overall_status"
+      ],
+      "title": "EvidenceCompletenessLedger",
+      "type": "object"
+    },
+    "EvidenceFreshness": {
+      "additionalProperties": false,
+      "description": "Freshness evaluated at a caller-supplied decision time.",
+      "properties": {
+        "evaluated_at": {
+          "format": "date-time",
+          "title": "Evaluated At",
+          "type": "string"
+        },
+        "max_age_seconds": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Age Seconds"
+        },
+        "observed_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Observed At"
+        },
+        "status": {
+          "$ref": "#/$defs/FreshnessStatus"
+        },
+        "valid_until": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Valid Until"
+        }
+      },
+      "required": [
+        "status",
+        "evaluated_at"
+      ],
+      "title": "EvidenceFreshness",
+      "type": "object"
+    },
+    "EvidenceProvenance": {
+      "additionalProperties": false,
+      "description": "A bounded, referenceable evidence receipt.",
+      "properties": {
+        "basis": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EvidenceBasis"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Confidence"
+        },
+        "evidence_id": {
+          "maxLength": 200,
+          "minLength": 1,
+          "pattern": "^[^\\s]+$",
+          "title": "Evidence Id",
+          "type": "string"
+        },
+        "freshness": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EvidenceFreshness"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "reason_codes": {
+          "default": [],
+          "items": {
+            "pattern": "^[a-z0-9][a-z0-9_.:-]{0,63}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Reason Codes",
+          "type": "array"
+        },
+        "schema_version": {
+          "const": "evidence-provenance.v1",
+          "default": "evidence-provenance.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "source": {
+          "maxLength": 100,
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9_.:-]*$",
+          "title": "Source",
+          "type": "string"
+        },
+        "source_ids": {
+          "default": [],
+          "items": {
+            "maxLength": 200,
+            "minLength": 1,
+            "pattern": "^[^\\s]+$",
+            "type": "string"
+          },
+          "maxItems": 50,
+          "title": "Source Ids",
+          "type": "array"
+        },
+        "status": {
+          "$ref": "#/$defs/EvidenceStatus"
+        }
+      },
+      "required": [
+        "evidence_id",
+        "status",
+        "source"
+      ],
+      "title": "EvidenceProvenance",
+      "type": "object"
+    },
+    "EvidenceStage": {
+      "enum": [
+        "collection",
+        "normalization",
+        "catalog_lookup",
+        "persistence",
+        "graph_join",
+        "analysis"
+      ],
+      "title": "EvidenceStage",
+      "type": "string"
+    },
+    "EvidenceStatus": {
+      "description": "Whether a bounded evidence-producing operation completed.",
+      "enum": [
+        "complete",
+        "partial",
+        "unavailable",
+        "failed"
+      ],
+      "title": "EvidenceStatus",
+      "type": "string"
+    },
+    "FreshnessStatus": {
+      "enum": [
+        "fresh",
+        "stale",
+        "unknown"
+      ],
+      "title": "FreshnessStatus",
+      "type": "string"
+    },
+    "IdentityRelationship": {
+      "additionalProperties": false,
+      "description": "One structural join assertion or an explicit incomplete join attempt.",
+      "properties": {
+        "evidence_refs": {
+          "default": [],
+          "items": {
+            "maxLength": 500,
+            "minLength": 1,
+            "pattern": "^[^\\s]+$",
+            "type": "string"
+          },
+          "maxItems": 50,
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "reason_codes": {
+          "default": [],
+          "items": {
+            "pattern": "^[a-z0-9][a-z0-9_.:-]{0,63}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Reason Codes",
+          "type": "array"
+        },
+        "relationship_id": {
+          "maxLength": 500,
+          "minLength": 1,
+          "pattern": "^[^\\s]+$",
+          "title": "Relationship Id",
+          "type": "string"
+        },
+        "relationship_type": {
+          "$ref": "#/$defs/IdentityRelationshipType"
+        },
+        "source_ref": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "minLength": 1,
+              "pattern": "^[^\\s]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Ref"
+        },
+        "status": {
+          "$ref": "#/$defs/EvidenceStatus"
+        },
+        "target_ref": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "minLength": 1,
+              "pattern": "^[^\\s]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Target Ref"
+        }
+      },
+      "required": [
+        "relationship_id",
+        "relationship_type",
+        "status"
+      ],
+      "title": "IdentityRelationship",
+      "type": "object"
+    },
+    "IdentityRelationshipType": {
+      "description": "Structural relationships only; permissions are deliberately excluded.",
+      "enum": [
+        "member_of",
+        "assumes",
+        "trusts",
+        "runs_as",
+        "owns"
+      ],
+      "title": "IdentityRelationshipType",
+      "type": "string"
+    },
+    "IdentitySourceKind": {
+      "description": "Supported identity-source families; ``provider`` keeps the exact vendor.",
+      "enum": [
+        "okta",
+        "aws",
+        "azure",
+        "gcp",
+        "saas"
+      ],
+      "title": "IdentitySourceKind",
+      "type": "string"
+    },
+    "ProviderNativeId": {
+      "additionalProperties": false,
+      "description": "One exact provider identifier retained for deterministic correlation.",
+      "properties": {
+        "account": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "pattern": "^[^\\s]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Account"
+        },
+        "id_type": {
+          "maxLength": 100,
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9_.:-]*$",
+          "title": "Id Type",
+          "type": "string"
+        },
+        "provider": {
+          "maxLength": 100,
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9_.:-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/$defs/IdentitySourceKind"
+        },
+        "value": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "pattern": "^[^\\s]+$",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source",
+        "provider",
+        "id_type",
+        "value"
+      ],
+      "title": "ProviderNativeId",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Public contract for evidence-backed cross-provider identity/resource joins.",
+  "properties": {
+    "completeness": {
+      "$ref": "#/$defs/EvidenceCompletenessLedger"
+    },
+    "evidence": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/EvidenceProvenance"
+      },
+      "maxItems": 5000,
+      "title": "Evidence",
+      "type": "array"
+    },
+    "identities": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/CanonicalIdentityEntity"
+      },
+      "maxItems": 10000,
+      "title": "Identities",
+      "type": "array"
+    },
+    "relationships": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/IdentityRelationship"
+      },
+      "maxItems": 50000,
+      "title": "Relationships",
+      "type": "array"
+    },
+    "resources": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/CanonicalResourceReference"
+      },
+      "maxItems": 10000,
+      "title": "Resources",
+      "type": "array"
+    },
+    "schema_version": {
+      "const": "identity-resource-joins.v1",
+      "default": "identity-resource-joins.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "tenant_id": {
+      "maxLength": 500,
+      "minLength": 1,
+      "pattern": "^[^\\s]+$",
+      "title": "Tenant Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "tenant_id",
+    "completeness"
+  ],
+  "title": "IdentityResourceJoinContract",
+  "type": "object"
+}

--- a/docs/schemas/v1/index.json
+++ b/docs/schemas/v1/index.json
@@ -152,6 +152,11 @@
       "schema": "HealthResponse.json"
     },
     {
+      "doc": "Public contract for evidence-backed cross-provider identity/resource joins.",
+      "name": "IdentityResourceJoinContract",
+      "schema": "IdentityResourceJoinContract.json"
+    },
+    {
       "doc": "Body for POST /v1/auth/invitations \u2014 admin provisions a NEW tenant.",
       "name": "InvitationRequest",
       "schema": "InvitationRequest.json"

--- a/docs/schemas/v1/index.json
+++ b/docs/schemas/v1/index.json
@@ -152,7 +152,7 @@
       "schema": "HealthResponse.json"
     },
     {
-      "doc": "Public contract for evidence-backed cross-provider identity/resource joins.",
+      "doc": "Public shape for evidence-backed cross-provider identity/resource joins.",
       "name": "IdentityResourceJoinContract",
       "schema": "IdentityResourceJoinContract.json"
     },

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -57,7 +57,12 @@ class SecurityDimensions(_CoreSecurityDimensions):
 
 
 class IdentityResourceJoinContract(_CoreIdentityResourceJoinContract):
-    """Public contract for evidence-backed cross-provider identity/resource joins."""
+    """Public shape for evidence-backed cross-provider identity/resource joins.
+
+    JSON Schema enforces local field/status constraints. Cross-record identity,
+    resource, freshness, and evidence-anchor invariants require the executable
+    Pydantic validator inherited from the core contract.
+    """
 
 
 # Fields that fan out one child scan job per element when a request carries more

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -14,6 +14,7 @@ from agent_bom.config import API_MAX_BATCH_SCAN_TARGETS
 from agent_bom.evidence.semantics import EvidenceCompletenessLedger as _CoreEvidenceCompletenessLedger
 from agent_bom.evidence.semantics import SecurityDimensions as _CoreSecurityDimensions
 from agent_bom.finding_scope import FindingClass, FindingSeverityFilter, canonical_finding_severity_filter
+from agent_bom.identity.join_contract import IdentityResourceJoinContract as _CoreIdentityResourceJoinContract
 
 # ─── Enums ─────────────────────────────────────────────────────────────────
 
@@ -53,6 +54,10 @@ class EvidenceCompletenessLedger(_CoreEvidenceCompletenessLedger):
 
 class SecurityDimensions(_CoreSecurityDimensions):
     """Public contract keeping security dimensions and evidence independent."""
+
+
+class IdentityResourceJoinContract(_CoreIdentityResourceJoinContract):
+    """Public contract for evidence-backed cross-provider identity/resource joins."""
 
 
 # Fields that fan out one child scan job per element when a request carries more

--- a/src/agent_bom/identity/__init__.py
+++ b/src/agent_bom/identity/__init__.py
@@ -13,6 +13,16 @@ degrades to a clear status rather than raising.
 from __future__ import annotations
 
 from agent_bom.identity.entra_nhi import discover_entra_non_human_identities
+from agent_bom.identity.join_contract import (
+    CanonicalIdentityEntity,
+    CanonicalIdentityType,
+    CanonicalResourceReference,
+    IdentityRelationship,
+    IdentityRelationshipType,
+    IdentityResourceJoinContract,
+    IdentitySourceKind,
+    ProviderNativeId,
+)
 from agent_bom.identity.okta_nhi import (
     DiscoveredNonHumanIdentity,
     NHIDiscoveryResult,
@@ -24,6 +34,14 @@ __all__ = [
     "DiscoveredNonHumanIdentity",
     "NHIDiscoveryResult",
     "NHIDiscoveryStatus",
+    "CanonicalIdentityEntity",
+    "CanonicalIdentityType",
+    "CanonicalResourceReference",
+    "IdentityRelationship",
+    "IdentityRelationshipType",
+    "IdentityResourceJoinContract",
+    "IdentitySourceKind",
+    "ProviderNativeId",
     "discover_entra_non_human_identities",
     "discover_okta_non_human_identities",
 ]

--- a/src/agent_bom/identity/__init__.py
+++ b/src/agent_bom/identity/__init__.py
@@ -17,11 +17,13 @@ from agent_bom.identity.join_contract import (
     CanonicalIdentityEntity,
     CanonicalIdentityType,
     CanonicalResourceReference,
+    IdentityJoinMethod,
     IdentityRelationship,
     IdentityRelationshipType,
     IdentityResourceJoinContract,
     IdentitySourceKind,
     ProviderNativeId,
+    canonical_identity_relationship_id,
 )
 from agent_bom.identity.okta_nhi import (
     DiscoveredNonHumanIdentity,
@@ -37,11 +39,13 @@ __all__ = [
     "CanonicalIdentityEntity",
     "CanonicalIdentityType",
     "CanonicalResourceReference",
+    "IdentityJoinMethod",
     "IdentityRelationship",
     "IdentityRelationshipType",
     "IdentityResourceJoinContract",
     "IdentitySourceKind",
     "ProviderNativeId",
+    "canonical_identity_relationship_id",
     "discover_entra_non_human_identities",
     "discover_okta_non_human_identities",
 ]

--- a/src/agent_bom/identity/__init__.py
+++ b/src/agent_bom/identity/__init__.py
@@ -24,6 +24,7 @@ from agent_bom.identity.join_contract import (
     IdentitySourceKind,
     ProviderNativeId,
     canonical_identity_relationship_id,
+    canonical_provider_native_assertion_id,
 )
 from agent_bom.identity.okta_nhi import (
     DiscoveredNonHumanIdentity,
@@ -46,6 +47,7 @@ __all__ = [
     "IdentitySourceKind",
     "ProviderNativeId",
     "canonical_identity_relationship_id",
+    "canonical_provider_native_assertion_id",
     "discover_entra_non_human_identities",
     "discover_okta_non_human_identities",
 ]

--- a/src/agent_bom/identity/join_contract.py
+++ b/src/agent_bom/identity/join_contract.py
@@ -453,6 +453,14 @@ class IdentityResourceJoinContract(_StrictIdentityModel):
             [(resource.resource_id, resource.native_ids) for resource in self.resources],
             kind="resource",
         )
+        identity_native_keys = {
+            _native_key(native_id) for identity in self.identities for native_id in identity.native_ids
+        }
+        resource_native_keys = {
+            _native_key(native_id) for resource in self.resources for native_id in resource.native_ids
+        }
+        if identity_native_keys & resource_native_keys:
+            raise ValueError("one provider-native ID cannot resolve to both a canonical identity and resource")
 
         evidence_by_id = {item.evidence_id: item for item in self.evidence}
         if len(evidence_by_id) != len(self.evidence):

--- a/src/agent_bom/identity/join_contract.py
+++ b/src/agent_bom/identity/join_contract.py
@@ -492,6 +492,24 @@ class IdentityResourceJoinContract(_StrictIdentityModel):
             if not native_assertion_ids.issubset(evidence_source_ids):
                 raise ValueError("complete catalog row native assertions must match evidence source_ids")
 
+        endpoint_evidence_refs: dict[str, tuple[str, ...]] = {
+            **{item.entity_id: item.evidence_refs for item in self.identities},
+            **{item.resource_id: item.evidence_refs for item in self.resources},
+        }
+        endpoint_catalog_receipts = {
+            endpoint_id: {
+                source_id
+                for ref in evidence_refs
+                if (
+                    evidence_by_id[ref].status is EvidenceStatus.COMPLETE
+                    and evidence_by_id[ref].basis in {EvidenceBasis.OBSERVED, EvidenceBasis.RUNTIME_OBSERVED}
+                    and self._is_fresh_for_decision(evidence_by_id[ref])
+                )
+                for source_id in evidence_by_id[ref].source_ids
+            }
+            for endpoint_id, evidence_refs in endpoint_evidence_refs.items()
+        }
+
         endpoint_types: dict[str, CanonicalIdentityType | str] = {
             **{item.entity_id: item.entity_type for item in self.identities},
             **{item.resource_id: _RESOURCE_TYPE for item in self.resources},
@@ -538,6 +556,21 @@ class IdentityResourceJoinContract(_StrictIdentityModel):
                 if relationship.target_native_id not in endpoint_native_ids[relationship.target_ref]:
                     raise ValueError("target evidence anchor does not match the canonical endpoint")
             if relationship.asserted:
+                source_ref = relationship.source_ref
+                target_ref = relationship.target_ref
+                source_native_id = relationship.source_native_id
+                target_native_id = relationship.target_native_id
+                if source_ref is None or target_ref is None or source_native_id is None or target_native_id is None:
+                    raise ValueError("complete relationships require exact canonical and provider-native endpoints")
+                source_assertion_id = canonical_provider_native_assertion_id(source_native_id)
+                target_assertion_id = canonical_provider_native_assertion_id(target_native_id)
+                if (
+                    source_assertion_id not in endpoint_catalog_receipts[source_ref]
+                    or target_assertion_id not in endpoint_catalog_receipts[target_ref]
+                ):
+                    raise ValueError(
+                        "complete relationship endpoint native assertions must match authoritative catalog evidence source_ids"
+                    )
                 join_evidence = [evidence_by_id[ref] for ref in relationship.evidence_refs]
                 if any(
                     item.status is not EvidenceStatus.COMPLETE or item.basis not in {EvidenceBasis.OBSERVED, EvidenceBasis.RUNTIME_OBSERVED}

--- a/src/agent_bom/identity/join_contract.py
+++ b/src/agent_bom/identity/join_contract.py
@@ -453,12 +453,8 @@ class IdentityResourceJoinContract(_StrictIdentityModel):
             [(resource.resource_id, resource.native_ids) for resource in self.resources],
             kind="resource",
         )
-        identity_native_keys = {
-            _native_key(native_id) for identity in self.identities for native_id in identity.native_ids
-        }
-        resource_native_keys = {
-            _native_key(native_id) for resource in self.resources for native_id in resource.native_ids
-        }
+        identity_native_keys = {_native_key(native_id) for identity in self.identities for native_id in identity.native_ids}
+        resource_native_keys = {_native_key(native_id) for resource in self.resources for native_id in resource.native_ids}
         if identity_native_keys & resource_native_keys:
             raise ValueError("one provider-native ID cannot resolve to both a canonical identity and resource")
 

--- a/src/agent_bom/identity/join_contract.py
+++ b/src/agent_bom/identity/join_contract.py
@@ -9,8 +9,12 @@ explicit non-edges with bounded reason codes.
 
 from __future__ import annotations
 
+import hashlib
+import json
+from datetime import datetime
 from enum import StrEnum
-from typing import Annotated, Literal, Self
+from itertools import chain
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -18,14 +22,21 @@ from agent_bom.evidence.semantics import (
     ComponentName,
     EvidenceBasis,
     EvidenceCompletenessLedger,
+    EvidenceFreshness,
     EvidenceProvenance,
     EvidenceStatus,
+    FreshnessStatus,
+    Identifier,
     ReasonCode,
 )
 
 CanonicalIdentifier = Annotated[str, Field(min_length=1, max_length=500, pattern=r"^[^\s]+$")]
 NativeIdentifier = Annotated[str, Field(min_length=1, max_length=2048, pattern=r"^[^\s]+$")]
 DisplayName = Annotated[str, Field(min_length=1, max_length=300)]
+
+MAX_IDENTITY_JOIN_EVIDENCE_REFERENCES = 100_000
+MAX_IDENTITY_JOIN_NATIVE_IDENTIFIERS = 100_000
+MAX_IDENTITY_JOIN_FRESHNESS_SECONDS = 31_536_000
 
 
 class IdentitySourceKind(StrEnum):
@@ -58,6 +69,25 @@ class IdentityRelationshipType(StrEnum):
     OWNS = "owns"
 
 
+class IdentityJoinMethod(StrEnum):
+    """Authoritative provider mechanism that established a structural join."""
+
+    DIRECTORY_MEMBERSHIP = "directory_membership"
+    ROLE_ASSIGNMENT = "role_assignment"
+    TRUST_POLICY = "trust_policy"
+    WORKLOAD_BINDING = "workload_binding"
+    OWNERSHIP_RECORD = "ownership_record"
+
+
+_JOIN_METHOD_BY_RELATIONSHIP = {
+    IdentityRelationshipType.MEMBER_OF: IdentityJoinMethod.DIRECTORY_MEMBERSHIP,
+    IdentityRelationshipType.ASSUMES: IdentityJoinMethod.ROLE_ASSIGNMENT,
+    IdentityRelationshipType.TRUSTS: IdentityJoinMethod.TRUST_POLICY,
+    IdentityRelationshipType.RUNS_AS: IdentityJoinMethod.WORKLOAD_BINDING,
+    IdentityRelationshipType.OWNS: IdentityJoinMethod.OWNERSHIP_RECORD,
+}
+
+
 class _StrictIdentityModel(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
 
@@ -66,8 +96,38 @@ def _dedupe(values: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(values))
 
 
+_SOURCE_PROVIDERS: dict[IdentitySourceKind, frozenset[str]] = {
+    IdentitySourceKind.OKTA: frozenset({"okta"}),
+    IdentitySourceKind.AWS: frozenset({"aws"}),
+    IdentitySourceKind.AZURE: frozenset({"azure", "entra"}),
+    IdentitySourceKind.GCP: frozenset({"gcp"}),
+}
+_RESERVED_PROVIDERS = frozenset(chain.from_iterable(_SOURCE_PROVIDERS.values()))
+_PROVIDER_NATIVE_JSON_SCHEMA_EXTRA: dict[str, Any] = {
+    "allOf": [
+        *(
+            {
+                "if": {"properties": {"source": {"const": source.value}}, "required": ["source"]},
+                "then": {"properties": {"provider": {"enum": sorted(providers)}}},
+            }
+            for source, providers in _SOURCE_PROVIDERS.items()
+        ),
+        {
+            "if": {"properties": {"source": {"const": "saas"}}, "required": ["source"]},
+            "then": {"properties": {"provider": {"not": {"enum": sorted(_RESERVED_PROVIDERS)}}}},
+        },
+    ]
+}
+
+
+def _native_key(value: ProviderNativeId) -> tuple[IdentitySourceKind, str, str, str, str]:
+    return (value.source, value.provider, value.account or "", value.id_type, value.value)
+
+
 class ProviderNativeId(_StrictIdentityModel):
     """One exact provider identifier retained for deterministic correlation."""
+
+    model_config = ConfigDict(json_schema_extra=_PROVIDER_NATIVE_JSON_SCHEMA_EXTRA)
 
     source: IdentitySourceKind
     provider: ComponentName
@@ -75,9 +135,31 @@ class ProviderNativeId(_StrictIdentityModel):
     value: NativeIdentifier
     account: NativeIdentifier | None = None
 
+    @model_validator(mode="after")
+    def validate_provider_family(self) -> Self:
+        expected = _SOURCE_PROVIDERS.get(self.source)
+        if expected is not None and self.provider not in expected:
+            raise ValueError("provider must match its source family")
+        if self.source is IdentitySourceKind.SAAS and self.provider in _RESERVED_PROVIDERS:
+            raise ValueError("provider must match its source family")
+        return self
+
+
+_CATALOG_ROW_JSON_SCHEMA_EXTRA: dict[str, Any] = {
+    "allOf": [
+        {"properties": {"status": {"enum": ["complete", "partial"]}}},
+        {
+            "if": {"properties": {"status": {"const": "partial"}}, "required": ["status"]},
+            "then": {"properties": {"reason_codes": {"minItems": 1}}},
+        },
+    ]
+}
+
 
 class _ObservedCatalogReference(_StrictIdentityModel):
     """Shared completeness and provenance rules for normalized catalog rows."""
+
+    model_config = ConfigDict(json_schema_extra=_CATALOG_ROW_JSON_SCHEMA_EXTRA)
 
     display_name: DisplayName
     native_ids: tuple[ProviderNativeId, ...] = Field(min_length=1, max_length=20)
@@ -88,7 +170,7 @@ class _ObservedCatalogReference(_StrictIdentityModel):
     @field_validator("native_ids")
     @classmethod
     def unique_native_ids(cls, value: tuple[ProviderNativeId, ...]) -> tuple[ProviderNativeId, ...]:
-        keys = {(item.source, item.provider, item.id_type, item.value) for item in value}
+        keys = {_native_key(item) for item in value}
         if len(keys) != len(value):
             raise ValueError("provider-native identifiers must be unique within one canonical row")
         return value
@@ -121,13 +203,76 @@ class CanonicalResourceReference(_ObservedCatalogReference):
     resource_type: ComponentName
 
 
+_RELATIONSHIP_JSON_SCHEMA_EXTRA: dict[str, Any] = {
+    "allOf": [
+        *(
+            {
+                "if": {
+                    "properties": {"relationship_type": {"const": relationship_type.value}},
+                    "required": ["relationship_type"],
+                },
+                "then": {"properties": {"join_method": {"const": join_method.value}}},
+            }
+            for relationship_type, join_method in _JOIN_METHOD_BY_RELATIONSHIP.items()
+        ),
+        {
+            "if": {"properties": {"status": {"const": "complete"}}, "required": ["status"]},
+            "then": {
+                "required": [
+                    "source_ref",
+                    "target_ref",
+                    "evidence_refs",
+                    "source_native_id",
+                    "target_native_id",
+                    "provider_assertion_ids",
+                ],
+                "properties": {
+                    "source_ref": {"type": "string"},
+                    "target_ref": {"type": "string"},
+                    "evidence_refs": {"minItems": 1},
+                    "source_native_id": {"type": "object"},
+                    "target_native_id": {"type": "object"},
+                    "provider_assertion_ids": {"minItems": 1},
+                },
+            },
+        },
+        {
+            "if": {"properties": {"status": {"const": "partial"}}, "required": ["status"]},
+            "then": {
+                "properties": {
+                    "reason_codes": {"minItems": 1},
+                    "evidence_refs": {"minItems": 1},
+                },
+                "anyOf": [
+                    {"required": ["source_ref"], "properties": {"source_ref": {"type": "string"}}},
+                    {"required": ["target_ref"], "properties": {"target_ref": {"type": "string"}}},
+                ],
+            },
+        },
+        {
+            "if": {
+                "properties": {"status": {"enum": ["partial", "unavailable", "failed"]}},
+                "required": ["status"],
+            },
+            "then": {"properties": {"reason_codes": {"minItems": 1}}},
+        },
+    ]
+}
+
+
 class IdentityRelationship(_StrictIdentityModel):
     """One structural join assertion or an explicit incomplete join attempt."""
 
+    model_config = ConfigDict(json_schema_extra=_RELATIONSHIP_JSON_SCHEMA_EXTRA)
+
     relationship_id: CanonicalIdentifier
     relationship_type: IdentityRelationshipType
+    join_method: IdentityJoinMethod
     source_ref: CanonicalIdentifier | None = None
     target_ref: CanonicalIdentifier | None = None
+    source_native_id: ProviderNativeId | None = None
+    target_native_id: ProviderNativeId | None = None
+    provider_assertion_ids: tuple[Identifier, ...] = Field(default=(), max_length=20)
     status: EvidenceStatus
     evidence_refs: tuple[CanonicalIdentifier, ...] = Field(default=(), max_length=50)
     reason_codes: tuple[ReasonCode, ...] = Field(default=(), max_length=20)
@@ -137,6 +282,11 @@ class IdentityRelationship(_StrictIdentityModel):
     def dedupe_values(cls, value: tuple[str, ...]) -> tuple[str, ...]:
         return _dedupe(value)
 
+    @field_validator("provider_assertion_ids")
+    @classmethod
+    def canonicalize_assertion_ids(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(sorted(set(value)))
+
     @model_validator(mode="after")
     def validate_join_state(self) -> Self:
         if self.status is EvidenceStatus.COMPLETE:
@@ -144,6 +294,10 @@ class IdentityRelationship(_StrictIdentityModel):
                 raise ValueError("complete relationships require both canonical endpoints")
             if not self.evidence_refs:
                 raise ValueError("complete relationships require evidence references")
+            if self.source_native_id is None or self.target_native_id is None:
+                raise ValueError("complete relationships require exact provider-native evidence anchors")
+            if not self.provider_assertion_ids:
+                raise ValueError("complete relationships require provider assertion evidence anchors")
             return self
         if not self.reason_codes:
             raise ValueError("incomplete relationships require a reason code")
@@ -159,6 +313,26 @@ class IdentityRelationship(_StrictIdentityModel):
         """Only complete joins are eligible to become graph edges."""
 
         return self.status is EvidenceStatus.COMPLETE and bool(self.source_ref and self.target_ref)
+
+
+def _relationship_semantic_material(relationship: IdentityRelationship) -> dict[str, object]:
+    return {
+        "join_method": relationship.join_method.value,
+        "provider_assertion_ids": list(relationship.provider_assertion_ids),
+        "relationship_type": relationship.relationship_type.value,
+        "source_native_id": (relationship.source_native_id.model_dump(mode="json") if relationship.source_native_id is not None else None),
+        "source_ref": relationship.source_ref,
+        "target_native_id": (relationship.target_native_id.model_dump(mode="json") if relationship.target_native_id is not None else None),
+        "target_ref": relationship.target_ref,
+    }
+
+
+def canonical_identity_relationship_id(*, tenant_id: str, relationship: IdentityRelationship) -> str:
+    """Return the tenant-scoped deterministic ID for one semantic relationship."""
+
+    material = {"tenant_id": tenant_id, **_relationship_semantic_material(relationship)}
+    encoded = json.dumps(material, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    return "join:sha256:" + hashlib.sha256(encoded).hexdigest()
 
 
 _MEMBER_SOURCES = {
@@ -179,10 +353,26 @@ _RESOURCE_TYPE = "resource"
 
 
 class IdentityResourceJoinContract(_StrictIdentityModel):
-    """Versioned cross-provider identity/resource catalog and structural joins."""
+    """Versioned cross-provider identity/resource catalog and structural joins.
+
+    The generated JSON Schema enforces local shape and status conditions. Its
+    cross-record uniqueness, referential, freshness, and evidence-anchor rules
+    require this class's executable ``model_validate`` validator.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "$comment": (
+                "Cross-record identity, resource, relationship, freshness, and evidence-anchor invariants "
+                "require IdentityResourceJoinContract.model_validate; JSON Schema alone is not sufficient."
+            )
+        }
+    )
 
     schema_version: Literal["identity-resource-joins.v1"] = "identity-resource-joins.v1"
     tenant_id: CanonicalIdentifier
+    evaluated_at: datetime
+    freshness_max_age_seconds: int = Field(ge=1, le=MAX_IDENTITY_JOIN_FRESHNESS_SECONDS)
     identities: tuple[CanonicalIdentityEntity, ...] = Field(default=(), max_length=10_000)
     resources: tuple[CanonicalResourceReference, ...] = Field(default=(), max_length=10_000)
     relationships: tuple[IdentityRelationship, ...] = Field(default=(), max_length=50_000)
@@ -192,6 +382,13 @@ class IdentityResourceJoinContract(_StrictIdentityModel):
     @property
     def overall_status(self) -> EvidenceStatus:
         return self.completeness.overall_status
+
+    @field_validator("evaluated_at")
+    @classmethod
+    def require_aware_evaluation_time(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("evaluated_at must include a timezone")
+        return value
 
     @model_validator(mode="after")
     def validate_contract(self) -> Self:
@@ -204,17 +401,37 @@ class IdentityResourceJoinContract(_StrictIdentityModel):
         if set(identity_by_id) & set(resource_by_id):
             raise ValueError("identity and resource canonical IDs must not collide")
 
+        total_native_ids = sum(len(item.native_ids) for item in chain(self.identities, self.resources))
+        if total_native_ids > MAX_IDENTITY_JOIN_NATIVE_IDENTIFIERS:
+            raise ValueError("contract exceeds the aggregate provider-native identifier budget")
+
+        total_evidence_refs = (
+            sum(len(item.evidence_refs) for item in self.identities)
+            + sum(len(item.evidence_refs) for item in self.resources)
+            + sum(len(item.evidence_refs) for item in self.relationships)
+        )
+        if total_evidence_refs > MAX_IDENTITY_JOIN_EVIDENCE_REFERENCES:
+            raise ValueError("contract exceeds the aggregate evidence-reference budget")
+
         relationship_ids = {item.relationship_id for item in self.relationships}
         if len(relationship_ids) != len(self.relationships):
             raise ValueError("relationship IDs must be unique")
 
-        native_owner: dict[tuple[IdentitySourceKind, str, str, str], str] = {}
+        native_owner: dict[tuple[IdentitySourceKind, str, str, str, str], str] = {}
         for identity in self.identities:
             for native_id in identity.native_ids:
-                key = (native_id.source, native_id.provider, native_id.id_type, native_id.value)
+                key = _native_key(native_id)
                 owner = native_owner.setdefault(key, identity.entity_id)
                 if owner != identity.entity_id:
                     raise ValueError("one provider-native identity cannot resolve to two canonical entities")
+
+        resource_native_owner: dict[tuple[IdentitySourceKind, str, str, str, str], str] = {}
+        for resource in self.resources:
+            for native_id in resource.native_ids:
+                key = _native_key(native_id)
+                owner = resource_native_owner.setdefault(key, resource.resource_id)
+                if owner != resource.resource_id:
+                    raise ValueError("one provider-native resource cannot resolve to two canonical resources")
 
         evidence_by_id = {item.evidence_id: item for item in self.evidence}
         if len(evidence_by_id) != len(self.evidence):
@@ -227,22 +444,64 @@ class IdentityResourceJoinContract(_StrictIdentityModel):
         for relationship in self.relationships:
             referenced_evidence.update(relationship.evidence_refs)
         if missing_evidence := referenced_evidence - set(evidence_by_id):
-            raise ValueError(f"contract references unknown evidence: {sorted(missing_evidence)}")
+            sample = sorted(missing_evidence)[:10]
+            raise ValueError(f"contract references {len(missing_evidence)} unknown evidence records; sample={sample}")
+
+        for row in chain(self.identities, self.resources):
+            if row.status is not EvidenceStatus.COMPLETE:
+                continue
+            row_evidence = [evidence_by_id[ref] for ref in row.evidence_refs]
+            if any(
+                item.status is not EvidenceStatus.COMPLETE or item.basis not in {EvidenceBasis.OBSERVED, EvidenceBasis.RUNTIME_OBSERVED}
+                for item in row_evidence
+            ):
+                raise ValueError("complete catalog rows require complete, authoritative evidence")
 
         endpoint_types: dict[str, CanonicalIdentityType | str] = {
             **{item.entity_id: item.entity_type for item in self.identities},
             **{item.resource_id: _RESOURCE_TYPE for item in self.resources},
         }
+        endpoint_native_ids: dict[str, tuple[ProviderNativeId, ...]] = {
+            **{item.entity_id: item.native_ids for item in self.identities},
+            **{item.resource_id: item.native_ids for item in self.resources},
+        }
+        semantic_relationships: set[str] = set()
         for relationship in self.relationships:
             for endpoint in (relationship.source_ref, relationship.target_ref):
                 if endpoint is not None and endpoint not in endpoint_types:
                     raise ValueError("relationship references an unknown canonical endpoint")
+            if (
+                relationship.relationship_type is IdentityRelationshipType.MEMBER_OF
+                and relationship.source_ref is not None
+                and relationship.source_ref == relationship.target_ref
+            ):
+                raise ValueError("member_of self-loop is not a valid structural relationship")
             if relationship.source_ref and relationship.target_ref:
                 self._validate_direction(
                     relationship.relationship_type,
                     endpoint_types[relationship.source_ref],
                     endpoint_types[relationship.target_ref],
                 )
+            expected_method = _JOIN_METHOD_BY_RELATIONSHIP[relationship.relationship_type]
+            if relationship.join_method is not expected_method:
+                raise ValueError("join method does not match the structural relationship type")
+
+            semantic_key = json.dumps(
+                _relationship_semantic_material(relationship),
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            )
+            if semantic_key in semantic_relationships:
+                raise ValueError("duplicate semantic relationship must be merged into one assertion")
+            semantic_relationships.add(semantic_key)
+
+            if relationship.source_ref is not None and relationship.source_native_id is not None:
+                if relationship.source_native_id not in endpoint_native_ids[relationship.source_ref]:
+                    raise ValueError("source evidence anchor does not match the canonical endpoint")
+            if relationship.target_ref is not None and relationship.target_native_id is not None:
+                if relationship.target_native_id not in endpoint_native_ids[relationship.target_ref]:
+                    raise ValueError("target evidence anchor does not match the canonical endpoint")
             if relationship.asserted:
                 join_evidence = [evidence_by_id[ref] for ref in relationship.evidence_refs]
                 if any(
@@ -250,7 +509,32 @@ class IdentityResourceJoinContract(_StrictIdentityModel):
                     for item in join_evidence
                 ):
                     raise ValueError("complete relationships require complete, directly observed evidence")
+                evidence_anchor_ids = set(chain.from_iterable(item.source_ids for item in join_evidence))
+                if not set(relationship.provider_assertion_ids).issubset(evidence_anchor_ids):
+                    raise ValueError("complete relationship evidence anchors must match evidence source_ids")
+                if any(
+                    item.freshness is not None and item.freshness.observed_at is not None and item.freshness.observed_at > self.evaluated_at
+                    for item in join_evidence
+                ):
+                    raise ValueError("complete relationships cannot use future evidence")
+                if any(not self._is_fresh_for_decision(item) for item in join_evidence):
+                    raise ValueError("complete relationships require fresh evidence under the contract policy")
+
+            expected_relationship_id = canonical_identity_relationship_id(tenant_id=self.tenant_id, relationship=relationship)
+            if relationship.relationship_id != expected_relationship_id:
+                raise ValueError("relationship ID does not match its deterministic tenant-scoped identity")
         return self
+
+    def _is_fresh_for_decision(self, evidence: EvidenceProvenance) -> bool:
+        freshness = evidence.freshness
+        if freshness is None or freshness.observed_at is None:
+            return False
+        expected = EvidenceFreshness.evaluate(
+            observed_at=freshness.observed_at,
+            evaluated_at=self.evaluated_at,
+            max_age_seconds=self.freshness_max_age_seconds,
+        )
+        return freshness == expected and expected.status is FreshnessStatus.FRESH
 
     @staticmethod
     def _validate_direction(

--- a/src/agent_bom/identity/join_contract.py
+++ b/src/agent_bom/identity/join_contract.py
@@ -121,7 +121,7 @@ _PROVIDER_NATIVE_JSON_SCHEMA_EXTRA: dict[str, Any] = {
 
 
 def _native_key(value: ProviderNativeId) -> tuple[IdentitySourceKind, str, str, str, str]:
-    return (value.source, value.provider, value.account or "", value.id_type, value.value)
+    return (value.source, value.provider, value.account, value.id_type, value.value)
 
 
 class ProviderNativeId(_StrictIdentityModel):
@@ -133,7 +133,9 @@ class ProviderNativeId(_StrictIdentityModel):
     provider: ComponentName
     id_type: ComponentName
     value: NativeIdentifier
-    account: NativeIdentifier | None = None
+    account: NativeIdentifier = Field(
+        description="Required provider scope: account, organization, tenant, subscription, or project identifier."
+    )
 
     @model_validator(mode="after")
     def validate_provider_family(self) -> Self:
@@ -143,6 +145,17 @@ class ProviderNativeId(_StrictIdentityModel):
         if self.source is IdentitySourceKind.SAAS and self.provider in _RESERVED_PROVIDERS:
             raise ValueError("provider must match its source family")
         return self
+
+
+def canonical_provider_native_assertion_id(native_id: ProviderNativeId) -> str:
+    """Return a stable receipt anchor for one fully scoped provider-native ID."""
+
+    material = {
+        "schema_version": "provider-native-assertion.v1",
+        **native_id.model_dump(mode="json"),
+    }
+    encoded = json.dumps(material, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    return "native:sha256:" + hashlib.sha256(encoded).hexdigest()
 
 
 _CATALOG_ROW_JSON_SCHEMA_EXTRA: dict[str, Any] = {
@@ -201,6 +214,21 @@ class CanonicalResourceReference(_ObservedCatalogReference):
 
     resource_id: CanonicalIdentifier
     resource_type: ComponentName
+
+
+def _validate_native_owners(
+    rows: list[tuple[str, tuple[ProviderNativeId, ...]]],
+    *,
+    kind: Literal["identity", "resource"],
+) -> None:
+    native_owner: dict[tuple[IdentitySourceKind, str, str, str, str], str] = {}
+    for canonical_id, native_ids in rows:
+        for native_id in native_ids:
+            key = _native_key(native_id)
+            owner = native_owner.setdefault(key, canonical_id)
+            if owner != canonical_id:
+                plural = "entities" if kind == "identity" else "resources"
+                raise ValueError(f"one provider-native {kind} cannot resolve to two canonical {plural}")
 
 
 _RELATIONSHIP_JSON_SCHEMA_EXTRA: dict[str, Any] = {
@@ -417,21 +445,14 @@ class IdentityResourceJoinContract(_StrictIdentityModel):
         if len(relationship_ids) != len(self.relationships):
             raise ValueError("relationship IDs must be unique")
 
-        native_owner: dict[tuple[IdentitySourceKind, str, str, str, str], str] = {}
-        for identity in self.identities:
-            for native_id in identity.native_ids:
-                key = _native_key(native_id)
-                owner = native_owner.setdefault(key, identity.entity_id)
-                if owner != identity.entity_id:
-                    raise ValueError("one provider-native identity cannot resolve to two canonical entities")
-
-        resource_native_owner: dict[tuple[IdentitySourceKind, str, str, str, str], str] = {}
-        for resource in self.resources:
-            for native_id in resource.native_ids:
-                key = _native_key(native_id)
-                owner = resource_native_owner.setdefault(key, resource.resource_id)
-                if owner != resource.resource_id:
-                    raise ValueError("one provider-native resource cannot resolve to two canonical resources")
+        _validate_native_owners(
+            [(identity.entity_id, identity.native_ids) for identity in self.identities],
+            kind="identity",
+        )
+        _validate_native_owners(
+            [(resource.resource_id, resource.native_ids) for resource in self.resources],
+            kind="resource",
+        )
 
         evidence_by_id = {item.evidence_id: item for item in self.evidence}
         if len(evidence_by_id) != len(self.evidence):
@@ -456,6 +477,12 @@ class IdentityResourceJoinContract(_StrictIdentityModel):
                 for item in row_evidence
             ):
                 raise ValueError("complete catalog rows require complete, authoritative evidence")
+            if any(not self._is_fresh_for_decision(item) for item in row_evidence):
+                raise ValueError("complete catalog rows require fresh evidence under the contract policy")
+            evidence_source_ids = set(chain.from_iterable(item.source_ids for item in row_evidence))
+            native_assertion_ids = {canonical_provider_native_assertion_id(native_id) for native_id in row.native_ids}
+            if not native_assertion_ids.issubset(evidence_source_ids):
+                raise ValueError("complete catalog row native assertions must match evidence source_ids")
 
         endpoint_types: dict[str, CanonicalIdentityType | str] = {
             **{item.entity_id: item.entity_type for item in self.identities},
@@ -528,6 +555,8 @@ class IdentityResourceJoinContract(_StrictIdentityModel):
     def _is_fresh_for_decision(self, evidence: EvidenceProvenance) -> bool:
         freshness = evidence.freshness
         if freshness is None or freshness.observed_at is None:
+            return False
+        if freshness.observed_at > self.evaluated_at:
             return False
         expected = EvidenceFreshness.evaluate(
             observed_at=freshness.observed_at,

--- a/src/agent_bom/identity/join_contract.py
+++ b/src/agent_bom/identity/join_contract.py
@@ -1,0 +1,276 @@
+"""Provider-neutral identity and resource join contract.
+
+The contract is intentionally additive: collectors can normalize authoritative
+identity/resource references without changing the existing graph builders. It
+does not infer aliases or permissions. Only complete, directly observed
+structural relationships are asserted; partial and unavailable attempts remain
+explicit non-edges with bounded reason codes.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from agent_bom.evidence.semantics import (
+    ComponentName,
+    EvidenceBasis,
+    EvidenceCompletenessLedger,
+    EvidenceProvenance,
+    EvidenceStatus,
+    ReasonCode,
+)
+
+CanonicalIdentifier = Annotated[str, Field(min_length=1, max_length=500, pattern=r"^[^\s]+$")]
+NativeIdentifier = Annotated[str, Field(min_length=1, max_length=2048, pattern=r"^[^\s]+$")]
+DisplayName = Annotated[str, Field(min_length=1, max_length=300)]
+
+
+class IdentitySourceKind(StrEnum):
+    """Supported identity-source families; ``provider`` keeps the exact vendor."""
+
+    OKTA = "okta"
+    AWS = "aws"
+    AZURE = "azure"
+    GCP = "gcp"
+    SAAS = "saas"
+
+
+class CanonicalIdentityType(StrEnum):
+    """Provider-neutral identity entities used by the join contract."""
+
+    PERSON = "person"
+    SERVICE_ACCOUNT = "service_account"
+    WORKLOAD_IDENTITY = "workload_identity"
+    ROLE = "role"
+    GROUP = "group"
+
+
+class IdentityRelationshipType(StrEnum):
+    """Structural relationships only; permissions are deliberately excluded."""
+
+    MEMBER_OF = "member_of"
+    ASSUMES = "assumes"
+    TRUSTS = "trusts"
+    RUNS_AS = "runs_as"
+    OWNS = "owns"
+
+
+class _StrictIdentityModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
+
+
+def _dedupe(values: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(values))
+
+
+class ProviderNativeId(_StrictIdentityModel):
+    """One exact provider identifier retained for deterministic correlation."""
+
+    source: IdentitySourceKind
+    provider: ComponentName
+    id_type: ComponentName
+    value: NativeIdentifier
+    account: NativeIdentifier | None = None
+
+
+class _ObservedCatalogReference(_StrictIdentityModel):
+    """Shared completeness and provenance rules for normalized catalog rows."""
+
+    display_name: DisplayName
+    native_ids: tuple[ProviderNativeId, ...] = Field(min_length=1, max_length=20)
+    status: EvidenceStatus = EvidenceStatus.COMPLETE
+    evidence_refs: tuple[CanonicalIdentifier, ...] = Field(min_length=1, max_length=50)
+    reason_codes: tuple[ReasonCode, ...] = Field(default=(), max_length=20)
+
+    @field_validator("native_ids")
+    @classmethod
+    def unique_native_ids(cls, value: tuple[ProviderNativeId, ...]) -> tuple[ProviderNativeId, ...]:
+        keys = {(item.source, item.provider, item.id_type, item.value) for item in value}
+        if len(keys) != len(value):
+            raise ValueError("provider-native identifiers must be unique within one canonical row")
+        return value
+
+    @field_validator("evidence_refs", "reason_codes")
+    @classmethod
+    def dedupe_values(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return _dedupe(value)
+
+    @model_validator(mode="after")
+    def validate_observed_row(self) -> Self:
+        if self.status not in {EvidenceStatus.COMPLETE, EvidenceStatus.PARTIAL}:
+            raise ValueError("unavailable or failed inventory must not emit a fabricated catalog row")
+        if self.status is EvidenceStatus.PARTIAL and not self.reason_codes:
+            raise ValueError("partial catalog rows require a reason code")
+        return self
+
+
+class CanonicalIdentityEntity(_ObservedCatalogReference):
+    """Canonical identity with one or more authoritative provider-native IDs."""
+
+    entity_id: CanonicalIdentifier
+    entity_type: CanonicalIdentityType
+
+
+class CanonicalResourceReference(_ObservedCatalogReference):
+    """Bounded resource reference that an observed identity relationship targets."""
+
+    resource_id: CanonicalIdentifier
+    resource_type: ComponentName
+
+
+class IdentityRelationship(_StrictIdentityModel):
+    """One structural join assertion or an explicit incomplete join attempt."""
+
+    relationship_id: CanonicalIdentifier
+    relationship_type: IdentityRelationshipType
+    source_ref: CanonicalIdentifier | None = None
+    target_ref: CanonicalIdentifier | None = None
+    status: EvidenceStatus
+    evidence_refs: tuple[CanonicalIdentifier, ...] = Field(default=(), max_length=50)
+    reason_codes: tuple[ReasonCode, ...] = Field(default=(), max_length=20)
+
+    @field_validator("evidence_refs", "reason_codes")
+    @classmethod
+    def dedupe_values(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return _dedupe(value)
+
+    @model_validator(mode="after")
+    def validate_join_state(self) -> Self:
+        if self.status is EvidenceStatus.COMPLETE:
+            if not self.source_ref or not self.target_ref:
+                raise ValueError("complete relationships require both canonical endpoints")
+            if not self.evidence_refs:
+                raise ValueError("complete relationships require evidence references")
+            return self
+        if not self.reason_codes:
+            raise ValueError("incomplete relationships require a reason code")
+        if self.status is EvidenceStatus.PARTIAL:
+            if not self.source_ref and not self.target_ref:
+                raise ValueError("partial relationships require at least one known endpoint")
+            if not self.evidence_refs:
+                raise ValueError("partial relationships require evidence references")
+        return self
+
+    @property
+    def asserted(self) -> bool:
+        """Only complete joins are eligible to become graph edges."""
+
+        return self.status is EvidenceStatus.COMPLETE and bool(self.source_ref and self.target_ref)
+
+
+_MEMBER_SOURCES = {
+    CanonicalIdentityType.PERSON,
+    CanonicalIdentityType.SERVICE_ACCOUNT,
+    CanonicalIdentityType.WORKLOAD_IDENTITY,
+    CanonicalIdentityType.GROUP,
+}
+_ASSUME_SOURCES = set(_MEMBER_SOURCES)
+_TRUST_TARGETS = {
+    CanonicalIdentityType.PERSON,
+    CanonicalIdentityType.SERVICE_ACCOUNT,
+    CanonicalIdentityType.WORKLOAD_IDENTITY,
+    CanonicalIdentityType.ROLE,
+}
+_OWNER_SOURCES = set(_MEMBER_SOURCES)
+_RESOURCE_TYPE = "resource"
+
+
+class IdentityResourceJoinContract(_StrictIdentityModel):
+    """Versioned cross-provider identity/resource catalog and structural joins."""
+
+    schema_version: Literal["identity-resource-joins.v1"] = "identity-resource-joins.v1"
+    tenant_id: CanonicalIdentifier
+    identities: tuple[CanonicalIdentityEntity, ...] = Field(default=(), max_length=10_000)
+    resources: tuple[CanonicalResourceReference, ...] = Field(default=(), max_length=10_000)
+    relationships: tuple[IdentityRelationship, ...] = Field(default=(), max_length=50_000)
+    evidence: tuple[EvidenceProvenance, ...] = Field(default=(), max_length=5_000)
+    completeness: EvidenceCompletenessLedger
+
+    @property
+    def overall_status(self) -> EvidenceStatus:
+        return self.completeness.overall_status
+
+    @model_validator(mode="after")
+    def validate_contract(self) -> Self:
+        identity_by_id = {item.entity_id: item for item in self.identities}
+        resource_by_id = {item.resource_id: item for item in self.resources}
+        if len(identity_by_id) != len(self.identities):
+            raise ValueError("canonical identity IDs must be unique")
+        if len(resource_by_id) != len(self.resources):
+            raise ValueError("canonical resource IDs must be unique")
+        if set(identity_by_id) & set(resource_by_id):
+            raise ValueError("identity and resource canonical IDs must not collide")
+
+        relationship_ids = {item.relationship_id for item in self.relationships}
+        if len(relationship_ids) != len(self.relationships):
+            raise ValueError("relationship IDs must be unique")
+
+        native_owner: dict[tuple[IdentitySourceKind, str, str, str], str] = {}
+        for identity in self.identities:
+            for native_id in identity.native_ids:
+                key = (native_id.source, native_id.provider, native_id.id_type, native_id.value)
+                owner = native_owner.setdefault(key, identity.entity_id)
+                if owner != identity.entity_id:
+                    raise ValueError("one provider-native identity cannot resolve to two canonical entities")
+
+        evidence_by_id = {item.evidence_id: item for item in self.evidence}
+        if len(evidence_by_id) != len(self.evidence):
+            raise ValueError("evidence IDs must be unique")
+        referenced_evidence: set[str] = set()
+        for identity in self.identities:
+            referenced_evidence.update(identity.evidence_refs)
+        for resource in self.resources:
+            referenced_evidence.update(resource.evidence_refs)
+        for relationship in self.relationships:
+            referenced_evidence.update(relationship.evidence_refs)
+        if missing_evidence := referenced_evidence - set(evidence_by_id):
+            raise ValueError(f"contract references unknown evidence: {sorted(missing_evidence)}")
+
+        endpoint_types: dict[str, CanonicalIdentityType | str] = {
+            **{item.entity_id: item.entity_type for item in self.identities},
+            **{item.resource_id: _RESOURCE_TYPE for item in self.resources},
+        }
+        for relationship in self.relationships:
+            for endpoint in (relationship.source_ref, relationship.target_ref):
+                if endpoint is not None and endpoint not in endpoint_types:
+                    raise ValueError("relationship references an unknown canonical endpoint")
+            if relationship.source_ref and relationship.target_ref:
+                self._validate_direction(
+                    relationship.relationship_type,
+                    endpoint_types[relationship.source_ref],
+                    endpoint_types[relationship.target_ref],
+                )
+            if relationship.asserted:
+                join_evidence = [evidence_by_id[ref] for ref in relationship.evidence_refs]
+                if any(
+                    item.status is not EvidenceStatus.COMPLETE or item.basis not in {EvidenceBasis.OBSERVED, EvidenceBasis.RUNTIME_OBSERVED}
+                    for item in join_evidence
+                ):
+                    raise ValueError("complete relationships require complete, directly observed evidence")
+        return self
+
+    @staticmethod
+    def _validate_direction(
+        relationship_type: IdentityRelationshipType,
+        source_type: CanonicalIdentityType | str,
+        target_type: CanonicalIdentityType | str,
+    ) -> None:
+        valid = False
+        if relationship_type is IdentityRelationshipType.MEMBER_OF:
+            valid = source_type in _MEMBER_SOURCES and target_type is CanonicalIdentityType.GROUP
+        elif relationship_type is IdentityRelationshipType.ASSUMES:
+            valid = source_type in _ASSUME_SOURCES and target_type is CanonicalIdentityType.ROLE
+        elif relationship_type is IdentityRelationshipType.TRUSTS:
+            valid = source_type is CanonicalIdentityType.ROLE and target_type in _TRUST_TARGETS
+        elif relationship_type is IdentityRelationshipType.RUNS_AS:
+            valid = source_type == _RESOURCE_TYPE and target_type in {
+                CanonicalIdentityType.SERVICE_ACCOUNT,
+                CanonicalIdentityType.WORKLOAD_IDENTITY,
+            }
+        elif relationship_type is IdentityRelationshipType.OWNS:
+            valid = source_type in _OWNER_SOURCES and target_type == _RESOURCE_TYPE
+        if not valid:
+            raise ValueError(f"invalid {relationship_type.value} relationship direction")

--- a/tests/test_identity_resource_join_contract.py
+++ b/tests/test_identity_resource_join_contract.py
@@ -32,6 +32,7 @@ from agent_bom.identity.join_contract import (
     IdentitySourceKind,
     ProviderNativeId,
     canonical_identity_relationship_id,
+    canonical_provider_native_assertion_id,
 )
 
 _EVALUATED_AT = datetime(2026, 9, 4, tzinfo=timezone.utc)
@@ -44,7 +45,7 @@ def _evidence(
     *,
     basis: EvidenceBasis = EvidenceBasis.OBSERVED,
     status: EvidenceStatus = EvidenceStatus.COMPLETE,
-    source_id: str | None = None,
+    source_ids: tuple[str, ...] | None = None,
 ) -> EvidenceProvenance:
     freshness = EvidenceFreshness.evaluate(
         observed_at=_EVALUATED_AT - timedelta(hours=1),
@@ -56,14 +57,14 @@ def _evidence(
         basis=basis,
         status=status,
         source=source,
-        source_ids=((source_id or evidence_id),),
+        source_ids=source_ids or (evidence_id,),
         freshness=freshness,
         reason_codes=() if status is EvidenceStatus.COMPLETE else ("source_incomplete",),
     )
 
 
-def _native(source: IdentitySourceKind, provider: str, id_type: str, value: str) -> ProviderNativeId:
-    return ProviderNativeId(source=source, provider=provider, id_type=id_type, value=value)
+def _native(source: IdentitySourceKind, provider: str, account: str, id_type: str, value: str) -> ProviderNativeId:
+    return ProviderNativeId(source=source, provider=provider, account=account, id_type=id_type, value=value)
 
 
 def _identity(
@@ -108,34 +109,28 @@ def _payload() -> dict:
     return _contract().model_dump(mode="json", exclude_computed_fields=True)
 
 
+def _bind_native_assertion(contract: dict, *, evidence_id: str, native_id: dict) -> None:
+    evidence = next(item for item in contract["evidence"] if item["evidence_id"] == evidence_id)
+    evidence["source_ids"].append(canonical_provider_native_assertion_id(ProviderNativeId.model_validate(native_id)))
+
+
 def _contract() -> IdentityResourceJoinContract:
     membership_assertion = "okta-membership:00uABCDef123:00gEng-Prod"
     workload_assertion = "azure-workload-binding:payments-api"
     trust_assertion = "aws-trust-policy:DeployRole:gcp-scanner"
     owner_assertion = "asset-owner:github-bot:artifact-bucket"
-    evidence = (
-        _evidence("evidence:okta:1", "okta-scim"),
-        _evidence("evidence:aws:1", "aws-iam"),
-        _evidence("evidence:azure:1", "azure-graph"),
-        _evidence("evidence:gcp:1", "gcp-iam"),
-        _evidence("evidence:saas:1", "github-saas"),
-        _evidence("evidence:okta-membership:1", "okta-membership", source_id=membership_assertion),
-        _evidence("evidence:azure-binding:1", "azure-workload-binding", source_id=workload_assertion),
-        _evidence("evidence:aws-trust:1", "aws-trust-policy", source_id=trust_assertion),
-        _evidence("evidence:asset-owner:1", "asset-owner-catalog", source_id=owner_assertion),
-    )
     identities = (
         _identity(
             "identity:person:alice",
             CanonicalIdentityType.PERSON,
-            _native(IdentitySourceKind.OKTA, "okta", "user_id", "00uABCDef123"),
+            _native(IdentitySourceKind.OKTA, "okta", "okta-org-acme", "user_id", "00uABCDef123"),
             "evidence:okta:1",
             display_name="Alice Example",
         ),
         _identity(
             "identity:group:engineering",
             CanonicalIdentityType.GROUP,
-            _native(IdentitySourceKind.OKTA, "okta", "group_id", "00gEng-Prod"),
+            _native(IdentitySourceKind.OKTA, "okta", "okta-org-acme", "group_id", "00gEng-Prod"),
             "evidence:okta:1",
         ),
         _identity(
@@ -144,6 +139,7 @@ def _contract() -> IdentityResourceJoinContract:
             _native(
                 IdentitySourceKind.AWS,
                 "aws",
+                "123456789012",
                 "arn",
                 "arn:aws:iam::123456789012:role/DeployRole",
             ),
@@ -155,6 +151,7 @@ def _contract() -> IdentityResourceJoinContract:
             _native(
                 IdentitySourceKind.AZURE,
                 "azure",
+                "subscription-sub-1",
                 "principal_id",
                 "7D41A138-3028-4B6A-9D21-A61C4E978173",
             ),
@@ -166,6 +163,7 @@ def _contract() -> IdentityResourceJoinContract:
             _native(
                 IdentitySourceKind.GCP,
                 "gcp",
+                "project-1",
                 "email",
                 "Scanner@project-1.iam.gserviceaccount.com",
             ),
@@ -174,7 +172,7 @@ def _contract() -> IdentityResourceJoinContract:
         _identity(
             "identity:service-account:github-bot",
             CanonicalIdentityType.SERVICE_ACCOUNT,
-            _native(IdentitySourceKind.SAAS, "github", "app_id", "Iv1.AbcDEF-123"),
+            _native(IdentitySourceKind.SAAS, "github", "github-org-acme", "app_id", "Iv1.AbcDEF-123"),
             "evidence:saas:1",
         ),
     )
@@ -187,6 +185,7 @@ def _contract() -> IdentityResourceJoinContract:
                 _native(
                     IdentitySourceKind.AZURE,
                     "azure",
+                    "subscription-sub-1",
                     "resource_id",
                     "/subscriptions/Sub-1/resourceGroups/Prod/providers/Microsoft.App/containerApps/payments-api",
                 ),
@@ -201,12 +200,50 @@ def _contract() -> IdentityResourceJoinContract:
                 _native(
                     IdentitySourceKind.AWS,
                     "aws",
+                    "123456789012",
                     "arn",
                     "arn:aws:s3:::Artifact-Bucket-Prod",
                 ),
             ),
             evidence_refs=("evidence:aws:1",),
         ),
+    )
+    evidence = (
+        _evidence(
+            "evidence:okta:1",
+            "okta-scim",
+            source_ids=tuple(canonical_provider_native_assertion_id(item.native_ids[0]) for item in identities[:2]),
+        ),
+        _evidence(
+            "evidence:aws:1",
+            "aws-iam",
+            source_ids=(
+                canonical_provider_native_assertion_id(identities[2].native_ids[0]),
+                canonical_provider_native_assertion_id(resources[1].native_ids[0]),
+            ),
+        ),
+        _evidence(
+            "evidence:azure:1",
+            "azure-graph",
+            source_ids=(
+                canonical_provider_native_assertion_id(identities[3].native_ids[0]),
+                canonical_provider_native_assertion_id(resources[0].native_ids[0]),
+            ),
+        ),
+        _evidence(
+            "evidence:gcp:1",
+            "gcp-iam",
+            source_ids=(canonical_provider_native_assertion_id(identities[4].native_ids[0]),),
+        ),
+        _evidence(
+            "evidence:saas:1",
+            "github-saas",
+            source_ids=(canonical_provider_native_assertion_id(identities[5].native_ids[0]),),
+        ),
+        _evidence("evidence:okta-membership:1", "okta-membership", source_ids=(membership_assertion,)),
+        _evidence("evidence:azure-binding:1", "azure-workload-binding", source_ids=(workload_assertion,)),
+        _evidence("evidence:aws-trust:1", "aws-trust-policy", source_ids=(trust_assertion,)),
+        _evidence("evidence:asset-owner:1", "asset-owner-catalog", source_ids=(owner_assertion,)),
     )
     relationship_specs = (
         dict(
@@ -407,6 +444,8 @@ def test_account_is_part_of_provider_native_identity_scope() -> None:
     account_b["entity_id"] = "identity:person:alice-in-org-b"
     account_b["native_ids"][0]["account"] = "okta-org-b"
     contract["identities"].extend((account_a, account_b))
+    _bind_native_assertion(contract, evidence_id="evidence:okta:1", native_id=account_a["native_ids"][0])
+    _bind_native_assertion(contract, evidence_id="evidence:okta:1", native_id=account_b["native_ids"][0])
 
     validated = IdentityResourceJoinContract.model_validate(contract)
 
@@ -521,6 +560,52 @@ def test_provider_must_match_its_source_family() -> None:
         IdentityResourceJoinContract.model_validate(contract)
 
 
+def test_complete_provider_native_id_requires_explicit_account_scope() -> None:
+    contract = _payload()
+    contract["identities"][0]["native_ids"][0].pop("account", None)
+
+    with pytest.raises(ValidationError, match="account"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_native_assertion_id_is_deterministic_and_scope_sensitive() -> None:
+    native_id = _contract().identities[0].native_ids[0]
+    same_native_id = ProviderNativeId.model_validate(native_id.model_dump(mode="json"))
+    other_scope = native_id.model_copy(update={"account": "okta-org-other"})
+
+    assert canonical_provider_native_assertion_id(native_id) == canonical_provider_native_assertion_id(same_native_id)
+    assert canonical_provider_native_assertion_id(native_id) != canonical_provider_native_assertion_id(other_scope)
+
+
+def test_complete_catalog_row_rejects_stale_evidence() -> None:
+    contract = _payload()
+    inventory = next(item for item in contract["evidence"] if item["evidence_id"] == "evidence:okta:1")
+    inventory["freshness"] = {
+        "status": "stale",
+        "observed_at": (_EVALUATED_AT - timedelta(days=2)).isoformat(),
+        "valid_until": (_EVALUATED_AT - timedelta(days=1)).isoformat(),
+        "evaluated_at": _EVALUATED_AT.isoformat(),
+        "max_age_seconds": _FRESHNESS_MAX_AGE_SECONDS,
+    }
+
+    with pytest.raises(ValidationError, match="catalog.*fresh"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_catalog_evidence_must_bind_to_exact_provider_native_id() -> None:
+    contract = _payload()
+    contract["identities"][0]["native_ids"][0]["value"] = "00uFabricated"
+    contract["relationships"][0]["source_native_id"]["value"] = "00uFabricated"
+    relationship = IdentityRelationship.model_validate(contract["relationships"][0])
+    contract["relationships"][0]["relationship_id"] = canonical_identity_relationship_id(
+        tenant_id=contract["tenant_id"],
+        relationship=relationship,
+    )
+
+    with pytest.raises(ValidationError, match="native.*evidence source_ids"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
 def test_provider_native_resource_scope_includes_account() -> None:
     contract = _payload()
     account_a = deepcopy(contract["resources"][0])
@@ -530,6 +615,8 @@ def test_provider_native_resource_scope_includes_account() -> None:
     account_b["resource_id"] = "resource:azure:payments-api-org-b"
     account_b["native_ids"][0]["account"] = "subscription-b"
     contract["resources"].extend((account_a, account_b))
+    _bind_native_assertion(contract, evidence_id="evidence:azure:1", native_id=account_a["native_ids"][0])
+    _bind_native_assertion(contract, evidence_id="evidence:azure:1", native_id=account_b["native_ids"][0])
 
     validated = IdentityResourceJoinContract.model_validate(contract)
 
@@ -565,6 +652,17 @@ def test_checked_in_json_schema_enforces_partial_reason_codes() -> None:
 
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(contract, schema)
+
+
+def test_checked_in_json_schema_requires_provider_scope() -> None:
+    schema = json.loads((Path("docs/schemas/v1/IdentityResourceJoinContract.json")).read_text())
+    contract = _contract().model_dump(mode="json")
+    del contract["identities"][0]["native_ids"][0]["account"]
+
+    with pytest.raises(jsonschema.ValidationError) as exc_info:
+        jsonschema.validate(contract, schema)
+
+    assert "account" in str(exc_info.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_identity_resource_join_contract.py
+++ b/tests/test_identity_resource_join_contract.py
@@ -617,6 +617,46 @@ def test_catalog_evidence_must_bind_to_exact_provider_native_id() -> None:
         IdentityResourceJoinContract.model_validate(contract)
 
 
+@pytest.mark.parametrize(
+    ("relationship_index", "catalog_name", "row_index"),
+    [
+        (0, "identities", 0),
+        (1, "resources", 0),
+    ],
+)
+def test_complete_join_rejects_unreceipted_native_id_on_partial_endpoint(
+    relationship_index: int,
+    catalog_name: str,
+    row_index: int,
+) -> None:
+    contract = _payload()
+    fabricated_native_id = deepcopy(contract[catalog_name][row_index]["native_ids"][0])
+    fabricated_native_id["value"] = "00uFabricated"
+    contract[catalog_name][row_index].update(
+        native_ids=[fabricated_native_id],
+        status="partial",
+        reason_codes=["source_incomplete"],
+    )
+    contract["relationships"][relationship_index]["source_native_id"] = fabricated_native_id
+    relationship = IdentityRelationship.model_validate(contract["relationships"][relationship_index])
+    contract["relationships"][relationship_index]["relationship_id"] = canonical_identity_relationship_id(
+        tenant_id=contract["tenant_id"],
+        relationship=relationship,
+    )
+
+    with pytest.raises(ValidationError, match="endpoint native assertions.*catalog evidence source_ids"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_complete_join_allows_receipted_native_id_on_partial_endpoint() -> None:
+    contract = _payload()
+    contract["identities"][0].update(status="partial", reason_codes=["source_incomplete"])
+
+    validated = IdentityResourceJoinContract.model_validate(contract)
+
+    assert validated.relationships[0].asserted is True
+
+
 def test_provider_native_resource_scope_includes_account() -> None:
     contract = _payload()
     account_a = deepcopy(contract["resources"][0])

--- a/tests/test_identity_resource_join_contract.py
+++ b/tests/test_identity_resource_join_contract.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import json
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import jsonschema
 import pytest
 from pydantic import ValidationError
 
+import agent_bom.identity.join_contract as join_contract_module
 from agent_bom.evidence.semantics import (
     CompletenessEntry,
     EvidenceBasis,
     EvidenceCompletenessLedger,
+    EvidenceFreshness,
     EvidenceProvenance,
     EvidenceStage,
     EvidenceStatus,
@@ -17,12 +25,17 @@ from agent_bom.identity.join_contract import (
     CanonicalIdentityEntity,
     CanonicalIdentityType,
     CanonicalResourceReference,
+    IdentityJoinMethod,
     IdentityRelationship,
     IdentityRelationshipType,
     IdentityResourceJoinContract,
     IdentitySourceKind,
     ProviderNativeId,
+    canonical_identity_relationship_id,
 )
+
+_EVALUATED_AT = datetime(2026, 9, 4, tzinfo=timezone.utc)
+_FRESHNESS_MAX_AGE_SECONDS = 86_400
 
 
 def _evidence(
@@ -31,12 +44,20 @@ def _evidence(
     *,
     basis: EvidenceBasis = EvidenceBasis.OBSERVED,
     status: EvidenceStatus = EvidenceStatus.COMPLETE,
+    source_id: str | None = None,
 ) -> EvidenceProvenance:
+    freshness = EvidenceFreshness.evaluate(
+        observed_at=_EVALUATED_AT - timedelta(hours=1),
+        evaluated_at=_EVALUATED_AT,
+        max_age_seconds=_FRESHNESS_MAX_AGE_SECONDS,
+    )
     return EvidenceProvenance(
         evidence_id=evidence_id,
         basis=basis,
         status=status,
         source=source,
+        source_ids=((source_id or evidence_id),),
+        freshness=freshness,
         reason_codes=() if status is EvidenceStatus.COMPLETE else ("source_incomplete",),
     )
 
@@ -88,16 +109,20 @@ def _payload() -> dict:
 
 
 def _contract() -> IdentityResourceJoinContract:
+    membership_assertion = "okta-membership:00uABCDef123:00gEng-Prod"
+    workload_assertion = "azure-workload-binding:payments-api"
+    trust_assertion = "aws-trust-policy:DeployRole:gcp-scanner"
+    owner_assertion = "asset-owner:github-bot:artifact-bucket"
     evidence = (
         _evidence("evidence:okta:1", "okta-scim"),
         _evidence("evidence:aws:1", "aws-iam"),
         _evidence("evidence:azure:1", "azure-graph"),
         _evidence("evidence:gcp:1", "gcp-iam"),
         _evidence("evidence:saas:1", "github-saas"),
-        _evidence("evidence:okta-membership:1", "okta-membership"),
-        _evidence("evidence:azure-binding:1", "azure-workload-binding"),
-        _evidence("evidence:aws-trust:1", "aws-trust-policy"),
-        _evidence("evidence:asset-owner:1", "asset-owner-catalog"),
+        _evidence("evidence:okta-membership:1", "okta-membership", source_id=membership_assertion),
+        _evidence("evidence:azure-binding:1", "azure-workload-binding", source_id=workload_assertion),
+        _evidence("evidence:aws-trust:1", "aws-trust-policy", source_id=trust_assertion),
+        _evidence("evidence:asset-owner:1", "asset-owner-catalog", source_id=owner_assertion),
     )
     identities = (
         _identity(
@@ -183,45 +208,72 @@ def _contract() -> IdentityResourceJoinContract:
             evidence_refs=("evidence:aws:1",),
         ),
     )
-    relationships = (
-        IdentityRelationship(
-            relationship_id="join:okta:alice-engineering",
+    relationship_specs = (
+        dict(
             relationship_type=IdentityRelationshipType.MEMBER_OF,
+            join_method=IdentityJoinMethod.DIRECTORY_MEMBERSHIP,
             source_ref="identity:person:alice",
             target_ref="identity:group:engineering",
+            source_native_id=identities[0].native_ids[0],
+            target_native_id=identities[1].native_ids[0],
+            provider_assertion_ids=(membership_assertion,),
             status=EvidenceStatus.COMPLETE,
             evidence_refs=("evidence:okta-membership:1",),
         ),
-        IdentityRelationship(
-            relationship_id="join:azure:payments-runs-as",
+        dict(
             relationship_type=IdentityRelationshipType.RUNS_AS,
+            join_method=IdentityJoinMethod.WORKLOAD_BINDING,
             source_ref="resource:azure:payments-api",
             target_ref="identity:workload:payments",
+            source_native_id=resources[0].native_ids[0],
+            target_native_id=identities[3].native_ids[0],
+            provider_assertion_ids=(workload_assertion,),
             status=EvidenceStatus.COMPLETE,
             evidence_refs=("evidence:azure-binding:1",),
         ),
-        IdentityRelationship(
-            relationship_id="join:aws:deploy-trust",
+        dict(
             relationship_type=IdentityRelationshipType.TRUSTS,
+            join_method=IdentityJoinMethod.TRUST_POLICY,
             source_ref="identity:role:deploy",
             target_ref="identity:service-account:gcp-scanner",
+            source_native_id=identities[2].native_ids[0],
+            target_native_id=identities[4].native_ids[0],
+            provider_assertion_ids=(trust_assertion,),
             status=EvidenceStatus.COMPLETE,
             evidence_refs=("evidence:aws-trust:1",),
         ),
-        IdentityRelationship(
-            relationship_id="join:saas:github-owns-bucket",
+        dict(
             relationship_type=IdentityRelationshipType.OWNS,
+            join_method=IdentityJoinMethod.OWNERSHIP_RECORD,
             source_ref="identity:service-account:github-bot",
             target_ref="resource:aws:artifact-bucket",
+            source_native_id=identities[5].native_ids[0],
+            target_native_id=resources[1].native_ids[0],
+            provider_assertion_ids=(owner_assertion,),
             status=EvidenceStatus.COMPLETE,
             evidence_refs=("evidence:asset-owner:1",),
         ),
     )
+    relationships = []
+    for spec in relationship_specs:
+        relationship = IdentityRelationship(relationship_id="pending", **spec)
+        relationships.append(
+            relationship.model_copy(
+                update={
+                    "relationship_id": canonical_identity_relationship_id(
+                        tenant_id="tenant-acme",
+                        relationship=relationship,
+                    )
+                }
+            )
+        )
     return IdentityResourceJoinContract(
         tenant_id="tenant-acme",
+        evaluated_at=_EVALUATED_AT,
+        freshness_max_age_seconds=_FRESHNESS_MAX_AGE_SECONDS,
         identities=identities,
         resources=resources,
-        relationships=relationships,
+        relationships=tuple(relationships),
         evidence=evidence,
         completeness=_complete_ledger(),
     )
@@ -256,6 +308,7 @@ def test_incomplete_join_attempts_are_explicit_non_edges(status: EvidenceStatus)
     relationship = IdentityRelationship(
         relationship_id=f"join:attempt:{status.value}",
         relationship_type=IdentityRelationshipType.ASSUMES,
+        join_method=IdentityJoinMethod.ROLE_ASSIGNMENT,
         source_ref="identity:person:alice",
         target_ref=None,
         status=status,
@@ -272,6 +325,7 @@ def test_incomplete_join_requires_a_bounded_reason() -> None:
         IdentityRelationship(
             relationship_id="join:attempt:missing-reason",
             relationship_type=IdentityRelationshipType.ASSUMES,
+            join_method=IdentityJoinMethod.ROLE_ASSIGNMENT,
             source_ref="identity:person:alice",
             status=EvidenceStatus.UNAVAILABLE,
         )
@@ -342,3 +396,217 @@ def test_public_schema_exposes_closed_types_and_explicit_evidence_states() -> No
     assert definitions["EvidenceStatus"]["enum"] == ["complete", "partial", "unavailable", "failed"]
     assert "has_permission" not in definitions["IdentityRelationshipType"]["enum"]
     assert schema["additionalProperties"] is False
+
+
+def test_account_is_part_of_provider_native_identity_scope() -> None:
+    contract = _payload()
+    account_a = deepcopy(contract["identities"][0])
+    account_a["entity_id"] = "identity:person:alice-in-org-a"
+    account_a["native_ids"][0]["account"] = "okta-org-a"
+    account_b = deepcopy(contract["identities"][0])
+    account_b["entity_id"] = "identity:person:alice-in-org-b"
+    account_b["native_ids"][0]["account"] = "okta-org-b"
+    contract["identities"].extend((account_a, account_b))
+
+    validated = IdentityResourceJoinContract.model_validate(contract)
+
+    assert len(validated.identities) == 8
+
+
+def test_provider_native_resource_cannot_resolve_to_two_resources() -> None:
+    contract = _payload()
+    duplicate = deepcopy(contract["resources"][0])
+    duplicate["resource_id"] = "resource:azure:payments-api-duplicate"
+    contract["resources"].append(duplicate)
+
+    with pytest.raises(ValidationError, match="provider-native resource"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_complete_catalog_row_rejects_unavailable_evidence() -> None:
+    contract = _payload()
+    contract["evidence"][0].update(status="unavailable", basis=None, reason_codes=["collector_denied"])
+
+    with pytest.raises(ValidationError, match="complete catalog rows"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_complete_join_rejects_stale_evidence() -> None:
+    contract = _payload()
+    evaluated_at = datetime(2026, 9, 4, tzinfo=timezone.utc)
+    membership = next(item for item in contract["evidence"] if item["evidence_id"] == "evidence:okta-membership:1")
+    membership["freshness"] = {
+        "status": "stale",
+        "observed_at": (evaluated_at - timedelta(days=2)).isoformat(),
+        "valid_until": (evaluated_at - timedelta(days=1)).isoformat(),
+        "evaluated_at": evaluated_at.isoformat(),
+        "max_age_seconds": 86_400,
+    }
+
+    with pytest.raises(ValidationError, match="fresh evidence"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_complete_join_rejects_unknown_freshness() -> None:
+    contract = _payload()
+    membership = next(item for item in contract["evidence"] if item["evidence_id"] == "evidence:okta-membership:1")
+    membership["freshness"] = None
+
+    with pytest.raises(ValidationError, match="fresh evidence"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_complete_join_rejects_evidence_observed_after_decision_time() -> None:
+    contract = _payload()
+    membership = next(item for item in contract["evidence"] if item["evidence_id"] == "evidence:okta-membership:1")
+    membership["freshness"] = {
+        "status": "fresh",
+        "observed_at": (_EVALUATED_AT + timedelta(hours=1)).isoformat(),
+        "valid_until": (_EVALUATED_AT + timedelta(hours=25)).isoformat(),
+        "evaluated_at": _EVALUATED_AT.isoformat(),
+        "max_age_seconds": _FRESHNESS_MAX_AGE_SECONDS,
+    }
+
+    with pytest.raises(ValidationError, match="future evidence"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_complete_join_rejects_evidence_not_bound_to_endpoints() -> None:
+    contract = _payload()
+    contract["relationships"][0]["source_ref"] = "identity:service-account:github-bot"
+
+    with pytest.raises(ValidationError, match="evidence anchor"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_provider_assertion_id_must_be_present_in_evidence_source_ids() -> None:
+    contract = _payload()
+    contract["relationships"][0]["provider_assertion_ids"] = ["unrelated-provider-assertion"]
+
+    with pytest.raises(ValidationError, match="evidence anchors.*source_ids"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_semantically_duplicate_relationship_is_rejected() -> None:
+    contract = _payload()
+    duplicate = deepcopy(contract["relationships"][0])
+    duplicate["relationship_id"] = "join:okta:alice-engineering-copy"
+    contract["relationships"].append(duplicate)
+
+    with pytest.raises(ValidationError, match="semantic relationship"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_relationship_id_must_match_tenant_scoped_semantics() -> None:
+    contract = _payload()
+    contract["relationships"][0]["relationship_id"] = "join:caller-selected"
+
+    with pytest.raises(ValidationError, match="deterministic tenant-scoped"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_join_method_must_match_relationship_type() -> None:
+    contract = _payload()
+    contract["relationships"][0]["join_method"] = "trust_policy"
+
+    with pytest.raises(ValidationError, match="join method"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_provider_must_match_its_source_family() -> None:
+    contract = _payload()
+    contract["identities"][0]["native_ids"][0]["provider"] = "aws"
+
+    with pytest.raises(ValidationError, match="provider.*source family"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_provider_native_resource_scope_includes_account() -> None:
+    contract = _payload()
+    account_a = deepcopy(contract["resources"][0])
+    account_a["resource_id"] = "resource:azure:payments-api-org-a"
+    account_a["native_ids"][0]["account"] = "subscription-a"
+    account_b = deepcopy(contract["resources"][0])
+    account_b["resource_id"] = "resource:azure:payments-api-org-b"
+    account_b["native_ids"][0]["account"] = "subscription-b"
+    contract["resources"].extend((account_a, account_b))
+
+    validated = IdentityResourceJoinContract.model_validate(contract)
+
+    assert len(validated.resources) == 4
+
+
+def test_group_cannot_be_a_member_of_itself() -> None:
+    contract = _payload()
+    contract["relationships"][0].update(
+        source_ref="identity:group:engineering",
+        target_ref="identity:group:engineering",
+    )
+
+    with pytest.raises(ValidationError, match="member_of self-loop"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_checked_in_json_schema_enforces_complete_relationship_shape() -> None:
+    schema = json.loads((Path("docs/schemas/v1/IdentityResourceJoinContract.json")).read_text())
+    contract = _contract().model_dump(mode="json")
+    contract["relationships"][0]["evidence_refs"] = []
+
+    with pytest.raises(jsonschema.ValidationError) as exc_info:
+        jsonschema.validate(contract, schema)
+
+    assert list(exc_info.value.path)[-1] == "evidence_refs"
+
+
+def test_checked_in_json_schema_enforces_partial_reason_codes() -> None:
+    schema = json.loads((Path("docs/schemas/v1/IdentityResourceJoinContract.json")).read_text())
+    contract = _contract().model_dump(mode="json")
+    contract["relationships"][0].update(status="partial", reason_codes=[])
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(contract, schema)
+
+
+@pytest.mark.parametrize(
+    ("mutator", "field"),
+    [
+        (lambda payload: payload["identities"][0]["native_ids"][0].update(provider="aws"), "provider"),
+        (lambda payload: payload["relationships"][0].update(join_method="trust_policy"), "join_method"),
+    ],
+)
+def test_checked_in_json_schema_enforces_local_cross_field_rules(mutator, field: str) -> None:
+    schema = json.loads((Path("docs/schemas/v1/IdentityResourceJoinContract.json")).read_text())
+    contract = _contract().model_dump(mode="json")
+    mutator(contract)
+
+    with pytest.raises(jsonschema.ValidationError) as exc_info:
+        jsonschema.validate(contract, schema)
+
+    assert field in str(exc_info.value)
+
+
+def test_checked_in_schema_names_the_executable_validator_boundary() -> None:
+    schema = json.loads((Path("docs/schemas/v1/IdentityResourceJoinContract.json")).read_text())
+
+    assert "model_validate" in schema["$comment"]
+    assert "JSON Schema alone is not sufficient" in schema["$comment"]
+
+
+def test_aggregate_evidence_reference_budget_is_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    contract = _payload()
+    current_reference_count = sum(
+        len(item["evidence_refs"]) for group in (contract["identities"], contract["resources"], contract["relationships"]) for item in group
+    )
+    monkeypatch.setattr(join_contract_module, "MAX_IDENTITY_JOIN_EVIDENCE_REFERENCES", current_reference_count - 1)
+
+    with pytest.raises(ValidationError, match="aggregate evidence-reference budget"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_aggregate_native_identifier_budget_is_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    contract = _payload()
+    current_native_id_count = sum(len(item["native_ids"]) for group in (contract["identities"], contract["resources"]) for item in group)
+    monkeypatch.setattr(join_contract_module, "MAX_IDENTITY_JOIN_NATIVE_IDENTIFIERS", current_native_id_count - 1)
+
+    with pytest.raises(ValidationError, match="aggregate provider-native identifier budget"):
+        IdentityResourceJoinContract.model_validate(contract)

--- a/tests/test_identity_resource_join_contract.py
+++ b/tests/test_identity_resource_join_contract.py
@@ -462,6 +462,17 @@ def test_provider_native_resource_cannot_resolve_to_two_resources() -> None:
         IdentityResourceJoinContract.model_validate(contract)
 
 
+def test_provider_native_id_cannot_resolve_to_both_identity_and_resource() -> None:
+    contract = _payload()
+    shared_native_id = deepcopy(contract["identities"][0]["native_ids"][0])
+    contract["resources"][0]["native_ids"] = [shared_native_id]
+    contract["resources"][0]["evidence_refs"] = contract["identities"][0]["evidence_refs"]
+    contract["relationships"] = []
+
+    with pytest.raises(ValidationError, match="both.*identity.*resource"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
 def test_complete_catalog_row_rejects_unavailable_evidence() -> None:
     contract = _payload()
     contract["evidence"][0].update(status="unavailable", basis=None, reason_codes=["collector_denied"])

--- a/tests/test_identity_resource_join_contract.py
+++ b/tests/test_identity_resource_join_contract.py
@@ -1,0 +1,344 @@
+"""Canonical cross-provider identity/resource join contract."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from agent_bom.evidence.semantics import (
+    CompletenessEntry,
+    EvidenceBasis,
+    EvidenceCompletenessLedger,
+    EvidenceProvenance,
+    EvidenceStage,
+    EvidenceStatus,
+)
+from agent_bom.identity.join_contract import (
+    CanonicalIdentityEntity,
+    CanonicalIdentityType,
+    CanonicalResourceReference,
+    IdentityRelationship,
+    IdentityRelationshipType,
+    IdentityResourceJoinContract,
+    IdentitySourceKind,
+    ProviderNativeId,
+)
+
+
+def _evidence(
+    evidence_id: str,
+    source: str,
+    *,
+    basis: EvidenceBasis = EvidenceBasis.OBSERVED,
+    status: EvidenceStatus = EvidenceStatus.COMPLETE,
+) -> EvidenceProvenance:
+    return EvidenceProvenance(
+        evidence_id=evidence_id,
+        basis=basis,
+        status=status,
+        source=source,
+        reason_codes=() if status is EvidenceStatus.COMPLETE else ("source_incomplete",),
+    )
+
+
+def _native(source: IdentitySourceKind, provider: str, id_type: str, value: str) -> ProviderNativeId:
+    return ProviderNativeId(source=source, provider=provider, id_type=id_type, value=value)
+
+
+def _identity(
+    entity_id: str,
+    entity_type: CanonicalIdentityType,
+    native_id: ProviderNativeId,
+    evidence_ref: str,
+    *,
+    display_name: str | None = None,
+) -> CanonicalIdentityEntity:
+    return CanonicalIdentityEntity(
+        entity_id=entity_id,
+        entity_type=entity_type,
+        display_name=display_name or entity_id,
+        native_ids=(native_id,),
+        evidence_refs=(evidence_ref,),
+    )
+
+
+def _complete_ledger() -> EvidenceCompletenessLedger:
+    return EvidenceCompletenessLedger(
+        entries=(
+            CompletenessEntry(
+                stage=EvidenceStage.COLLECTION,
+                component="identity-inventory",
+                status=EvidenceStatus.COMPLETE,
+                returned_count=6,
+                expected_count=6,
+            ),
+            CompletenessEntry(
+                stage=EvidenceStage.GRAPH_JOIN,
+                component="identity-resource-join",
+                status=EvidenceStatus.COMPLETE,
+                returned_count=4,
+                expected_count=4,
+            ),
+        )
+    )
+
+
+def _payload() -> dict:
+    return _contract().model_dump(mode="json", exclude_computed_fields=True)
+
+
+def _contract() -> IdentityResourceJoinContract:
+    evidence = (
+        _evidence("evidence:okta:1", "okta-scim"),
+        _evidence("evidence:aws:1", "aws-iam"),
+        _evidence("evidence:azure:1", "azure-graph"),
+        _evidence("evidence:gcp:1", "gcp-iam"),
+        _evidence("evidence:saas:1", "github-saas"),
+        _evidence("evidence:okta-membership:1", "okta-membership"),
+        _evidence("evidence:azure-binding:1", "azure-workload-binding"),
+        _evidence("evidence:aws-trust:1", "aws-trust-policy"),
+        _evidence("evidence:asset-owner:1", "asset-owner-catalog"),
+    )
+    identities = (
+        _identity(
+            "identity:person:alice",
+            CanonicalIdentityType.PERSON,
+            _native(IdentitySourceKind.OKTA, "okta", "user_id", "00uABCDef123"),
+            "evidence:okta:1",
+            display_name="Alice Example",
+        ),
+        _identity(
+            "identity:group:engineering",
+            CanonicalIdentityType.GROUP,
+            _native(IdentitySourceKind.OKTA, "okta", "group_id", "00gEng-Prod"),
+            "evidence:okta:1",
+        ),
+        _identity(
+            "identity:role:deploy",
+            CanonicalIdentityType.ROLE,
+            _native(
+                IdentitySourceKind.AWS,
+                "aws",
+                "arn",
+                "arn:aws:iam::123456789012:role/DeployRole",
+            ),
+            "evidence:aws:1",
+        ),
+        _identity(
+            "identity:workload:payments",
+            CanonicalIdentityType.WORKLOAD_IDENTITY,
+            _native(
+                IdentitySourceKind.AZURE,
+                "azure",
+                "principal_id",
+                "7D41A138-3028-4B6A-9D21-A61C4E978173",
+            ),
+            "evidence:azure:1",
+        ),
+        _identity(
+            "identity:service-account:gcp-scanner",
+            CanonicalIdentityType.SERVICE_ACCOUNT,
+            _native(
+                IdentitySourceKind.GCP,
+                "gcp",
+                "email",
+                "Scanner@project-1.iam.gserviceaccount.com",
+            ),
+            "evidence:gcp:1",
+        ),
+        _identity(
+            "identity:service-account:github-bot",
+            CanonicalIdentityType.SERVICE_ACCOUNT,
+            _native(IdentitySourceKind.SAAS, "github", "app_id", "Iv1.AbcDEF-123"),
+            "evidence:saas:1",
+        ),
+    )
+    resources = (
+        CanonicalResourceReference(
+            resource_id="resource:azure:payments-api",
+            resource_type="container-app",
+            display_name="payments-api",
+            native_ids=(
+                _native(
+                    IdentitySourceKind.AZURE,
+                    "azure",
+                    "resource_id",
+                    "/subscriptions/Sub-1/resourceGroups/Prod/providers/Microsoft.App/containerApps/payments-api",
+                ),
+            ),
+            evidence_refs=("evidence:azure:1",),
+        ),
+        CanonicalResourceReference(
+            resource_id="resource:aws:artifact-bucket",
+            resource_type="object-store",
+            display_name="artifact-bucket",
+            native_ids=(
+                _native(
+                    IdentitySourceKind.AWS,
+                    "aws",
+                    "arn",
+                    "arn:aws:s3:::Artifact-Bucket-Prod",
+                ),
+            ),
+            evidence_refs=("evidence:aws:1",),
+        ),
+    )
+    relationships = (
+        IdentityRelationship(
+            relationship_id="join:okta:alice-engineering",
+            relationship_type=IdentityRelationshipType.MEMBER_OF,
+            source_ref="identity:person:alice",
+            target_ref="identity:group:engineering",
+            status=EvidenceStatus.COMPLETE,
+            evidence_refs=("evidence:okta-membership:1",),
+        ),
+        IdentityRelationship(
+            relationship_id="join:azure:payments-runs-as",
+            relationship_type=IdentityRelationshipType.RUNS_AS,
+            source_ref="resource:azure:payments-api",
+            target_ref="identity:workload:payments",
+            status=EvidenceStatus.COMPLETE,
+            evidence_refs=("evidence:azure-binding:1",),
+        ),
+        IdentityRelationship(
+            relationship_id="join:aws:deploy-trust",
+            relationship_type=IdentityRelationshipType.TRUSTS,
+            source_ref="identity:role:deploy",
+            target_ref="identity:service-account:gcp-scanner",
+            status=EvidenceStatus.COMPLETE,
+            evidence_refs=("evidence:aws-trust:1",),
+        ),
+        IdentityRelationship(
+            relationship_id="join:saas:github-owns-bucket",
+            relationship_type=IdentityRelationshipType.OWNS,
+            source_ref="identity:service-account:github-bot",
+            target_ref="resource:aws:artifact-bucket",
+            status=EvidenceStatus.COMPLETE,
+            evidence_refs=("evidence:asset-owner:1",),
+        ),
+    )
+    return IdentityResourceJoinContract(
+        tenant_id="tenant-acme",
+        identities=identities,
+        resources=resources,
+        relationships=relationships,
+        evidence=evidence,
+        completeness=_complete_ledger(),
+    )
+
+
+def test_cross_provider_entities_preserve_native_ids_exactly() -> None:
+    contract = _contract()
+
+    assert {identity.entity_type for identity in contract.identities} == set(CanonicalIdentityType)
+    native_values = {native.value for identity in contract.identities for native in identity.native_ids}
+    assert "arn:aws:iam::123456789012:role/DeployRole" in native_values
+    assert "7D41A138-3028-4B6A-9D21-A61C4E978173" in native_values
+    assert "Scanner@project-1.iam.gserviceaccount.com" in native_values
+    assert "Iv1.AbcDEF-123" in native_values
+
+
+def test_only_complete_observed_structural_joins_are_asserted() -> None:
+    contract = _contract()
+
+    assert contract.overall_status is EvidenceStatus.COMPLETE
+    assert all(relationship.asserted for relationship in contract.relationships)
+    assert {relationship.relationship_type for relationship in contract.relationships} == {
+        IdentityRelationshipType.MEMBER_OF,
+        IdentityRelationshipType.RUNS_AS,
+        IdentityRelationshipType.TRUSTS,
+        IdentityRelationshipType.OWNS,
+    }
+
+
+@pytest.mark.parametrize("status", [EvidenceStatus.PARTIAL, EvidenceStatus.UNAVAILABLE])
+def test_incomplete_join_attempts_are_explicit_non_edges(status: EvidenceStatus) -> None:
+    relationship = IdentityRelationship(
+        relationship_id=f"join:attempt:{status.value}",
+        relationship_type=IdentityRelationshipType.ASSUMES,
+        source_ref="identity:person:alice",
+        target_ref=None,
+        status=status,
+        evidence_refs=("evidence:okta:1",) if status is EvidenceStatus.PARTIAL else (),
+        reason_codes=("authoritative_target_id_missing",),
+    )
+
+    assert relationship.asserted is False
+    assert relationship.status is status
+
+
+def test_incomplete_join_requires_a_bounded_reason() -> None:
+    with pytest.raises(ValidationError, match="reason"):
+        IdentityRelationship(
+            relationship_id="join:attempt:missing-reason",
+            relationship_type=IdentityRelationshipType.ASSUMES,
+            source_ref="identity:person:alice",
+            status=EvidenceStatus.UNAVAILABLE,
+        )
+
+
+def test_permission_join_vocabulary_is_intentionally_absent() -> None:
+    payload = {
+        "relationship_id": "join:forbidden:permission",
+        "relationship_type": "has_permission",
+        "source_ref": "identity:person:alice",
+        "target_ref": "resource:aws:artifact-bucket",
+        "status": "complete",
+        "evidence_refs": ["evidence:aws:1"],
+    }
+
+    with pytest.raises(ValidationError):
+        IdentityRelationship.model_validate(payload)
+
+
+def test_complete_join_rejects_inferred_or_modeled_evidence() -> None:
+    contract = _payload()
+    membership_evidence = next(item for item in contract["evidence"] if item["evidence_id"] == "evidence:okta-membership:1")
+    membership_evidence["basis"] = "inferred"
+
+    with pytest.raises(ValidationError, match="directly observed"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_duplicate_provider_native_id_cannot_resolve_to_two_entities() -> None:
+    contract = _payload()
+    duplicate = dict(contract["identities"][0])
+    duplicate["entity_id"] = "identity:person:alice-duplicate"
+    contract["identities"].append(duplicate)
+
+    with pytest.raises(ValidationError, match="provider-native identity"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_complete_join_references_must_resolve_inside_the_contract() -> None:
+    contract = _payload()
+    contract["relationships"][0]["target_ref"] = "identity:group:missing"
+
+    with pytest.raises(ValidationError, match="unknown canonical endpoint"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_join_direction_is_validated_by_relationship_type() -> None:
+    contract = _payload()
+    contract["relationships"][0]["source_ref"] = "resource:aws:artifact-bucket"
+
+    with pytest.raises(ValidationError, match="member_of"):
+        IdentityResourceJoinContract.model_validate(contract)
+
+
+def test_public_schema_exposes_closed_types_and_explicit_evidence_states() -> None:
+    from agent_bom.api.models import IdentityResourceJoinContract as PublicContract
+
+    schema = PublicContract.model_json_schema()
+    definitions = schema["$defs"]
+    assert definitions["CanonicalIdentityType"]["enum"] == [
+        "person",
+        "service_account",
+        "workload_identity",
+        "role",
+        "group",
+    ]
+    assert definitions["IdentitySourceKind"]["enum"] == ["okta", "aws", "azure", "gcp", "saas"]
+    assert definitions["EvidenceStatus"]["enum"] == ["complete", "partial", "unavailable", "failed"]
+    assert "has_permission" not in definitions["IdentityRelationshipType"]["enum"]
+    assert schema["additionalProperties"] is False


### PR DESCRIPTION
Summary
- define canonical identity-to-resource joins across Okta, AWS, Azure, GCP, and SaaS
- bind complete joins to scoped, authoritative, fresh catalog receipts and deterministic tenant-scoped relationship IDs
- reject cross-kind native-ID ambiguity without fabricating permission edges or claiming connector/runtime wiring

Verification
- uv run pytest -q tests/test_identity_resource_join_contract.py tests/test_evidence_semantics_contract.py tests/test_contract_schemas.py tests/api/test_api_models_extra_forbid.py (66 passed)
- make lint
- make format-check
- make preflight
- git diff --check
- all six branch commits verified with good signatures after rebase onto current main

Notes
- schema and validation foundation only; connector ingestion, graph persistence, API/UI surfaces, and permission calculation remain separate lanes