### PR TITLE
fix(ci): require exact marketplace tool contracts

### DIFF
--- a/.github/workflows/surface-freshness.yml
+++ b/.github/workflows/surface-freshness.yml
@@ -83,9 +83,13 @@ jobs:
           GLAMA_API_URL: ${{ vars.GLAMA_API_URL }}
           DOCKER_IMAGE: ${{ vars.DOCKER_IMAGE }}
         run: |
+          python3 scripts/check_glama_listing.py \
+            --write-tool-names /tmp/surface-expected-tool-names.json \
+            --git-ref "${{ steps.expected.outputs.release_sha }}"
           PYTHONPATH=src python3 scripts/check_surface_freshness.py \
             --expected "$EXPECTED_VERSION" \
             --expected-tool-count "${{ steps.expected.outputs.tool_count }}" \
+            --expected-tool-names-file /tmp/surface-expected-tool-names.json \
             --out surface-freshness.json
           {
             echo "report<<EOF"
@@ -107,6 +111,7 @@ jobs:
 
             const emoji = (s) => ({
               fresh: "✅ fresh",
+              fresh_degraded: "⚠️ partial evidence",
               stale: "⚠️ STALE",
               not_configured: "❓ unmonitored (misconfigured)",
               unreachable: "🔌 unreachable",
@@ -127,6 +132,7 @@ jobs:
               "- `stale` — surface published a different version; use that provider's supported publish or sync path, then re-run verification.",
               "- `unmonitored (misconfigured)` — a required repo variable is unset, so this surface is NOT being watched. Set the named variable.",
               "- `unreachable` — the surface URL is configured but the probe failed (network / HTTP / parse).",
+              "- `partial evidence` — the visible listing matches, but exact machine-readable verification is unavailable; the issue remains open.",
               "",
               "Optional overrides (blank/unset repo vars fall back to defaults): `DOCKER_IMAGE` (`ghcr.io/msaad00/agent-bom`), `GLAMA_LISTING_URL`, `GLAMA_API_URL`, `SMITHERY_SERVER_QUALIFIED_NAME` (`agent-bom/agent-bom`).",
               "",

--- a/scripts/check_surface_freshness.py
+++ b/scripts/check_surface_freshness.py
@@ -347,9 +347,7 @@ def probe_smithery(
             "deployment_url": deployment_url,
             "tool_count": len(tools),
         }
-        actual_tool_names = sorted(
-            tool.get("name") for tool in tools if isinstance(tool, dict) and isinstance(tool.get("name"), str)
-        )
+        actual_tool_names = sorted(tool.get("name") for tool in tools if isinstance(tool, dict) and isinstance(tool.get("name"), str))
         if expected_tool_count is not None:
             result["expected_tool_count"] = expected_tool_count
             if len(tools) != expected_tool_count:

--- a/scripts/check_surface_freshness.py
+++ b/scripts/check_surface_freshness.py
@@ -54,7 +54,6 @@ DEFAULT_ATTEMPTS = 3
 DEFAULT_BACKOFF = 5.0
 
 OK_STATUSES = {"fresh"}
-ALERT_STATUSES = {"stale", "not_configured", "unreachable"}
 
 
 def expected_tool_count() -> int:
@@ -71,6 +70,20 @@ def expected_tool_count() -> int:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return int(module._load_readme_tool_count())
+
+
+def _load_expected_tool_names(path: Path) -> list[str]:
+    """Load a release-bound tool-name contract from a JSON list."""
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"could not read expected tool-name contract: {exc}") from exc
+    if not isinstance(payload, list) or not payload or not all(isinstance(name, str) and name for name in payload):
+        raise SystemExit("expected tool-name contract must be a non-empty JSON string list")
+    if len(payload) != len(set(payload)):
+        raise SystemExit("expected tool-name contract contains duplicate names")
+    return sorted(payload)
 
 
 def _env_or(name: str, default: str) -> str:
@@ -251,11 +264,19 @@ def probe_docker(expected: str, image: str, **kw: Any) -> dict[str, Any]:
         return _classify("Docker", None, expected, error=str(exc))
 
 
-def probe_glama(expected: str, *, expected_tool_count: int | None = None, **kw: Any) -> dict[str, Any]:
+def probe_glama(
+    expected: str,
+    *,
+    expected_tool_count: int | None = None,
+    expected_tool_names_file: Path | None = None,
+    **kw: Any,
+) -> dict[str, Any]:
     """Delegate to check_glama_listing.py so the probe logic stays in one place."""
     command = [sys.executable, str(GLAMA_SCRIPT), "--expected", expected, "--json"]
     if expected_tool_count is not None:
         command.extend(["--expected-tool-count", str(expected_tool_count)])
+    if expected_tool_names_file is not None:
+        command.extend(["--expected-tool-names-file", str(expected_tool_names_file)])
     proc = subprocess.run(
         command,
         capture_output=True,
@@ -278,11 +299,21 @@ def probe_glama(expected: str, *, expected_tool_count: int | None = None, **kw: 
         "expected": expected,
         "tool_count": payload.get("tool_count"),
         "expected_tool_count": payload.get("expected_tool_count"),
+        "exact_tool_set": payload.get("exact_tool_set"),
+        "exact_input_schemas": payload.get("exact_input_schemas"),
+        "degraded_reason": payload.get("degraded_reason"),
         "error": payload.get("error"),
     }
 
 
-def probe_smithery(expected: str, qualified_name: str, *, expected_tool_count: int | None = None, **kw: Any) -> dict[str, Any]:
+def probe_smithery(
+    expected: str,
+    qualified_name: str,
+    *,
+    expected_tool_count: int | None = None,
+    expected_tool_names: list[str] | None = None,
+    **kw: Any,
+) -> dict[str, Any]:
     """Probe Smithery's public catalog listing.
 
     Smithery-hosted remote servers are OAuth-gated and do not expose agent-bom's
@@ -316,11 +347,25 @@ def probe_smithery(expected: str, qualified_name: str, *, expected_tool_count: i
             "deployment_url": deployment_url,
             "tool_count": len(tools),
         }
+        actual_tool_names = sorted(
+            tool.get("name") for tool in tools if isinstance(tool, dict) and isinstance(tool.get("name"), str)
+        )
         if expected_tool_count is not None:
             result["expected_tool_count"] = expected_tool_count
             if len(tools) != expected_tool_count:
                 result["status"] = "stale"
                 result["error"] = f"catalog advertises {len(tools)} tools; expected {expected_tool_count}"
+        if expected_tool_names is not None:
+            exact_tool_set = actual_tool_names == expected_tool_names
+            result["exact_tool_set"] = exact_tool_set
+            if not exact_tool_set:
+                result["status"] = "stale"
+                missing = sorted(set(expected_tool_names) - set(actual_tool_names))
+                unexpected = sorted(set(actual_tool_names) - set(expected_tool_names))
+                result["error"] = (
+                    "catalog tool-name set differs from the immutable release contract"
+                    f"; missing={missing or 'none'}; unexpected={unexpected or 'none'}"
+                )
         return result
     except (RuntimeError, ValueError) as exc:
         return _classify("Smithery", None, expected, error=str(exc))
@@ -332,6 +377,12 @@ def main(argv: list[str] | None = None) -> int:
     # One shipped tool inventory, so one expectation. The Glama-specific spelling
     # stays accepted because the workflow passes it.
     parser.add_argument("--expected-tool-count", "--expected-glama-tool-count", dest="expected_tool_count", type=int, default=None)
+    parser.add_argument(
+        "--expected-tool-names-file",
+        type=Path,
+        default=None,
+        help="JSON list of immutable released MCP tool names required from marketplace inventories.",
+    )
     parser.add_argument("--docker-image", default=_env_or("DOCKER_IMAGE", DEFAULT_DOCKER_IMAGE))
     parser.add_argument("--smithery-server", default=_env_or("SMITHERY_SERVER_QUALIFIED_NAME", DEFAULT_SMITHERY_SERVER))
     parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
@@ -355,16 +406,30 @@ def main(argv: list[str] | None = None) -> int:
     # reported a catalog advertising 36 of 77 tools as fresh — the drift this
     # monitor exists to catch, invisible to the person most likely to look.
     tool_count = args.expected_tool_count if args.expected_tool_count is not None else expected_tool_count()
+    expected_tool_names = _load_expected_tool_names(args.expected_tool_names_file) if args.expected_tool_names_file else None
+    if expected_tool_names is not None and len(expected_tool_names) != tool_count:
+        raise SystemExit("expected tool-name contract and tool count do not match")
     kw = {"timeout": args.timeout, "attempts": args.attempts, "backoff": args.backoff_seconds}
 
     surfaces = [
         probe_pypi(expected, **kw),
         probe_docker(expected, args.docker_image, **kw),
-        probe_glama(expected, expected_tool_count=tool_count, **kw),
-        probe_smithery(expected, args.smithery_server, expected_tool_count=tool_count, **kw),
+        probe_glama(
+            expected,
+            expected_tool_count=tool_count,
+            expected_tool_names_file=args.expected_tool_names_file,
+            **kw,
+        ),
+        probe_smithery(
+            expected,
+            args.smithery_server,
+            expected_tool_count=tool_count,
+            expected_tool_names=expected_tool_names,
+            **kw,
+        ),
     ]
 
-    drift = [s for s in surfaces if s["status"] in ALERT_STATUSES]
+    drift = [s for s in surfaces if s["status"] not in OK_STATUSES]
     report = {
         "expected": expected,
         "all_fresh": len(drift) == 0,

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -597,6 +597,9 @@ def test_surface_freshness_targets_the_latest_published_release():
     # advertises a tool list. The Glama-specific spelling this used to pin is
     # still accepted by the script as an alias.
     assert '--expected-tool-count "${{ steps.expected.outputs.tool_count }}"' in workflow
+    assert "--write-tool-names /tmp/surface-expected-tool-names.json" in workflow
+    assert '--git-ref "${{ steps.expected.outputs.release_sha }}"' in workflow
+    assert "--expected-tool-names-file /tmp/surface-expected-tool-names.json" in workflow
     assert 'git show "${RELEASE_SHA}:docs/PRODUCT_METRICS.json"' in workflow
     assert 'select(.name == "MCP tools")' in workflow
     assert 'METRICS_VERSION" != "$VERSION"' in workflow

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -435,6 +435,85 @@ def test_smithery_listing_matching_the_shipped_tool_count_is_fresh(monkeypatch):
     assert result["tool_count"] == 77
 
 
+def test_smithery_listing_rejects_count_collision_with_wrong_tool_names(monkeypatch):
+    """A matching count must not substitute for the immutable name set."""
+    script = _load_script("check_surface_freshness.py")
+    monkeypatch.setattr(script, "_http_json", _smithery_listing_with(2))
+
+    result = script.probe_smithery(
+        "0.103.2",
+        "agent-bom/agent-bom",
+        expected_tool_count=2,
+        expected_tool_names=["graph_correlate", "scan"],
+        timeout=1,
+        attempts=1,
+        backoff=0,
+    )
+
+    assert result["status"] == "stale"
+    assert result["exact_tool_set"] is False
+    assert "tool-name set differs" in result["error"]
+
+
+def test_glama_probe_forwards_immutable_tool_name_contract(monkeypatch, tmp_path):
+    script = _load_script("check_surface_freshness.py")
+    names_file = tmp_path / "expected-tool-names.json"
+    names_file.write_text('["graph_correlate", "scan"]\n', encoding="utf-8")
+    seen: list[str] = []
+
+    def fake_run(command, **_kwargs):
+        seen.extend(command)
+        return subprocess.CompletedProcess(command, 0, stdout='{"status":"fresh"}\n', stderr="")
+
+    monkeypatch.setattr(script.subprocess, "run", fake_run)
+
+    result = script.probe_glama(
+        "0.103.2",
+        expected_tool_count=2,
+        expected_tool_names_file=names_file,
+        timeout=1,
+        attempts=1,
+        backoff=0,
+    )
+
+    assert result["status"] == "fresh"
+    assert seen[seen.index("--expected-tool-names-file") + 1] == str(names_file)
+
+
+def test_surface_freshness_does_not_close_on_degraded_evidence(monkeypatch, tmp_path):
+    """An unavailable machine inventory is partial evidence, never all-fresh."""
+    script = _load_script("check_surface_freshness.py")
+
+    def fresh(name):
+        return lambda expected, *args, **kwargs: {
+            "surface": name,
+            "status": "fresh",
+            "version": expected,
+            "expected": expected,
+        }
+
+    monkeypatch.setattr(script, "probe_pypi", fresh("PyPI"))
+    monkeypatch.setattr(script, "probe_docker", fresh("Docker"))
+    monkeypatch.setattr(
+        script,
+        "probe_glama",
+        lambda expected, **_kwargs: {
+            "surface": "Glama",
+            "status": "fresh_degraded",
+            "version": expected,
+            "expected": expected,
+            "degraded_reason": "Glama public API inventory was unreachable",
+        },
+    )
+    monkeypatch.setattr(script, "probe_smithery", fresh("Smithery"))
+
+    out = tmp_path / "report.json"
+    assert script.main(["--expected", "0.103.2", "--out", str(out)]) == 0
+
+    report = json.loads(out.read_text())
+    assert report["all_fresh"] is False
+
+
 def test_legacy_glama_tool_count_flag_is_still_accepted(monkeypatch, tmp_path):
     """Renaming the flag must not break anything still passing the old spelling."""
     script = _load_script("check_surface_freshness.py")


### PR DESCRIPTION
## Summary

- bind Surface Freshness to the immutable released MCP tool-name inventory
- reject equal-count but different Smithery or Glama catalogs
- keep the drift tracker open when Glama only provides degraded, non-machine-readable evidence

## Verification

- 107 focused tests passed
- Ruff passed
- actionlint passed
- make preflight passed
- git diff --check passed
- live v0.103.2 probe correctly reported Glama 84/86 and Smithery 84/86, missing graph_correlate and graph_correlation_status

## Notes

This hardens the closure evidence for #5094. It does not claim provider parity or close the drift issue before the public catalogs converge.