### PR TITLE
fix(ci): validate README contracts before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -905,6 +905,7 @@ jobs:
           ./scripts/build-msi.ps1 -BundleDir $env:BUNDLE_DIR -OutputPath (Join-Path $env:RUNNER_TEMP "agent-bom-endpoint.msi") -Version $version -DryRun
 
   # 3. Python correctness
+  # Public-doc contracts run even for UI-only, docs-only, and mixed changes.
   # Fast changed-domain/product-boundary feedback starts package proof while
   # the exhaustive PR shards continue in parallel. The core aggregator below
   # requires every applicable shard plus measured graph evidence. The existing
@@ -919,34 +920,18 @@ jobs:
     needs: changes
     if: ${{ !cancelled() }}
     steps:
-      - name: Documentation-only test skip
-        if: needs.changes.result == 'success' && needs.changes.outputs.python != 'true'
-        run: echo "No Python test input changed; smoke is not required."
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: >-
-          needs.changes.result != 'success' ||
-          needs.changes.outputs.python == 'true'
         with:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-python
-        if: >-
-          needs.changes.result != 'success' ||
-          needs.changes.outputs.python == 'true'
         with:
           python-version: "3.13"
 
       - name: Install dependencies
-        if: >-
-          needs.changes.result != 'success' ||
-          needs.changes.outputs.python == 'true'
         run: uv sync --frozen --extra dev --extra api --extra mcp-server
 
       - name: Run changed-domain and cross-surface smoke
