### PR TITLE
fix(registry): require schema evidence in daily monitors

### DIFF
--- a/.github/workflows/deployment-freshness.yml
+++ b/.github/workflows/deployment-freshness.yml
@@ -2,7 +2,7 @@ name: Deployment Freshness
 
 # Checks that the protected Railway surface serves the exact latest release
 # version and MCP tool-schema inventory, and that
-# the Smithery catalog listing is live with a non-empty tool inventory. Runs
+# the Smithery catalog matches released tool names and input schemas. Runs
 # daily and on-demand. Opens an issue if stale or misconfigured.
 #
 # No hosted-demo probe here. The public demo IS ours (Cloud Run, see
@@ -109,77 +109,42 @@ jobs:
         continue-on-error: true
         env:
           SMITHERY_SERVER_QUALIFIED_NAME: ${{ vars.SMITHERY_SERVER_QUALIFIED_NAME }}
+          SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
           EXPECTED_TOOL_COUNT: ${{ steps.expected.outputs.tool_count }}
         run: |
-          QUALIFIED_NAME="${SMITHERY_SERVER_QUALIFIED_NAME:-agentbom/agent-bom}"
-          RESPONSE=$(EXPECTED_TOOL_COUNT="$EXPECTED_TOOL_COUNT" python3 - <<'PY'
-          import json
-          import os
-          import sys
-          import urllib.error
-          import urllib.parse
-          import urllib.request
-
-          name = os.environ.get("SMITHERY_SERVER_QUALIFIED_NAME") or "agentbom/agent-bom"
-          if "/" not in name:
-              print(json.dumps({"error": f"invalid Smithery qualified name: {name!r}"}))
-              sys.exit(1)
-          namespace, server = name.split("/", 1)
-          url = "https://api.smithery.ai/servers/" + urllib.parse.quote(namespace, safe="") + "/" + urllib.parse.quote(server, safe="")
-          req = urllib.request.Request(
-              url,
-              headers={"Accept": "application/json", "User-Agent": "agent-bom-deployment-freshness"},
-          )
-          try:
-              with urllib.request.urlopen(req, timeout=15) as response:
-                  data = json.loads(response.read().decode("utf-8", errors="replace"))
-          except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
-              print(json.dumps({"error": str(exc), "url": url}))
-              sys.exit(1)
-          tools = data.get("tools") if isinstance(data.get("tools"), list) else []
-          print(json.dumps({
-              "qualified_name": data.get("qualifiedName"),
-              "remote": bool(data.get("remote")),
-              "deployment_url": data.get("deploymentUrl") or "",
-              "tool_count": len(tools),
-          }, separators=(",", ":")))
-          PY
-          ) || {
-            {
-              echo "public_version=unreachable"
-              echo "tool_count=unknown"
-              echo "auth_required=smithery-oauth"
-              echo "probe_failed=true"
-            } >> "$GITHUB_OUTPUT"
-            echo "::warning::Could not verify Smithery catalog listing"
-            exit 0
-          }
-          STATE=$(echo "$RESPONSE" | EXPECTED_QUALIFIED_NAME="$QUALIFIED_NAME" EXPECTED_TOOL_COUNT="$EXPECTED_TOOL_COUNT" python3 -c "
-          import json, os, sys
-          data = json.load(sys.stdin)
-          if data.get('qualified_name') != os.environ['EXPECTED_QUALIFIED_NAME'] or not data.get('remote') or not data.get('deployment_url') or int(data.get('tool_count') or 0) < 1:
-              print('invalid')
-          elif int(data.get('tool_count') or 0) != int(os.environ['EXPECTED_TOOL_COUNT']):
-              print('tool_count_drift')
-          else:
-              print('catalog_live')
-          ")
-          TOOL_COUNT=$(echo "$RESPONSE" | python3 -c "import json, sys; print(json.load(sys.stdin).get('tool_count', 'unknown'))")
-          DEPLOY_URL=$(echo "$RESPONSE" | python3 -c "import json, sys; print(json.load(sys.stdin).get('deployment_url', 'unknown'))")
+          set -euo pipefail
+          # Stay fail-closed if contract extraction or probing exits early.
+          echo "probe_failed=true" >> "$GITHUB_OUTPUT"
+          python3 scripts/check_glama_listing.py \
+            --write-tool-names /tmp/deployment-expected-tool-names.json \
+            --git-ref "${{ steps.expected.outputs.release_sha }}"
+          SERVER_CARD_URL="${SMITHERY_MCP_URL:-https://agent-bom-mcp.up.railway.app/mcp}"
+          SERVER_CARD_URL=$(python3 -c 'import sys; from urllib.parse import urlsplit, urlunsplit; p=urlsplit(sys.argv[1]); print(urlunsplit((p.scheme,p.netloc,"/.well-known/mcp/server-card.json","","")))' "$SERVER_CARD_URL")
+          python3 scripts/check_surface_freshness.py \
+            --expected "${{ steps.expected.outputs.version }}" \
+            --expected-tool-count "$EXPECTED_TOOL_COUNT" \
+            --expected-tool-names-file /tmp/deployment-expected-tool-names.json \
+            --server-card-url "$SERVER_CARD_URL" \
+            --write-tool-contract /tmp/deployment-expected-tool-contract.json
+          python3 scripts/check_surface_freshness.py \
+            --surface smithery \
+            --expected "${{ steps.expected.outputs.version }}" \
+            --expected-tool-count "$EXPECTED_TOOL_COUNT" \
+            --expected-tool-names-file /tmp/deployment-expected-tool-names.json \
+            --expected-tool-contract-file /tmp/deployment-expected-tool-contract.json \
+            --out /tmp/deployment-smithery-report.json
+          STATE=$(jq -er '.surfaces[0].status' /tmp/deployment-smithery-report.json)
+          TOOL_COUNT=$(jq -r '.surfaces[0].tool_count // "unknown"' /tmp/deployment-smithery-report.json)
           {
             echo "public_version=$STATE"
             echo "tool_count=$TOOL_COUNT"
             echo "auth_required=smithery-oauth"
           } >> "$GITHUB_OUTPUT"
-          echo "Smithery catalog state: $STATE"
-          echo "Smithery deployment URL: $DEPLOY_URL"
-          echo "Smithery tool count: $TOOL_COUNT"
-          if [ "$STATE" = "tool_count_drift" ]; then
+          if [ "$STATE" = "fresh" ]; then
+            echo "probe_failed=false" >> "$GITHUB_OUTPUT"
+          else
             echo "stale=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Smithery catalog tool inventory differs from the published release contract (${TOOL_COUNT}/${EXPECTED_TOOL_COUNT})"
-          elif [ "$STATE" != "catalog_live" ]; then
-            echo "probe_failed=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Smithery catalog listing is missing remote deployment metadata or tools"
+            echo "::warning::Smithery catalog differs from the published tool-name and input-schema contract"
           fi
 
       - name: Open issue if deployment surfaces drift or public endpoint is misconfigured
@@ -217,7 +182,7 @@ jobs:
           | Railway (protected) | $RAILWAY | $EXPECTED | true | $RAILWAY_TOOLS |
           | Public marketplace | $PUBLIC | $EXPECTED | $PUBLIC_AUTH | $PUBLIC_TOOLS |
 
-          **Action**: Ensure the protected Railway deployment is fresh and the Smithery catalog API lists a remote deployment with tools, then re-run this workflow.
+          **Action**: Ensure the protected Railway deployment is fresh and the Smithery catalog API matches the released tool names and input schemas, then re-run this workflow.
 
           This issue was auto-updated by the deployment-freshness workflow.
           EOF
@@ -236,7 +201,7 @@ jobs:
           | Railway (protected) | $RAILWAY | $EXPECTED | true | $RAILWAY_TOOLS |
           | Public marketplace | $PUBLIC | $EXPECTED | $PUBLIC_AUTH | $PUBLIC_TOOLS |
 
-          **Action**: Ensure the protected Railway deployment is fresh and the Smithery catalog API lists a remote deployment with tools, then re-run this workflow.
+          **Action**: Ensure the protected Railway deployment is fresh and the Smithery catalog API matches the released tool names and input schemas, then re-run this workflow.
 
           This issue was auto-created by the deployment-freshness workflow.
           EOF
@@ -292,7 +257,7 @@ jobs:
           fi
 
       - name: Close supply-chain drift issue when deployment is fresh
-        if: steps.railway.outputs.stale != 'true' && steps.railway.outputs.probe_failed != 'true' && steps.public.outputs.not_configured != 'true' && steps.public.outputs.stale != 'true' && steps.public.outputs.probe_failed != 'true' && steps.public.outputs.auth_gate != 'true'
+        if: steps.railway.outputs.stale != 'true' && steps.railway.outputs.probe_failed != 'true' && steps.public.outputs.public_version == 'fresh' && steps.public.outputs.probe_failed == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/surface-freshness.yml
+++ b/.github/workflows/surface-freshness.yml
@@ -78,18 +78,29 @@ jobs:
         id: probe
         env:
           EXPECTED_VERSION: ${{ steps.expected.outputs.version }}
+          SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
           SMITHERY_SERVER_QUALIFIED_NAME: ${{ vars.SMITHERY_SERVER_QUALIFIED_NAME }}
           GLAMA_LISTING_URL: ${{ vars.GLAMA_LISTING_URL }}
           GLAMA_API_URL: ${{ vars.GLAMA_API_URL }}
           DOCKER_IMAGE: ${{ vars.DOCKER_IMAGE }}
         run: |
+          set -euo pipefail
           python3 scripts/check_glama_listing.py \
             --write-tool-names /tmp/surface-expected-tool-names.json \
             --git-ref "${{ steps.expected.outputs.release_sha }}"
+          SERVER_CARD_URL="${SMITHERY_MCP_URL:-https://agent-bom-mcp.up.railway.app/mcp}"
+          SERVER_CARD_URL=$(python3 -c 'import sys; from urllib.parse import urlsplit, urlunsplit; p=urlsplit(sys.argv[1]); print(urlunsplit((p.scheme,p.netloc,"/.well-known/mcp/server-card.json","","")))' "$SERVER_CARD_URL")
+          python3 scripts/check_surface_freshness.py \
+            --expected "$EXPECTED_VERSION" \
+            --expected-tool-count "${{ steps.expected.outputs.tool_count }}" \
+            --expected-tool-names-file /tmp/surface-expected-tool-names.json \
+            --server-card-url "$SERVER_CARD_URL" \
+            --write-tool-contract /tmp/surface-expected-tool-contract.json
           PYTHONPATH=src python3 scripts/check_surface_freshness.py \
             --expected "$EXPECTED_VERSION" \
             --expected-tool-count "${{ steps.expected.outputs.tool_count }}" \
             --expected-tool-names-file /tmp/surface-expected-tool-names.json \
+            --expected-tool-contract-file /tmp/surface-expected-tool-contract.json \
             --out surface-freshness.json
           {
             echo "report<<EOF"

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -261,3 +261,12 @@ For dependency-heavy or security-driven releases, also verify:
 | **ClawHub** | curated `integrations/openclaw/*/SKILL.md` set | publish-registries.yml | workflow_run |
 | **MCP Registry** | `integrations/mcp-registry/server.json` | publish-mcp-registry.yml | workflow_run |
 | **Railway** | `deploy/docker/Dockerfile.sse` | deploy-mcp-sse.yml | release workflow_call / workflow_dispatch |
+
+### Daily schema verification
+
+Both freshness monitors compare marketplace input schemas with the public server
+card after validating its version and tool names against the published release.
+Missing required-argument lists or unknown-argument constraints count as drift,
+even when all tool names match. If the server card is unavailable or cannot be
+bound to the release, the monitors do not close the drift issue. This is catalog
+evidence; it does not replace an authenticated MCP protocol check.

--- a/scripts/check_surface_freshness.py
+++ b/scripts/check_surface_freshness.py
@@ -86,6 +86,41 @@ def _load_expected_tool_names(path: Path) -> list[str]:
     return sorted(payload)
 
 
+def _load_tool_contract(path: Path) -> list[dict[str, Any]]:
+    if path.stat().st_size > 2 * 1024 * 1024:
+        raise ValueError("tool contract exceeds bounded input size")
+    return _validate_tool_contract(json.loads(path.read_text(encoding="utf-8")))
+
+
+def _validate_tool_contract(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, list) or not payload:
+        raise ValueError("tool contract must be a non-empty list")
+    tools = []
+    for tool in payload:
+        if not isinstance(tool, dict):
+            raise ValueError("tool contract contains a malformed tool")
+        name = tool.get("name")
+        if not isinstance(name, str) or not name or name != name.strip() or not isinstance(tool.get("inputSchema"), dict):
+            raise ValueError("tool contract contains an invalid name or schema")
+        tools.append({"name": name, "inputSchema": tool["inputSchema"]})
+    if len({tool["name"] for tool in tools}) != len(tools):
+        raise ValueError("tool contract contains duplicate names")
+    return sorted(tools, key=lambda tool: tool["name"])
+
+
+def _released_server_card(url: str, expected: str, names: list[str], **kw: Any) -> list[dict[str, Any]]:
+    parsed = urllib.parse.urlsplit(url)
+    if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError("server-card URL must be HTTPS without credentials, query, or fragment")
+    data = _http_json(url, **kw)
+    if not isinstance(data, dict) or not isinstance(data.get("serverInfo"), dict) or data["serverInfo"].get("version") != expected:
+        raise ValueError("server-card version does not match the released version")
+    tools = _validate_tool_contract(data.get("tools"))
+    if [tool["name"] for tool in tools] != names:
+        raise ValueError("server-card tool names do not match the immutable release contract")
+    return tools
+
+
 def _env_or(name: str, default: str) -> str:
     """Return env var if non-blank; otherwise ``default``.
 
@@ -269,6 +304,7 @@ def probe_glama(
     *,
     expected_tool_count: int | None = None,
     expected_tool_names_file: Path | None = None,
+    expected_tool_contract_file: Path | None = None,
     **kw: Any,
 ) -> dict[str, Any]:
     """Delegate to check_glama_listing.py so the probe logic stays in one place."""
@@ -277,6 +313,8 @@ def probe_glama(
         command.extend(["--expected-tool-count", str(expected_tool_count)])
     if expected_tool_names_file is not None:
         command.extend(["--expected-tool-names-file", str(expected_tool_names_file)])
+    if expected_tool_contract_file is not None:
+        command.extend(["--expected-tool-contract-file", str(expected_tool_contract_file)])
     proc = subprocess.run(
         command,
         capture_output=True,
@@ -312,6 +350,7 @@ def probe_smithery(
     *,
     expected_tool_count: int | None = None,
     expected_tool_names: list[str] | None = None,
+    expected_tool_contract: list[dict[str, Any]] | None = None,
     **kw: Any,
 ) -> dict[str, Any]:
     """Probe Smithery's public catalog listing.
@@ -319,7 +358,9 @@ def probe_smithery(
     Smithery-hosted remote servers are OAuth-gated and do not expose agent-bom's
     raw `/health` route. Freshness for this surface is therefore the catalog
     contract: the listing exists, is remote, has a deployment URL, and advertises
-    the full shipped tool inventory. Version freshness is covered by PyPI/Docker
+    the full shipped tool inventory. When supplied, the release-bound input-schema
+    contract must match exactly, including required fields and unknown-argument
+    rejection. Version freshness is covered by PyPI/Docker
     plus the protected Railway health check.
 
     The tool count is part of that contract. A listing that advertises a strict
@@ -347,7 +388,7 @@ def probe_smithery(
             "deployment_url": deployment_url,
             "tool_count": len(tools),
         }
-        actual_tool_names = sorted(tool.get("name") for tool in tools if isinstance(tool, dict) and isinstance(tool.get("name"), str))
+        actual_tool_names = sorted(str(tool["name"]) for tool in tools if isinstance(tool, dict) and isinstance(tool.get("name"), str))
         if expected_tool_count is not None:
             result["expected_tool_count"] = expected_tool_count
             if len(tools) != expected_tool_count:
@@ -364,6 +405,18 @@ def probe_smithery(
                     "catalog tool-name set differs from the immutable release contract"
                     f"; missing={missing or 'none'}; unexpected={unexpected or 'none'}"
                 )
+        result["exact_input_schemas"] = None
+        if expected_tool_contract is not None:
+            try:
+                actual_contract = _validate_tool_contract(tools)
+            except ValueError:
+                actual_contract = []
+            result["exact_input_schemas"] = json.dumps(actual_contract, sort_keys=True) == json.dumps(
+                expected_tool_contract, sort_keys=True
+            )
+            if not result["exact_input_schemas"]:
+                result["status"] = "stale"
+                result["error"] = "catalog input schemas differ from the release-bound server-card contract"
         return result
     except (RuntimeError, ValueError) as exc:
         return _classify("Smithery", None, expected, error=str(exc))
@@ -381,6 +434,12 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="JSON list of immutable released MCP tool names required from marketplace inventories.",
     )
+    parser.add_argument("--expected-tool-contract-file", type=Path, help="Release-bound tool names and input schemas.")
+    parser.add_argument("--server-card-url", help="Public HTTPS server card used to extract a release-bound schema contract.")
+    parser.add_argument(
+        "--write-tool-contract", type=Path, help="Validate the server card against released names/version, write schemas, and exit."
+    )
+    parser.add_argument("--surface", choices=["all", "smithery"], default="all")
     parser.add_argument("--docker-image", default=_env_or("DOCKER_IMAGE", DEFAULT_DOCKER_IMAGE))
     parser.add_argument("--smithery-server", default=_env_or("SMITHERY_SERVER_QUALIFIED_NAME", DEFAULT_SMITHERY_SERVER))
     parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
@@ -409,23 +468,50 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("expected tool-name contract and tool count do not match")
     kw = {"timeout": args.timeout, "attempts": args.attempts, "backoff": args.backoff_seconds}
 
-    surfaces = [
-        probe_pypi(expected, **kw),
-        probe_docker(expected, args.docker_image, **kw),
-        probe_glama(
-            expected,
-            expected_tool_count=tool_count,
-            expected_tool_names_file=args.expected_tool_names_file,
-            **kw,
-        ),
+    if args.write_tool_contract:
+        if not args.server_card_url or expected_tool_names is None:
+            raise SystemExit("schema extraction requires a server-card URL and immutable released tool names")
+        try:
+            extracted_contract = _released_server_card(args.server_card_url, expected, expected_tool_names, **kw)
+        except (RuntimeError, ValueError) as exc:
+            raise SystemExit(f"could not establish released schema contract: {exc}") from exc
+        args.write_tool_contract.write_text(json.dumps(extracted_contract, indent=2) + "\n", encoding="utf-8")
+        return 0
+    try:
+        contract = _load_tool_contract(args.expected_tool_contract_file) if args.expected_tool_contract_file else None
+    except (OSError, ValueError) as exc:
+        raise SystemExit("could not load expected schema contract") from exc
+    if contract is not None:
+        contract_names = [tool["name"] for tool in contract]
+        if len(contract_names) != tool_count or (expected_tool_names is not None and contract_names != expected_tool_names):
+            raise SystemExit("schema contract differs from expected tool names or count")
+        expected_tool_names = contract_names
+
+    surfaces = []
+    if args.surface == "all":
+        surfaces.extend(
+            [
+                probe_pypi(expected, **kw),
+                probe_docker(expected, args.docker_image, **kw),
+                probe_glama(
+                    expected,
+                    expected_tool_count=tool_count,
+                    expected_tool_names_file=args.expected_tool_names_file,
+                    expected_tool_contract_file=args.expected_tool_contract_file,
+                    **kw,
+                ),
+            ]
+        )
+    surfaces.append(
         probe_smithery(
             expected,
             args.smithery_server,
             expected_tool_count=tool_count,
             expected_tool_names=expected_tool_names,
+            expected_tool_contract=contract,
             **kw,
-        ),
-    ]
+        )
+    )
 
     drift = [s for s in surfaces if s["status"] not in OK_STATUSES]
     report = {

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -535,7 +535,7 @@ def test_deployment_freshness_workflow_uses_bearer_token_and_parses_tool_count()
     workflow = (ROOT / ".github" / "workflows" / "deployment-freshness.yml").read_text()
     assert "RAILWAY_MCP_BEARER_TOKEN" in workflow
     assert "SMITHERY_SERVER_QUALIFIED_NAME" in workflow
-    assert "api.smithery.ai/servers" in workflow
+    assert "--surface smithery" in workflow
     assert "python3 -m agent_bom.deployment_probe" in workflow
     assert "tool_count" in workflow
     assert "smithery-oauth" in workflow
@@ -562,10 +562,10 @@ def test_deployment_freshness_marks_smithery_tool_count_drift() -> None:
     workflow = (ROOT / ".github" / "workflows" / "deployment-freshness.yml").read_text()
 
     assert "EXPECTED_TOOL_COUNT: ${{ steps.expected.outputs.tool_count }}" in workflow
-    assert 'EXPECTED_TOOL_COUNT="$EXPECTED_TOOL_COUNT"' in workflow
-    assert "int(data.get('tool_count') or 0) != int(os.environ['EXPECTED_TOOL_COUNT'])" in workflow
+    assert '--expected-tool-count "$EXPECTED_TOOL_COUNT"' in workflow
+    assert "--expected-tool-contract-file" in workflow
     assert 'echo "stale=true" >> "$GITHUB_OUTPUT"' in workflow
-    assert "Smithery catalog tool inventory differs from the published release contract" in workflow
+    assert "Smithery catalog differs from the published tool-name and input-schema contract" in workflow
 
 
 def test_publishing_guide_does_not_pin_a_stale_mcp_tool_count() -> None:

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -887,3 +887,205 @@ def test_default_smithery_listing_uses_product_namespace():
     script = _load_script("check_surface_freshness.py")
     assert script.DEFAULT_SMITHERY_SERVER == "agentbom/agent-bom"
     assert script._smithery_catalog_url(script.DEFAULT_SMITHERY_SERVER) == "https://api.smithery.ai/servers/agentbom/agent-bom"
+
+
+def _strict_marketplace_tool():
+    return {
+        "name": "check",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"package": {"type": "string"}},
+            "required": ["package"],
+            "additionalProperties": False,
+        },
+    }
+
+
+@pytest.mark.parametrize("missing", ["required", "additionalProperties"])
+def test_smithery_rejects_schema_constraint_loss(monkeypatch, missing):
+    script = _load_script("check_surface_freshness.py")
+    expected = [_strict_marketplace_tool()]
+    actual = json.loads(json.dumps(expected))
+    actual[0]["inputSchema"].pop(missing)
+    monkeypatch.setattr(
+        script,
+        "_http_json",
+        lambda *_a, **_kw: {
+            "qualifiedName": "agentbom/agent-bom",
+            "remote": True,
+            "deploymentUrl": "https://agent-bom--agentbom.run.tools",
+            "tools": actual,
+        },
+    )
+    result = script.probe_smithery(
+        "0.103.2", "agentbom/agent-bom", expected_tool_count=1, expected_tool_names=["check"], expected_tool_contract=expected
+    )
+    assert result["status"] == "stale"
+    assert result["exact_input_schemas"] is False
+
+
+def test_smithery_accepts_exact_schemas(monkeypatch):
+    script = _load_script("check_surface_freshness.py")
+    tools = [_strict_marketplace_tool()]
+    monkeypatch.setattr(
+        script,
+        "_http_json",
+        lambda *_a, **_kw: {
+            "qualifiedName": "agentbom/agent-bom",
+            "remote": True,
+            "deploymentUrl": "https://agent-bom--agentbom.run.tools",
+            "tools": tools,
+        },
+    )
+    result = script.probe_smithery(
+        "0.103.2", "agentbom/agent-bom", expected_tool_count=1, expected_tool_names=["check"], expected_tool_contract=tools
+    )
+    assert result["status"] == "fresh"
+    assert result["exact_input_schemas"] is True
+
+
+@pytest.mark.parametrize("fault", ["version", "names", "duplicate", "schema"])
+def test_monitor_rejects_unbound_server_card(monkeypatch, tmp_path, fault):
+    script = _load_script("check_surface_freshness.py")
+    card = {"serverInfo": {"version": "0.103.2"}, "tools": [_strict_marketplace_tool()]}
+    if fault == "version":
+        card["serverInfo"]["version"] = "0.1.0"
+    elif fault == "names":
+        card["tools"][0]["name"] = "wrong"
+    elif fault == "duplicate":
+        card["tools"].append(_strict_marketplace_tool())
+    else:
+        card["tools"][0]["inputSchema"] = None
+    monkeypatch.setattr(script, "_http_json", lambda *_a, **_kw: card)
+    names = tmp_path / "names.json"
+    names.write_text('["check"]')
+    dest = tmp_path / "contract.json"
+    with pytest.raises(SystemExit):
+        script.main(
+            [
+                "--expected",
+                "0.103.2",
+                "--expected-tool-count",
+                "1",
+                "--expected-tool-names-file",
+                str(names),
+                "--server-card-url",
+                "https://example.com/.well-known/mcp/server-card.json",
+                "--write-tool-contract",
+                str(dest),
+            ]
+        )
+    assert not dest.exists()
+
+
+def test_smithery_schema_drift_keeps_consolidated_issue_open(monkeypatch, tmp_path, capsys):
+    script = _load_script("check_surface_freshness.py")
+    tools = [_strict_marketplace_tool()]
+    contract = tmp_path / "contract.json"
+    contract.write_text(json.dumps(tools))
+    actual = json.loads(json.dumps(tools))
+    actual[0]["inputSchema"].pop("required")
+    monkeypatch.setattr(
+        script,
+        "_http_json",
+        lambda *_a, **_kw: {
+            "qualifiedName": "agentbom/agent-bom",
+            "remote": True,
+            "deploymentUrl": "https://agent-bom--agentbom.run.tools",
+            "tools": actual,
+        },
+    )
+    assert (
+        script.main(
+            [
+                "--surface",
+                "smithery",
+                "--expected",
+                "0.103.2",
+                "--expected-tool-count",
+                "1",
+                "--expected-tool-contract-file",
+                str(contract),
+                "--fail-on-stale",
+            ]
+        )
+        == 1
+    )
+    result = json.loads(capsys.readouterr().out)
+    assert result["all_fresh"] is False
+    assert result["surfaces"][0]["exact_input_schemas"] is False
+
+
+def test_both_daily_monitors_require_exact_schema_evidence():
+    for name in ("surface-freshness.yml", "deployment-freshness.yml"):
+        workflow = (ROOT / ".github/workflows" / name).read_text()
+        assert "--write-tool-contract" in workflow
+        assert "--expected-tool-contract-file" in workflow
+        assert "--expected-tool-names-file" in workflow
+
+
+def test_monitor_writes_only_validated_release_schemas(monkeypatch, tmp_path):
+    script = _load_script("check_surface_freshness.py")
+    tools = [_strict_marketplace_tool()]
+    monkeypatch.setattr(script, "_http_json", lambda *_a, **_kw: {"serverInfo": {"version": "0.103.2"}, "tools": tools})
+    names = tmp_path / "names.json"
+    names.write_text('["check"]')
+    dest = tmp_path / "contract.json"
+    assert (
+        script.main(
+            [
+                "--expected",
+                "0.103.2",
+                "--expected-tool-count",
+                "1",
+                "--expected-tool-names-file",
+                str(names),
+                "--server-card-url",
+                "https://example.com/.well-known/mcp/server-card.json",
+                "--write-tool-contract",
+                str(dest),
+            ]
+        )
+        == 0
+    )
+    assert json.loads(dest.read_text()) == tools
+
+
+@pytest.mark.parametrize(
+    "url",
+    ["http://example.com/card", "https://user:secret@example.com/card", "https://example.com/card?token=x", "https://example.com/card#x"],
+)
+def test_release_schema_source_rejects_unsafe_urls(monkeypatch, url):
+    script = _load_script("check_surface_freshness.py")
+    monkeypatch.setattr(script, "_http_json", lambda *_a, **_kw: pytest.fail("must reject URL before network access"))
+    with pytest.raises(ValueError):
+        script._released_server_card(url, "0.103.2", ["check"])
+
+
+def test_monitor_does_not_ignore_missing_requested_contract(tmp_path):
+    script = _load_script("check_surface_freshness.py")
+    with pytest.raises(SystemExit, match="could not load expected schema contract"):
+        script.main(["--expected-tool-count", "1", "--expected-tool-contract-file", str(tmp_path / "missing.json")])
+
+
+def test_glama_monitor_forwards_required_schema_contract(monkeypatch, tmp_path):
+    script = _load_script("check_surface_freshness.py")
+    contract = tmp_path / "contract.json"
+    seen = []
+
+    def run(command, **_kw):
+        seen.extend(command)
+        return subprocess.CompletedProcess(command, 1, stdout=json.dumps({"status": "stale", "exact_input_schemas": False}))
+
+    monkeypatch.setattr(script.subprocess, "run", run)
+    result = script.probe_glama("0.103.2", expected_tool_contract_file=contract)
+    assert seen[seen.index("--expected-tool-contract-file") + 1] == str(contract)
+    assert result["status"] == "stale"
+    assert result["exact_input_schemas"] is False
+
+
+def test_deployment_issue_closure_requires_explicit_verified_success():
+    workflow = (ROOT / ".github/workflows/deployment-freshness.yml").read_text()
+    close_step = workflow.split("- name: Close supply-chain drift issue when deployment is fresh", 1)[1]
+    assert "steps.public.outputs.public_version == 'fresh'" in close_step
+    assert "steps.public.outputs.probe_failed == 'false'" in close_step


### PR DESCRIPTION
## Summary
- Prevent daily registry monitors from reporting success when tool counts or names match but input-schema constraints are missing. Both monitors compare schemas with a public server card validated against the released version and immutable tool names.
- Replace the deployment workflow's separate count-only Smithery probe with the shared checker. Issue closure requires explicit successful schema verification; unavailable or invalid expected evidence remains fail-closed.
- Document the catalog evidence boundary without changing server authentication or relaxing the publishing gate.

## Verification
- Five focused regressions failed before repair.
- 144 tests passed across surface freshness, deployment, and registry publishing contract suites.
- Ruff, targeted mypy, affected-file hooks, make preflight, workflow pipefail/timeouts, public-doc hygiene, and git diff --check passed.
- Live verification identified Smithery catalog API schema projection as unresolved; complete public-page verification is a separate follow-up.

## Notes
Related: #5092, #5093, #5094. No package publication or application deployment included.
