### PR TITLE
feat(cloud): normalize provider resource inventories

### DIFF
--- a/src/agent_bom/cloud/resource_model.py
+++ b/src/agent_bom/cloud/resource_model.py
@@ -5,14 +5,14 @@ Each provider's inventory historically emitted its own dict shape
 different keys for AWS/GCP). That makes the graph, CIS, and findings layers
 re-learn every provider's vocabulary and blocks cross-cloud normalization.
 
-:class:`CloudResource` is the single shape every provider maps onto. Adapters
-translate native resources into normalized ones (``provider`` + normalized
-:class:`CloudResourceType` + the native type string for provenance); downstream
-consumers read the normalized fields and never the provider-specific dicts.
+:class:`CloudResource` is the provider-neutral shape each provider can map onto.
+Adapters translate native resources into normalized ones (``provider`` +
+normalized :class:`CloudResourceType` + the native type string for provenance),
+letting downstream consumers migrate off provider-specific dicts incrementally.
 
 This module is additive — it does not change existing inventory output. It
-provides the normalized *view* that later phases (graph ingestion, gap-fill,
-AWS/GCP adapters) consume.
+provides the normalized *view* that later phases (graph ingestion and gap-fill)
+consume.
 """
 
 from __future__ import annotations
@@ -50,6 +50,7 @@ class CloudResourceType(str, Enum):
     AI_SERVICE = "ai_service"  # Azure OpenAI / Bedrock / Vertex
     AI_MODEL_DEPLOYMENT = "ai_model_deployment"
     ML_WORKSPACE = "ml_workspace"  # Azure ML / SageMaker / Vertex Workbench
+    DATA_WAREHOUSE = "data_warehouse"  # Redshift / Snowflake warehouse
     OTHER = "other"
 
 
@@ -62,7 +63,7 @@ class CloudResource:
     ``resource_type`` is the normalized category consumers branch on.
     """
 
-    provider: str  # "azure" | "aws" | "gcp"
+    provider: str  # "azure" | "aws" | "gcp" | "snowflake"
     resource_type: CloudResourceType
     native_type: str
     resource_id: str  # provider-native id / ARN / self-link
@@ -87,6 +88,19 @@ class CloudResource:
             "tags": dict(self.tags),
             "owner": self.owner,
         }
+
+
+@dataclass(frozen=True)
+class _CollectionAdapter:
+    """Declarative mapping from one native inventory collection."""
+
+    resource_type: CloudResourceType
+    native_type: str
+    id_fields: tuple[str, ...]
+    name_fields: tuple[str, ...] = ("name",)
+    region_fields: tuple[str, ...] = ("region", "location", "zone")
+    resource_group_fields: tuple[str, ...] = ("resource_group",)
+    native_type_field: str = ""
 
 
 # Native Azure inventory collection -> (normalized type, native type string).
@@ -151,16 +165,272 @@ def normalize_azure_inventory(inventory: dict[str, Any]) -> list[CloudResource]:
     return resources
 
 
