### PR TITLE
fix(ci): enforce bounded npm advisory batches

### DIFF
--- a/scripts/check_npm_advisories.py
+++ b/scripts/check_npm_advisories.py
@@ -10,6 +10,7 @@ import json
 import sys
 import time
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
@@ -19,7 +20,9 @@ VALID_SEVERITIES = {"info", "low", "moderate", "high", "critical"}
 MAX_COMPRESSED_RESPONSE_BYTES = 8 * 1024 * 1024
 MAX_DECOMPRESSED_RESPONSE_BYTES = 32 * 1024 * 1024
 MAX_REQUEST_BODY_BYTES = 2 * 1024 * 1024
-REQUEST_TIMEOUT_SECONDS = 120
+PACKAGE_BATCH_SIZE = 50
+MAX_WORKERS = 4
+REQUEST_TIMEOUT_SECONDS = 30
 MAX_REQUEST_ATTEMPTS = 3
 
 
@@ -123,8 +126,8 @@ def _fetch_once(payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]]
     return report
 
 
-def fetch_report(payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]]]:
-    """Fetch the exact lockfile projection with bounded retries."""
+def _fetch_with_retries(payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]]]:
+    """Fetch one bounded package batch with bounded retries."""
     for attempt in range(1, MAX_REQUEST_ATTEMPTS + 1):
         try:
             return _fetch_once(payload)
@@ -137,6 +140,23 @@ def fetch_report(payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]
             )
             time.sleep(attempt * 2)
     raise AssertionError("unreachable")
+
+
+def fetch_report(payload: dict[str, list[str]]) -> dict[str, list[dict[str, Any]]]:
+    """Fetch the exact lockfile projection in bounded parallel batches."""
+    items = list(payload.items())
+    batches = [dict(items[offset : offset + PACKAGE_BATCH_SIZE]) for offset in range(0, len(items), PACKAGE_BATCH_SIZE)]
+    if not batches:
+        return {}
+
+    combined: dict[str, list[dict[str, Any]]] = {}
+    with ThreadPoolExecutor(max_workers=min(MAX_WORKERS, len(batches))) as executor:
+        for report in executor.map(_fetch_with_retries, batches):
+            for package, advisories in report.items():
+                if package in combined:
+                    raise ValueError(f"npm advisory response duplicated package: {package}")
+                combined[package] = advisories
+    return combined
 
 
 def run(path: Path) -> int:

--- a/tests/test_npm_advisory_guard.py
+++ b/tests/test_npm_advisory_guard.py
@@ -170,7 +170,7 @@ def test_fetch_report_uses_a_bounded_transport_read(monkeypatch) -> None:
 
     assert check_npm_advisories.fetch_report({"pkg": ["1.0.0"]}) == {}
     assert seen_limits == [check_npm_advisories.MAX_COMPRESSED_RESPONSE_BYTES + 1]
-    assert seen_timeouts == [120]
+    assert seen_timeouts == [30]
     assert json.loads(seen_requests[0].data) == {"pkg": ["1.0.0"]}
     assert seen_requests[0].get_header("Content-encoding") is None
     assert seen_requests[0].get_header("Content-type") == "application/json"
@@ -188,14 +188,13 @@ def test_fetch_report_bounds_the_exact_request_body(monkeypatch) -> None:
         check_npm_advisories.fetch_report({"package-name": ["1.0.0"]})
 
 
-def test_fetch_report_sends_large_lockfiles_once_and_rejects_unrequested_packages(
-    monkeypatch,
-) -> None:
+def test_fetch_report_batches_large_lockfiles_across_four_workers(monkeypatch) -> None:
+    seen_workers: list[int] = []
     request_payloads: list[dict[str, list[str]]] = []
 
-    class Response:
-        def __init__(self, body: bytes):
-            self.body = body
+    class Executor:
+        def __init__(self, max_workers: int):
+            seen_workers.append(max_workers)
 
         def __enter__(self):
             return self
