### PR TITLE
fix(graph): require complete path evidence

### DIFF
--- a/src/agent_bom/graph/path_evidence.py
+++ b/src/agent_bom/graph/path_evidence.py
@@ -41,8 +41,19 @@ def _has_relationship_provenance(edge: UnifiedEdge) -> bool:
     """Require an edge-level receipt; snapshot membership alone is structural."""
 
     correlation = _correlation_provenance(edge)
-    source_ids = correlation.get("source_scan_ids")
-    return bool(edge.source_scan_id or (isinstance(source_ids, list) and source_ids) or edge.provenance)
+    observations = correlation.get("observations")
+    if isinstance(observations, list) and any(
+        isinstance(item, Mapping)
+        and str(item.get("scan_id") or "").strip()
+        and str(item.get("source_edge_id") or "").strip()
+        and str(item.get("evidence_digest") or "").strip()
+        for item in observations
+    ):
+        return True
+
+    provenance_source = edge.provenance.get("source") if isinstance(edge.provenance, dict) else None
+    relationship_evidence = {key: value for key, value in edge.evidence.items() if key != "freshness"}
+    return bool(str(provenance_source or "").strip() or relationship_evidence)
 
 
 def _freshness(edge: UnifiedEdge) -> str:
@@ -74,7 +85,12 @@ def _evidence_tier(edge: UnifiedEdge) -> str:
 def _analysis(graph: UnifiedGraph, *, hop_count: int) -> dict[str, Any]:
     status = graph.analysis_status.get("attack_path_fusion")
     if status is None:
-        return {"status": "complete", "reason_codes": [], "limits": {}, "observed": {"hop_count": hop_count}}
+        return {
+            "status": "not_recorded",
+            "reason_codes": ["analysis_not_recorded"],
+            "limits": {},
+            "observed": {"hop_count": hop_count},
+        }
     result = status.to_dict()
     observed = dict(result.get("observed") or {})
     observed["hop_count"] = hop_count
@@ -127,6 +143,7 @@ def annotate_attack_path_evidence(path: AttackPath, graph: UnifiedGraph) -> Atta
             )
             continue
         source_ids = _source_snapshot_ids(edge, graph)
+        freshness = _freshness(edge)
         receipts.append(
             {
                 "source_node_id": source,
@@ -135,7 +152,7 @@ def annotate_attack_path_evidence(path: AttackPath, graph: UnifiedGraph) -> Atta
                 "source_snapshot_ids": source_ids,
                 "evidence_tier": _evidence_tier(edge),
                 "confidence": float(edge.confidence),
-                "freshness": _freshness(edge),
+                "freshness": freshness,
                 "runtime_observed_state": _runtime_state(edge),
                 "direction": edge.direction,
                 "traversable": bool(edge.traversable),
@@ -144,6 +161,7 @@ def annotate_attack_path_evidence(path: AttackPath, graph: UnifiedGraph) -> Atta
                     and edge.direction == "directed"
                     and source_ids
                     and _has_relationship_provenance(edge)
+                    and freshness in {"fresh", "stale_allowed"}
                     and edge.source == source
                     and edge.target == target
                 ),
@@ -152,7 +170,7 @@ def annotate_attack_path_evidence(path: AttackPath, graph: UnifiedGraph) -> Atta
         )
 
     analysis = _analysis(graph, hop_count=max(len(path.hops) - 1, 0))
-    truncated = analysis.get("status") in {"limited", "skipped", "failed"}
+    truncated = analysis.get("status") in {"limited", "skipped", "failed", "not_recorded"}
     if truncated:
         for receipt in receipts:
             receipt["truncated"] = True
@@ -219,7 +237,11 @@ def _path_completeness(path: AttackPath) -> dict[str, Any]:
         return {"status": "unavailable", **base, "reasonCodes": ["analysis_status_unknown"]}
     if expected_hops and not receipts:
         return {"status": "unavailable", **base, "reasonCodes": ["hop_evidence_not_recorded"]}