-        if: >-
-          needs.changes.result != 'success' ||
-          needs.changes.outputs.python == 'true'
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -959,6 +944,9 @@ jobs:
           mapfile -t TARGETED < <(uv run python scripts/pytest_ci_plan.py targeted --root . "${CHANGED[@]}")
           SMOKE=(
             tests/test_ci_workflow_contract.py
+            tests/test_doc_architecture_svgs.py
+            tests/test_public_frontdoor_contract.py
+            tests/test_public_docs_cli_alignment.py
             tests/test_cli_entry_points.py
             tests/test_product_surface_contract.py
             tests/api/test_api_scan_findings_wiring.py

--- a/README.md
+++ b/README.md
@@ -91,9 +91,10 @@ infrastructure and runtime observations remain separately labeled.
 
 The credential-free lab runs repository, CycloneDX, Kubernetes IaC, and MCP
 parsers plus the bundled advisory scanner for `pillow@9.0.0` / `CVE-2023-4863`.
-Correlation connects the OCI digest, Kubernetes UID, MCP tool, workload identity,
-and local gateway receipts. An observed call and a separate opt-in block have
-independent receipts; neither is proof of a deployed remediation.
+Correlation connects scoped runtime identities, MCP tools, and gateway receipts
+with per-hop source provenance. Shared OCI digests are metadata, not runtime
+identity. Runtime observation and strict block proof have independent receipts;
+neither is proof of a deployed remediation.
 
 [Run the reference lab](examples/reference-evidence-lab/README.md) ·
 [Capture protocol](docs/CAPTURE.md)

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -42,7 +42,7 @@ def test_required_ci_contexts_use_docs_only_fast_paths_without_disappearing() ->
     workflow_text = CI_WORKFLOW.read_text(encoding="utf-8")
     assert "scripts/classify_ci_changes.py" in workflow_text
     assert "Documentation-only safety checks" in workflow_text
-    assert "Documentation-only test skip" in workflow_text
+    assert "Documentation-only test skip" not in workflow_text
     assert "Documentation-only package skip" in workflow_text
 
 
@@ -235,6 +235,18 @@ def test_python_smoke_gate_combines_changed_domain_and_cross_surface_contracts()
     assert "tests/test_cli_entry_points.py" in run
     assert "tests/test_product_surface_contract.py" in run
     assert "tests/api/test_api_scan_findings_wiring.py" in run
+
+
+def test_readme_contracts_run_for_ui_and_documentation_only_changes() -> None:
+    """Public presentation edits must fail PR CI before the full main suite."""
+    smoke = _ci()["jobs"]["test-smoke"]
+    steps = smoke["steps"]
+    for step in steps:
+        if "uses" in step or step.get("name") in {"Install dependencies", "Run changed-domain and cross-surface smoke"}:
+            assert step.get("if") is None
+    run = next(step["run"] for step in steps if step.get("name") == "Run changed-domain and cross-surface smoke")
+    for contract in ("test_doc_architecture_svgs.py", "test_public_frontdoor_contract.py", "test_public_docs_cli_alignment.py"):
+        assert f"tests/{contract}" in run
 
 
 def test_package_build_waits_for_smoke_not_long_correctness_shards() -> None:

--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -218,7 +218,7 @@ def test_readme_links_end_to_end_workflow_before_persona_detail() -> None:
     workflow = readme[workflow_heading:persona_heading]
     normalized_workflow = " ".join(workflow.split())
     assert "runtime enforcement in your own environment" in normalized_workflow
-    assert "### Product proof: independent evidence, one verifiable path" in workflow
+    assert "### See what needs fixing — and why" in workflow
     assert "Reference evidence lab — modeled local infrastructure" in normalized_workflow
     assert "correlation-receipts-live.png" in workflow
     assert "correlation-path-live.png" in workflow

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -142,7 +142,8 @@ def test_readme_distinguishes_graph_relationship_provenance() -> None:
     normalized = " ".join(readme.lower().split())
 
     assert "Graph views use observed nodes and relationships" not in readme
-    assert "correlates exact oci digest" in normalized
+    assert "shared oci digests are metadata, not runtime identity" in normalized
+    assert "scoped runtime identities" in normalized
     assert "per-hop source provenance" in normalized
     assert "runtime observation and strict block proof" in normalized
     assert "observed graph evidence" not in readme
@@ -222,7 +223,7 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert "Add a read-only connection" in normalized_intro
     assert "Inventory is always the output" in normalized_intro
     assert "workflow-dark.svg" in intro
-    assert "### Product proof: independent evidence, one verifiable path" in intro
+    assert "### See what needs fixing — and why" in intro
 
     quick_start = readme.split("## Quick start", 1)[1].split("\n## ", 1)[0]
     primary_block = re.search(r"```bash\n(.*?)\n```", quick_start, re.S)
@@ -232,8 +233,9 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
 
     assert "<summary><b>Try without a repository</b></summary>" in readme
     for image in ("correlation-receipts-live.png", "correlation-path-live.png"):
-        assert readme.count(image) == 2  # linked thumbnail: href plus src
-    assert "[Open the full product gallery](docs/GALLERY.md)" in readme
+        assert readme.count(image) == 1  # one full-width screenshot per stage
+        assert image.replace("-live.png", "-light-live.png") in readme
+    assert "[Explore the product gallery](docs/GALLERY.md)" in readme
     assert "gateway-policies-live.png" not in readme
 
     # Persona surfaces keep security engineering and GRC as separate lanes

--- a/tests/test_public_frontdoor_contract.py
+++ b/tests/test_public_frontdoor_contract.py
@@ -105,7 +105,7 @@ def test_readme_shows_the_end_to_end_product_journey_and_links_the_gallery() -> 
     assert all(image in journey for image in images)
     assert [journey.index(image) for image in images] == sorted(journey.index(image) for image in images)
     assert 'width="920"' in journey
-    assert "[Open the full product gallery](docs/GALLERY.md)" in journey
+    assert "[Explore the product gallery](docs/GALLERY.md)" in journey
     assert "reference evidence lab — modeled local infrastructure" in normalized
     assert "CVE-2023-4863" in journey
     assert "DEMO-VULN" not in journey


### PR DESCRIPTION
## Summary
- Repair four README contract failures reproduced on main after the investigation UI refresh; keep the outcome-first layout and theme-aware screenshots.
- State scoped runtime identity and shared-digest metadata boundaries in the existing evidence disclosure.
- Run the compact public-documentation contracts on every PR, including UI-only and documentation-only changes, so these failures cannot hide until the full main suite.

## Verification
- Before repair: 4 failed, 48 passed across the three README contract files; the new CI gating regression also failed.
- After repair: 140 passed across README, workflow, CLI, product-surface, and API scan-wiring smoke tests.
- `make preflight`; changed-file pre-commit hooks; Ruff; CI pipefail, workflow timeout, public-doc hygiene, and `git diff --check` passed.

## Notes
- References #5108. Close after merge and passing exact-main CI.
- No application code, generated screenshots, release tag, publication, or deployment changes.