@@ -203,31 +202,43 @@ def test_fetch_report_sends_large_lockfiles_once_and_rejects_unrequested_package
         def __exit__(self, *_args):
             return None
 
-        def read(self, _limit: int) -> bytes:
-            return self.body
+        def map(self, function, payloads):
+            return [function(payload) for payload in payloads]
 
-    def open_response(request, timeout: int):
-        assert timeout == check_npm_advisories.REQUEST_TIMEOUT_SECONDS
-        request_payload = json.loads(request.data)
-        request_payloads.append(request_payload)
-        first_name = next(iter(request_payload))
-        return Response(json.dumps({first_name: []}).encode())
+    def fetch_once(payload):
+        request_payloads.append(payload)
+        return {name: [] for name in payload}
 
     monkeypatch.setattr(
-        check_npm_advisories.urllib.request,
-        "urlopen",
-        open_response,
+        check_npm_advisories,
+        "ThreadPoolExecutor",
+        Executor,
+        raising=False,
     )
+    monkeypatch.setattr(check_npm_advisories, "_fetch_once", fetch_once)
     payload = {f"pkg-{index:03d}": ["1.0.0"] for index in range(205)}
 
     report = check_npm_advisories.fetch_report(payload)
 
-    assert request_payloads == [payload]
-    assert report == {"pkg-000": []}
+    assert seen_workers == [4]
+    assert [len(request_payload) for request_payload in request_payloads] == [50, 50, 50, 50, 5]
+    assert report == {name: [] for name in payload}
+
+
+def test_fetch_report_rejects_unrequested_packages(monkeypatch) -> None:
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self, _limit: int) -> bytes:
+            return b'{"not-requested":[]}'
 
     def inject_unrequested(_request, timeout: int):
         assert timeout == check_npm_advisories.REQUEST_TIMEOUT_SECONDS
-        return Response(b'{"not-requested":[]}')
+        return Response()
 
     monkeypatch.setattr(
         check_npm_advisories.urllib.request,
@@ -239,11 +250,12 @@ def test_fetch_report_sends_large_lockfiles_once_and_rejects_unrequested_package
 
 
 def test_fetch_report_retries_the_exact_payload(monkeypatch) -> None:
-    seen_payloads: list[dict[str, list[str]]] = []
+    attempts_by_batch: dict[str, int] = {}
 
     def fetch_once(payload):
-        seen_payloads.append(payload)
-        if len(seen_payloads) == 1:
+        first_package = next(iter(payload))
+        attempts_by_batch[first_package] = attempts_by_batch.get(first_package, 0) + 1
+        if first_package == "pkg-050" and attempts_by_batch[first_package] == 1:
             raise TimeoutError("transient npm timeout")
         return {}
 
@@ -252,7 +264,7 @@ def test_fetch_report_retries_the_exact_payload(monkeypatch) -> None:
     payload = {f"pkg-{index:03d}": ["1.0.0"] for index in range(101)}
 
     assert check_npm_advisories.fetch_report(payload) == {}
-    assert seen_payloads == [payload, payload]
+    assert attempts_by_batch == {"pkg-000": 1, "pkg-050": 2, "pkg-100": 1}
 
 
 def test_fetch_report_exhausts_bounded_retries(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- split each exact npm lockfile projection into deterministic 50-package batches
- process at most four batches concurrently with a 30-second request timeout and three attempts per batch
- preserve size bounds, response-scope validation, and fail-closed behavior

## Verification
- observed the regression tests fail on the merged implementation: one 120-second request and no worker pool
- /Users/mohamedsaad/repos/Agent-Bom/.venv/bin/python -m pytest -q tests/test_npm_advisory_guard.py tests/test_ci_workflow_contract.py (44 passed)
- make lint
- make preflight
- live bounded advisory scan: UI 692 package names, SDK 23 package names, no high/critical vulnerabilities
- live bounded advisory scan of the consolidated dependency lockfile: 692 package names, no high/critical vulnerabilities

## Notes
- no release tag or publication is included