### PR TITLE
fix(mcp): enforce runtime evidence write authorization

### DIFF
--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -412,10 +412,20 @@ ingest_external_scan(scan_json="<SARIF or scanner JSON>", parse_only=true)
 ### runtime_evidence_ingest
 Ingest CWPP runtime/EDR workload signals into the durable evidence store.
 Requires a pre-registered source (`AGENT_BOM_RUNTIME_EVIDENCE_SOURCES`) and
-shared secret. Metadata only; never writes to a customer cloud target. Fail-closed
-on auth. Write-annotated (`findings:write`).
+shared secret. The source tenant must match the MCP server's authoritative
+tenant binding. Metadata only; never writes to a customer cloud target.
+Fail-closed on auth. Write-annotated (`findings:write`). If evidence persistence
+succeeds but the audit sink fails, the response reports `status: partial` and
+`audit_status: unavailable` rather than implying complete success.
 ```
-runtime_evidence_ingest(source_id="edr-1", secret="...", signals_json="[]")
+runtime_evidence_ingest(
+  source_id="edr-1",
+  secret="...",
+  signals_json="[]",
+  operator_role="admin",
+  operator_scopes="findings:write",
+  reason="ingest approved runtime evidence"
+)
 ```
 
 ## Resources

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -370,7 +370,8 @@ _SERVER_CARD_TOOLS = [
         "name": "runtime_evidence_ingest",
         "description": (
             "Ingest CWPP runtime/EDR workload signals into the durable evidence store "
-            "(authenticated source; metadata only; never writes to a customer cloud target)"
+            "(authenticated source matching the server tenant; admin + findings:write + "
+            "audit reason; metadata only; never writes to a customer cloud target)"
         ),
         "annotations": {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True},
     },

--- a/src/agent_bom/mcp_server_specialized.py
+++ b/src/agent_bom/mcp_server_specialized.py
@@ -318,6 +318,18 @@ def register_specialized_ai_tools(
                 ),
             ),
         ],
