### PR TITLE
fix(registry): verify complete Smithery public schemas

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -271,12 +271,13 @@ jobs:
           done
           LATEST_SUCCESS_UPSTREAM=$(jq -sr 'first | .upstreamUrl // empty' /tmp/smithery-success-releases.jsonl)
           jq -S '[.tools[].name] | sort' /tmp/smithery-catalog.json > /tmp/smithery-actual-tool-names.json
-          jq -S '[.tools[] | {name, inputSchema}] | sort_by(.name)' \
-            /tmp/smithery-catalog.json > /tmp/smithery-actual-tool-contract.json
+          python3 scripts/check_surface_freshness.py \
+            --smithery-server agentbom/agent-bom \
+            --write-smithery-tool-contract /tmp/smithery-actual-tool-contract.json
           jq -S '{description}' \
             /tmp/smithery-catalog.json > /tmp/smithery-actual-listing-metadata.json
           if cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-tool-names.json && \
-            cmp -s /tmp/smithery-expected-tool-contract.json /tmp/smithery-actual-tool-contract.json && \
+            python3 scripts/check_surface_freshness.py --compare-tool-contract-files /tmp/smithery-expected-tool-contract.json /tmp/smithery-actual-tool-contract.json && \
             cmp -s /tmp/smithery-expected-listing-metadata.json /tmp/smithery-actual-listing-metadata.json && \
             [ "$LATEST_SUCCESS_UPSTREAM" = "$SMITHERY_MCP_URL" ]; then
             TOOL_COUNT=$(jq -r '.tools | length' /tmp/smithery-catalog.json)
@@ -460,8 +461,9 @@ jobs:
                 "https://api.smithery.ai/servers/agentbom/agent-bom" \
                 -o /tmp/smithery-catalog.json; then
               jq -S '[.tools[].name] | sort' /tmp/smithery-catalog.json > /tmp/smithery-actual-tool-names.json
-              jq -S '[.tools[] | {name, inputSchema}] | sort_by(.name)' \
-                /tmp/smithery-catalog.json > /tmp/smithery-actual-tool-contract.json
+              python3 scripts/check_surface_freshness.py \
+                --smithery-server agentbom/agent-bom \
+                --write-smithery-tool-contract /tmp/smithery-actual-tool-contract.json
               jq -S '{description}' \
                 /tmp/smithery-catalog.json > /tmp/smithery-actual-listing-metadata.json
               ACTUAL=$(jq -r 'length' /tmp/smithery-actual-tool-names.json)
@@ -470,7 +472,7 @@ jobs:
             fi
             if [ "$ACTUAL" = "$EXPECTED_TOOL_COUNT" ] && \
               cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-tool-names.json && \
-              cmp -s /tmp/smithery-expected-tool-contract.json /tmp/smithery-actual-tool-contract.json && \
+              python3 scripts/check_surface_freshness.py --compare-tool-contract-files /tmp/smithery-expected-tool-contract.json /tmp/smithery-actual-tool-contract.json && \
               cmp -s /tmp/smithery-expected-listing-metadata.json /tmp/smithery-actual-listing-metadata.json; then
               echo "Smithery catalog exposes the released tool, schema, and listing contract for v${VERSION} (${ACTUAL} tools)"
               exit 0

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -266,7 +266,10 @@ For dependency-heavy or security-driven releases, also verify:
 
 Both freshness monitors compare marketplace input schemas with the public server
 card after validating its version and tool names against the published release.
-Missing required-argument lists or unknown-argument constraints count as drift,
-even when all tool names match. If the server card is unavailable or cannot be
+Smithery's catalog API omits some root schema fields. The checker verifies those
+constraints from the complete schemas embedded in Smithery's public page, while
+requiring its server identity, tool names, and shared schema fields to agree with
+the catalog. Missing or inconsistent complete evidence counts as drift even when
+all tool names match. If the server card is unavailable or cannot be
 bound to the release, the monitors do not close the drift issue. This is catalog
 evidence; it does not replace an authenticated MCP protocol check.

--- a/scripts/check_surface_freshness.py
+++ b/scripts/check_surface_freshness.py
@@ -121,6 +121,113 @@ def _released_server_card(url: str, expected: str, names: list[str], **kw: Any) 
     return tools
 
 