-    if len(receipts) != expected_hops or any(not item.get("complete") or item.get("truncated") for item in receipts):
+    if len(receipts) != expected_hops or any(item.get("truncated") for item in receipts):
+        return {"status": "partial", **base, "reasonCodes": ["incomplete_hop_evidence"]}
+    if any(str(item.get("freshness") or "unknown") not in {"fresh", "stale_allowed"} for item in receipts):
+        return {"status": "partial", **base, "reasonCodes": ["unknown_evidence_freshness"]}
+    if any(not item.get("complete") for item in receipts):
         return {"status": "partial", **base, "reasonCodes": ["incomplete_hop_evidence"]}
     return {"status": "complete", **base, "reasonCodes": []}
 
@@ -233,11 +255,10 @@ def exposure_evidence_dimensions(path: AttackPath, target_node: Any | None) -> d
 
     reachability_value = str(path.reachability or "").lower()
     reachability_basis = [str(item) for item in path.reachability_basis if str(item)]
-    if (
-        reachability_value in {"confirmed", "likely", "unlikely"}
-        and reachability_basis
-        and completeness["status"] in {"complete", "partial"}
-    ):
+    reachability_supported = completeness["status"] == "complete" or (
+        completeness["status"] == "partial" and reachability_value in {"likely", "unlikely"}
+    )
+    if reachability_value in {"confirmed", "likely", "unlikely"} and reachability_basis and reachability_supported:
         reachability = {
             "status": completeness["status"],
             "verdict": reachability_value,

--- a/tests/test_exposure_path_evidence_parity.py
+++ b/tests/test_exposure_path_evidence_parity.py
@@ -44,6 +44,7 @@ def test_exposure_path_surfaces_carry_independent_evidence_dimensions() -> None:
                 "source_node_id": "agent:a",
                 "target_node_id": target.id,
                 "relationship": "vulnerable_to",
+                "freshness": "fresh",
                 "complete": True,
                 "truncated": False,
             }
@@ -106,6 +107,41 @@ def test_missing_path_evidence_stays_unavailable_and_does_not_alias_risk() -> No
     api_payload = _serialize_both(path, nodes=[target], edges=[])[1]
     assert api_payload["evidence"]["isKev"] is None
     assert api_payload["evidence"]["networkExploitable"] is None
+
+
+def test_persisted_confirmed_path_without_freshness_is_not_reprojected_as_confirmed() -> None:
+    target = UnifiedNode(
+        id="vuln:cve",
+        entity_type=EntityType.VULNERABILITY,
+        label="CVE-2026-1",
+        severity="critical",
+    )
+    path = AttackPath(
+        source="agent:a",
+        target=target.id,
+        hops=["agent:a", target.id],
+        edges=["vulnerable_to"],
+        composite_risk=99.0,
+        reachability="confirmed",
+        reachability_basis=["legacy_structural_path"],
+        hop_evidence=[
+            {
+                "source_node_id": "agent:a",
+                "target_node_id": target.id,
+                "relationship": "vulnerable_to",
+                "complete": True,
+                "truncated": False,
+            }
+        ],
+        analysis={"status": "complete", "reason_codes": [], "limits": {}, "observed": {"hop_count": 1}},
+    )
+
+    for payload in _serialize_both(path, nodes=[target], edges=[]):
+        dimensions = payload["evidenceDimensions"]
+        assert dimensions["completeness"]["status"] == "partial"
+        assert dimensions["completeness"]["reasonCodes"] == ["unknown_evidence_freshness"]
+        assert dimensions["reachability"]["status"] == "unavailable"
+        assert dimensions["reachability"]["verdict"] is None
 
 
 def test_path_relationship_names_do_not_fabricate_edges_or_traversability() -> None:

--- a/tests/test_graph_attack_path_e2e.py
+++ b/tests/test_graph_attack_path_e2e.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from agent_bom.api.agent_identity_store import InMemoryAgentIdentityStore, issue_identity, issue_jit_grant
 from agent_bom.api.routes.graph import _derived_attack_paths, _fusion_signals_for_path