+_AWS_COLLECTION_MAP: dict[str, _CollectionAdapter] = {
+    "buckets": _CollectionAdapter(CloudResourceType.OBJECT_STORE, "AWS::S3::Bucket", ("arn", "id", "name")),
+    "instances": _CollectionAdapter(
+        CloudResourceType.COMPUTE_INSTANCE,
+        "AWS::EC2::Instance",
+        ("instance_id", "arn", "id", "name"),
+    ),
+    "security_groups": _CollectionAdapter(
+        CloudResourceType.NETWORK_SECURITY_GROUP,
+        "AWS::EC2::SecurityGroup",
+        ("group_id", "arn", "id", "name"),
+    ),
+    "roles": _CollectionAdapter(CloudResourceType.MANAGED_IDENTITY, "AWS::IAM::Role", ("arn", "role_id", "id", "name")),
+    "rds_instances": _CollectionAdapter(
+        CloudResourceType.DATABASE,
+        "AWS::RDS::DBInstance",
+        ("db_instance_arn", "arn", "db_instance_identifier", "id", "name"),
+    ),
+    "lambda_functions": _CollectionAdapter(
+        CloudResourceType.SERVERLESS_FUNCTION,
+        "AWS::Lambda::Function",
+        ("function_arn", "arn", "id", "name"),
+    ),
+    "dynamodb_tables": _CollectionAdapter(
+        CloudResourceType.DATABASE,
+        "AWS::DynamoDB::Table",
+        ("table_arn", "arn", "id", "name"),
+    ),
+    "eks_clusters": _CollectionAdapter(
+        CloudResourceType.CONTAINER_CLUSTER,
+        "AWS::EKS::Cluster",
+        ("arn", "id", "name"),
+    ),
+    "elb_load_balancers": _CollectionAdapter(
+        CloudResourceType.LOAD_BALANCER,
+        "AWS::ElasticLoadBalancingV2::LoadBalancer",
+        ("load_balancer_arn", "arn", "id", "name"),
+    ),
+    "vpcs": _CollectionAdapter(CloudResourceType.VIRTUAL_NETWORK, "AWS::EC2::VPC", ("vpc_id", "arn", "id", "name")),
+    "secrets": _CollectionAdapter(
+        CloudResourceType.SECRET_STORE,
+        "AWS::SecretsManager::Secret",
+        ("arn", "id", "name"),
+    ),
+    "ecr_repositories": _CollectionAdapter(
+        CloudResourceType.CONTAINER_REGISTRY,
+        "AWS::ECR::Repository",
+        ("repository_arn", "arn", "uri", "id", "name"),
+    ),
+    "redshift_clusters": _CollectionAdapter(
+        CloudResourceType.DATA_WAREHOUSE,
+        "AWS::Redshift::Cluster",
+        ("arn", "cluster_identifier", "id", "name"),
+    ),
+    "messaging": _CollectionAdapter(CloudResourceType.MESSAGING, "AWS::Messaging::Endpoint", ("arn", "url", "id", "name")),
+    "api_gateways": _CollectionAdapter(
+        CloudResourceType.LOAD_BALANCER,
+        "AWS::ApiGateway::RestApi",
+        ("arn", "id", "name"),
+    ),
+    "ip_addresses": _CollectionAdapter(
+        CloudResourceType.PUBLIC_IP,
+        "AWS::EC2::EIP",
+        ("allocation_id", "public_ip", "id", "name"),
+    ),
+}
+
+
+_GCP_COLLECTION_MAP: dict[str, _CollectionAdapter] = {
+    "buckets": _CollectionAdapter(CloudResourceType.OBJECT_STORE, "storage.googleapis.com/Bucket", ("id", "self_link", "name")),
+    "instances": _CollectionAdapter(
+        CloudResourceType.COMPUTE_INSTANCE,
+        "compute.googleapis.com/Instance",
+        ("id", "self_link", "instance_id", "name"),
+    ),
+    "firewalls": _CollectionAdapter(
+        CloudResourceType.NETWORK_SECURITY_GROUP,
+        "compute.googleapis.com/Firewall",
+        ("id", "self_link", "name"),
+    ),
+    "service_accounts": _CollectionAdapter(
+        CloudResourceType.MANAGED_IDENTITY,
+        "iam.googleapis.com/ServiceAccount",
+        ("email", "arn", "principal_id", "id", "name"),
+    ),
+    "gke_clusters": _CollectionAdapter(
+        CloudResourceType.CONTAINER_CLUSTER,
+        "container.googleapis.com/Cluster",
+        ("id", "self_link", "name"),
+    ),
+    "cloud_run_services": _CollectionAdapter(
+        CloudResourceType.CONTAINER_APP,
+        "run.googleapis.com/Service",
+        ("id", "self_link", "name"),
+    ),
+    "cloud_functions": _CollectionAdapter(
+        CloudResourceType.SERVERLESS_FUNCTION,
+        "cloudfunctions.googleapis.com/Function",
+        ("id", "self_link", "name"),
+    ),
+    "cloud_sql_instances": _CollectionAdapter(
+        CloudResourceType.DATABASE,
+        "sqladmin.googleapis.com/DatabaseInstance",
+        ("id", "self_link", "name"),
+    ),
+    "vpc_networks": _CollectionAdapter(
+        CloudResourceType.VIRTUAL_NETWORK,
+        "compute.googleapis.com/Network",
+        ("id", "self_link", "name"),
+    ),
+    "load_balancers": _CollectionAdapter(
+        CloudResourceType.LOAD_BALANCER,
+        "compute.googleapis.com/LoadBalancer",
+        ("id", "self_link", "name"),
+    ),
+    "api_gateways": _CollectionAdapter(
+        CloudResourceType.LOAD_BALANCER,
+        "apigateway.googleapis.com/Gateway",
+        ("id", "self_link", "name"),
+    ),
+    "ip_addresses": _CollectionAdapter(
+        CloudResourceType.PUBLIC_IP,
+        "compute.googleapis.com/Address",
+        ("id", "self_link", "address", "name"),
+    ),
+    "disks": _CollectionAdapter(
+        CloudResourceType.BLOCK_STORAGE,
+        "compute.googleapis.com/Disk",
+        ("id", "self_link", "name"),
+    ),
+    "pubsub_topics": _CollectionAdapter(
+        CloudResourceType.MESSAGING,
+        "pubsub.googleapis.com/Topic",
+        ("id", "self_link", "name"),
+    ),
+}
+
+
+_SNOWFLAKE_COLLECTION_MAP: dict[str, _CollectionAdapter] = {
+    "warehouses": _CollectionAdapter(CloudResourceType.DATA_WAREHOUSE, "SNOWFLAKE::WAREHOUSE", ("id", "name")),
+    "databases": _CollectionAdapter(CloudResourceType.DATABASE, "SNOWFLAKE::DATABASE", ("id", "name")),
+    "schemas": _CollectionAdapter(
+        CloudResourceType.DATABASE,
+        "SNOWFLAKE::SCHEMA",
+        ("fqn", "id", "name"),
+        resource_group_fields=("database_name", "database"),
+    ),
+    "objects": _CollectionAdapter(
+        CloudResourceType.DATABASE,
+        "SNOWFLAKE::OBJECT",
+        ("fqn", "id", "name"),
+        resource_group_fields=("schema", "database"),
+        native_type_field="object_type",
+    ),
+}
+
+
+def _first_text(item: dict[str, Any], fields: tuple[str, ...]) -> str:
+    for field_name in fields:
+        value = item.get(field_name)
+        if value not in (None, ""):
+            return str(value).strip()
+    return ""
+
+
+def _resource_tags(item: dict[str, Any]) -> dict[str, str]:
+    raw_tags = item.get("tags")
+    if not isinstance(raw_tags, dict):
+        raw_tags = item.get("labels")
+    if not isinstance(raw_tags, dict):
+        return {}
+    return {str(key): str(value) for key, value in raw_tags.items()}
+
+
+def _normalize_collections(
+    inventory: dict[str, Any],
+    *,
+    provider: str,
+    collection_map: dict[str, _CollectionAdapter],
+    account_fields: tuple[str, ...],
+) -> list[CloudResource]:
+    """Apply declarative native-collection mappings without mutating input."""
+    default_account = _first_text(inventory, account_fields)
+    default_region = _first_text(inventory, ("region", "location"))
+    resources: list[CloudResource] = []
+    for collection, adapter in collection_map.items():
+        for item in inventory.get(collection, []) or []:
+            if not isinstance(item, dict):
+                continue
+            resource_id = _first_text(item, adapter.id_fields)
+            name = _first_text(item, adapter.name_fields)
+            if not resource_id and not name:
+                continue
+            tags = _resource_tags(item)
+            native_type = str(item.get("native_type") or adapter.native_type)
+            if adapter.native_type_field:
+                item_native_type = str(item.get(adapter.native_type_field) or "").strip()
+                if item_native_type:
+                    native_type = f"{provider.upper()}::{item_native_type.upper()}"
+            resources.append(
+                CloudResource(
+                    provider=provider,
+                    resource_type=adapter.resource_type,
+                    native_type=native_type,
+                    resource_id=resource_id,
+                    name=name,
+                    account=_first_text(item, account_fields) or default_account,
+                    region=_first_text(item, adapter.region_fields) or default_region,
+                    resource_group=_first_text(item, adapter.resource_group_fields),
+                    tags=tags,
+                    owner=str(item.get("owner") or tags.get("owner") or tags.get("Owner") or ""),
+                    raw=item,
+                )
+            )
+    return resources
+
+
+def normalize_aws_inventory(inventory: dict[str, Any]) -> list[CloudResource]:
+    """Map the current AWS estate inventory collections onto ``CloudResource``."""
+    return _normalize_collections(
+        inventory,
+        provider="aws",
+        collection_map=_AWS_COLLECTION_MAP,
+        account_fields=("account_id", "account"),
+    )
+
+
+def normalize_gcp_inventory(inventory: dict[str, Any]) -> list[CloudResource]:
+    """Map the current GCP estate inventory collections onto ``CloudResource``."""
+    return _normalize_collections(
+        inventory,
+        provider="gcp",
+        collection_map=_GCP_COLLECTION_MAP,
+        account_fields=("project_id", "account_id", "account"),
+    )
+
+
+def normalize_snowflake_inventory(inventory: dict[str, Any]) -> list[CloudResource]:
+    """Map a Snowflake services/object payload onto ``CloudResource``.
+
+    Snowflake currently reaches the graph through separate ``snowflake_*``
+    report blocks rather than ``cloud_inventory``. This adapter accepts either
+    block after the caller stamps ``provider=snowflake`` and also supports a
+    combined payload; graph migration remains a separate change.
+    """
+    return _normalize_collections(
+        inventory,
+        provider="snowflake",
+        collection_map=_SNOWFLAKE_COLLECTION_MAP,
+        account_fields=("account", "account_id"),
+    )
+
+
 _PROVIDER_NORMALIZERS = {
+    "aws": normalize_aws_inventory,
     "azure": normalize_azure_inventory,
+    "gcp": normalize_gcp_inventory,
+    "snowflake": normalize_snowflake_inventory,
 }
 
 
 def normalize_cloud_inventory(inventory: dict[str, Any]) -> list[CloudResource]:
     """Dispatch to the per-provider normalizer based on ``inventory['provider']``.
 
-    Returns an empty list for providers without a normalizer yet (AWS/GCP land
-    here until their adapters are added), so callers can rely on the shape.
+    Returns an empty list for unknown providers so callers can rely on the
+    result shape without guessing provider semantics.
     """
     provider = str(inventory.get("provider") or "").lower()
     normalizer = _PROVIDER_NORMALIZERS.get(provider)

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -5362,16 +5362,20 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
                     )
 
     # ── Data / secret / registry / network resources (normalized model) ──
