### PR TITLE
feat(graph): expose independent path evidence

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1090,19 +1090,13 @@ def _exposure_relationships_for_path(
     relationships: list[dict[str, Any]] = []
     for index, (source, target) in enumerate(zip(path.hops, path.hops[1:], strict=False)):
         edge: UnifiedEdge | None = by_pair.get((source, target))
-        relationship = ""
-        if edge is not None:
-            relationship = _rel_value(edge)
-            edge_id = edge.id
-            direction = edge.direction
-            traversable = edge.traversable
-            confidence = edge.confidence
-        else:
-            relationship = path.edges[index] if index < len(path.edges) else "related"
-            edge_id = f"{relationship}:{source}:{target}"
-            direction = "directed"
-            traversable = True
-            confidence = 1.0
+        if edge is None:
+            continue
+        relationship = _rel_value(edge)
+        edge_id = edge.id
+        direction = edge.direction
+        traversable = edge.traversable
+        confidence = edge.confidence
         relationships.append(
             {
                 "id": edge_id,
@@ -1125,13 +1119,7 @@ def _severity_for_exposure_path(path: AttackPath, nodes_by_id: dict[str, Any]) -
             severity = str(node.severity).lower()
     if severity:
         return severity
-    if path.composite_risk >= 90 or path.composite_risk >= 9:
-        return "critical"
-    if path.composite_risk >= 70 or path.composite_risk >= 7:
-        return "high"
-    if path.composite_risk >= 40 or path.composite_risk >= 4:
-        return "medium"
-    return "none"
+    return "unknown"
 
 
 def _exposure_path_for_attack_path(
@@ -1153,6 +1141,9 @@ def _exposure_path_for_attack_path(
     agents = [hop for hop in hops if hop["role"] == "agent"]
     findings = _finding_ids_for_nodes(nodes_by_id, path.hops, path.vuln_ids)
     label_parts = [findings[0] if findings else target["label"], agents[0]["label"] if agents else source["label"]]
+    from agent_bom.graph.path_evidence import exposure_evidence_dimensions
+
+    finding_node = nodes_by_id.get(path.target)
     exposure: dict[str, Any] = {
         "id": f"{path.source}::{path.target}::{'->'.join(path.hops)}",
         "label": " via ".join(part for part in label_parts if part) or path.summary or "Exposure path",
@@ -1172,6 +1163,7 @@ def _exposure_path_for_attack_path(
         "exposedCredentials": list(path.credential_exposure),
         "reachability": path.reachability,
         "reachabilityBasis": list(path.reachability_basis),
+        "evidenceDimensions": exposure_evidence_dimensions(path, finding_node),
         "provenance": {"source": "graph_attack_path", "scanId": scan_id} if scan_id else {"source": "graph_attack_path"},
     }
     if rank is not None:
@@ -1184,19 +1176,18 @@ def _exposure_path_for_attack_path(
             "ecosystem": getattr(package_node, "attributes", {}).get("ecosystem", "") if package_node is not None else "",
             "serverName": servers[0]["label"] if servers else "",
         }
-    finding_node = nodes_by_id.get(path.target)
     if finding_node is not None:
         attributes = getattr(finding_node, "attributes", {}) or {}
         exposure["evidence"] = {
             "cvssScore": attributes.get("cvss_score"),
             "cvssVector": attributes.get("cvss_vector"),
             "epssScore": attributes.get("epss_score"),
-            "isKev": bool(attributes.get("is_kev")),
+            "isKev": attributes.get("is_kev"),
             "attackVector": attributes.get("attack_vector"),
             "attackComplexity": attributes.get("attack_complexity"),
             "privilegesRequired": attributes.get("privileges_required"),
             "userInteraction": attributes.get("user_interaction"),
-            "networkExploitable": bool(attributes.get("network_exploitable")),
+            "networkExploitable": attributes.get("network_exploitable"),
             "impactCategory": attributes.get("impact_category"),
             "source": "graph_attack_path",
         }

--- a/src/agent_bom/graph/path_evidence.py
+++ b/src/agent_bom/graph/path_evidence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from typing import Any
 
 from agent_bom.graph.container import AttackPath, UnifiedGraph
@@ -184,4 +185,125 @@ def annotate_attack_path_evidence(path: AttackPath, graph: UnifiedGraph) -> Atta
     return path
 
 
-__all__ = ["annotate_attack_path_evidence"]
+def _unavailable_dimension(reason: str, **facts: object) -> dict[str, Any]:
+    return {
+        "status": "unavailable",
+        **facts,
+        "basis": [],
+        "reasonCodes": [reason],
+    }
+
+
+def _path_completeness(path: AttackPath) -> dict[str, Any]:
+    """Project only recorded analyzer and hop coverage; never infer complete."""
+
+    analysis = path.analysis if isinstance(path.analysis, Mapping) else {}
+    analysis_status = str(analysis.get("status") or "")
+    analysis_reasons = [str(item) for item in analysis.get("reason_codes", []) if str(item)]
+    receipts = [item for item in path.hop_evidence if isinstance(item, Mapping)]
+    expected_hops = max(len(path.hops) - 1, 0)
+    base = {
+        "expectedHops": expected_hops,
+        "evidencedHops": len(receipts),
+        "analysisStatus": analysis_status or None,
+    }
+    if not analysis_status:
+        return {"status": "unavailable", **base, "reasonCodes": ["analysis_not_recorded"]}
+    if analysis_status == "failed":
+        return {"status": "failed", **base, "reasonCodes": analysis_reasons or ["analysis_failed"]}
+    if analysis_status in {"skipped", "not_recorded"}:
+        return {"status": "unavailable", **base, "reasonCodes": analysis_reasons or [analysis_status]}
+    if analysis_status == "limited":
+        return {"status": "partial", **base, "reasonCodes": analysis_reasons or ["analysis_limited"]}
+    if analysis_status != "complete":
+        return {"status": "unavailable", **base, "reasonCodes": ["analysis_status_unknown"]}
+    if expected_hops and not receipts:
+        return {"status": "unavailable", **base, "reasonCodes": ["hop_evidence_not_recorded"]}
+    if len(receipts) != expected_hops or any(not item.get("complete") or item.get("truncated") for item in receipts):
+        return {"status": "partial", **base, "reasonCodes": ["incomplete_hop_evidence"]}
+    return {"status": "complete", **base, "reasonCodes": []}
+
+
+def exposure_evidence_dimensions(path: AttackPath, target_node: Any | None) -> dict[str, Any]:
+    """Build independent evidence dimensions shared by graph response surfaces."""
+
+    attributes = getattr(target_node, "attributes", {}) if target_node is not None else {}
+    attributes = attributes if isinstance(attributes, Mapping) else {}
+    completeness = _path_completeness(path)
+
+    reachability_value = str(path.reachability or "").lower()
+    reachability_basis = [str(item) for item in path.reachability_basis if str(item)]
+    if (
+        reachability_value in {"confirmed", "likely", "unlikely"}
+        and reachability_basis
+        and completeness["status"] in {"complete", "partial"}
+    ):
+        reachability = {
+            "status": completeness["status"],
+            "verdict": reachability_value,
+            "basis": reachability_basis,
+        }
+        if completeness["status"] == "partial":
+            reachability["reasonCodes"] = list(completeness["reasonCodes"])
+    else:
+        reachability = _unavailable_dimension("reachability_not_assessed", verdict=None)
+
+    explicit_exploitability = str(attributes.get("exploitability") or "").lower()
+    if explicit_exploitability in {"exploitable", "not_exploitable"}:
+        exploitability = {
+            "status": "complete",
+            "verdict": explicit_exploitability,
+            "basis": ["finding_attribute:exploitability"],
+        }
+    elif attributes.get("network_exploitable") is True:
+        exploitability = {
+            "status": "complete",
+            "verdict": "exploitable",
+            "basis": ["finding_attribute:network_exploitable"],
+        }
+    else:
+        exploitability = _unavailable_dimension("exploitability_not_assessed", verdict=None)
+
+    impact_category = str(attributes.get("impact_category") or "").strip()
+    impact = (
+        {
+            "status": "complete",
+            "category": impact_category,
+            "basis": ["finding_attribute:impact_category"],
+        }
+        if impact_category
+        else _unavailable_dimension("impact_not_assessed", category=None)
+    )
+
+    explicit_actionability = attributes.get("actionability")
+    if isinstance(explicit_actionability, bool):
+        actionability = {
+            "status": "complete",
+            "actionable": explicit_actionability,
+            "basis": ["finding_attribute:actionability"],
+        }
+    elif attributes.get("actionable") is True:
+        actionability = {
+            "status": "complete",
+            "actionable": True,
+            "basis": ["finding_attribute:actionable"],
+        }
+    elif attributes.get("fixed_version") or attributes.get("remediation"):
+        actionability = {
+            "status": "complete",
+            "actionable": True,
+            "basis": ["finding_remediation_evidence"],
+        }
+    else:
+        actionability = _unavailable_dimension("actionability_not_assessed", actionable=None)
+
+    return {
+        "reachability": reachability,
+        "exploitability": exploitability,
+        "impact": impact,
+        "actionability": actionability,
+        "completeness": completeness,
+    }
+
+
+__all__ = ["annotate_attack_path_evidence", "exposure_evidence_dimensions"]

--- a/src/agent_bom/mcp_tools/graph.py
+++ b/src/agent_bom/mcp_tools/graph.py
@@ -9,6 +9,7 @@ import uuid
 from typing import Any
 
 from agent_bom.graph.completeness import graph_completeness
+from agent_bom.graph.path_evidence import exposure_evidence_dimensions
 from agent_bom.graph.severity import severity_rank
 from agent_bom.mcp_errors import (
     CODE_INTERNAL_UNEXPECTED,
@@ -188,6 +189,8 @@ def _relationship_refs(path: Any, edges: list[Any]) -> list[dict[str, Any]]:
                 "source": source,
                 "target": target,
                 "relationship": relationship_value,
+                "direction": str(getattr(edge, "direction", "")) or "unknown",
+                "traversable": bool(getattr(edge, "traversable", False)),
                 "confidence": float(getattr(edge, "confidence", 1.0) or 0.0),
             }
         )
@@ -203,14 +206,7 @@ def _severity_for_path(path: Any, nodes_by_id: dict[str, Any]) -> str:
             severity = candidate
     if severity:
         return severity
-    risk = float(getattr(path, "composite_risk", 0.0) or 0.0)
-    if risk >= 90 or risk >= 9:
-        return "critical"
-    if risk >= 70 or risk >= 7:
-        return "high"
-    if risk >= 40 or risk >= 4:
-        return "medium"
-    return "none"
+    return "unknown"
 
 
 def _exposure_path_payload(path: Any, *, nodes_by_id: dict[str, Any], edges: list[Any], rank: int, scan_id: str) -> dict[str, Any]:
@@ -218,6 +214,7 @@ def _exposure_path_payload(path: Any, *, nodes_by_id: dict[str, Any], edges: lis
     source = _node_ref(str(getattr(path, "source", "") or ""), nodes_by_id) if getattr(path, "source", "") else (hops[0] if hops else {})
     target = _node_ref(str(getattr(path, "target", "") or ""), nodes_by_id) if getattr(path, "target", "") else (hops[-1] if hops else {})
     relationships = _relationship_refs(path, edges)
+    target_node = nodes_by_id.get(str(getattr(path, "target", "") or ""))
     return {
         "id": f"{source.get('id', '')}::{target.get('id', '')}::{'->'.join(getattr(path, 'hops', []) or [])}",
         "rank": rank,
@@ -234,6 +231,9 @@ def _exposure_path_payload(path: Any, *, nodes_by_id: dict[str, Any], edges: lis
         "findings": list(getattr(path, "vuln_ids", []) or []),
         "reachableTools": list(getattr(path, "tool_exposure", []) or []),
         "exposedCredentials": list(getattr(path, "credential_exposure", []) or []),
+        "reachability": str(getattr(path, "reachability", "unknown") or "unknown"),
+        "reachabilityBasis": list(getattr(path, "reachability_basis", []) or []),
+        "evidenceDimensions": exposure_evidence_dimensions(path, target_node),
         "provenance": {"source": "mcp_exposure_paths", "scanId": scan_id},
     }
 

--- a/tests/test_exposure_path_evidence_parity.py
+++ b/tests/test_exposure_path_evidence_parity.py
@@ -1,0 +1,123 @@
+"""Exposure-path surfaces preserve independent, server-authored evidence."""
+
+from agent_bom.api.routes.graph import _exposure_path_for_attack_path
+from agent_bom.graph import AttackPath, EntityType, RelationshipType, UnifiedEdge, UnifiedNode
+from agent_bom.mcp_tools.graph import _exposure_path_payload
+
+
+def _serialize_both(
+    path: AttackPath,
+    *,
+    nodes: list[UnifiedNode],
+    edges: list[UnifiedEdge],
+) -> tuple[dict, dict]:
+    nodes_by_id = {node.id: node for node in nodes}
+    return (
+        _exposure_path_payload(path, nodes_by_id=nodes_by_id, edges=edges, rank=1, scan_id="scan-1"),
+        _exposure_path_for_attack_path(path, nodes_by_id=nodes_by_id, edges=edges, rank=1, scan_id="scan-1"),
+    )
+
+
+def test_exposure_path_surfaces_carry_independent_evidence_dimensions() -> None:
+    target = UnifiedNode(
+        id="vuln:cve",
+        entity_type=EntityType.VULNERABILITY,
+        label="CVE-2026-1",
+        severity="high",
+        attributes={
+            "network_exploitable": True,
+            "impact_category": "code-execution",
+            "actionable": True,
+            "is_kev": True,
+        },
+    )
+    path = AttackPath(
+        source="agent:a",
+        target=target.id,
+        hops=["agent:a", target.id],
+        edges=["vulnerable_to"],
+        composite_risk=99.0,
+        reachability="confirmed",
+        reachability_basis=["directed_provenance_backed_hops"],
+        hop_evidence=[
+            {
+                "source_node_id": "agent:a",
+                "target_node_id": target.id,
+                "relationship": "vulnerable_to",
+                "complete": True,
+                "truncated": False,
+            }
+        ],
+        analysis={"status": "complete", "reason_codes": [], "limits": {}, "observed": {"hop_count": 1}},
+    )
+    edge = UnifiedEdge(
+        source="agent:a",
+        target=target.id,
+        relationship=RelationshipType.VULNERABLE_TO,
+        traversable=False,
+    )
+
+    for payload in _serialize_both(path, nodes=[target], edges=[edge]):
+        dimensions = payload["evidenceDimensions"]
+        assert dimensions["reachability"] == {
+            "status": "complete",
+            "verdict": "confirmed",
+            "basis": ["directed_provenance_backed_hops"],
+        }
+        assert dimensions["exploitability"]["verdict"] == "exploitable"
+        assert dimensions["impact"]["category"] == "code-execution"
+        assert dimensions["actionability"]["actionable"] is True
+        assert dimensions["completeness"]["status"] == "complete"
+        assert payload["relationships"][0]["traversable"] is False
+
+
+def test_missing_path_evidence_stays_unavailable_and_does_not_alias_risk() -> None:
+    target = UnifiedNode(
+        id="vuln:cve",
+        entity_type=EntityType.VULNERABILITY,
+        label="CVE-2026-1",
+        risk_score=99.0,
+    )
+    path = AttackPath(
+        source="agent:a",
+        target=target.id,
+        hops=["agent:a", target.id],
+        edges=["vulnerable_to"],
+        composite_risk=99.0,
+    )
+
+    for payload in _serialize_both(path, nodes=[target], edges=[]):
+        dimensions = payload["evidenceDimensions"]
+        assert dimensions["reachability"]["status"] == "unavailable"
+        assert dimensions["reachability"]["verdict"] is None
+        assert dimensions["exploitability"]["status"] == "unavailable"
+        assert dimensions["exploitability"]["verdict"] is None
+        assert dimensions["impact"] == {
+            "status": "unavailable",
+            "category": None,
+            "basis": [],
+            "reasonCodes": ["impact_not_assessed"],
+        }
+        assert dimensions["actionability"]["actionable"] is None
+        assert dimensions["completeness"]["status"] == "unavailable"
+        assert payload["severity"] == "unknown"
+        assert payload["relationships"] == []
+
+    api_payload = _serialize_both(path, nodes=[target], edges=[])[1]
+    assert api_payload["evidence"]["isKev"] is None
+    assert api_payload["evidence"]["networkExploitable"] is None
+
+
+def test_path_relationship_names_do_not_fabricate_edges_or_traversability() -> None:
+    path = AttackPath(
+        source="agent:a",
+        target="vuln:cve",
+        hops=["agent:a", "vuln:cve"],
+        edges=["vulnerable_to"],
+        reachability="confirmed",
+        reachability_basis=["graph_path"],
+    )
+
+    for payload in _serialize_both(path, nodes=[], edges=[]):
+        assert payload["relationships"] == []
+        assert payload["edgeIds"] == []

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -1724,7 +1724,8 @@ class TestGraphStoreBackendSelection:
         assert body["attack_paths"][0]["tool_exposure"] == ["run_shell"]
         assert body["attack_paths"][0]["exposure_path"]["source"]["id"] == "agent:a"
         assert body["attack_paths"][0]["exposure_path"]["target"]["id"] == "vuln:cve"
-        assert body["attack_paths"][0]["exposure_path"]["severity"] == "high"
+        assert body["attack_paths"][0]["exposure_path"]["riskScore"] == 8.8
+        assert body["attack_paths"][0]["exposure_path"]["severity"] == "unknown"
         assert body["stats"]["analysis_status"]["attack_path_fusion"]["status"] == "limited"
         assert attack_path_response.json()["stats"]["analysis_status"]["attack_path_fusion"]["status"] == "limited"
         assert ("latest_snapshot_id", "default", "scan") in recording_graph_store.calls


### PR DESCRIPTION
Summary
- return evidence dimensions and unavailable semantics from the canonical path evidence contract
- prevent serializers from fabricating traversable vulnerable_to edges
- keep evidence basis, provenance, and path status aligned across graph API and MCP output

Verification
- uv run pytest -q tests/test_exposure_path_evidence_parity.py tests/test_graph_api.py (70 passed)
- 98 related graph/evidence tests and 10 MCP exposure tests passed on the source commit
- targeted Ruff, formatting, mypy, relevant preflight stages, and diff checks passed on the source commit

Notes
- mechanical output-parity lane; it does not broaden reachability or exploitability claims