### PR TITLE
fix(auth): honor explicit loopback bootstrap roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ pip install 'agent-bom[ui]'
 AGENT_BOM_NO_AUTH_ROLE=analyst agent-bom serve --persist ~/.agent-bom/control-plane.db
 ```
 
+The explicit role applies to the generated loopback API key and browser sessions.
+`analyst` can run scans but cannot manage API keys. With no explicit role, the
+local bootstrap retains its admin default; non-loopback listeners still require
+configured authentication. Restart after changing the bootstrap role.
+
+
 The explicit SQLite path keeps scan jobs, findings, compliance history, and
 graph inventory available together after a restart. Omit `--persist` only for
 an intentionally ephemeral process. The explicit local `analyst` role permits

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1660,8 +1660,15 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         if not raw_key:
             return Absent()
         if self._api_key and secrets.compare_digest(raw_key, self._api_key):
+            from agent_bom.api.auth import Role
+            from agent_bom.api.server import get_dev_api_key, get_dev_api_role
+
+            role = get_dev_api_role() if get_dev_api_key() == self._api_key else Role.ADMIN
+            required = Role(self._required_role(request.method, request.url.path))
+            if not self._role_allows(role, required):
+                return Resolved(JSONResponse(status_code=403, content={"detail": "Forbidden — insufficient role"}))
             request.state.api_key_name = "static-key"
-            request.state.api_key_role = "admin"
+            request.state.api_key_role = role.value
             request.state.tenant_id = "default"
             request.state.auth_method = "static_api_key"
             return Resolved(await self._call_with_tenant_context(request, call_next))
@@ -1902,6 +1909,11 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             if not await anyio.to_thread.run_sync(tenant_access_active, tenant_id):
                 return JSONResponse(status_code=401, content={"detail": "Unauthorized — managed trial is inactive"})
         effective_role = session_role
+        if auth_method == "browser_session_dev_key":
+            from agent_bom.api.server import get_dev_api_key, get_dev_api_role
+
+            if get_dev_api_key() is None or session_role != get_dev_api_role():
+                return JSONResponse(status_code=401, content={"detail": "Unauthorized — loopback session is no longer active"})
         if auth_method in {"oidc", "saml"} or subject.startswith("saml:"):
             resolved_role, scim_error = self._resolve_runtime_role(
                 request,

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -621,7 +621,7 @@ async def create_loopback_dev_session(request: Request, response: Response) -> N
     browser session as the packaged, same-origin dashboard.
     """
     from agent_bom.api.audit_log import log_action
-    from agent_bom.api.server import get_dev_api_key
+    from agent_bom.api.server import get_dev_api_key, get_dev_api_role
 
     if get_dev_api_key() is None:
         raise HTTPException(status_code=404, detail="Loopback dev session is not active")
@@ -632,7 +632,7 @@ async def create_loopback_dev_session(request: Request, response: Response) -> N
         response,
         request,
         subject="loopback-dev-key",
-        role="admin",
+        role=get_dev_api_role().value,
         tenant_id="default",
         auth_method="browser_session_dev_key",
     )

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -847,6 +847,7 @@ _runtime_api_key_seeded = False
 # zero flags. Never persisted; non-loopback binds never set this (the CLI auth
 # gate refuses them first). See cli/_server._should_auto_generate_dev_key.
 _dev_api_key: str | None = None
+_dev_api_role: Role = Role.ADMIN
 
 
 def set_dev_api_key(raw_key: str | None) -> None:
@@ -857,13 +858,26 @@ def set_dev_api_key(raw_key: str | None) -> None:
     cookie so the first-party same-origin UI authenticates automatically on a
     loopback bind. Process-local and never written to disk.
     """
-    global _dev_api_key
-    _dev_api_key = (raw_key or "").strip() or None
+    global _dev_api_key, _dev_api_role
+    value = (raw_key or "").strip() or None
+    role = Role.ADMIN
+    if value:
+        try:
+            role = Role((os.environ.get("AGENT_BOM_NO_AUTH_ROLE") or "admin").strip().lower())
+        except ValueError:
+            raise ValueError("Invalid explicit loopback role") from None
+    _dev_api_key = value
+    _dev_api_role = role
 
 
 def get_dev_api_key() -> str | None:
     """Return the active ephemeral loopback dev API key, if any."""
     return _dev_api_key
+
+
+def get_dev_api_role() -> Role:
+    """Role selected for the active authenticated loopback bootstrap."""
+    return _dev_api_role
 
 
 def _env_truthy(name: str) -> bool:
@@ -918,7 +932,8 @@ def _seed_runtime_api_key(raw_key: str | None) -> bool:
     if _runtime_api_key_seeded:
         return get_key_store().has_keys()
 
-    get_key_store().add(create_api_key_record(value, "runtime:admin", Role.ADMIN))
+    role = get_dev_api_role() if value == get_dev_api_key() else Role.ADMIN
+    get_key_store().add(create_api_key_record(value, f"runtime:{role.value}", role))
     _runtime_api_key_seeded = True
     return True
 
@@ -1504,7 +1519,7 @@ def _maybe_attach_dev_session_cookie(response: Any, request: Request) -> None:
     try:
         token, csrf = create_browser_session_token(
             subject="loopback-dev-key",
-            role="admin",
+            role=get_dev_api_role().value,
             tenant_id="default",
             auth_method="browser_session_dev_key",
             key_id=None,

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -719,12 +719,12 @@ def serve_cmd(
 
     from agent_bom.api.server import configure_api, set_dev_api_key, set_job_store
 
+    set_dev_api_key(dev_api_key)
     configure_api(
         cors_allow_all=cors_allow_all,
         api_key=api_key or dev_api_key,
         allow_unauthenticated=allow_insecure_no_auth,
     )
-    set_dev_api_key(dev_api_key)
     if persist_path:
         # Do not rely only on the server module's first-import environment
         # selection. Embedded callers and tests can import the app before the

--- a/tests/api/test_api_hardening.py
+++ b/tests/api/test_api_hardening.py
@@ -2318,3 +2318,65 @@ def test_dev_session_cookie_not_reissued_when_session_present(monkeypatch):
     _maybe_attach_dev_session_cookie(response, SimpleNamespace(cookies={SESSION_COOKIE_NAME: existing_token}))
     set_cookies = [v.decode() for k, v in response.raw_headers if k == b"set-cookie"]
     assert set_cookies == []
+
+
+@pytest.mark.parametrize("role", ["viewer", "analyst", "admin"])
+@pytest.mark.parametrize("transport", ["bearer", "header", "packaged_cookie", "dev_session"])
+def test_explicit_loopback_role_is_shared_across_credentials(monkeypatch, role, transport):
+    from agent_bom.api import server
+    from agent_bom.cli._server import _generate_dev_api_key
+
+    _clear_dev_key_auth_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_NO_AUTH_ROLE", role)
+    key = _generate_dev_api_key()
+    server.set_dev_api_key(key)
+    server.configure_api(api_key=key)
+    client = TestClient(app)
+    headers = {}
+    if transport == "bearer":
+        headers = {"Authorization": f"Bearer {key}"}
+    elif transport == "header":
+        headers = {"X-API-Key": key}
+    elif transport == "dev_session":
+        assert client.post("/v1/auth/dev-session", headers={"Origin": "http://localhost:3000"}).status_code == 204
+    else:
+        response = Response()
+        server._maybe_attach_dev_session_cookie(response, SimpleNamespace(cookies={}))
+        for name, value in response.raw_headers:
+            if name == b"set-cookie":
+                cookie = value.decode().split(";", 1)[0]
+                cookie_name, cookie_value = cookie.split("=", 1)
+                client.cookies.set(cookie_name, cookie_value)
+    try:
+        response = client.get("/v1/auth/me", headers=headers)
+        assert response.status_code == 200
+        assert response.json()["role"] == role
+        assert client.get("/v1/auth/keys", headers=headers).status_code == (200 if role == "admin" else 403)
+    finally:
+        server.set_dev_api_key(None)
+
+
+def test_invalid_explicit_dev_role_rejects_bootstrap(monkeypatch):
+    from agent_bom.api.server import set_dev_api_key
+
+    monkeypatch.setenv("AGENT_BOM_NO_AUTH_ROLE", "owner")
+    with pytest.raises(ValueError, match="role"):
+        set_dev_api_key("ephemeral-test-key")
+
+
+def test_dev_session_cannot_retain_previous_bootstrap_role(monkeypatch):
+    from agent_bom.api import server
+
+    _clear_dev_key_auth_env(monkeypatch)
+    monkeypatch.delenv("AGENT_BOM_NO_AUTH_ROLE", raising=False)
+    server.set_dev_api_key("ephemeral-role-test")
+    server.configure_api(api_key="ephemeral-role-test")
+    client = TestClient(app)
+    assert client.post("/v1/auth/dev-session", headers={"Origin": "http://localhost:3000"}).status_code == 204
+    assert client.get("/v1/auth/me").json()["role"] == "admin"
+    monkeypatch.setenv("AGENT_BOM_NO_AUTH_ROLE", "analyst")
+    server.set_dev_api_key("ephemeral-role-test")
+    try:
+        assert client.get("/v1/auth/me").status_code == 401
+    finally:
+        server.set_dev_api_key(None)


### PR DESCRIPTION
## Summary
- Apply an explicitly selected loopback role to generated API keys and both browser-session paths; keep the existing admin default when no role is selected.
- Seed the selected role before API configuration and reject stale dev sessions after the active bootstrap role changes.
- Reject invalid role configuration and preserve non-loopback/authentication restrictions.

## Verification
- Nine new regression failures reproduced against unchanged main.
- `pytest -q tests/api/test_api_hardening.py tests/test_cli_server.py --no-cov`: 170 passed.
- Live isolated `AGENT_BOM_NO_AUTH_ROLE=analyst agent-bom serve --persist <temporary-db>`: session exchange 204, `/v1/auth/me` analyst, `/v1/auth/keys` 403.
- `make preflight`: passed.
- `mypy src/agent_bom`: passed across 890 files.
- Changed-file pre-commit suite: all applicable hooks passed except isolated mypy, whose four unchanged `no-any-return` diagnostics were reproduced on clean baseline (three health-return sites and one middleware return site).
- `git diff --check`: passed.

## Notes
No authentication opt-out or anonymous elevation was added. Restart after changing the bootstrap role. No release or deployment.