+from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
 from agent_bom.graph.cnapp_overlay import apply_cnapp_overlay
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
@@ -95,6 +96,14 @@ def test_every_attack_path_class_fires_end_to_end():
     cnapp = apply_cnapp_overlay(g)
     eff = apply_effective_permissions(g)
     gov = apply_governance_overlay(g, tenant_id="default", identity_store=store, drift_store=_NoDrift())
+
+    # This fixture asserts the scored, fully evidenced path class. Record both
+    # analyzer completion and relationship freshness explicitly rather than
+    # relying on in-memory topology to imply either contract.
+    g.analysis_status["attack_path_fusion"] = GraphAnalysisStatus(status=GraphAnalysisState.COMPLETE)
+    for edge in g.edges:
+        edge.evidence.setdefault("source", "e2e_fixture")
+        edge.evidence["freshness"] = "fresh"
 
     # Overlays produced the structure for every class.
     assert cnapp["exposed_nodes"] >= 1 and cnapp["data_stores_added"] >= 1

--- a/tests/test_graph_correlation_mechanical.py
+++ b/tests/test_graph_correlation_mechanical.py
@@ -12,12 +12,15 @@ from agent_bom.graph.attack_path_fusion import apply_attack_path_fusion, compute
 from agent_bom.graph.container import AttackPath, UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import UnifiedNode
-from agent_bom.graph.path_evidence import annotate_attack_path_evidence
+from agent_bom.graph.path_evidence import annotate_attack_path_evidence, exposure_evidence_dimensions
 from agent_bom.graph.types import EntityType, RelationshipType
 
 
 def _ordinary_vulnerability_graph() -> UnifiedGraph:
     graph = UnifiedGraph(scan_id="scan-a", tenant_id="tenant-a")
+    graph.analysis_status["attack_path_fusion"] = GraphAnalysisStatus(
+        status=GraphAnalysisState.COMPLETE,
+    )
     graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
     graph.add_node(UnifiedNode(id="server:a", entity_type=EntityType.SERVER, label="server-a"))
     graph.add_node(
@@ -37,6 +40,7 @@ def _ordinary_vulnerability_graph() -> UnifiedGraph:
             relationship=RelationshipType.USES,
             source_scan_id="scan-a",
             provenance={"source": "repository"},
+            evidence={"freshness": "fresh"},
         )
     )
     graph.add_edge(
@@ -45,7 +49,7 @@ def _ordinary_vulnerability_graph() -> UnifiedGraph:
             target="vuln:CVE-2026-1",
             relationship=RelationshipType.VULNERABLE_TO,
             source_scan_id="scan-a",
-            evidence={"advisory": "CVE-2026-1"},
+            evidence={"advisory": "CVE-2026-1", "freshness": "fresh"},
         )
     )
     return graph
@@ -242,6 +246,7 @@ def test_bidirectional_hop_remains_structural_not_confirmed() -> None:
 
 def test_stale_allowed_hop_cannot_be_promoted_to_confirmed() -> None:
     graph = UnifiedGraph(scan_id="corr-stale", tenant_id="tenant-a")