+def _contract_json(value: Any) -> str:
+    """Canonical JSON comparison: preserve types, equate JSON numeric spellings."""
+
+    def normalize(item: Any) -> Any:
+        if isinstance(item, float) and item.is_integer():
+            return int(item)
+        if isinstance(item, dict):
+            return {key: normalize(child) for key, child in item.items()}
+        if isinstance(item, list):
+            return [normalize(child) for child in item]
+        return item
+
+    return json.dumps(normalize(value), sort_keys=True, allow_nan=False)
+
+
+def _extract_smithery_public_contract(page: str, qualified_name: str) -> list[dict[str, Any]]:
+    """Read complete schemas from Smithery's public RSC data, without execution."""
+    if len(page.encode("utf-8")) > 2 * 1024 * 1024:
+        raise ValueError("Smithery public page exceeds bounded input size")
+    decoder = json.JSONDecoder()
+    chunks = []
+    for match in re.finditer(r"self\.__next_f\.push\(", page):
+        payload, _ = decoder.raw_decode(page, match.end())
+        if isinstance(payload, list) and len(payload) == 2 and payload[0] == 1 and isinstance(payload[1], str):
+            chunks.append(payload[1])
+    stream = "".join(chunks).encode("utf-8")
+    pos = 0
+    records = []
+    seen_ids: set[str] = set()
+    while pos < len(stream):
+        record_match = re.match(rb"([0-9a-f]*):", stream[pos:])
+        if record_match is None:
+            raise ValueError("invalid Smithery public data record")
+        ident = record_match[1].decode()
+        pos += record_match.end()
+        if ident:
+            if ident in seen_ids:
+                raise ValueError("duplicate Smithery public data record")
+            seen_ids.add(ident)
+        if len(seen_ids) > 10000:
+            raise ValueError("Smithery public data has too many records")
+        if stream[pos : pos + 1] == b"T":
+            end = stream.find(b",", pos)
+            if end < 0 or not re.fullmatch(rb"[0-9a-f]+", stream[pos + 1 : end]):
+                raise ValueError("invalid Smithery text record")
+            pos = end + 1 + int(stream[pos + 1 : end], 16)
+            if pos > len(stream):
+                raise ValueError("truncated Smithery text record")
+            continue
+        end = stream.find(b"\n", pos)
+        if end < 0:
+            raise ValueError("truncated Smithery public data record")
+        raw = stream[pos:end]
+        pos = end + 1
+        if raw[:1] in (b"{", b"["):
+            records.append(json.loads(raw))
+    candidates = []
+    visited = 0
+
+    def visit(value: Any, depth: int = 0) -> None:
+        nonlocal visited
+        visited += 1
+        if visited > 100000 or depth > 64:
+            raise ValueError("Smithery public data exceeds traversal bounds")
+        if isinstance(value, dict):
+            if value.get("qualifiedName") == qualified_name and isinstance(value.get("tools"), list):
+                namespace, slug = qualified_name.split("/", 1)
+                if value.get("namespace") != namespace or value.get("slug") != slug or value.get("remote") is not True:
+                    raise ValueError("Smithery public data has inconsistent server identity")
+                candidates.append(_validate_tool_contract(value["tools"]))
+            for child in value.values():
+                visit(child, depth + 1)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child, depth + 1)
+
+    for record in records:
+        visit(record)
+    if len(candidates) != 1:
+        raise ValueError("Smithery public data lacks one unambiguous server contract")
+    return candidates[0]
+
+
+def _smithery_public_contract(qualified_name: str, catalog_tools: Any, **kw: Any) -> list[dict[str, Any]]:
+    namespace, slug = qualified_name.split("/", 1)
+    url = "https://smithery.ai/servers/" + urllib.parse.quote(namespace, safe="") + "/" + urllib.parse.quote(slug, safe="")
+    req = urllib.request.Request(url, headers={"Accept": "text/html", "User-Agent": "agent-bom-freshness-probe"})
+    with urllib.request.urlopen(req, timeout=kw.get("timeout", DEFAULT_TIMEOUT)) as response:
+        payload = response.read(2 * 1024 * 1024 + 1)
+    if len(payload) > 2 * 1024 * 1024:
+        raise ValueError("Smithery public page exceeds bounded input size")
+    full = _extract_smithery_public_contract(payload.decode("utf-8"), qualified_name)
+    catalog = _validate_tool_contract(catalog_tools)
+    if [tool["name"] for tool in catalog] != [tool["name"] for tool in full]:
+        raise ValueError("Smithery public page and catalog tool names disagree")
+    # The catalog API projects root schemas to type/properties. Only its known
+    # omitted fields may differ; never mask a changed type/property/constraint.
+    for reduced, complete in zip(catalog, full):
+        schema = complete["inputSchema"].copy()
+        for key in ("title", "required", "additionalProperties"):
+            if key not in reduced["inputSchema"]:
+                schema.pop(key, None)
+        if _contract_json(schema) != _contract_json(reduced["inputSchema"]):
+            raise ValueError("Smithery public page and catalog schema values disagree")
+    return full
+
+
 def _env_or(name: str, default: str) -> str:
     """Return env var if non-blank; otherwise ``default``.
 
@@ -411,9 +518,15 @@ def probe_smithery(
                 actual_contract = _validate_tool_contract(tools)
             except ValueError:
                 actual_contract = []
-            result["exact_input_schemas"] = json.dumps(actual_contract, sort_keys=True) == json.dumps(
-                expected_tool_contract, sort_keys=True
-            )
+            result["inventory_source"] = "catalog-api"
+            result["catalog_exact_input_schemas"] = _contract_json(actual_contract) == _contract_json(expected_tool_contract)
+            if not result["catalog_exact_input_schemas"]:
+                try:
+                    actual_contract = _smithery_public_contract(qualified_name, tools, **kw)
+                    result["inventory_source"] = "public-page"
+                except (OSError, ValueError, RecursionError):
+                    result["schema_evidence_error"] = "complete Smithery schema evidence is unavailable or inconsistent"
+            result["exact_input_schemas"] = _contract_json(actual_contract) == _contract_json(expected_tool_contract)
             if not result["exact_input_schemas"]:
                 result["status"] = "stale"
                 result["error"] = "catalog input schemas differ from the release-bound server-card contract"
@@ -439,6 +552,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--write-tool-contract", type=Path, help="Validate the server card against released names/version, write schemas, and exit."
     )
+    parser.add_argument(
+        "--write-smithery-tool-contract", type=Path, help="Write complete public schemas after checking catalog consistency."
+    )
+    parser.add_argument("--compare-tool-contract-files", type=Path, nargs=2, metavar=("EXPECTED", "ACTUAL"))
     parser.add_argument("--surface", choices=["all", "smithery"], default="all")
     parser.add_argument("--docker-image", default=_env_or("DOCKER_IMAGE", DEFAULT_DOCKER_IMAGE))
     parser.add_argument("--smithery-server", default=_env_or("SMITHERY_SERVER_QUALIFIED_NAME", DEFAULT_SMITHERY_SERVER))
@@ -457,6 +574,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    if args.compare_tool_contract_files:
+        try:
+            left, right = (_load_tool_contract(path) for path in args.compare_tool_contract_files)
+            return 0 if _contract_json(left) == _contract_json(right) else 1
+        except (OSError, ValueError, RecursionError) as exc:
+            raise SystemExit("could not compare complete tool contracts") from exc
+
     expected = (args.expected or _expected_version()).lstrip("v").strip()
     # Default it rather than leaving it None. An unset expectation used to turn
     # the tool-count assertion off for Smithery entirely, so a bare local run
@@ -467,6 +591,19 @@ def main(argv: list[str] | None = None) -> int:
     if expected_tool_names is not None and len(expected_tool_names) != tool_count:
         raise SystemExit("expected tool-name contract and tool count do not match")
     kw = {"timeout": args.timeout, "attempts": args.attempts, "backoff": args.backoff_seconds}
+
+    if args.write_smithery_tool_contract:
+        try:
+            data = _http_json(_smithery_catalog_url(args.smithery_server), **kw)
+            if data.get("qualifiedName") != args.smithery_server or data.get("remote") is not True or not data.get("deploymentUrl"):
+                raise ValueError("Smithery catalog identity or remote metadata is invalid")
+            observed = _smithery_public_contract(args.smithery_server, data.get("tools"), **kw)
+        except (OSError, RuntimeError, ValueError, RecursionError) as exc:
+            raise SystemExit("complete Smithery schema evidence is unavailable or inconsistent") from exc
+        args.write_smithery_tool_contract.write_text(
+            json.dumps(observed, sort_keys=True, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+        return 0
 
     if args.write_tool_contract:
         if not args.server_card_url or expected_tool_names is None:

--- a/tests/test_publish_registries_release_auth_gate.py
+++ b/tests/test_publish_registries_release_auth_gate.py
@@ -35,7 +35,7 @@ def test_smithery_publication_is_idempotent_and_bounds_authorization_recovery() 
     assert "cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-server-card-tool-names.json" in workflow
     assert "smithery-expected-tool-contract.json" in workflow
     assert "smithery-actual-tool-contract.json" in workflow
-    assert "cmp -s /tmp/smithery-expected-tool-contract.json /tmp/smithery-actual-tool-contract.json" in workflow
+    assert "--compare-tool-contract-files /tmp/smithery-expected-tool-contract.json /tmp/smithery-actual-tool-contract.json" in workflow
     assert "smithery-expected-listing-metadata.json" in workflow
     assert "smithery-actual-listing-metadata.json" in workflow
     assert "cmp -s /tmp/smithery-expected-listing-metadata.json /tmp/smithery-actual-listing-metadata.json" in workflow

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -904,6 +904,12 @@ def _strict_marketplace_tool():
 @pytest.mark.parametrize("missing", ["required", "additionalProperties"])
 def test_smithery_rejects_schema_constraint_loss(monkeypatch, missing):
     script = _load_script("check_surface_freshness.py")
+
+    def unavailable(*_a, **_kw):
+        raise ValueError("public evidence unavailable")
+
+    monkeypatch.setattr(script, "_smithery_public_contract", unavailable)
+
     expected = [_strict_marketplace_tool()]
     actual = json.loads(json.dumps(expected))
     actual[0]["inputSchema"].pop(missing)
@@ -980,6 +986,12 @@ def test_monitor_rejects_unbound_server_card(monkeypatch, tmp_path, fault):
 
 def test_smithery_schema_drift_keeps_consolidated_issue_open(monkeypatch, tmp_path, capsys):
     script = _load_script("check_surface_freshness.py")
+
+    def unavailable(*_a, **_kw):
+        raise ValueError("public evidence unavailable")
+
+    monkeypatch.setattr(script, "_smithery_public_contract", unavailable)
+
     tools = [_strict_marketplace_tool()]
     contract = tmp_path / "contract.json"
     contract.write_text(json.dumps(tools))
@@ -1089,3 +1101,114 @@ def test_deployment_issue_closure_requires_explicit_verified_success():
     close_step = workflow.split("- name: Close supply-chain drift issue when deployment is fresh", 1)[1]
     assert "steps.public.outputs.public_version == 'fresh'" in close_step
     assert "steps.public.outputs.probe_failed == 'false'" in close_step
+
+
+def _smithery_public_page(tools, *, qualified_name="agentbom/agent-bom", prefix=""):
+    namespace, slug = qualified_name.split("/")
+    server = {"qualifiedName": qualified_name, "namespace": namespace, "slug": slug, "remote": True, "tools": tools}
+    flight = prefix + "1:" + json.dumps({"server": server}) + "\n"
+    return "<script>self.__next_f.push(" + json.dumps([1, flight]) + ")</script>"
+
+
+def test_smithery_public_schema_preserves_exact_constraints():
+    script = _load_script("check_surface_freshness.py")
+    tools = [_strict_marketplace_tool()]
+    assert script._extract_smithery_public_contract(_smithery_public_page(tools), "agentbom/agent-bom") == tools
+
+
+@pytest.mark.parametrize(
+    "fault", ["wrong_server", "duplicate_record", "truncated", "oversized", "duplicate_tool", "deep", "malformed_schema"]
+)
+def test_smithery_public_schema_fails_closed(fault):
+    script = _load_script("check_surface_freshness.py")
+    tools = [_strict_marketplace_tool()]
+    page = _smithery_public_page(tools)
+    if fault == "wrong_server":
+        page = _smithery_public_page(tools, qualified_name="other/server")
+    elif fault == "duplicate_record":
+        page += page
+    elif fault == "truncated":
+        page = '<script>self.__next_f.push([1,"2:Tff,short"])</script>'
+    elif fault == "oversized":
+        page += " " * (2 * 1024 * 1024)
+    elif fault == "duplicate_tool":
+        page = _smithery_public_page(tools + tools)
+    elif fault == "malformed_schema":
+        page = _smithery_public_page([{"name": "check", "inputSchema": None}])
+    else:
+        value = "end"
+        for _ in range(70):
+            value = [value]
+        tools[0]["inputSchema"]["default"] = value
+        page = _smithery_public_page(tools)
+    with pytest.raises((ValueError, RecursionError)):
+        script._extract_smithery_public_contract(page, "agentbom/agent-bom")
+
+
+def test_smithery_public_text_records_cannot_inject_schema_candidates():
+    script = _load_script("check_surface_freshness.py")
+    fake = "1:" + json.dumps({"qualifiedName": "agentbom/agent-bom", "tools": []}) + "\n"
+    prefix = "0:T" + format(len(fake.encode()), "x") + "," + fake
+    tools = [_strict_marketplace_tool()]
+    assert script._extract_smithery_public_contract(_smithery_public_page(tools, prefix=prefix), "agentbom/agent-bom") == tools
+
+
+def test_smithery_complete_public_evidence_resolves_catalog_projection(monkeypatch):
+    script = _load_script("check_surface_freshness.py")
+    tools = [_strict_marketplace_tool()]
+    reduced = json.loads(json.dumps(tools))
+    reduced[0]["inputSchema"].pop("required")
+    reduced[0]["inputSchema"].pop("additionalProperties")
+    monkeypatch.setattr(
+        script,
+        "_http_json",
+        lambda *_a, **_kw: {
+            "qualifiedName": "agentbom/agent-bom",
+            "remote": True,
+            "deploymentUrl": "https://agent-bom--agentbom.run.tools",
+            "tools": reduced,
+        },
+    )
+    monkeypatch.setattr(script, "_smithery_public_contract", lambda *_a, **_kw: tools)
+    result = script.probe_smithery(
+        "0.103.2", "agentbom/agent-bom", expected_tool_count=1, expected_tool_names=["check"], expected_tool_contract=tools
+    )
+    assert result["status"] == "fresh"
+    assert result["exact_input_schemas"] is True
+    assert result["catalog_exact_input_schemas"] is False
+    assert result["inventory_source"] == "public-page"
+
+
+@pytest.mark.parametrize("mismatch", [False, True])
+def test_smithery_public_schemas_must_agree_with_catalog_values(monkeypatch, mismatch):
+    import io
+
+    script = _load_script("check_surface_freshness.py")
+    tools = [_strict_marketplace_tool()]
+    reduced = json.loads(json.dumps(tools))
+    reduced[0]["inputSchema"].pop("required")
+    if mismatch:
+        reduced[0]["inputSchema"]["properties"]["package"]["type"] = "integer"
+    monkeypatch.setattr(script.urllib.request, "urlopen", lambda *_a, **_kw: io.BytesIO(_smithery_public_page(tools).encode()))
+    if mismatch:
+        with pytest.raises(ValueError, match="schema values disagree"):
+            script._smithery_public_contract("agentbom/agent-bom", reduced)
+    else:
+        assert script._smithery_public_contract("agentbom/agent-bom", reduced) == tools
+
+
+def test_smithery_contract_comparison_preserves_types_and_numeric_values():
+    script = _load_script("check_surface_freshness.py")
+    assert script._contract_json({"default": 3.0}) == script._contract_json({"default": 3})
+    assert script._contract_json({"default": 0.5}) != script._contract_json({"default": 0})
+    assert script._contract_json({"additionalProperties": False}) != script._contract_json({"additionalProperties": 0})
+    assert script._contract_json({"type": "integer"}) != script._contract_json({"type": "number"})
+
+
+def test_smithery_publisher_uses_complete_public_schema_evidence():
+    workflow = (ROOT / ".github/workflows/publish-registries.yml").read_text()
+    assert workflow.count("--write-smithery-tool-contract /tmp/smithery-actual-tool-contract.json") == 2
+    assert (
+        workflow.count("--compare-tool-contract-files /tmp/smithery-expected-tool-contract.json /tmp/smithery-actual-tool-contract.json")
+        == 2
+    )


### PR DESCRIPTION
## Summary
- Verify complete Smithery input schemas from its public page. The catalog API projects away root `required`, `additionalProperties`, and `title`; its identity, tool names, and remaining schema values must still agree with the full public evidence.
- Use this exact contract in publishing and both daily monitors. Missing, malformed, inconsistent, or ambiguous schema evidence fails closed, and issue closure requires explicit verification success.
- Parse bounded public React data without executing scripts, including byte-counted text records. Compare JSON numeric values consistently while preserving boolean/string/schema-type distinctions.

## Verification
- `pytest -q tests/test_surface_freshness.py tests/test_deployment.py tests/test_publish_registries_release_auth_gate.py tests/test_publish_registries_glama_gate.py`: 158 passed.
- Regressions cover dropped constraints, unavailable evidence, wrong identities, duplicate records/tools, truncation, size/depth limits, text-record injection, conflicting catalog properties, and valid exact schemas.
- Ruff, targeted mypy, affected-file hooks, `make preflight`, and `git diff --check` passed.
- Live v0.103.2 check: PyPI, Docker, Glama, and Smithery all fresh. Both marketplaces match all 86 released tool names and complete input schemas. Smithery proof records `inventory_source: public-page` and `catalog_exact_input_schemas: false` rather than claiming its reduced API is complete.

## Notes
Related: #5092, #5093, #5094. Personal publisher access is verified and its GitHub Actions credential is configured. The publishing workflow still needs a successful run after this exact head is reviewed and merged. No package tag or application deployment is included.