-    _add_normalized_cloud_resources(
-        graph,
-        original_inventory,
-        provider=provider,
-        account_id=account_id,
-        account_node_id=account_node_id,
-        region=region,
-        data_sources=data_sources,
-        resource_ids=resource_ids,
-    )
+    # AWS and GCP still use the dedicated builder loops above. Their normalized
+    # adapters are an additive contract until those paths are migrated; feeding
+    # them through this Azure gap-fill path would double-emit the same resource.
+    if provider == "azure":
+        _add_normalized_cloud_resources(
+            graph,
+            original_inventory,
+            provider=provider,
+            account_id=account_id,
+            account_node_id=account_node_id,
+            region=region,
+            data_sources=data_sources,
+            resource_ids=resource_ids,
+        )
 
     # ── Network edge: WAF, API gateways, ENIs/NICs, subnets, NAT/IGW, IPs ──
     _add_network_edge_inventory(

--- a/tests/cloud/test_cloud_resource_model.py
+++ b/tests/cloud/test_cloud_resource_model.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from agent_bom.cloud.resource_model import (
     CloudResource,
     CloudResourceType,
@@ -96,3 +98,155 @@ def test_network_topology_normalizes_to_shared_types() -> None:
     assert by_type[CloudResourceType.VIRTUAL_NETWORK].native_type == "Microsoft.Network/virtualNetworks"
     assert by_type[CloudResourceType.PUBLIC_IP].raw["ip_address"] == "1.2.3.4"
     assert by_type[CloudResourceType.LOAD_BALANCER].native_type == "Microsoft.Network/loadBalancers"
+
+
+_PROVIDER_INVENTORIES = {
+    "aws": {
+        "provider": "aws",
+        "account_id": "123456789012",
+        "region": "us-east-1",
+        "buckets": [{"name": "evidence", "arn": "arn:aws:s3:::evidence", "tags": {"environment": "prod"}}],
+        "rds_instances": [
+            {
+                "name": "orders",
+                "db_instance_arn": "arn:aws:rds:us-east-1:123456789012:db:orders",
+                "tags": {"owner": "data"},
+            }
+        ],
+        "redshift_clusters": [{"name": "analytics", "cluster_identifier": "analytics"}],
+        "roles": [{"name": "scanner", "arn": "arn:aws:iam::123456789012:role/scanner"}],
+    },
+    "gcp": {
+        "provider": "gcp",
+        "project_id": "project-1",
+        "account_id": "project-1",
+        "region": "us-central1",
+        "buckets": [{"name": "evidence", "id": "project-1/evidence", "labels": {"environment": "prod"}}],
+        "cloud_sql_instances": [
+            {
+                "name": "orders",
+                "id": "projects/project-1/instances/orders",
+                "location": "us-central1",
+                "labels": {"owner": "data"},
+            }
+        ],
+        "service_accounts": [{"name": "scanner", "email": "scanner@project-1.iam.gserviceaccount.com"}],
+    },
+    "snowflake": {
+        "provider": "snowflake",
+        "account": "ACME_PROD",
+        "warehouses": [{"name": "ANALYTICS", "owner": "SYSADMIN"}],
+        "databases": [{"name": "ORDERS", "owner": "DATA_ADMIN"}],
+        "schemas": [{"name": "PUBLIC", "database_name": "ORDERS", "fqn": "ORDERS.PUBLIC"}],
+        "objects": [
+            {
+                "name": "CUSTOMERS",
+                "database": "ORDERS",
+                "schema": "PUBLIC",
+                "fqn": "ORDERS.PUBLIC.CUSTOMERS",
+                "object_type": "TABLE",
+            }
+        ],
+    },
+}
+
+
+@pytest.mark.parametrize("provider", sorted(_PROVIDER_INVENTORIES))
+def test_dispatch_normalizes_each_shipped_cloud_provider(provider: str) -> None:
+    resources = normalize_cloud_inventory(_PROVIDER_INVENTORIES[provider])
+
+    assert resources, f"{provider} returned no normalized resources"
+    assert {resource.provider for resource in resources} == {provider}
+    assert {resource.account for resource in resources} == {
+        "123456789012" if provider == "aws" else "project-1" if provider == "gcp" else "ACME_PROD"
+    }
+    assert all(resource.resource_id or resource.name for resource in resources)
+    assert all(resource.native_type for resource in resources)
+
+
+def test_database_and_analytics_warehouse_types_are_provider_neutral() -> None:
+    resources = {provider: normalize_cloud_inventory(inventory) for provider, inventory in _PROVIDER_INVENTORIES.items()}
+
+    for provider in ("aws", "gcp", "snowflake"):
+        assert any(resource.resource_type is CloudResourceType.DATABASE for resource in resources[provider])
+    assert any(resource.resource_type is CloudResourceType.DATA_WAREHOUSE for resource in resources["aws"])
+    assert any(resource.resource_type is CloudResourceType.DATA_WAREHOUSE for resource in resources["snowflake"])
+
+
+def test_provider_specific_identity_and_metadata_map_to_one_contract() -> None:
+    aws = normalize_cloud_inventory(_PROVIDER_INVENTORIES["aws"])
+    gcp = normalize_cloud_inventory(_PROVIDER_INVENTORIES["gcp"])
+    snowflake = normalize_cloud_inventory(_PROVIDER_INVENTORIES["snowflake"])
+
+    aws_role = next(resource for resource in aws if resource.name == "scanner")
+    gcp_service_account = next(resource for resource in gcp if resource.name == "scanner")
+    assert aws_role.resource_type is CloudResourceType.MANAGED_IDENTITY
+    assert gcp_service_account.resource_type is CloudResourceType.MANAGED_IDENTITY
+    assert gcp_service_account.resource_id == "scanner@project-1.iam.gserviceaccount.com"
+
+    aws_bucket = next(resource for resource in aws if resource.name == "evidence")
+    gcp_bucket = next(resource for resource in gcp if resource.name == "evidence")
+    assert aws_bucket.resource_type is gcp_bucket.resource_type is CloudResourceType.OBJECT_STORE
+    assert aws_bucket.tags == gcp_bucket.tags == {"environment": "prod"}
+
+    sf_schema = next(resource for resource in snowflake if resource.name == "PUBLIC")
+    sf_table = next(resource for resource in snowflake if resource.name == "CUSTOMERS")
+    assert sf_schema.resource_id == "ORDERS.PUBLIC"
+    assert sf_table.resource_id == "ORDERS.PUBLIC.CUSTOMERS"
+    assert sf_table.native_type == "SNOWFLAKE::TABLE"
+
+
+@pytest.mark.parametrize(
+    ("provider", "collection", "expected_type"),
+    [
+        ("aws", "buckets", CloudResourceType.OBJECT_STORE),
+        ("aws", "instances", CloudResourceType.COMPUTE_INSTANCE),
+        ("aws", "security_groups", CloudResourceType.NETWORK_SECURITY_GROUP),
+        ("aws", "roles", CloudResourceType.MANAGED_IDENTITY),
+        ("aws", "rds_instances", CloudResourceType.DATABASE),
+        ("aws", "lambda_functions", CloudResourceType.SERVERLESS_FUNCTION),
+        ("aws", "dynamodb_tables", CloudResourceType.DATABASE),
+        ("aws", "eks_clusters", CloudResourceType.CONTAINER_CLUSTER),
+        ("aws", "elb_load_balancers", CloudResourceType.LOAD_BALANCER),
+        ("aws", "vpcs", CloudResourceType.VIRTUAL_NETWORK),
+        ("aws", "secrets", CloudResourceType.SECRET_STORE),
+        ("aws", "ecr_repositories", CloudResourceType.CONTAINER_REGISTRY),
+        ("aws", "redshift_clusters", CloudResourceType.DATA_WAREHOUSE),
+        ("aws", "messaging", CloudResourceType.MESSAGING),
+        ("aws", "api_gateways", CloudResourceType.LOAD_BALANCER),
+        ("aws", "ip_addresses", CloudResourceType.PUBLIC_IP),
+        ("gcp", "buckets", CloudResourceType.OBJECT_STORE),
+        ("gcp", "instances", CloudResourceType.COMPUTE_INSTANCE),
+        ("gcp", "firewalls", CloudResourceType.NETWORK_SECURITY_GROUP),
+        ("gcp", "service_accounts", CloudResourceType.MANAGED_IDENTITY),
+        ("gcp", "gke_clusters", CloudResourceType.CONTAINER_CLUSTER),
+        ("gcp", "cloud_run_services", CloudResourceType.CONTAINER_APP),
+        ("gcp", "cloud_functions", CloudResourceType.SERVERLESS_FUNCTION),
+        ("gcp", "cloud_sql_instances", CloudResourceType.DATABASE),
+        ("gcp", "vpc_networks", CloudResourceType.VIRTUAL_NETWORK),
+        ("gcp", "load_balancers", CloudResourceType.LOAD_BALANCER),
+        ("gcp", "api_gateways", CloudResourceType.LOAD_BALANCER),
+        ("gcp", "ip_addresses", CloudResourceType.PUBLIC_IP),
+        ("gcp", "disks", CloudResourceType.BLOCK_STORAGE),
+        ("gcp", "pubsub_topics", CloudResourceType.MESSAGING),
+        ("snowflake", "warehouses", CloudResourceType.DATA_WAREHOUSE),
+        ("snowflake", "databases", CloudResourceType.DATABASE),
+        ("snowflake", "schemas", CloudResourceType.DATABASE),
+        ("snowflake", "objects", CloudResourceType.DATABASE),
+    ],
+)
+def test_every_mapped_collection_has_an_explicit_provider_neutral_type(
+    provider: str,
+    collection: str,
+    expected_type: CloudResourceType,
+) -> None:
+    inventory = {
+        "provider": provider,
+        "account_id": "account-1",
+        collection: [{"name": "resource-1"}],
+    }
+
+    resources = normalize_cloud_inventory(inventory)
+
+    assert len(resources) == 1
+    assert resources[0].resource_type is expected_type

--- a/tests/test_graph_cloud_resource_ingestion.py
+++ b/tests/test_graph_cloud_resource_ingestion.py
@@ -8,6 +8,8 @@ attack-path analysis.
 
 from __future__ import annotations
 
+import pytest
+
 from agent_bom.graph.builder import build_unified_graph_from_report
 
 
@@ -110,3 +112,38 @@ def test_public_ip_exposed_to_load_balancer_edge() -> None:
     lb_node = "cloud_resource:azure:load_balancer:lb"
     exposed = [e for e in edges if e.relationship.value == "exposed_to" and e.source == pip_node and e.target == lb_node]
     assert exposed, "no EXPOSED_TO edge from public IP to the load balancer it fronts"
+
+
+@pytest.mark.parametrize(
+    ("inventory", "dedicated_node", "duplicate_node"),
+    [
+        (
+            {
+                "provider": "aws",
+                "status": "ok",
+                "account_id": "123456789012",
+                "region": "us-east-1",
+                "rds_instances": [{"name": "orders", "arn": "arn:aws:rds:us-east-1:123456789012:db:orders"}],
+            },
+            "cloud_resource:aws:rds:database:orders",
+            "cloud_resource:aws:database:orders",
+        ),
+        (
+            {
+                "provider": "gcp",
+                "status": "ok",
+                "project_id": "project-1",
+                "account_id": "project-1",
+                "cloud_sql_instances": [{"name": "orders", "id": "projects/project-1/instances/orders"}],
+            },
+            "cloud_resource:gcp:cloudsql:database:orders",
+            "cloud_resource:gcp:database:orders",
+        ),
+    ],
+)
+def test_normalized_views_do_not_double_emit_builder_specific_resources(inventory: dict, dedicated_node: str, duplicate_node: str) -> None:
+    """Adapters are additive until each provider's builder path is migrated."""
+    graph = build_unified_graph_from_report({"cloud_inventory": [inventory]})
+
+    assert dedicated_node in graph.nodes
+    assert duplicate_node not in graph.nodes


### PR DESCRIPTION
Summary
- add a canonical provider-neutral cloud resource model with stable IDs and native references
- normalize AWS, Azure, GCP, and SaaS resource facts for graph ingestion while preserving source and freshness
- keep Snowflake and permission semantics as separate explicit lanes

Verification
- uv run pytest -q tests/cloud/test_cloud_resource_model.py tests/test_graph_cloud_resource_ingestion.py (52 passed)
- adjacent AWS/GCP/Azure/Snowflake/resource/graph suite (149 passed) on the source commit
- Ruff, formatting, mypy, and diff checks passed on the source commit

Notes
- additive normalization adapter; no connector or graph-builder rewrite