+    graph.analysis_status["attack_path_fusion"] = GraphAnalysisStatus(status=GraphAnalysisState.COMPLETE)
     graph.add_node(UnifiedNode(id="workload:public", entity_type=EntityType.CLOUD_RESOURCE, label="public workload"))
     graph.add_node(UnifiedNode(id="data_store:crown", entity_type=EntityType.DATA_STORE, label="crown jewel"))
     graph.add_edge(
@@ -250,7 +255,19 @@ def test_stale_allowed_hop_cannot_be_promoted_to_confirmed() -> None:
             target="data_store:crown",
             relationship=RelationshipType.CAN_ACCESS,
             source_scan_id="corr-stale",
-            provenance={"correlation": {"source_scan_ids": ["scan-a"], "freshness": "stale_allowed"}},
+            provenance={
+                "correlation": {
+                    "source_scan_ids": ["scan-a"],
+                    "freshness": "stale_allowed",
+                    "observations": [
+                        {
+                            "scan_id": "scan-a",
+                            "source_edge_id": "can_access:workload:public:data_store:crown",
+                            "evidence_digest": "sha256:receipt",
+                        }
+                    ],
+                }
+            },
         )
     )
     path = AttackPath(
@@ -318,7 +335,7 @@ def test_confirmed_path_carries_complete_per_hop_evidence() -> None:
         "source_snapshot_ids": ["scan-a"],
         "evidence_tier": "static_evidence",
         "confidence": 1.0,
-        "freshness": "unknown",
+        "freshness": "fresh",
         "runtime_observed_state": "not_observed",
         "direction": "directed",
         "traversable": True,
@@ -345,6 +362,125 @@ def test_attack_path_evidence_survives_sqlite_round_trip(tmp_path: Path) -> None
 
     assert restored.hop_evidence == path.hop_evidence
     assert restored.analysis == path.analysis
+    assert restored.reachability == "confirmed"
+    assert exposure_evidence_dimensions(restored, graph.nodes[restored.target])["reachability"] == {
+        "status": "complete",
+        "verdict": "confirmed",
+        "basis": ["import_path"],
+    }
+
+
+def test_missing_analyzer_status_cannot_confirm_fresh_hops() -> None:
+    graph = UnifiedGraph(scan_id="scan-a", tenant_id="tenant-a")
+    graph.add_node(UnifiedNode(id="workload:public", entity_type=EntityType.CLOUD_RESOURCE, label="public workload"))
+    graph.add_node(UnifiedNode(id="data_store:crown", entity_type=EntityType.DATA_STORE, label="crown jewel"))
+    graph.add_edge(
+        UnifiedEdge(
+            source="workload:public",
+            target="data_store:crown",
+            relationship=RelationshipType.CAN_ACCESS,
+            source_scan_id="scan-a",
+            evidence={"source": "policy_evaluator", "freshness": "fresh"},
+        )
+    )
+    path = AttackPath(
+        source="workload:public",
+        target="data_store:crown",
+        hops=["workload:public", "data_store:crown"],
+        edges=[RelationshipType.CAN_ACCESS.value],
+        composite_risk=80.0,
+        reachability="likely",
+    )
+
+    annotate_attack_path_evidence(path, graph)
+
+    assert path.analysis["status"] == "not_recorded"
+    assert path.hop_evidence[0]["truncated"] is True
+    assert path.reachability == "unknown"
+    dimensions = exposure_evidence_dimensions(path, graph.nodes[path.target])
+    assert dimensions["reachability"]["status"] == "unavailable"
+    assert dimensions["completeness"]["status"] == "unavailable"
+
+
+def test_unknown_freshness_cannot_complete_or_confirm_hop_evidence(tmp_path: Path) -> None:
+    graph = UnifiedGraph(scan_id="scan-a", tenant_id="tenant-a")
+    graph.analysis_status["attack_path_fusion"] = GraphAnalysisStatus(status=GraphAnalysisState.COMPLETE)
+    graph.add_node(UnifiedNode(id="workload:public", entity_type=EntityType.CLOUD_RESOURCE, label="public workload"))
+    graph.add_node(UnifiedNode(id="data_store:crown", entity_type=EntityType.DATA_STORE, label="crown jewel"))
+    graph.add_edge(
+        UnifiedEdge(
+            source="workload:public",
+            target="data_store:crown",
+            relationship=RelationshipType.CAN_ACCESS,
+            source_scan_id="scan-a",
+            evidence={"source": "policy_evaluator"},
+        )
+    )
+    path = AttackPath(
+        source="workload:public",
+        target="data_store:crown",
+        hops=["workload:public", "data_store:crown"],
+        edges=[RelationshipType.CAN_ACCESS.value],
+        composite_risk=80.0,
+        reachability="likely",
+    )
+
+    annotate_attack_path_evidence(path, graph)
+
+    assert path.hop_evidence[0]["freshness"] == "unknown"
+    assert path.hop_evidence[0]["complete"] is False
+    assert path.reachability == "unknown"
+    dimensions = exposure_evidence_dimensions(path, graph.nodes[path.target])
+    assert dimensions["reachability"]["status"] == "unavailable"
+    assert dimensions["completeness"] == {
+        "status": "partial",
+        "expectedHops": 1,
+        "evidencedHops": 1,
+        "analysisStatus": "complete",
+        "reasonCodes": ["unknown_evidence_freshness"],
+    }
+
+    graph.attack_paths = [path]
+    store = SQLiteGraphStore(tmp_path / "graph.db")
+    store.save_graph(graph)
+    restored = store.load_graph(tenant_id="tenant-a", scan_id="scan-a").attack_paths[0]
+    restored_dimensions = exposure_evidence_dimensions(restored, graph.nodes[restored.target])
+    assert restored.reachability == "unknown"
+    assert restored_dimensions["reachability"]["status"] == "unavailable"
+    assert restored_dimensions["completeness"]["reasonCodes"] == ["unknown_evidence_freshness"]
+
+
+def test_snapshot_membership_and_irrelevant_provenance_are_not_relationship_receipts() -> None:
+    graph = UnifiedGraph(scan_id="corr-a", tenant_id="tenant-a")
+    graph.analysis_status["attack_path_fusion"] = GraphAnalysisStatus(status=GraphAnalysisState.COMPLETE)
+    graph.add_node(UnifiedNode(id="workload:public", entity_type=EntityType.CLOUD_RESOURCE, label="public workload"))
+    graph.add_node(UnifiedNode(id="data_store:crown", entity_type=EntityType.DATA_STORE, label="crown jewel"))
+    graph.add_edge(
+        UnifiedEdge(
+            source="workload:public",
+            target="data_store:crown",
+            relationship=RelationshipType.CAN_ACCESS,
+            source_scan_id="corr-a",
+            provenance={
+                "note": "not a relationship receipt",
+                "correlation": {"source_scan_ids": ["scan-a"], "freshness": "fresh"},
+            },
+        )
+    )
+    path = AttackPath(
+        source="workload:public",
+        target="data_store:crown",
+        hops=["workload:public", "data_store:crown"],
+        edges=[RelationshipType.CAN_ACCESS.value],
+        composite_risk=80.0,
+        reachability="likely",
+    )
+
+    annotate_attack_path_evidence(path, graph)
+
+    assert path.hop_evidence[0]["complete"] is False
+    assert path.reachability == "unknown"
+    assert exposure_evidence_dimensions(path, graph.nodes[path.target])["completeness"]["status"] == "partial"
 
 
 def test_final_fusion_runs_after_runtime_code_ci_and_endpoint_overlays(monkeypatch: Any) -> None:

--- a/tests/test_graph_crown_jewel_paths.py
+++ b/tests/test_graph_crown_jewel_paths.py
@@ -9,6 +9,7 @@ graph cockpit humans use.
 from __future__ import annotations
 
 from agent_bom.api.routes.graph import _derived_attack_paths, _derived_toxic_combination_paths
+from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import UnifiedNode
@@ -17,6 +18,7 @@ from agent_bom.graph.types import EntityType, RelationshipType
 
 def _crown_jewel_graph(*, evidence_backed: bool = True) -> UnifiedGraph:
     g = UnifiedGraph(scan_id="cj", tenant_id="t")
+    g.analysis_status["attack_path_fusion"] = GraphAnalysisStatus(status=GraphAnalysisState.COMPLETE)
     # An internet-exposed, vulnerable VM that reaches a PCI data store.
     g.add_node(
         UnifiedNode(


### PR DESCRIPTION
## Summary
- Require recorded complete analysis and per-hop evidence before confirming a directed attack path.
- Preserve unknown, stale, limited, and failed evidence as explicit states across API and MCP exposure projections.
- Preserve independent reachability, exploitability, impact, actionability, and completeness dimensions.

## Verification
- 24 focused graph/exposure regression tests passed after rebasing onto main `382698abe`.
- Full mypy (890 source files), `make preflight`, and changed-file pre-commit hooks passed.

## Notes
This repairs backend path-evidence completeness. Runtime occurrence identity and stricter frontend receipt validation follow as focused changes. No publication or deployment.