+        operator_role: Annotated[
+            str,
+            Field(description="Operator role for this write action. Must be admin."),
+        ] = "viewer",
+        operator_scopes: Annotated[
+            str,
+            Field(description="Comma-separated operator scopes. Must include findings:write."),
+        ] = "",
+        reason: Annotated[
+            str,
+            Field(description="Human audit reason for ingesting runtime evidence."),
+        ] = "",
     ) -> str:
         """Ingest CWPP runtime/EDR workload signals into the local evidence store.
 
@@ -328,9 +340,14 @@ def register_specialized_ai_tools(
         return await execute_tool_async(
             "runtime_evidence_ingest",
             runtime_evidence_ingest_impl,
+            destructive=True,
+            required_scope="findings:write",
             source_id=source_id,
             secret=secret,
             signals_json=signals_json,
+            operator_role=operator_role,
+            operator_scopes=operator_scopes,
+            reason=reason,
             _truncate_response=truncate_response,
         )
 

--- a/src/agent_bom/mcp_tools/runtime_evidence.py
+++ b/src/agent_bom/mcp_tools/runtime_evidence.py
@@ -11,35 +11,117 @@ from agent_bom.security import sanitize_error
 logger = logging.getLogger(__name__)
 
 
+def _write_denial(
+    *,
+    operator_role: str,
+    operator_scopes: str,
+    reason: str,
+    authenticated_actor: str,
+) -> dict[str, Any] | None:
+    """Validate the auditable context carried by an authorized MCP write."""
+    role = (operator_role or "").strip().lower()
+    scopes = {part.strip().lower() for part in (operator_scopes or "").split(",") if part.strip()}
+    if role != "admin":
+        return {
+            "error": "runtime evidence write action requires admin role",
+            "status": "blocked",
+            "required_role": "admin",
+            "provided_role": role or "unset",
+        }
+    if not scopes & {"*", "findings:*", "findings:write"}:
+        return {
+            "error": "runtime evidence write action requires findings:write scope",
+            "status": "blocked",
+            "required_role": "admin",
+            "required_scope": "findings:write",
+        }
+    if len((reason or "").strip()) < 8:
+        return {
+            "error": "runtime evidence write action requires an audit reason of at least 8 characters",
+            "status": "blocked",
+            "required_role": "admin",
+        }
+    if not (authenticated_actor or "").strip():
+        return {
+            "error": "runtime evidence write action requires authenticated operator actor",
+            "status": "blocked",
+            "required_role": "admin",
+            "required_scope": "findings:write",
+        }
+    return None
+
+
 async def runtime_evidence_ingest_impl(
     *,
     source_id: str,
     secret: str,
     signals_json: str,
+    operator_role: str = "viewer",
+    operator_scopes: str = "",
+    reason: str = "",
+    _authenticated_actor: str = "",
     _truncate_response: Any,
 ) -> str:
     """Authenticate a registered source and ingest a JSON array of signals."""
+    denial = _write_denial(
+        operator_role=operator_role,
+        operator_scopes=operator_scopes,
+        reason=reason,
+        authenticated_actor=_authenticated_actor,
+    )
+    if denial is not None:
+        return json.dumps(denial)
     try:
         from agent_bom.cloud.runtime_workload_evidence import (
             SourceAuthenticationError,
+            get_runtime_source_registry,
             ingest_runtime_signals_payload,
         )
+        from agent_bom.mcp_tenant import resolve_mcp_tool_tenant_id
 
+        registry = get_runtime_source_registry()
+        source = registry.authenticate(source_id, secret)
+        if source.tenant_id != resolve_mcp_tool_tenant_id():
+            return json.dumps({"error": "runtime evidence source authentication failed"})
         payload = json.loads(signals_json)
         result = ingest_runtime_signals_payload(
             source_id=source_id,
             secret=secret,
             payload=payload,
             persist=True,
+            registry=registry,
         )
-        return _truncate_response(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+        payload = result.to_dict()
+        try:
+            from agent_bom.api.audit_log import log_action
+
+            log_action(
+                "runtime_evidence.ingest",
+                actor=_authenticated_actor.strip(),
+                resource=f"runtime-evidence/source/{result.source_id}",
+                tenant_id=result.tenant_id,
+                reason=reason.strip(),
+                accepted=payload["accepted"],
+                persisted=payload["persisted"],
+                rejected_stale=payload["rejected_stale"],
+                rejected_incomplete=payload["rejected_incomplete"],
+            )
+            payload["status"] = "ok"
+            payload["audit_status"] = "recorded"
+        except Exception as exc:  # noqa: BLE001 - evidence ingest succeeds independently of audit sink availability
+            logger.warning("MCP runtime evidence audit logging failed: %s", sanitize_error(exc, generic=True))
+            payload["status"] = "partial"
+            payload["audit_status"] = "unavailable"
+            payload["audit_error"] = "Runtime evidence was persisted, but its audit event is unavailable."
+        return _truncate_response(json.dumps(payload, indent=2, sort_keys=True))
     except SourceAuthenticationError:
         return json.dumps({"error": "runtime evidence source authentication failed"})
     except (json.JSONDecodeError, ValueError, TypeError) as exc:
         return json.dumps({"error": sanitize_error(exc)})
     except Exception as exc:  # noqa: BLE001
-        logger.exception("MCP runtime_evidence_ingest error")
-        return json.dumps({"error": sanitize_error(exc)})
+        safe_error = sanitize_error(exc, generic=True)
+        logger.warning("MCP runtime_evidence_ingest error: %s", safe_error)
+        return json.dumps({"error": safe_error})
 
 
 __all__ = ["runtime_evidence_ingest_impl"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -832,6 +832,203 @@ def test_ingest_external_scan_annotation_is_write():
 
 
 # ---------------------------------------------------------------------------
+# Tool: runtime_evidence_ingest — durable-write authorization
+#
+# The source shared secret authenticates the evidence producer.  It does not
+# replace the MCP operator token/role/scope/reason required to invoke a durable
+# write through this surface.
+# ---------------------------------------------------------------------------
+
+
+def _runtime_source_registry(*, tenant_id: str = "tenant-alpha"):
+    from agent_bom.cloud.runtime_workload_evidence import RuntimeEvidenceSource, RuntimeSourceRegistry
+
+    registry = RuntimeSourceRegistry()
+    registry.add(
+        RuntimeEvidenceSource.register(
+            source_id="edr-1",
+            tenant_id=tenant_id,
+            provider="aws",
+            account_id="123456789012",
+            kind="edr",
+            secret="source-secret",
+        )
+    )
+    return registry
+
+
+def _call_runtime_evidence_impl(**overrides):
+    from agent_bom.mcp_tools.runtime_evidence import runtime_evidence_ingest_impl
+
+    arguments = {
+        "source_id": "edr-1",
+        "secret": "source-secret",
+        "signals_json": "[]",
+        "operator_role": "admin",
+        "operator_scopes": "findings:write",
+        "reason": "ingest approved runtime evidence",
+        "_authenticated_actor": "operator-token",
+        "_truncate_response": lambda value: value,
+        **overrides,
+    }
+    return json.loads(_run(runtime_evidence_ingest_impl(**arguments)))
+
+
+@patch("agent_bom.mcp_tools.runtime_evidence.runtime_evidence_ingest_impl")
+def test_runtime_evidence_ingest_blocks_stdio_before_handler(mock_ingest):
+    """Stdio and tokens missing the admin role cannot reach persistence."""
+    from agent_bom import mcp_server
+    from agent_bom.mcp_server import create_mcp_server
+
+    server = create_mcp_server()
+    for auth_scopes in ("", "findings:write"):
+        with patch.object(mcp_server, "_current_tool_request", _fixed_request_meta(auth_scopes)):
+            result = _call_tool(
+                server,
+                "runtime_evidence_ingest",
+                {"source_id": "edr-1", "secret": "source-secret", "signals_json": "[]"},
+            )
+
+        assert result.get("status") == "blocked", result
+        assert result.get("required_role") == "admin", result
+    mock_ingest.assert_not_called()
+
+
+@patch("agent_bom.mcp_tools.runtime_evidence.runtime_evidence_ingest_impl")
+def test_runtime_evidence_ingest_requires_findings_write_scope(mock_ingest):
+    """An authenticated admin token without findings:write stays blocked."""
+    from agent_bom import mcp_server
+    from agent_bom.mcp_server import create_mcp_server
+
+    server = create_mcp_server()
+    with patch.object(mcp_server, "_current_tool_request", _fixed_request_meta("admin")):
+        result = _call_tool(
+            server,
+            "runtime_evidence_ingest",
+            {
+                "source_id": "edr-1",
+                "secret": "source-secret",
+                "signals_json": "[]",
+                "operator_role": "admin",
+                "operator_scopes": "findings:write",
+                "reason": "ingest approved runtime evidence",
+            },
+        )
+
+    assert result.get("status") == "blocked", result
+    assert result.get("required_scope") == "findings:write", result
+    mock_ingest.assert_not_called()
+
+
+def test_runtime_evidence_ingest_impl_requires_audit_context():
+    """The handler independently rejects a missing audit reason before ingest."""
+    with patch("agent_bom.cloud.runtime_workload_evidence.ingest_runtime_signals_payload") as mock_ingest:
+        result = _call_runtime_evidence_impl(reason="")
+
+    assert result.get("status") == "blocked", result
+    assert "audit reason" in result.get("error", ""), result
+    mock_ingest.assert_not_called()
+
+
+def test_runtime_evidence_ingest_allows_authorized_operator_and_keeps_source_auth(monkeypatch):
+    """Operator authorization and the source secret remain independent gates."""
+    from agent_bom import mcp_server
+    from agent_bom.cloud.runtime_workload_evidence import IngestResult, set_runtime_source_registry
+    from agent_bom.mcp_server import create_mcp_server
+
+    monkeypatch.setenv("AGENT_BOM_MCP_TENANT_ID", "tenant-alpha")
+    registry = _runtime_source_registry()
+    set_runtime_source_registry(registry)
+    args = {
+        "source_id": "edr-1",
+        "secret": "source-secret",
+        "signals_json": "[]",
+        "operator_role": "admin",
+        "operator_scopes": "findings:write",
+        "reason": "ingest approved runtime evidence",
+    }
+    server = create_mcp_server()
+    with (
+        patch.object(mcp_server, "_current_tool_request", _fixed_request_meta("admin,findings:write")),
+        patch(
+            "agent_bom.cloud.runtime_workload_evidence.ingest_runtime_signals_payload",
+            return_value=IngestResult(source_id="edr-1", tenant_id="tenant-alpha"),
+        ) as mock_ingest,
+    ):
+        result = _call_tool(server, "runtime_evidence_ingest", args)
+
+    assert result.get("status") != "blocked", result
+    assert result["tenant_id"] == "tenant-alpha"
+    assert mock_ingest.call_args.kwargs["registry"] is registry
+
+    with patch.object(mcp_server, "_current_tool_request", _fixed_request_meta("admin,findings:write")):
+        denied = _call_tool(server, "runtime_evidence_ingest", {**args, "secret": "wrong-secret"})
+
+    assert denied == {"error": "runtime evidence source authentication failed"}
+    set_runtime_source_registry(None)
+
+
+def test_runtime_evidence_ingest_rejects_cross_tenant_source_before_persistence(monkeypatch):
+    """A valid source secret cannot cross the MCP server's tenant binding."""
+    from agent_bom.cloud.runtime_workload_evidence import set_runtime_source_registry
+
+    monkeypatch.setenv("AGENT_BOM_MCP_TENANT_ID", "tenant-alpha")
+    set_runtime_source_registry(_runtime_source_registry(tenant_id="tenant-beta"))
+    try:
+        with patch("agent_bom.cloud.runtime_workload_evidence.ingest_runtime_signals_payload") as mock_ingest:
+            result = _call_runtime_evidence_impl()
+
+        assert result == {"error": "runtime evidence source authentication failed"}
+        mock_ingest.assert_not_called()
+    finally:
+        set_runtime_source_registry(None)
+
+
+def test_runtime_evidence_ingest_unexpected_error_is_generic(caplog, monkeypatch):
+    """Unexpected secret-path errors expose neither raw details nor tracebacks."""
+    from agent_bom.cloud.runtime_workload_evidence import set_runtime_source_registry
+
+    monkeypatch.setenv("AGENT_BOM_MCP_TENANT_ID", "tenant-alpha")
+    set_runtime_source_registry(_runtime_source_registry())
+    sensitive = "token=top-secret at /private/customer/runtime.db"
+    try:
+        with patch(
+            "agent_bom.cloud.runtime_workload_evidence.ingest_runtime_signals_payload",
+            side_effect=RuntimeError(sensitive),
+        ):
+            result = _call_runtime_evidence_impl()
+    finally:
+        set_runtime_source_registry(None)
+
+    assert result == {"error": "An internal error occurred. Please contact support."}
+    assert "top-secret" not in caplog.text
+    assert "/private/customer/runtime.db" not in caplog.text
+
+
+def test_runtime_evidence_ingest_reports_partial_when_postwrite_audit_fails(monkeypatch):
+    """Persisted evidence must not silently imply that its audit event succeeded."""
+    from agent_bom.cloud.runtime_workload_evidence import IngestResult, set_runtime_source_registry
+
+    monkeypatch.setenv("AGENT_BOM_MCP_TENANT_ID", "tenant-alpha")
+    set_runtime_source_registry(_runtime_source_registry())
+    try:
+        with (
+            patch(
+                "agent_bom.cloud.runtime_workload_evidence.ingest_runtime_signals_payload",
+                return_value=IngestResult(source_id="edr-1", tenant_id="tenant-alpha", persisted=1),
+            ),
+            patch("agent_bom.api.audit_log.log_action", side_effect=RuntimeError("audit sink unavailable")),
+        ):
+            result = _call_runtime_evidence_impl()
+    finally:
+        set_runtime_source_registry(None)
+
+    assert result["persisted"] == 1
+    assert result["status"] == "partial"
+    assert result["audit_status"] == "unavailable"
+
+
+# ---------------------------------------------------------------------------
 # Tool: policy_check
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Require authenticated operator context, admin role, findings write scope, and an audit reason for MCP runtime-evidence ingestion.
- Authenticate the registered source and enforce tenant ownership before persistence.
- Report post-write audit-sink failure as partial and sanitize unexpected errors.

## Verification
- Rebased onto merged API/UI scope repair `fb7faf9df46e9f8e1de53d97a76b5484c625c22f`.
- `PYTHONPATH=src pytest -q tests/test_mcp_server.py tests/test_mcp_tool_output_contract.py tests/test_mcp_auth_posture.py --no-cov`: 212 passed, 1 skipped. Registry-dependent contracts were run with network access.
- `make preflight`: passed.
- `mypy src/agent_bom`: passed across 890 source files.
- `pre-commit run --files site-docs/reference/mcp-tools.md src/agent_bom/mcp_server_metadata.py src/agent_bom/mcp_server_specialized.py src/agent_bom/mcp_tools/runtime_evidence.py tests/test_mcp_server.py`: all applicable hooks passed.
- `git diff --check`: passed.

## Notes
Authorization and tenant checks fail closed before persistence. A failed audit sink after a successful write returns partial status; the durable write is not represented as rolled back. No release or deployment.
