### PR TITLE
fix(registry): verify public schemas and migrate Smithery namespace

### DIFF
--- a/.github/workflows/deployment-freshness.yml
+++ b/.github/workflows/deployment-freshness.yml
@@ -111,7 +111,7 @@ jobs:
           SMITHERY_SERVER_QUALIFIED_NAME: ${{ vars.SMITHERY_SERVER_QUALIFIED_NAME }}
           EXPECTED_TOOL_COUNT: ${{ steps.expected.outputs.tool_count }}
         run: |
-          QUALIFIED_NAME="${SMITHERY_SERVER_QUALIFIED_NAME:-agent-bom/agent-bom}"
+          QUALIFIED_NAME="${SMITHERY_SERVER_QUALIFIED_NAME:-agentbom/agent-bom}"
           RESPONSE=$(EXPECTED_TOOL_COUNT="$EXPECTED_TOOL_COUNT" python3 - <<'PY'
           import json
           import os
@@ -120,7 +120,7 @@ jobs:
           import urllib.parse
           import urllib.request
 
-          name = os.environ.get("SMITHERY_SERVER_QUALIFIED_NAME") or "agent-bom/agent-bom"
+          name = os.environ.get("SMITHERY_SERVER_QUALIFIED_NAME") or "agentbom/agent-bom"
           if "/" not in name:
               print(json.dumps({"error": f"invalid Smithery qualified name: {name!r}"}))
               sys.exit(1)
@@ -253,7 +253,7 @@ jobs:
             const labels = ["supply-chain-drift", "security-preventive", "automated"];
 
             const unmonitored = [
-              "**Smithery / public marketplace** — set repo variable `SMITHERY_SERVER_QUALIFIED_NAME` only if the listing is not `agent-bom/agent-bom`. The monitor checks Smithery's catalog API because Smithery-hosted remotes are OAuth-gated and do not expose agent-bom `/health`.",
+              "**Smithery / public marketplace** — set repo variable `SMITHERY_SERVER_QUALIFIED_NAME` only if the listing is not `agentbom/agent-bom`. The monitor checks Smithery's catalog API because Smithery-hosted remotes are OAuth-gated and do not expose agent-bom `/health`.",
             ];
 
             const body = [

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -244,7 +244,7 @@ jobs:
           set -euo pipefail
           echo "fresh=false" >> "$GITHUB_OUTPUT"
           if ! curl -fsS --connect-timeout 10 --max-time 30 \
-              "https://api.smithery.ai/servers/agent-bom/agent-bom" \
+              "https://api.smithery.ai/servers/agentbom/agent-bom" \
               -o /tmp/smithery-catalog.json; then
             echo "::error::Smithery catalog is unavailable; refusing to create a potentially duplicate release"
             exit 1
@@ -253,7 +253,7 @@ jobs:
           : > /tmp/smithery-success-releases.jsonl
           for PAGE in $(seq 1 "$MAX_RELEASE_PAGES"); do
             curl -fsS --connect-timeout 10 --max-time 30 \
-              -X GET "https://api.smithery.ai/servers/agent-bom%2Fagent-bom/releases?page=${PAGE}&pageSize=100" \
+              -X GET "https://api.smithery.ai/servers/agentbom%2Fagent-bom/releases?page=${PAGE}&pageSize=100" \
               -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" \
               -o /tmp/smithery-latest-releases.json
             jq -e \
@@ -300,7 +300,7 @@ jobs:
           SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
         run: |
           set -euo pipefail
-          QUALIFIED_NAME="agent-bom%2Fagent-bom"
+          QUALIFIED_NAME="agentbom%2Fagent-bom"
           echo "release_id=" >> "$GITHUB_OUTPUT"
           MAX_RELEASE_PAGES=20
           : > /tmp/smithery-active-releases.jsonl
@@ -358,7 +358,7 @@ jobs:
           SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
           VERSION: ${{ needs.release.outputs.version }}
         run: |
-          QUALIFIED_NAME="agent-bom%2Fagent-bom"
+          QUALIFIED_NAME="agentbom%2Fagent-bom"
           MCP_URL="${SMITHERY_MCP_URL}"
 
           echo "Publishing agent-bom v${VERSION} to Smithery..."
@@ -409,7 +409,7 @@ jobs:
           AUTHORIZATION_ATTEMPTED=false
           for ATTEMPT in $(seq 1 90); do
             curl -fsS --connect-timeout 10 --max-time 30 \
-              "https://api.smithery.ai/servers/agent-bom%2Fagent-bom/releases/${RELEASE_ID}" \
+              "https://api.smithery.ai/servers/agentbom%2Fagent-bom/releases/${RELEASE_ID}" \
               -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" \
               -o /tmp/smithery-release.json
             STATUS=$(jq -er '.status' /tmp/smithery-release.json)
@@ -430,7 +430,7 @@ jobs:
                   --upstream-url "$SMITHERY_MCP_URL"
                 HTTP_STATUS=$(curl -sS --connect-timeout 10 --max-time 30 \
                   -o /tmp/smithery-resume-response.json -w "%{http_code}" \
-                  -X POST "https://api.smithery.ai/servers/agent-bom%2Fagent-bom/releases/${RELEASE_ID}/resume" \
+                  -X POST "https://api.smithery.ai/servers/agentbom%2Fagent-bom/releases/${RELEASE_ID}/resume" \
                   -H "Authorization: Bearer ${SMITHERY_API_TOKEN}")
                 if [ "$HTTP_STATUS" != "202" ]; then
                   echo "::error::Smithery release could not be resumed after scan authorization (HTTP ${HTTP_STATUS})"
@@ -457,7 +457,7 @@ jobs:
           set -euo pipefail
           for ATTEMPT in $(seq 1 12); do
             if curl -fsS --connect-timeout 10 --max-time 30 \
-                "https://api.smithery.ai/servers/agent-bom/agent-bom" \
+                "https://api.smithery.ai/servers/agentbom/agent-bom" \
                 -o /tmp/smithery-catalog.json; then
               jq -S '[.tools[].name] | sort' /tmp/smithery-catalog.json > /tmp/smithery-actual-tool-names.json
               jq -S '[.tools[] | {name, inputSchema}] | sort_by(.name)' \

--- a/.github/workflows/surface-freshness.yml
+++ b/.github/workflows/surface-freshness.yml
@@ -8,7 +8,7 @@ name: Surface Freshness
 # three months without an alert.
 #
 # Optional repo variables (Settings -> Secrets and variables -> Actions -> Variables):
-#   SMITHERY_SERVER_QUALIFIED_NAME — override Smithery listing name; defaults to agent-bom/agent-bom
+#   SMITHERY_SERVER_QUALIFIED_NAME — override Smithery listing name; defaults to agentbom/agent-bom
 #   GLAMA_LISTING_URL  — override Glama listing URL (default: glama.ai/.../msaad00/agent-bom)
 #   GLAMA_API_URL      — override Glama public inventory API URL
 #   DOCKER_IMAGE       — override default ghcr.io/msaad00/agent-bom
@@ -134,7 +134,7 @@ jobs:
               "- `unreachable` — the surface URL is configured but the probe failed (network / HTTP / parse).",
               "- `partial evidence` — the visible listing matches, but exact machine-readable verification is unavailable; the issue remains open.",
               "",
-              "Optional overrides (blank/unset repo vars fall back to defaults): `DOCKER_IMAGE` (`ghcr.io/msaad00/agent-bom`), `GLAMA_LISTING_URL`, `GLAMA_API_URL`, `SMITHERY_SERVER_QUALIFIED_NAME` (`agent-bom/agent-bom`).",
+              "Optional overrides (blank/unset repo vars fall back to defaults): `DOCKER_IMAGE` (`ghcr.io/msaad00/agent-bom`), `GLAMA_LISTING_URL`, `GLAMA_API_URL`, `SMITHERY_SERVER_QUALIFIED_NAME` (`agentbom/agent-bom`).",
               "",
               "_Maintained automatically by the surface-freshness workflow. Self-closes when every surface is fresh and monitored._",
             ].join("\n");

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue?style=flat" alt="Apache-2.0 license"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom"><img src="https://img.shields.io/ossf-scorecard/github.com/msaad00/agent-bom?style=flat&label=OpenSSF%20scorecard" alt="OpenSSF Scorecard"></a>
   <a href="https://glama.ai/mcp/servers/msaad00/agent-bom"><img src="https://img.shields.io/badge/MCP-Glama-7c3aed?style=flat" alt="Glama MCP server"></a>
-  <a href="https://smithery.ai/servers/agent-bom/agent-bom"><img src="https://img.shields.io/badge/MCP-Smithery-1f6feb?style=flat" alt="Smithery MCP server"></a>
+  <a href="https://smithery.ai/servers/agentbom/agent-bom"><img src="https://img.shields.io/badge/MCP-Smithery-1f6feb?style=flat" alt="Smithery MCP server"></a>
 </p>
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -31,16 +31,16 @@ your ingress or platform edge.
 
 The daily deployment-freshness workflow probes this protected Railway `/health`
 surface with the configured bearer token, and probes Smithery through
-`https://api.smithery.ai/servers/agent-bom/agent-bom` for catalog liveness,
-remote deployment metadata, and non-empty tools.
+`https://api.smithery.ai/servers/agentbom/agent-bom` for catalog liveness,
+remote deployment metadata, and the exact released tool inventory.
 
 ### Step 2: Publish to Smithery
 
 **Option A — Web UI**:
 1. Go to https://smithery.ai/servers/new
-2. Namespace: `agent-bom`
+2. Namespace: `agentbom`
 3. Server ID: `agent-bom`
-4. Follow Smithery's managed remote flow for the `agent-bom/agent-bom` listing.
+4. Follow Smithery's managed remote flow for the `agentbom/agent-bom` listing.
 5. Click **Continue**
 
 **Option B — Automated**:
@@ -52,7 +52,9 @@ release-bound server card. If names, schemas, description, and the latest
 successful upstream URL already match, the workflow skips a duplicate
 deployment. If capabilities, listing metadata, or the upstream changed, it
 creates an external release using:
-- `SMITHERY_API_TOKEN`
+- `SMITHERY_API_TOKEN`: a publisher token belonging to the account that owns the
+  `agentbom` namespace. Store it as a GitHub Actions secret; never put it in
+  source files or use the protected MCP deployment bearer token here.
 
 `SMITHERY_MCP_URL` is retained only for the external-upstream publish mode. It
 must never point at Smithery's hosted proxy URL. Freshness monitoring no longer
@@ -74,7 +76,7 @@ provider still requires authorization or the exact catalog does not converge.
 After publishing, check:
 
 ```bash
-curl -fsSL https://api.smithery.ai/servers/agent-bom/agent-bom \
+curl -fsSL https://api.smithery.ai/servers/agentbom/agent-bom \
   | jq '{qualifiedName, remote, deploymentUrl, tool_count: (.tools | length)}'
 ```
 

--- a/scripts/check_glama_listing.py
+++ b/scripts/check_glama_listing.py
@@ -202,8 +202,8 @@ def _extract_schema_tool_contract(page: str, listing_url: str) -> list[dict[str,
             remaining -= 1
             if remaining < 0 or depth > 64 or type(index) is not int:
                 raise ValueError("schema reference limit exceeded")
-            # React Router's null and undefined sentinels carry no schema data.
-            if index in {-5, -7}:
+            # Turbo Stream encodes JSON null as -5; undefined (-7) is not null.
+            if index == -5:
                 return None
             if index < 0 or index >= len(table) or index in active:
                 raise ValueError("invalid or cyclic schema reference")

--- a/scripts/check_glama_listing.py
+++ b/scripts/check_glama_listing.py
@@ -176,6 +176,82 @@ def _api_inventory_result(
     return actual_tool_count, failures, exact_tool_set, exact_input_schemas
 
 
+def _extract_schema_tool_contract(page: str, listing_url: str) -> list[dict[str, object]]:
+    """Read bounded reference-table JSON from Glama's public schema route.
+
+    This decodes data only. Scripts are never evaluated, and unrelated route
+    data cannot substitute for the requested server's indexed tool inventory.
+    Unsupported encodings stay unavailable rather than weakening validation.
+    """
+    if len(page.encode("utf-8")) > 2 * 1024 * 1024:
+        raise ValueError("Glama schema page exceeds the bounded input size")
+    marker = "window.__reactRouterContext.streamController.enqueue("
+    if page.count(marker) != 1:
+        raise ValueError("Glama schema state is missing or ambiguous")
+    try:
+        encoded, _ = json.JSONDecoder().raw_decode(page.split(marker, 1)[1])
+        table = json.loads(encoded)
+        if not isinstance(table, list) or not table or len(table) > 50_000:
+            raise ValueError("invalid schema reference table")
+        cache: dict[int, object] = {}
+        active: set[int] = set()
+        remaining = 100_000
+
+        def decode(index: int, depth: int = 0) -> object:
+            nonlocal remaining
+            remaining -= 1
+            if remaining < 0 or depth > 64 or type(index) is not int:
+                raise ValueError("schema reference limit exceeded")
+            # React Router's null and undefined sentinels carry no schema data.
+            if index in {-5, -7}:
+                return None
+            if index < 0 or index >= len(table) or index in active:
+                raise ValueError("invalid or cyclic schema reference")
+            if index in cache:
+                return cache[index]
+            active.add(index)
+            value = table[index]
+            result: object
+            if isinstance(value, dict):
+                decoded: dict[str, object] = {}
+                for key, reference in value.items():
+                    if not re.fullmatch(r"_\d+", key):
+                        raise ValueError("invalid schema key reference")
+                    decoded_key = decode(int(key[1:]), depth + 1)
+                    if not isinstance(decoded_key, str) or decoded_key in decoded:
+                        raise ValueError("invalid or duplicate schema key")
+                    decoded[decoded_key] = decode(reference, depth + 1)
+                result = decoded
+            elif isinstance(value, list):
+                result = [decode(reference, depth + 1) for reference in value]
+            else:
+                result = value
+            active.remove(index)
+            cache[index] = result
+            return result
+
+        root = decode(0)
+        if not isinstance(root, dict):
+            raise ValueError("schema state root must be an object")
+        route = root["loaderData"]["routes/_public/mcp/servers/~namespace/~slug/_pages/schema/_route"]
+        server = route["mcpServer"]
+        parts = urllib.parse.urlsplit(listing_url).path.strip("/").split("/")
+        if len(parts) != 4 or parts[:2] != ["mcp", "servers"]:
+            raise ValueError("invalid listing path")
+        if (server["namespace"]["slug"], server["slug"]) != tuple(parts[-2:]):
+            raise ValueError("schema state belongs to another server")
+        tools = route["schema"]["tools"]
+        if (
+            not isinstance(tools, list)
+            or not tools
+            or any(not isinstance(tool, dict) or not isinstance(tool.get("inputSchema"), dict) for tool in tools)
+        ):
+            raise ValueError("schema state has incomplete tool contracts")
+        return tools
+    except (KeyError, IndexError, TypeError, RecursionError, ValueError) as exc:
+        raise ValueError("Glama public schema state is unavailable or malformed") from exc
+
+
 def _release_tool_names(git_ref: str | None) -> list[str]:
     """Parse the release's static server-card tool list without executing it."""
 
@@ -186,6 +262,8 @@ def _release_tool_names(git_ref: str | None) -> list[str]:
             continue
         targets = node.targets if isinstance(node, ast.Assign) else [node.target]
         if any(isinstance(target, ast.Name) and target.id == "_SERVER_CARD_TOOLS" for target in targets):
+            if node.value is None:
+                raise ValueError("release metadata has no static MCP tool value")
             raw_tools = ast.literal_eval(node.value)
             break
     if not isinstance(raw_tools, list) or not raw_tools:
@@ -193,7 +271,7 @@ def _release_tool_names(git_ref: str | None) -> list[str]:
     names = [tool.get("name") for tool in raw_tools if isinstance(tool, dict)]
     if len(names) != len(raw_tools) or any(not isinstance(name, str) or not name or name != name.strip() for name in names):
         raise ValueError("release metadata contains an invalid MCP tool name")
-    normalized = sorted(names)
+    normalized = sorted(name for name in names if isinstance(name, str))
     if len(set(normalized)) != len(normalized):
         raise ValueError("release metadata contains duplicate MCP tool names")
     return normalized
@@ -418,8 +496,10 @@ def main(argv: list[str] | None = None) -> int:
             listing_version = _extract_listing_version(page)
             failures = _check(page, version, tool_count)
             schema_tools: list[str] = []
+            schema_page = ""
             try:
-                schema_tools = _extract_schema_tool_names(_fetch(args.schema_url, args.timeout), args.url)
+                schema_page = _fetch(args.schema_url, args.timeout)
+                schema_tools = _extract_schema_tool_names(schema_page, args.url)
             except (urllib.error.URLError, TimeoutError):
                 # The directory API remains a valid fallback when the rendered
                 # Schema page cannot be fetched or has not populated yet.
@@ -438,8 +518,22 @@ def main(argv: list[str] | None = None) -> int:
             except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
                 api_error = exc
 
+            public_schema_result = False
+            if api_result is None and schema_page:
+                try:
+                    indexed_tools = _extract_schema_tool_contract(schema_page, args.url)
+                    api_result = _api_inventory_result(
+                        indexed_tools,
+                        tool_count=tool_count,
+                        expected_tool_names=expected_tool_names,
+                        expected_tool_contract=expected_tool_contract,
+                    )
+                    public_schema_result = True
+                except ValueError:
+                    pass  # Unsupported public data retains the degraded/unavailable status.
+
             if schema_tools:
-                inventory_source = "schema+api" if api_result is not None else "schema"
+                inventory_source = "schema-state" if public_schema_result else "schema+api" if api_result is not None else "schema"
                 actual_tool_count = len(schema_tools)
                 if actual_tool_count != tool_count:
                     failures.append(f"Glama public Schema exposes {actual_tool_count} tools; expected {tool_count}")
@@ -457,13 +551,15 @@ def main(argv: list[str] | None = None) -> int:
                         exact_tool_set = bool(exact_tool_set is not False and api_exact_set)
                     exact_input_schemas = api_exact_schemas
             elif api_result is not None:
-                inventory_source = "api"
+                inventory_source = "schema-state" if public_schema_result else "api"
                 actual_tool_count, api_failures, exact_tool_set, exact_input_schemas = api_result
                 failures.extend(api_failures)
             else:
                 inventory_source = "api"
                 failures.append(f"failed to verify Glama public API tool inventory: {api_error}")
                 last_probe_unreachable = True
+            if expected_tool_contract is not None and exact_input_schemas is None:
+                failures.append("could not verify requested input schemas from Glama indexed evidence")
             if not failures:
                 status = "fresh_degraded" if degraded_reason else "fresh"
                 if args.json:

--- a/scripts/check_surface_freshness.py
+++ b/scripts/check_surface_freshness.py
@@ -45,7 +45,7 @@ GLAMA_SCRIPT = ROOT / "scripts" / "check_glama_listing.py"
 
 PYPI_PACKAGE = "agent-bom"
 DEFAULT_DOCKER_IMAGE = "ghcr.io/msaad00/agent-bom"
-DEFAULT_SMITHERY_SERVER = "agent-bom/agent-bom"
+DEFAULT_SMITHERY_SERVER = "agentbom/agent-bom"
 # Requests to this origin carry an anonymous-pull bearer token, so pagination
 # links must never move off it.
 GHCR_ORIGIN = "https://ghcr.io"

--- a/site-docs/integrations/smithery.md
+++ b/site-docs/integrations/smithery.md
@@ -7,8 +7,8 @@ actually reads.
 
 The manifest and release workflow are ready for Smithery publication. The public
 catalog entry is considered live when Smithery's catalog API lists
-`agent-bom/agent-bom` as a remote server with a deployment URL and non-empty tool
-inventory. Smithery-hosted remotes are OAuth-gated by Smithery, so they do not
+`agentbom/agent-bom` as a remote server with a deployment URL and the exact
+released tool names and input schemas. Smithery-hosted remotes are OAuth-gated by Smithery, so they do not
 expose agent-bom's raw `/health` route.
 
 The external Streamable HTTP release is separate from the managed stdio manifest

--- a/tests/test_publish_registries_release_auth_gate.py
+++ b/tests/test_publish_registries_release_auth_gate.py
@@ -42,7 +42,7 @@ def test_smithery_publication_is_idempotent_and_bounds_authorization_recovery() 
     assert "LATEST_SUCCESS_UPSTREAM" in workflow
     assert 'select(.type == "external_shttp" and .status == "SUCCESS")' in workflow
     assert ": > /tmp/smithery-success-releases.jsonl" in workflow
-    assert 'GET "https://api.smithery.ai/servers/agent-bom%2Fagent-bom/releases?page=${PAGE}&pageSize=100"' in workflow
+    assert 'GET "https://api.smithery.ai/servers/agentbom%2Fagent-bom/releases?page=${PAGE}&pageSize=100"' in workflow
     assert '"$LATEST_SUCCESS_UPSTREAM" = "$SMITHERY_MCP_URL"' in workflow
     assert "tool catalog matches but the successful release upstream differs" in workflow
     assert "smithery_catalog.outputs.fresh != 'true'" in workflow

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -752,11 +752,13 @@ def test_ghcr_pagination_still_follows_a_same_origin_next_link(monkeypatch):
     assert result["status"] == "fresh"
 
 
-def _glama_schema_state(tools, *, namespace="msaad00", slug="agent-bom"):
+def _glama_schema_state(tools, *, namespace="msaad00", slug="agent-bom", null_reference=-5):
     """Encode the public schema route's reference-table JSON, without JS execution."""
     values = []
 
     def encode(value):
+        if value is None:
+            return null_reference
         index = len(values)
         values.append(None)
         if isinstance(value, dict):
@@ -871,3 +873,11 @@ def test_glama_schema_reference_tables_fail_closed(table):
     page = "<script>window.__reactRouterContext.streamController.enqueue(" + json.dumps(json.dumps(table)) + ");</script>"
     with pytest.raises(ValueError):
         script._extract_schema_tool_contract(page, script.DEFAULT_URL)
+
+
+def test_glama_schema_does_not_conflate_undefined_with_json_null():
+    script = _load_script("check_glama_listing.py")
+    tools = [{"name": "scan", "inputSchema": {"type": "object", "default": None}}]
+    assert script._extract_schema_tool_contract(_glama_schema_state(tools), script.DEFAULT_URL) == tools
+    with pytest.raises(ValueError):
+        script._extract_schema_tool_contract(_glama_schema_state(tools, null_reference=-7), script.DEFAULT_URL)

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -750,3 +750,124 @@ def test_ghcr_pagination_still_follows_a_same_origin_next_link(monkeypatch):
     result = script.probe_docker("0.98.3", "ghcr.io/msaad00/agent-bom", timeout=1, attempts=1, backoff=0)
 
     assert result["status"] == "fresh"
+
+
+def _glama_schema_state(tools, *, namespace="msaad00", slug="agent-bom"):
+    """Encode the public schema route's reference-table JSON, without JS execution."""
+    values = []
+
+    def encode(value):
+        index = len(values)
+        values.append(None)
+        if isinstance(value, dict):
+            values[index] = {f"_{encode(key)}": encode(item) for key, item in value.items()}
+        elif isinstance(value, list):
+            values[index] = [encode(item) for item in value]
+        else:
+            values[index] = value
+        return index
+
+    encode(
+        {
+            "loaderData": {
+                "routes/_public/mcp/servers/~namespace/~slug/_pages/schema/_route": {
+                    "mcpServer": {"namespace": {"slug": namespace}, "slug": slug},
+                    "schema": {"tools": tools},
+                }
+            }
+        }
+    )
+    return "<script>window.__reactRouterContext.streamController.enqueue(" + json.dumps(json.dumps(values)) + ");</script>"
+
+
+@pytest.mark.parametrize("mismatch", [False, True])
+def test_glama_checks_public_embedded_schemas_when_api_requires_auth(monkeypatch, capsys, tmp_path, mismatch):
+    script = _load_script("check_glama_listing.py")
+    expected = [{"name": "scan", "inputSchema": {"type": "object", "additionalProperties": False}}]
+    tools = [{"name": "scan", "inputSchema": {"type": "object"}}] if mismatch else expected
+    contract = tmp_path / "contract.json"
+    contract.write_text(json.dumps(expected))
+    schema = '<a href="/mcp/servers/msaad00/agent-bom/tools/scan">scan</a>' + _glama_schema_state(tools)
+    monkeypatch.setattr(
+        script, "_fetch", lambda url, timeout: schema if url.endswith("/schema") else "v0.103.2 MCP server mode exposes 1 MCP tools"
+    )
+    monkeypatch.setattr(
+        script,
+        "_fetch_json",
+        lambda *args: (_ for _ in ()).throw(urllib.error.HTTPError("https://glama.ai/api", 401, "Unauthorized", {}, None)),
+    )
+    result = script.main(
+        ["--expected", "0.103.2", "--expected-tool-count", "1", "--expected-tool-contract-file", str(contract), "--json", "--retries", "1"]
+    )
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert result == int(mismatch)
+    assert payload["status"] == ("stale" if mismatch else "fresh")
+    assert payload["exact_input_schemas"] is not mismatch
+    assert payload["inventory_source"] == "schema-state"
+
+
+def test_glama_embedded_schema_parser_rejects_unrelated_or_incomplete_evidence():
+    script = _load_script("check_glama_listing.py")
+    tools = [{"name": "scan", "inputSchema": {"type": "object"}}]
+    assert script._extract_schema_tool_contract(_glama_schema_state(tools), script.DEFAULT_URL) == tools
+    for page in (
+        _glama_schema_state(tools, slug="another-server"),
+        _glama_schema_state([{"name": "scan"}]),
+        '<script>window.__reactRouterContext.streamController.enqueue("[0]");</script>',
+        '<script>window.__reactRouterContext.streamController.enqueue("[{\\"_9\\":9}]");</script>',
+        "x" * (2 * 1024 * 1024 + 1),
+    ):
+        with pytest.raises(ValueError):
+            script._extract_schema_tool_contract(page, script.DEFAULT_URL)
+
+
+def test_glama_requires_exact_schema_proof_when_contract_is_requested(monkeypatch, capsys, tmp_path):
+    script = _load_script("check_glama_listing.py")
+    contract = tmp_path / "contract.json"
+    contract.write_text(json.dumps([{"name": "scan", "inputSchema": {"type": "object"}}]))
+    monkeypatch.setattr(
+        script,
+        "_fetch",
+        lambda url, timeout: (
+            '<a href="/mcp/servers/msaad00/agent-bom/tools/scan">scan</a>'
+            if url.endswith("/schema")
+            else "v0.103.2 MCP server mode exposes 1 MCP tools"
+        ),
+    )
+    monkeypatch.setattr(script, "_fetch_json", lambda *args: (_ for _ in ()).throw(urllib.error.URLError("401")))
+    assert (
+        script.main(
+            [
+                "--expected",
+                "0.103.2",
+                "--expected-tool-count",
+                "1",
+                "--expected-tool-contract-file",
+                str(contract),
+                "--json",
+                "--retries",
+                "1",
+            ]
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["exact_input_schemas"] is None
+    assert "could not verify requested input schemas" in payload["error"]
+
+
+@pytest.mark.parametrize(
+    "table",
+    [
+        [0],
+        [{"_9": 9}],
+        [{"_1": 2, "_3": 4}, "duplicate", 1, "duplicate", 2],
+        [[index + 1] for index in range(70)] + [None],
+        [None] * 50_001,
+    ],
+)
+def test_glama_schema_reference_tables_fail_closed(table):
+    script = _load_script("check_glama_listing.py")
+    page = "<script>window.__reactRouterContext.streamController.enqueue(" + json.dumps(json.dumps(table)) + ");</script>"
+    with pytest.raises(ValueError):
+        script._extract_schema_tool_contract(page, script.DEFAULT_URL)

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -374,9 +374,9 @@ def test_surface_freshness_reads_smithery_catalog_listing(monkeypatch):
     script = _load_script("check_surface_freshness.py")
 
     def fake_http_json(url, **_kwargs):
-        assert url == "https://api.smithery.ai/servers/agent-bom/agent-bom"
+        assert url == "https://api.smithery.ai/servers/agentbom/agent-bom"
         return {
-            "qualifiedName": "agent-bom/agent-bom",
+            "qualifiedName": "agentbom/agent-bom",
             "remote": True,
             "deploymentUrl": "https://agent-bom--agent-bom.run.tools",
             "tools": [{"name": "scan"}, {"name": "check"}],
@@ -384,7 +384,7 @@ def test_surface_freshness_reads_smithery_catalog_listing(monkeypatch):
 
     monkeypatch.setattr(script, "_http_json", fake_http_json)
 
-    result = script.probe_smithery("0.89.2", "agent-bom/agent-bom", timeout=1, attempts=1, backoff=0)
+    result = script.probe_smithery("0.89.2", "agentbom/agent-bom", timeout=1, attempts=1, backoff=0)
 
     assert result["surface"] == "Smithery"
     assert result["status"] == "fresh"
@@ -396,7 +396,7 @@ def test_surface_freshness_reads_smithery_catalog_listing(monkeypatch):
 def _smithery_listing_with(tool_count):
     def fake_http_json(_url, **_kwargs):
         return {
-            "qualifiedName": "agent-bom/agent-bom",
+            "qualifiedName": "agentbom/agent-bom",
             "remote": True,
             "deploymentUrl": "https://agent-bom--agent-bom.run.tools",
             "tools": [{"name": f"tool_{index}"} for index in range(tool_count)],
@@ -417,7 +417,7 @@ def test_smithery_listing_advertising_fewer_tools_than_shipped_is_stale(monkeypa
     script = _load_script("check_surface_freshness.py")
     monkeypatch.setattr(script, "_http_json", _smithery_listing_with(36))
 
-    result = script.probe_smithery("0.98.3", "agent-bom/agent-bom", expected_tool_count=77, timeout=1, attempts=1, backoff=0)
+    result = script.probe_smithery("0.98.3", "agentbom/agent-bom", expected_tool_count=77, timeout=1, attempts=1, backoff=0)
 
     assert result["status"] == "stale"
     assert result["tool_count"] == 36
@@ -429,7 +429,7 @@ def test_smithery_listing_matching_the_shipped_tool_count_is_fresh(monkeypatch):
     script = _load_script("check_surface_freshness.py")
     monkeypatch.setattr(script, "_http_json", _smithery_listing_with(77))
 
-    result = script.probe_smithery("0.98.3", "agent-bom/agent-bom", expected_tool_count=77, timeout=1, attempts=1, backoff=0)
+    result = script.probe_smithery("0.98.3", "agentbom/agent-bom", expected_tool_count=77, timeout=1, attempts=1, backoff=0)
 
     assert result["status"] == "fresh"
     assert result["tool_count"] == 77
@@ -442,7 +442,7 @@ def test_smithery_listing_rejects_count_collision_with_wrong_tool_names(monkeypa
 
     result = script.probe_smithery(
         "0.103.2",
-        "agent-bom/agent-bom",
+        "agentbom/agent-bom",
         expected_tool_count=2,
         expected_tool_names=["graph_correlate", "scan"],
         timeout=1,
@@ -544,7 +544,7 @@ def test_smithery_tool_count_is_not_gated_when_no_expectation_is_supplied(monkey
     script = _load_script("check_surface_freshness.py")
     monkeypatch.setattr(script, "_http_json", _smithery_listing_with(36))
 
-    result = script.probe_smithery("0.98.3", "agent-bom/agent-bom", timeout=1, attempts=1, backoff=0)
+    result = script.probe_smithery("0.98.3", "agentbom/agent-bom", timeout=1, attempts=1, backoff=0)
 
     assert result["status"] == "fresh"
 
@@ -881,3 +881,9 @@ def test_glama_schema_does_not_conflate_undefined_with_json_null():
     assert script._extract_schema_tool_contract(_glama_schema_state(tools), script.DEFAULT_URL) == tools
     with pytest.raises(ValueError):
         script._extract_schema_tool_contract(_glama_schema_state(tools, null_reference=-7), script.DEFAULT_URL)
+
+
+def test_default_smithery_listing_uses_product_namespace():
+    script = _load_script("check_surface_freshness.py")
+    assert script.DEFAULT_SMITHERY_SERVER == "agentbom/agent-bom"
+    assert script._smithery_catalog_url(script.DEFAULT_SMITHERY_SERVER) == "https://api.smithery.ai/servers/agentbom/agent-bom"


### PR DESCRIPTION
## Summary
- Verify Glama's public embedded schema data when its authenticated API is unavailable, with bounded data-only decoding and exact tool/schema comparison. Explicitly requested schema evidence remains fail-closed when unavailable.
- Move Smithery publishing, freshness checks, and documentation to the `agentbom/agent-bom` namespace, preserving upstream authentication and exact capability gates.
- Reject malformed reference tables and distinguish JSON null from undefined.

## Verification
- 179 tests passed across `test_surface_freshness.py`, `test_publish_registries_glama_gate.py`, `test_publish_registries_release_auth_gate.py`, `test_deployment.py`, and the three README/public-doc contract suites.
- `mypy --follow-imports=skip scripts/check_glama_listing.py` passed.
- `make preflight` and affected-file pre-commit hooks passed.
- Live Glama public data matched all 86 released tool names and input schemas against the deployed server card.
- `git diff --check` passed.

## Notes
- The new Smithery listing completed authorized capability inspection and lists all 86 released tool names. Its public catalog currently omits root `additionalProperties` in all 86 schemas and `required` in 33, so exact schema parity remains blocked. Keep this PR in draft until provider schema evidence and publisher credential setup pass. The publisher token must belong to the account owning `agentbom`.
- No package tag, package publication, or application deployment is included.
- Related: #5092, #5093, #5094. Registry issues remain open until live provider and workflow evidence passes.
