### PR TITLE
fix(auth): bind runtime ingestion to expiring source credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Runtime evidence ingestion now requires an expiring, source-scoped API key
+  or verified OIDC credential. API bodies, MCP arguments and CLI flags no longer
+  accept source secrets. CLI/MCP producers use the configured control-plane API;
+  legacy shared-secret source registrations fail closed. See the runtime
+  producer migration guide in `docs/CLOUD_CONNECT.md`.
+
 - MCP server startup now exposes eight scan and remediation tools by default.
   Select graph, cloud, runtime or audit profiles for specialized work, or use
   `--profile full` to preserve the complete catalog in existing clients.

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -658,8 +658,10 @@ evidence never replaces disk evidence.
 
 Ingest is hardened and fails closed (`runtime_workload_evidence.py`):
 
-- **Authenticated source.** Each source registers with a hashed shared secret;
-  a batch is accepted only after a constant-time secret check. Tenant, provider,
+- **Authenticated source.** Sources register identity metadata only. Batches require a
+  verified API key or OIDC bearer credential with the exact
+  `runtime:ingest:<source-id>` scope and a lifetime of at most one hour.
+  Expired, revoked, unscoped and non-expiring keys fail closed. Tenant, provider,
   and account are taken from the authenticated source — a payload that claims a
   different provider/account is rejected (confused-deputy guard).
 - **Freshness + provenance.** Every accepted signal must provide `observed_at`;
@@ -700,6 +702,47 @@ findings Evidence drawer shows a dedicated Workload runtime evidence panel
 `agent-bom cloud side-scan-capabilities` prints the honest provider surface;
 `agent-bom cloud side-scan --provider azure|gcp` runs the shipped executor
 (opt-in via `AGENT_BOM_SIDESCAN`).
+
+### Runtime producer authentication
+
+Register source metadata on the control plane through
+`AGENT_BOM_RUNTIME_EVIDENCE_SOURCES`, for example:
+
+```json
+[{"source_id":"edr-1","tenant_id":"tenant-alpha","provider":"aws","account_id":"123456789012","kind":"edr"}]
+```
+
+Use the existing authenticated `POST /v1/auth/keys` endpoint to provision a
+producer key with the exact scope `runtime:ingest:edr-1`, its tenant, an admin role, and an explicit `expires_at` no more than one hour after issuance.
+Alternatively, configure the existing OIDC verifier and use a verified bearer
+JWT with the same exact scope, tenant binding, `iat` and `exp`. Source identifiers
+in scopes are percent-encoded (for example, `edr/1` becomes `edr%2F1`). Wildcard
+scopes do not grant source authority. Rotate credentials before expiry; API key
+revocation is checked on each ingestion request.
+
+For CLI and MCP, configure `AGENT_BOM_API_URL` and exactly one of
+`AGENT_BOM_API_KEY` or `AGENT_BOM_API_TOKEN` in the process environment through
+external credential provisioning. Use an HTTPS origin; HTTP is accepted only
+for a loopback host. Set `AGENT_BOM_TENANT_ID` to the intended
+tenant. Credentials are transmitted in authentication headers, never evidence
+JSON or model-visible tool arguments. The MCP caller must independently pass
+its existing authenticated write-authorization gate.
+
+```bash
+agent-bom cloud runtime-evidence-ingest --source-id edr-1 --file signals.json \
+  --reason "Import approved runtime observations"
+```
+
+The command reports accepted, rejected and persisted counts. Inspect the
+corresponding finding's workload runtime evidence next. `--no-persist` validates
+through the same authenticated API without storing signals. It still requires a
+configured control plane. Successful writes include audit status; an audit sink
+failure after persistence is reported as partial, not as a successful audit.
+
+**Migration:** remove `secret` and `secret_hash` from source registrations;
+legacy registrations fail closed. Remove `secret` from API/MCP payloads and
+`--secret` / `AGENT_BOM_RUNTIME_EVIDENCE_SOURCE_SECRET` from producers. There is
+no shared-secret fallback. Evidence storage and existing receipts are unchanged.
 
 The Azure/GCP disk side-scan is now surface-aligned across CLI
 (`agent-bom cloud side-scan`), REST (`POST /v1/cloud/side-scan`), MCP

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -296,3 +296,12 @@ outputs, and demo script behind each workflow.
 - `fleet-audit` — Inventory and fleet scan playbook
 - `incident-triage` — Finding triage with blast radius and runtime context
 - `remediation-plan` — Human-reviewed remediation plan without file writes
+
+### Runtime ingestion credentials
+
+`runtime_evidence_ingest` sends metadata to the configured control-plane API.
+It accepts no credential arguments. Provision a source-bound, expiring API key
+or OIDC bearer credential in the server environment; the API verifies its exact
+source scope, tenant and lifetime (at most one hour). MCP write authorization
+remains independently required. See [runtime producer authentication](CLOUD_CONNECT.md#runtime-producer-authentication)
+for source registration, rotation and migration from shared-secret producers.

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-09-05",
+  "generated_on": "2026-09-06",
   "version": "0.103.2",
   "metrics": [
     {
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 891,
+      "value": 894,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-09-05`
+- Generated on: `2026-09-06`
 - Version: `0.103.2`
 
 | Metric | Value | Source | Notes |
@@ -17,7 +17,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 50 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 891 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 894 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -7014,8 +7014,11 @@
             ],
             "title": "Correlation Cohort Id"
           },
-          "secret": {
-            "title": "Secret",
+          "reason": {
+            "default": "Runtime evidence ingestion",
+            "maxLength": 1024,
+            "minLength": 8,
+            "title": "Reason",
             "type": "string"
           },
           "signals": {
@@ -7029,11 +7032,15 @@
           "source_id": {
             "title": "Source Id",
             "type": "string"
+          },
+          "validate_only": {
+            "default": false,
+            "title": "Validate Only",
+            "type": "boolean"
           }
         },
         "required": [
-          "source_id",
-          "secret"
+          "source_id"
         ],
         "title": "RuntimeEvidenceIngestRequest",
         "type": "object"
@@ -13834,7 +13841,7 @@
     },
     "/v1/cloud/runtime-evidence/ingest": {
       "post": {
-        "description": "Ingest a batch of CWPP runtime/EDR workload signals (#4158 stage 3).\n\nThe authenticated, tenant-scoped door for the runtime workload-evidence store.\nWithout this route the store had no caller in a deployed product and could\nnever be populated. Read-only posture: agent-bom never writes to a customer\ntarget and persists allowlisted metadata only (raw content and known\ncredential-shaped values are dropped at construction). Each source is\npre-registered with a hashed shared secret (no per-action credentials);\n``provider``/``account`` bind to the\nauthenticated source, never the payload (confused-deputy guard).\n\nFail-closed: an unknown source id, a bad secret, or a source owned by a\ndifferent tenant all return the same generic ``401`` so a caller cannot\nenumerate valid source ids or tenants. The ingest runs off the event loop in a\nworker thread under backpressure so a batch can never stall ``/health``.",
+        "description": "Ingest source-scoped metadata using an existing API key or OIDC token.\n\nThe verified credential must carry the exact runtime:ingest:<source_id>\nscope and have a lifetime of at most one hour. Source tenant/provider/account\ncome from server registration. Credentials are never accepted in this body.\nUnknown, expired, revoked, unscoped or cross-tenant authority fails closed.",
         "operationId": "cloud_runtime_evidence_ingest_v1_cloud_runtime_evidence_ingest_post",
         "parameters": [
           {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -4998,8 +4998,11 @@ components:
             type: string
           - type: 'null'
           title: Correlation Cohort Id
-        secret:
-          title: Secret
+        reason:
+          default: Runtime evidence ingestion
+          maxLength: 1024
+          minLength: 8
+          title: Reason
           type: string
         signals:
           items:
@@ -5010,9 +5013,12 @@ components:
         source_id:
           title: Source Id
           type: string
+        validate_only:
+          default: false
+          title: Validate Only
+          type: boolean
       required:
       - source_id
-      - secret
       title: RuntimeEvidenceIngestRequest
       type: object
     RuntimeEvidenceSignalIn:
@@ -9500,35 +9506,17 @@ paths:
       - cloud-connections
   /v1/cloud/runtime-evidence/ingest:
     post:
-      description: 'Ingest a batch of CWPP runtime/EDR workload signals (#4158 stage
-        3).
+      description: 'Ingest source-scoped metadata using an existing API key or OIDC
+        token.
 
 
-        The authenticated, tenant-scoped door for the runtime workload-evidence store.
+        The verified credential must carry the exact runtime:ingest:<source_id>
 
-        Without this route the store had no caller in a deployed product and could
+        scope and have a lifetime of at most one hour. Source tenant/provider/account
 
-        never be populated. Read-only posture: agent-bom never writes to a customer
+        come from server registration. Credentials are never accepted in this body.
 
-        target and persists allowlisted metadata only (raw content and known
-
-        credential-shaped values are dropped at construction). Each source is
-
-        pre-registered with a hashed shared secret (no per-action credentials);
-
-        ``provider``/``account`` bind to the
-
-        authenticated source, never the payload (confused-deputy guard).
-
-
-        Fail-closed: an unknown source id, a bad secret, or a source owned by a
-
-        different tenant all return the same generic ``401`` so a caller cannot
-
-        enumerate valid source ids or tenants. The ingest runs off the event loop
-        in a
-
-        worker thread under backpressure so a batch can never stall ``/health``.'
+        Unknown, expired, revoked, unscoped or cross-tenant authority fails closed.'
       operationId: cloud_runtime_evidence_ingest_v1_cloud_runtime_evidence_ingest_post
       parameters:
       - in: header

--- a/docs/schemas/v1/RuntimeEvidenceIngestRequest.json
+++ b/docs/schemas/v1/RuntimeEvidenceIngestRequest.json
@@ -193,8 +193,11 @@
       "default": null,
       "title": "Correlation Cohort Id"
     },
-    "secret": {
-      "title": "Secret",
+    "reason": {
+      "default": "Runtime evidence ingestion",
+      "maxLength": 1024,
+      "minLength": 8,
+      "title": "Reason",
       "type": "string"
     },
     "signals": {
@@ -208,11 +211,15 @@
     "source_id": {
       "title": "Source Id",
       "type": "string"
+    },
+    "validate_only": {
+      "default": false,
+      "title": "Validate Only",
+      "type": "boolean"
     }
   },
   "required": [
-    "source_id",
-    "secret"
+    "source_id"
   ],
   "title": "RuntimeEvidenceIngestRequest",
   "type": "object"

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -271,10 +271,8 @@ AGENT_BOM_GCP_IMPERSONATE_SA
 AGENT_BOM_GCP_INVENTORY
 # Defensive cap (default 200) on the number of projects walked in the GCP org/folder tree multi-project fan-out.
 AGENT_BOM_GCP_MAX_PROJECTS
-# JSON array provisioning CWPP runtime-evidence ingest sources (source_id/tenant/provider/account/secret_hash); read once to build the process-global source registry. Fail-closed: empty/malformed registers no source.
+# JSON array provisioning CWPP runtime-evidence ingest sources (source_id/tenant_id/provider/account_id/kind); read once to build the process-global source registry. Fail-closed: empty/malformed registers no source.
 AGENT_BOM_RUNTIME_EVIDENCE_SOURCES
-# CLI/MCP convenience secret for one ingest call (never logged); prefer hashed secrets in AGENT_BOM_RUNTIME_EVIDENCE_SOURCES for durable sources.
-AGENT_BOM_RUNTIME_EVIDENCE_SOURCE_SECRET
 AGENT_BOM_GRAPH_DB
 AGENT_BOM_GRAPH_DELTA_SLACK_WEBHOOK
 AGENT_BOM_GRAPH_DELTA_WEBHOOK

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -415,15 +415,17 @@ ingest_external_scan(scan_json="<SARIF or scanner JSON>", parse_only=true)
 ### runtime_evidence_ingest
 Ingest CWPP runtime/EDR workload signals into the durable evidence store.
 Requires a pre-registered source (`AGENT_BOM_RUNTIME_EVIDENCE_SOURCES`) and
-shared secret. The source tenant must match the MCP server's authoritative
-tenant binding. Metadata only; never writes to a customer cloud target.
+a configured control-plane API (`AGENT_BOM_API_URL`). Provision exactly one of
+`AGENT_BOM_API_KEY` or `AGENT_BOM_API_TOKEN` in the server environment: it must
+carry the exact `runtime:ingest:<source-id>` scope and expire within one hour
+of issuance. Credentials are never tool arguments. The source tenant must match
+the MCP server's authoritative tenant binding. Metadata only; never writes to a customer cloud target.
 Fail-closed on auth. Write-annotated (`findings:write`). If evidence persistence
 succeeds but the audit sink fails, the response reports `status: partial` and
 `audit_status: unavailable` rather than implying complete success.
 ```
 runtime_evidence_ingest(
   source_id="edr-1",
-  secret="...",
   signals_json="[]",
   operator_role="admin",
   operator_scopes="findings:write",

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1718,6 +1718,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 request.state.api_key_role = effective_role.value
                 request.state.tenant_id = tenant_id
                 request.state.auth_method = "oidc"
+                request.state.verified_oidc_claims = dict(_claims)
                 # Short issuer suffix helps operators recognize which IdP
                 # resolved the token without leaking the full URL to all
                 # request-scoped log fields.

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -1063,7 +1063,8 @@ class RuntimeEvidenceIngestRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
     source_id: str
-    secret: str
+    validate_only: bool = False
+    reason: str = Field(default="Runtime evidence ingestion", min_length=8, max_length=1024)
     signals: list[RuntimeEvidenceSignalIn] = Field(default_factory=list, max_length=1000)
     correlation_cohort_id: str | None = Field(default=None, min_length=36, max_length=36)
     correlation_child_receipt: CorrelationCohortChildReceipt | None = None

--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -924,21 +924,12 @@ async def cloud_runtime_evidence_ingest(
     body: RuntimeEvidenceIngestRequest,
     _role: Any = _SCAN_DEP,
 ) -> dict[str, Any]:
-    """Ingest a batch of CWPP runtime/EDR workload signals (#4158 stage 3).
+    """Ingest source-scoped metadata using an existing API key or OIDC token.
 
-    The authenticated, tenant-scoped door for the runtime workload-evidence store.
-    Without this route the store had no caller in a deployed product and could
-    never be populated. Read-only posture: agent-bom never writes to a customer
-    target and persists allowlisted metadata only (raw content and known
-    credential-shaped values are dropped at construction). Each source is
-    pre-registered with a hashed shared secret (no per-action credentials);
-    ``provider``/``account`` bind to the
-    authenticated source, never the payload (confused-deputy guard).
-
-    Fail-closed: an unknown source id, a bad secret, or a source owned by a
-    different tenant all return the same generic ``401`` so a caller cannot
-    enumerate valid source ids or tenants. The ingest runs off the event loop in a
-    worker thread under backpressure so a batch can never stall ``/health``.
+    The verified credential must carry the exact runtime:ingest:<source_id>
+    scope and have a lifetime of at most one hour. Source tenant/provider/account
+    come from server registration. Credentials are never accepted in this body.
+    Unknown, expired, revoked, unscoped or cross-tenant authority fails closed.
     """
     tenant_id = _tenant(request)
 
@@ -948,16 +939,19 @@ async def cloud_runtime_evidence_ingest(
         # Tenant binding: the authenticated request tenant must own the source.
         # Fold "wrong tenant" into the same auth failure so a caller cannot probe
         # which source ids exist in another tenant.
-        if source is None or source.tenant_id != tenant_id:
+        requested_tenant = request.headers.get("X-Agent-Bom-Tenant-ID")
+        if source is None or source.tenant_id != tenant_id or (requested_tenant is not None and requested_tenant != tenant_id):
             raise SourceAuthenticationError("runtime evidence source authentication failed")
-        # Authenticate before checking cohort membership so a signed assignment
-        # never replaces the runtime source's existing secret boundary.
-        registry.authenticate(body.source_id, body.secret)
+        # A cohort receipt does not grant authority over its named source.
+        registry.authorize(body.source_id, principal)
+        if body.validate_only and (body.correlation_cohort_id or body.correlation_child_receipt):
+            raise CorrelationCohortIngestError("incomplete_receipt")
         cohort_id = (body.correlation_cohort_id or "").strip()
         cohort_receipt = body.correlation_child_receipt
         if bool(cohort_id) != bool(cohort_receipt):
             raise CorrelationCohortIngestError("incomplete_receipt")
         if cohort_id and cohort_receipt is not None:
+            cohort_max_age_seconds = cohort_receipt.max_age_hours * 3600
             context = validate_correlation_cohort_child(
                 tenant_id=tenant_id,
                 source_id=body.source_id,
@@ -979,10 +973,10 @@ async def cloud_runtime_evidence_ingest(
                     projection = ingest_runtime_signals(
                         registry=registry,
                         source_id=body.source_id,
-                        secret=body.secret,
+                        principal=principal,
                         raw_signals=[signal.model_dump(exclude_none=True) for signal in body.signals],
                         now=completed_child.completed_at if completed_child is not None else None,
-                        max_age_seconds=cohort_receipt.max_age_hours * 3600,
+                        max_age_seconds=cohort_max_age_seconds,
                         store=get_runtime_workload_evidence_store(),
                     )
                 except Exception as exc:  # noqa: BLE001 - safe stable projection error below
@@ -1040,9 +1034,9 @@ async def cloud_runtime_evidence_ingest(
                 result = ingest_runtime_signals(
                     registry=registry,
                     source_id=body.source_id,
-                    secret=body.secret,
+                    principal=principal,
                     raw_signals=[signal.model_dump(exclude_none=True) for signal in body.signals],
-                    max_age_seconds=cohort_receipt.max_age_hours * 3600,
+                    max_age_seconds=cohort_max_age_seconds,
                     store=None,
                 )
                 if not result.accepted or result.rejected_stale or result.rejected_incomplete:
@@ -1093,17 +1087,39 @@ async def cloud_runtime_evidence_ingest(
         result = ingest_runtime_signals(
             registry=registry,
             source_id=body.source_id,
-            secret=body.secret,
+            principal=principal,
             raw_signals=[s.model_dump(exclude_none=True) for s in body.signals],
-            store=get_runtime_workload_evidence_store(),
+            store=None if body.validate_only else get_runtime_workload_evidence_store(),
         )
         return result.to_dict()
 
     try:
+        from agent_bom.api.runtime_source_auth import runtime_source_principal
+
+        principal = await anyio.to_thread.run_sync(runtime_source_principal, request)
         async with adaptive_backpressure("runtime_evidence_ingest"):
-            return await anyio.to_thread.run_sync(_ingest)
+            response = await anyio.to_thread.run_sync(_ingest)
+        try:
+            from agent_bom.api.audit_log import log_action
+
+            await anyio.to_thread.run_sync(
+                lambda: log_action(
+                    "runtime_evidence.validate" if body.validate_only else "runtime_evidence.ingest",
+                    actor=principal.subject,
+                    tenant_id=tenant_id,
+                    resource=f"runtime-evidence/source/{body.source_id}",
+                    reason=body.reason,
+                    persisted=response.get("persisted"),
+                )
+            )
+            response["audit_status"] = "recorded"
+        except Exception:
+            _logger.warning("Runtime evidence audit event unavailable")
+            response["status"] = "partial"
+            response["audit_status"] = "unavailable"
+        return response
     except SourceAuthenticationError as exc:
-        # Generic 401 — never reveal whether the source id or the secret was wrong.
+        # Never reveal whether the source exists or which credential check failed.
         raise HTTPException(status_code=401, detail="Runtime evidence source authentication failed") from exc
     except CorrelationCohortIngestError as exc:
         if exc.code == "incomplete_receipt":

--- a/src/agent_bom/api/runtime_source_auth.py
+++ b/src/agent_bom/api/runtime_source_auth.py
@@ -1,0 +1,65 @@
+"""Resolve runtime source authority from existing API authentication."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, cast
+
+from agent_bom.cloud.runtime_source_auth import RuntimeSourcePrincipal, SourceAuthenticationError
+
+
+def _epoch(value: str | None) -> float:
+    if not value:
+        raise ValueError("missing credential timestamp")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("credential timestamp requires timezone")
+    return parsed.timestamp()
+
+
+def runtime_source_principal(request: Any) -> RuntimeSourcePrincipal:
+    """Accept verified, expiring API keys/SAML keys or verified OIDC JWTs.
+
+    Static keys, proxy assertions and unbound browser sessions cannot establish
+    source authority. Key state is re-read so revocation/rotation remain active.
+    """
+    from agent_bom.api.auth import get_key_store
+
+    state = request.state
+    tenant = str(getattr(state, "tenant_id", "") or "")
+    method = getattr(state, "auth_method", "")
+    try:
+        key_id = getattr(state, "api_key_id", None)
+        if method in {"api_key", "saml", "browser_session"} and key_id:
+            key = get_key_store().get(str(key_id))
+            if key is None or not key.is_usable() or key.tenant_id != tenant:
+                raise ValueError("inactive credential")
+            return RuntimeSourcePrincipal(
+                subject=f"api-key:{key.key_id}",
+                tenant_id=tenant,
+                scopes=tuple(key.scopes),
+                issued_at=_epoch(key.created_at),
+                expires_at=_epoch(key.expires_at),
+            )
+        if method == "oidc":
+            claims = getattr(state, "verified_oidc_claims", None)
+            if not isinstance(claims, dict) or not claims.get("iss") or not claims.get("sub"):
+                raise ValueError("missing verified identity")
+            scopes = claims.get("scope", claims.get("scp", []))
+            if isinstance(scopes, str):
+                scopes = scopes.split()
+            if not isinstance(scopes, list) or not all(isinstance(scope, str) for scope in scopes):
+                raise ValueError("invalid credential scopes")
+            issued, expires = claims.get("iat"), claims.get("exp")
+            if type(issued) not in (int, float) or type(expires) not in (int, float):
+                raise ValueError("missing credential lifetime")
+            return RuntimeSourcePrincipal(
+                subject=f"oidc:{claims['iss']}:{claims['sub']}",
+                tenant_id=tenant,
+                scopes=tuple(scopes),
+                issued_at=cast(float, issued),
+                expires_at=cast(float, expires),
+            )
+    except (ValueError, TypeError, OverflowError):
+        pass
+    raise SourceAuthenticationError("runtime evidence source authentication failed")

--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -1052,73 +1052,49 @@ cloud_group.add_command(side_scan_capabilities_cmd, "side-scan-capabilities")
 
 @click.command("runtime-evidence-ingest")
 @click.option("--source-id", required=True, help="Pre-registered runtime evidence source id.")
-@click.option(
-    "--secret",
-    required=True,
-    envvar="AGENT_BOM_RUNTIME_EVIDENCE_SOURCE_SECRET",
-    help="Shared secret for the source (or set AGENT_BOM_RUNTIME_EVIDENCE_SOURCE_SECRET).",
-)
-@click.option(
-    "--file",
-    "signals_file",
-    type=click.Path(exists=True, dir_okay=False, path_type=str),
-    required=True,
-    help='JSON file: a list of signals, or {"signals": [...]}.',
-)
-@click.option("--no-persist", is_flag=True, help="Authenticate + validate only; do not write the durable store.")
-def runtime_evidence_ingest_cmd(source_id: str, secret: str, signals_file: str, no_persist: bool) -> None:
-    """Ingest CWPP runtime/EDR workload signals into the local evidence store.
+@click.option("--file", "signals_file", type=click.Path(exists=True, dir_okay=False), required=True, help="JSON signal file.")
+@click.option("--no-persist", is_flag=True, help="Authenticate and validate through the API without persisting evidence.")
+@click.option("--reason", default="Runtime evidence ingestion", help="Audit reason for ingestion.")
+def runtime_evidence_ingest_cmd(source_id: str, signals_file: str, no_persist: bool, reason: str) -> None:
+    """Ingest runtime evidence through the authenticated control-plane API.
 
-    Sources must already be registered via ``AGENT_BOM_RUNTIME_EVIDENCE_SOURCES``
-    (hashed shared secret). Read-only toward customer targets: agent-bom never
-    writes to a cloud workload; only redacted metadata is persisted. Fail-closed
-    authentication — unknown source or bad secret exits non-zero.
+    Configure AGENT_BOM_API_URL and AGENT_BOM_API_KEY or AGENT_BOM_API_TOKEN
+    outside the command. The credential requires an exact source scope and a
+    lifetime of at most one hour. The API owns source/tenant validation and storage.
 
-    \b
-    Examples:
-      agent-bom cloud runtime-evidence-ingest \\
-        --source-id edr-1 --secret \"$SECRET\" --file signals.json
+    Example: agent-bom cloud runtime-evidence-ingest --source-id edr-1 --file signals.json
     """
     import json
     from pathlib import Path
 
     from rich.console import Console
 
-    from agent_bom.cloud.runtime_workload_evidence import (
-        SourceAuthenticationError,
-        ingest_runtime_signals_payload,
-    )
+    from agent_bom.cloud.runtime_evidence_client import push_runtime_evidence
+    from agent_bom.cloud.runtime_source_auth import SourceAuthenticationError
+    from agent_bom.security import sanitize_error
 
     con = Console()
     try:
         payload = json.loads(Path(signals_file).read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        con.print(f"\n  [red]invalid signals file:[/red] {exc}\n")
+        summary = push_runtime_evidence(source_id=source_id, payload=payload, reason=reason, validate_only=no_persist)
+    except (OSError, ValueError) as exc:
+        con.print(f"Invalid runtime evidence: {sanitize_error(exc, generic=True)}")
         raise SystemExit(2) from exc
-
-    try:
-        result = ingest_runtime_signals_payload(
-            source_id=source_id,
-            secret=secret,
-            payload=payload,
-            persist=not no_persist,
-        )
-    except SourceAuthenticationError:
-        con.print("\n  [red]runtime evidence source authentication failed[/red]\n")
-        raise SystemExit(1)
-    except ValueError as exc:
-        con.print(f"\n  [red]invalid payload:[/red] {exc}\n")
-        raise SystemExit(2) from exc
-
-    summary = result.to_dict()
-    con.print("\n  [bold]runtime evidence ingest[/bold] [dim]· metadata only · additive[/dim]")
+    except SourceAuthenticationError as exc:
+        con.print("Runtime evidence source authentication failed; configure a source-scoped API credential")
+        raise SystemExit(1) from exc
+    except Exception as exc:
+        con.print(f"Runtime evidence request failed: {sanitize_error(exc, generic=True)}")
+        raise SystemExit(1) from exc
+    con.print("Runtime evidence ingest · metadata only · additive")
     con.print(
-        f"  source={summary['source_id']} tenant={summary['tenant_id']} "
+        f"source={summary['source_id']} tenant={summary['tenant_id']} "
         f"accepted={summary['accepted']} persisted={summary['persisted']} "
-        f"deduped={summary['deduped']} stale={summary['rejected_stale']} "
-        f"incomplete={summary['rejected_incomplete']}"
+        f"deduped={summary['deduped']} stale={summary['rejected_stale']} incomplete={summary['rejected_incomplete']}"
     )
-    con.print()
+    if summary.get("status") == "partial" or summary.get("audit_status") == "unavailable":
+        con.print("Ingestion is partial: evidence counts are shown above; audit recording is unavailable.")
+        raise SystemExit(1)
     if summary["accepted"] == 0 and (summary["rejected_stale"] or summary["rejected_incomplete"]):
         raise SystemExit(2)
 

--- a/src/agent_bom/client.py
+++ b/src/agent_bom/client.py
@@ -718,6 +718,16 @@ class AgentBomClient:
             params=_strip_query_none({"tenant_id": tenant_id or self.tenant_id}),
         )
 
+    def ingest_runtime_evidence(
+        self, *, source_id: str, signals: Sequence[JsonObject], reason: str = "Runtime evidence ingestion", validate_only: bool = False
+    ) -> JsonObject:
+        """Send metadata with source-scoped transport authentication."""
+        return self._request(
+            "POST",
+            "/v1/cloud/runtime-evidence/ingest",
+            json={"source_id": source_id, "signals": list(signals), "reason": reason, "validate_only": validate_only},
+        )
+
     def ingest_runtime_events(
         self,
         events: Mapping[str, JsonValue] | Sequence[Mapping[str, JsonValue]],

--- a/src/agent_bom/cloud/runtime_evidence_client.py
+++ b/src/agent_bom/cloud/runtime_evidence_client.py
@@ -1,0 +1,56 @@
+"""CLI/MCP ingestion through the existing authenticated control-plane client."""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+from typing import Any
+from urllib.parse import urlsplit
+
+from agent_bom.client import AgentBomClient
+from agent_bom.cloud.runtime_source_auth import SourceAuthenticationError
+
+
+def push_runtime_evidence(
+    *, source_id: str, payload: Any, reason: str, validate_only: bool = False, tenant_id: str | None = None
+) -> dict[str, Any]:
+    """Resolve credentials from server configuration, never tool arguments."""
+    origin = os.environ.get("AGENT_BOM_API_URL", "").strip()
+    api_key = os.environ.get("AGENT_BOM_API_KEY", "").strip() or None
+    token = os.environ.get("AGENT_BOM_API_TOKEN", "").strip() or None
+    try:
+        parsed = urlsplit(origin)
+        # Credentials require TLS except for an explicit loopback control plane.
+        host = parsed.hostname or ""
+        loopback = host == "localhost"
+        if not loopback:
+            try:
+                loopback = ipaddress.ip_address(host).is_loopback
+            except ValueError:
+                pass
+        _ = parsed.port
+    except ValueError:
+        raise SourceAuthenticationError("Configure a valid control-plane API origin") from None
+    if (
+        parsed.scheme not in {"https", "http"}
+        or (parsed.scheme == "http" and not loopback)
+        or parsed.path not in {"", "/"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or not (api_key or token)
+        or (api_key and token)
+    ):
+        raise SourceAuthenticationError("Configure an API origin and one source-scoped API credential in the server environment")
+    signals = payload.get("signals") if isinstance(payload, dict) else payload
+    if not isinstance(signals, list) or len(signals) > 1000 or not all(isinstance(row, dict) for row in signals):
+        raise ValueError("Runtime evidence must contain at most 1000 signal objects")
+    with AgentBomClient(
+        base_url=origin,
+        api_key=api_key,
+        bearer_token=token,
+        tenant_id=tenant_id or os.environ.get("AGENT_BOM_TENANT_ID"),
+    ) as client:
+        return client.ingest_runtime_evidence(source_id=source_id, signals=signals, reason=reason, validate_only=validate_only)

--- a/src/agent_bom/cloud/runtime_source_auth.py
+++ b/src/agent_bom/cloud/runtime_source_auth.py
@@ -1,0 +1,51 @@
+"""Source-scoped authority derived from an already verified credential."""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from urllib.parse import quote
+
+MAX_RUNTIME_CREDENTIAL_TTL_SECONDS = 3600
+
+
+class SourceAuthenticationError(RuntimeError):
+    """A credential cannot authorize the requested runtime evidence source."""
+
+
+def runtime_source_scope(source_id: str) -> str:
+    """An exact source grant; wildcard grants deliberately do not substitute."""
+    return f"runtime:ingest:{quote(source_id, safe='')}"
+
+
+@dataclass(frozen=True)
+class RuntimeSourcePrincipal:
+    """Internal authority built only after transport credential verification.
+
+    This is not an HTTP input model. Scopes, identity and lifetime must come
+    from the verified JWT or persisted key record, never evidence parameters.
+    """
+
+    subject: str
+    tenant_id: str
+    scopes: tuple[str, ...]
+    issued_at: float
+    expires_at: float
+
+    def authorize(self, source_id: str, tenant_id: str) -> None:
+        now = time.time()
+        if (
+            not self.subject.strip()
+            or not self.tenant_id.strip()
+            or self.tenant_id != tenant_id
+            or runtime_source_scope(source_id) not in self.scopes
+            or type(self.issued_at) not in (int, float)
+            or type(self.expires_at) not in (int, float)
+            or not math.isfinite(self.issued_at)
+            or not math.isfinite(self.expires_at)
+            or self.issued_at > now
+            or self.expires_at <= now
+            or not 0 < self.expires_at - self.issued_at <= MAX_RUNTIME_CREDENTIAL_TTL_SECONDS
+        ):
+            raise SourceAuthenticationError("runtime evidence source authentication failed")

--- a/src/agent_bom/cloud/runtime_workload_evidence.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence.py
@@ -12,8 +12,8 @@ attack-path campaigns.
 
 Non-negotiable properties (issue #4158, honesty constraints):
 
-* **Authenticated ingest.** Every source is registered with a hashed shared
-  secret; a signal batch is accepted only after a constant-time secret check.
+* **Authenticated ingest.** Every source requires an exact source scope on a
+  verified, tenant-bound credential with a lifetime of at most one hour.
 * **Identity binding is source-authoritative.** Tenant / provider / account come
   from the authenticated source, never from the client payload — a spoofed
   provider/account on a raw signal is rejected (confused-deputy guard). A signal
@@ -37,8 +37,6 @@ Durable persistence lives in
 
 from __future__ import annotations
 
-import hashlib
-import hmac
 import json
 import logging
 import os
@@ -50,6 +48,7 @@ from enum import Enum
 from typing import Any, Iterable, Mapping
 
 from agent_bom.canonical_ids import canonical_id
+from agent_bom.cloud.runtime_source_auth import RuntimeSourcePrincipal, SourceAuthenticationError
 from agent_bom.security import sanitize_text
 
 logger = logging.getLogger(__name__)
@@ -134,10 +133,6 @@ def _sanitize_runtime_text(value: Any, *, redacted_value: str = "") -> str:
     if _contains_runtime_credential(value_text):
         return redacted_value
     return sanitize_text(value_text, max_len=_MAX_EVIDENCE_VALUE_LEN)
-
-
-class SourceAuthenticationError(RuntimeError):
-    """Raised when a runtime evidence source cannot be authenticated."""
 
 
 class IncompleteIdentityBindingError(ValueError):
@@ -229,45 +224,18 @@ class RuntimeEvidenceSource:
     provider: str
     account_id: str
     kind: str
-    secret_hash: str
 
     def __post_init__(self) -> None:
-        required = (self.source_id, self.tenant_id, self.provider, self.account_id, self.kind, self.secret_hash)
+        required = (self.source_id, self.tenant_id, self.provider, self.account_id, self.kind)
         if not all(str(part).strip() for part in required):
             raise ValueError("runtime evidence source requires all identity fields")
         if self.provider not in _VALID_PROVIDERS:
             raise ValueError(f"unsupported runtime source provider: {self.provider}")
-        if len(self.secret_hash) != 64 or any(ch not in "0123456789abcdef" for ch in self.secret_hash):
-            raise ValueError("secret_hash must be a 64-character lowercase sha256 hex digest")
 
     @classmethod
-    def register(
-        cls,
-        *,
-        source_id: str,
-        tenant_id: str,
-        provider: str,
-        account_id: str,
-        kind: str,
-        secret: str,
-    ) -> "RuntimeEvidenceSource":
-        """Register a source, storing only the sha256 of the shared secret."""
-        if not secret or len(secret) < 8:
-            raise ValueError("runtime source secret must be at least 8 characters")
-        digest = hashlib.sha256(secret.encode("utf-8")).hexdigest()
-        return cls(
-            source_id=source_id.strip(),
-            tenant_id=tenant_id.strip(),
-            provider=provider.strip().lower(),
-            account_id=account_id.strip(),
-            kind=kind.strip().lower(),
-            secret_hash=digest,
-        )
-
-    def authenticate(self, secret: str) -> bool:
-        """Constant-time comparison of a presented secret against the stored hash."""
-        presented = hashlib.sha256((secret or "").encode("utf-8")).hexdigest()
-        return hmac.compare_digest(presented, self.secret_hash)
+    def register(cls, *, source_id: str, tenant_id: str, provider: str, account_id: str, kind: str) -> "RuntimeEvidenceSource":
+        """Register authoritative source identity; credentials live in API auth."""
+        return cls(source_id.strip(), tenant_id.strip(), provider.strip().lower(), account_id.strip(), kind.strip().lower())
 
 
 class RuntimeSourceRegistry:
@@ -287,12 +255,12 @@ class RuntimeSourceRegistry:
     def get(self, source_id: str) -> RuntimeEvidenceSource | None:
         return self._sources.get(source_id)
 
-    def authenticate(self, source_id: str, secret: str) -> RuntimeEvidenceSource:
-        """Return the source only when it exists and the secret matches; else raise."""
+    def authorize(self, source_id: str, principal: RuntimeSourcePrincipal) -> RuntimeEvidenceSource:
+        """Return only the source explicitly granted to the verified principal."""
         source = self._sources.get(source_id)
-        if source is None or not source.authenticate(secret):
-            # One error for both cases so a caller cannot enumerate valid source ids.
+        if source is None:
             raise SourceAuthenticationError("runtime evidence source authentication failed")
+        principal.authorize(source_id, source.tenant_id)
         return source
 
 
@@ -505,7 +473,7 @@ def ingest_runtime_signals(
     *,
     registry: RuntimeSourceRegistry,
     source_id: str,
-    secret: str,
+    principal: RuntimeSourcePrincipal,
     raw_signals: Iterable[Mapping[str, Any]],
     now: str | None = None,
     max_age_seconds: int = DEFAULT_MAX_SIGNAL_AGE_SECONDS,
@@ -521,7 +489,7 @@ def ingest_runtime_signals(
     (within the batch, against ``dedup_seen``, or already persisted) in
     ``deduped``. Accepted signals are persisted through ``store`` when supplied.
     """
-    source = registry.authenticate(source_id, secret)
+    source = registry.authorize(source_id, principal)
     reference_now = now or _now_iso()
     result = IngestResult(source_id=source.source_id, tenant_id=source.tenant_id)
 
@@ -554,7 +522,7 @@ def ingest_runtime_signals(
 def ingest_runtime_signals_payload(
     *,
     source_id: str,
-    secret: str,
+    principal: RuntimeSourcePrincipal,
     payload: Any,
     persist: bool = True,
     now: str | None = None,
@@ -583,7 +551,7 @@ def ingest_runtime_signals_payload(
     return ingest_runtime_signals(
         registry=active_registry,
         source_id=source_id,
-        secret=secret,
+        principal=principal,
         raw_signals=cleaned,
         now=now,
         max_age_seconds=max_age_seconds,
@@ -876,31 +844,17 @@ _registry_lock = threading.Lock()
 
 
 def _source_from_entry(entry: Mapping[str, Any]) -> RuntimeEvidenceSource | None:
-    """Build one source from a config entry, preferring a pre-hashed secret.
-
-    ``secret_hash`` (a 64-char sha256 hex digest) is preferred so the plaintext
-    secret never has to sit in the environment; ``secret`` is accepted as a
-    convenience and hashed on load. A malformed entry is skipped (fail closed),
-    never raised — one bad entry must not sink the whole registry.
-    """
-    secret_hash = str(entry.get("secret_hash") or "").strip().lower()
+    """Provision identity only; obsolete credential-bearing entries fail closed."""
+    if "secret" in entry or "secret_hash" in entry:
+        logger.warning("runtime evidence source config contains retired credential fields; migrate to source-scoped API authentication")
+        return None
     try:
-        if secret_hash:
-            return RuntimeEvidenceSource(
-                source_id=str(entry.get("source_id") or "").strip(),
-                tenant_id=str(entry.get("tenant_id") or "").strip(),
-                provider=str(entry.get("provider") or "").strip().lower(),
-                account_id=str(entry.get("account_id") or "").strip(),
-                kind=str(entry.get("kind") or "").strip().lower(),
-                secret_hash=secret_hash,
-            )
         return RuntimeEvidenceSource.register(
             source_id=str(entry.get("source_id") or ""),
             tenant_id=str(entry.get("tenant_id") or ""),
             provider=str(entry.get("provider") or ""),
             account_id=str(entry.get("account_id") or ""),
             kind=str(entry.get("kind") or ""),
-            secret=str(entry.get("secret") or ""),
         )
     except ValueError:
         logger.warning("skipping malformed runtime evidence source entry")

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -382,7 +382,8 @@ _SERVER_CARD_TOOLS = [
         "name": "runtime_evidence_ingest",
         "description": (
             "Ingest CWPP runtime/EDR workload signals into the durable evidence store "
-            "(authenticated source matching the server tenant; admin + findings:write + "
+            "through the configured API (source-scoped credential with at most one-hour lifetime; "
+            "source matching the server tenant; admin + findings:write + "
             "audit reason; metadata only; never writes to a customer cloud target)"
         ),
         "annotations": {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},

--- a/src/agent_bom/mcp_server_specialized.py
+++ b/src/agent_bom/mcp_server_specialized.py
@@ -305,10 +305,6 @@ def register_specialized_ai_tools(
     @mcp.tool(annotations=write_action, title="Ingest CWPP Runtime Evidence")
     async def runtime_evidence_ingest(
         source_id: Annotated[str, Field(description="Pre-registered runtime evidence source id.")],
-        secret: Annotated[
-            str,
-            Field(description="Shared secret for the source (never logged)."),
-        ],
         signals_json: Annotated[
             str,
             Field(
@@ -333,8 +329,8 @@ def register_specialized_ai_tools(
     ) -> str:
         """Ingest CWPP runtime/EDR workload signals into the local evidence store.
 
-        Mutates the durable runtime-evidence store for the authenticated source's
-        tenant. Sources are provisioned via ``AGENT_BOM_RUNTIME_EVIDENCE_SOURCES``.
+        Uses the configured control-plane API with a short-lived source-scoped
+        credential from the server environment. No credential is a tool argument.
         Fail-closed on auth; never writes to a customer cloud target.
         """
         return await execute_tool_async(
@@ -343,7 +339,6 @@ def register_specialized_ai_tools(
             destructive=True,
             required_scope="findings:write",
             source_id=source_id,
-            secret=secret,
             signals_json=signals_json,
             operator_role=operator_role,
             operator_scopes=operator_scopes,

--- a/src/agent_bom/mcp_tools/runtime_evidence.py
+++ b/src/agent_bom/mcp_tools/runtime_evidence.py
@@ -6,6 +6,7 @@ import json
 import logging
 from typing import Any
 
+from agent_bom.cloud.runtime_source_auth import SourceAuthenticationError
 from agent_bom.security import sanitize_error
 
 logger = logging.getLogger(__name__)
@@ -54,7 +55,6 @@ def _write_denial(
 async def runtime_evidence_ingest_impl(
     *,
     source_id: str,
-    secret: str,
     signals_json: str,
     operator_role: str = "viewer",
     operator_scopes: str = "",
@@ -62,7 +62,7 @@ async def runtime_evidence_ingest_impl(
     _authenticated_actor: str = "",
     _truncate_response: Any,
 ) -> str:
-    """Authenticate a registered source and ingest a JSON array of signals."""
+    """Delegate source authentication to the configured control-plane API."""
     denial = _write_denial(
         operator_role=operator_role,
         operator_scopes=operator_scopes,
@@ -72,42 +72,34 @@ async def runtime_evidence_ingest_impl(
     if denial is not None:
         return json.dumps(denial)
     try:
-        from agent_bom.cloud.runtime_workload_evidence import (
-            SourceAuthenticationError,
-            get_runtime_source_registry,
-            ingest_runtime_signals_payload,
-        )
+        import anyio
+
+        from agent_bom.cloud.runtime_evidence_client import push_runtime_evidence
         from agent_bom.mcp_tenant import resolve_mcp_tool_tenant_id
 
-        registry = get_runtime_source_registry()
-        source = registry.authenticate(source_id, secret)
-        if source.tenant_id != resolve_mcp_tool_tenant_id():
-            return json.dumps({"error": "runtime evidence source authentication failed"})
         payload = json.loads(signals_json)
-        result = ingest_runtime_signals_payload(
-            source_id=source_id,
-            secret=secret,
-            payload=payload,
-            persist=True,
-            registry=registry,
+        tenant_id = resolve_mcp_tool_tenant_id()
+        payload = await anyio.to_thread.run_sync(
+            lambda: push_runtime_evidence(source_id=source_id, payload=payload, reason=reason.strip(), tenant_id=tenant_id)
         )
-        payload = result.to_dict()
+        if payload.get("source_id") != source_id or payload.get("tenant_id") != tenant_id:
+            raise SourceAuthenticationError("runtime evidence source authentication failed")
         try:
             from agent_bom.api.audit_log import log_action
 
             log_action(
                 "runtime_evidence.ingest",
                 actor=_authenticated_actor.strip(),
-                resource=f"runtime-evidence/source/{result.source_id}",
-                tenant_id=result.tenant_id,
+                resource=f"runtime-evidence/source/{source_id}",
+                tenant_id=tenant_id,
                 reason=reason.strip(),
                 accepted=payload["accepted"],
                 persisted=payload["persisted"],
                 rejected_stale=payload["rejected_stale"],
                 rejected_incomplete=payload["rejected_incomplete"],
             )
-            payload["status"] = "ok"
-            payload["audit_status"] = "recorded"
+            payload.setdefault("status", "ok")
+            payload.setdefault("audit_status", "recorded")
         except Exception as exc:  # noqa: BLE001 - evidence ingest succeeds independently of audit sink availability
             logger.warning("MCP runtime evidence audit logging failed: %s", sanitize_error(exc, generic=True))
             payload["status"] = "partial"

--- a/tests/api/test_correlation_cohort_push_ingest.py
+++ b/tests/api/test_correlation_cohort_push_ingest.py
@@ -29,10 +29,10 @@ from agent_bom.cloud.runtime_workload_evidence_store import (
 )
 from agent_bom.graph.correlation_service import GraphCorrelationService
 from tests.auth_helpers import PROXY_SECRET
+from tests.runtime_auth_helpers import runtime_headers
 
 TENANT = "tenant-alpha"
 OTHER_TENANT = "tenant-beta"
-RUNTIME_SECRET = "runtime-source-secret-value"
 HEADERS = {
     "X-Agent-Bom-Role": "analyst",
     "X-Agent-Bom-Tenant-ID": TENANT,
@@ -104,7 +104,6 @@ def _create_external_cohort(client: TestClient, *, max_age_hours: int = 24) -> d
             provider="aws",
             account_id="123456789012",
             kind="gateway",
-            secret=RUNTIME_SECRET,
         )
     )
     set_runtime_source_registry(registry)
@@ -137,7 +136,6 @@ def _runtime_payload(cohort: dict[str, Any], *, dedup_key: str = "evt-1") -> dic
     source_id = cohort["source_ids_by_kind"]["runtime"]
     return {
         "source_id": source_id,
-        "secret": RUNTIME_SECRET,
         "correlation_cohort_id": cohort["correlation_cohort_id"],
         "correlation_child_receipt": cohort["receipts"][source_id],
         "signals": [
@@ -162,7 +160,7 @@ def test_external_cohort_receipts_complete_exact_children_and_parent(cohort_clie
     assert pushed.json()["correlation_cohort_id"] == cohort["correlation_cohort_id"]
     runtime = client.post(
         "/v1/cloud/runtime-evidence/ingest",
-        headers=ADMIN_HEADERS,
+        headers=runtime_headers(cohort["source_ids_by_kind"]["runtime"]),
         json=_runtime_payload(cohort),
     )
     assert runtime.status_code == 200, runtime.text
@@ -230,13 +228,13 @@ def test_runtime_cohort_distinct_payload_race_has_one_durable_winner(cohort_clie
         first_future = pool.submit(
             client.post,
             "/v1/cloud/runtime-evidence/ingest",
-            headers=ADMIN_HEADERS,
+            headers=runtime_headers(cohort["source_ids_by_kind"]["runtime"]),
             json=first_payload,
         )
         assert claimed.wait(timeout=5)
         second = client.post(
             "/v1/cloud/runtime-evidence/ingest",
-            headers=ADMIN_HEADERS,
+            headers=runtime_headers(cohort["source_ids_by_kind"]["runtime"]),
             json=second_payload,
         )
         release.set()
@@ -481,7 +479,7 @@ def test_runtime_graph_commit_failure_leaves_no_selectable_cohort_snapshot(cohor
     monkeypatch.setattr(graph_store, "save_graph", _partial_then_fail)
     response = client.post(
         "/v1/cloud/runtime-evidence/ingest",
-        headers=ADMIN_HEADERS,
+        headers=runtime_headers(cohort["source_ids_by_kind"]["runtime"]),
         json=_runtime_payload(cohort),
     )
 
@@ -509,7 +507,7 @@ def test_runtime_projection_failure_reconciles_from_committed_child_on_retry(coh
     evidence_store = FailProjectionOnce()
     set_runtime_workload_evidence_store(evidence_store)
     payload = _runtime_payload(cohort, dedup_key="projection-retry")
-    first = client.post("/v1/cloud/runtime-evidence/ingest", headers=ADMIN_HEADERS, json=payload)
+    first = client.post("/v1/cloud/runtime-evidence/ingest", headers=runtime_headers(cohort["source_ids_by_kind"]["runtime"]), json=payload)
     child_id = cohort["receipts"][cohort["source_ids_by_kind"]["runtime"]]["child_job_id"]
 
     assert first.status_code == 503
@@ -520,7 +518,9 @@ def test_runtime_projection_failure_reconciles_from_committed_child_on_retry(coh
         "agent_bom.cloud.runtime_workload_evidence._now_iso",
         lambda: (datetime.now(timezone.utc) + timedelta(days=30)).isoformat(),
     )
-    replay = client.post("/v1/cloud/runtime-evidence/ingest", headers=ADMIN_HEADERS, json=payload)
+    replay = client.post(
+        "/v1/cloud/runtime-evidence/ingest", headers=runtime_headers(cohort["source_ids_by_kind"]["runtime"]), json=payload
+    )
     assert replay.status_code == 200
     projected = evidence_store.list_for_tenant(TENANT)
     assert [signal.dedup_key for signal in projected] == ["projection-retry"]
@@ -550,11 +550,13 @@ def test_runtime_same_hash_loser_reconciles_completed_child_before_returning(coh
         owner_future = pool.submit(
             client.post,
             "/v1/cloud/runtime-evidence/ingest",
-            headers=ADMIN_HEADERS,
+            headers=runtime_headers(cohort["source_ids_by_kind"]["runtime"]),
             json=payload,
         )
         assert owner_projection_started.wait(timeout=5)
-        replay = client.post("/v1/cloud/runtime-evidence/ingest", headers=ADMIN_HEADERS, json=payload)
+        replay = client.post(
+            "/v1/cloud/runtime-evidence/ingest", headers=runtime_headers(cohort["source_ids_by_kind"]["runtime"]), json=payload
+        )
         release_owner.set()
         owner = owner_future.result(timeout=5)
 
@@ -571,14 +573,14 @@ def test_runtime_stale_or_wrong_child_receipt_never_completes_child(cohort_clien
     cohort = _create_external_cohort(client, max_age_hours=1)
     payload = _runtime_payload(cohort)
     payload["signals"][0]["observed_at"] = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
-    stale = client.post("/v1/cloud/runtime-evidence/ingest", headers=ADMIN_HEADERS, json=payload)
+    stale = client.post("/v1/cloud/runtime-evidence/ingest", headers=runtime_headers(cohort["source_ids_by_kind"]["runtime"]), json=payload)
     assert stale.status_code == 409
     assert stale.json()["detail"] == "Correlation cohort evidence is stale"
 
     payload = _runtime_payload(cohort, dedup_key="wrong-receipt")
     result_source = cohort["source_ids_by_kind"]["result"]
     payload["correlation_child_receipt"] = cohort["receipts"][result_source]
-    wrong = client.post("/v1/cloud/runtime-evidence/ingest", headers=ADMIN_HEADERS, json=payload)
+    wrong = client.post("/v1/cloud/runtime-evidence/ingest", headers=runtime_headers(cohort["source_ids_by_kind"]["runtime"]), json=payload)
     assert wrong.status_code == 409
     assert wrong.json()["detail"] == "Correlation cohort receipt is invalid"
     runtime_source = cohort["source_ids_by_kind"]["runtime"]

--- a/tests/api/test_runtime_evidence_ingest_route.py
+++ b/tests/api/test_runtime_evidence_ingest_route.py
@@ -32,18 +32,15 @@ from agent_bom.cloud.runtime_workload_evidence_store import (
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.node import UnifiedNode
 from agent_bom.graph.types import EntityType
+from tests.runtime_auth_helpers import runtime_headers
 
 PROXY_SECRET = "test-proxy-secret-with-32-plus-bytes"
-SOURCE_SECRET = "s3cr3t-token-value-1234"
+
 TENANT = "tenant-alpha"
 
 
 def _proxy_headers(role: str = "admin", tenant: str = TENANT) -> dict[str, str]:
-    return {
-        "X-Agent-Bom-Role": role,
-        "X-Agent-Bom-Tenant-ID": tenant,
-        "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
-    }
+    return runtime_headers(tenant=tenant, role=role)
 
 
 def setup_module() -> None:
@@ -68,7 +65,6 @@ def _install_source(tenant: str = TENANT, account: str = "123456789012") -> None
             provider="aws",
             account_id=account,
             kind="edr",
-            secret=SOURCE_SECRET,
         )
     )
     set_runtime_source_registry(registry)
@@ -93,7 +89,7 @@ def test_ingest_persists_and_reaches_graph() -> None:
     resp = client.post(
         "/v1/cloud/runtime-evidence/ingest",
         headers=_proxy_headers(),
-        json={"source_id": "edr-1", "secret": SOURCE_SECRET, "signals": [_signal()]},
+        json={"source_id": "edr-1", "signals": [_signal()]},
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -130,7 +126,7 @@ def test_ingest_persists_and_reaches_graph() -> None:
 def test_ingest_dedups_on_retry() -> None:
     _install_source()
     client = TestClient(app)
-    payload = {"source_id": "edr-1", "secret": SOURCE_SECRET, "signals": [_signal(dedup_key="evt-dup")]}
+    payload = {"source_id": "edr-1", "signals": [_signal(dedup_key="evt-dup")]}
     first = client.post("/v1/cloud/runtime-evidence/ingest", headers=_proxy_headers(), json=payload)
     second = client.post("/v1/cloud/runtime-evidence/ingest", headers=_proxy_headers(), json=payload)
     assert first.json()["persisted"] == 1
@@ -147,14 +143,14 @@ def test_ingest_requires_observation_timestamp_in_api_contract() -> None:
     response = client.post(
         "/v1/cloud/runtime-evidence/ingest",
         headers=_proxy_headers(),
-        json={"source_id": "edr-1", "secret": SOURCE_SECRET, "signals": [signal]},
+        json={"source_id": "edr-1", "signals": [signal]},
     )
 
     assert response.status_code == 422
     assert response.json()["detail"][0]["loc"][-1] == "observed_at"
 
 
-def test_ingest_bad_secret_is_401() -> None:
+def test_ingest_legacy_secret_body_is_rejected() -> None:
     _install_source()
     client = TestClient(app)
     resp = client.post(
@@ -162,7 +158,7 @@ def test_ingest_bad_secret_is_401() -> None:
         headers=_proxy_headers(),
         json={"source_id": "edr-1", "secret": "wrong-secret-value", "signals": [_signal()]},
     )
-    assert resp.status_code == 401
+    assert resp.status_code == 422
 
 
 def test_ingest_unknown_source_is_401_not_enumerable() -> None:
@@ -171,7 +167,7 @@ def test_ingest_unknown_source_is_401_not_enumerable() -> None:
     resp = client.post(
         "/v1/cloud/runtime-evidence/ingest",
         headers=_proxy_headers(),
-        json={"source_id": "does-not-exist", "secret": SOURCE_SECRET, "signals": [_signal()]},
+        json={"source_id": "does-not-exist", "signals": [_signal()]},
     )
     assert resp.status_code == 401
 
@@ -184,7 +180,7 @@ def test_ingest_cross_tenant_source_rejected() -> None:
     resp = client.post(
         "/v1/cloud/runtime-evidence/ingest",
         headers=_proxy_headers(tenant="tenant-beta"),
-        json={"source_id": "edr-1", "secret": SOURCE_SECRET, "signals": [_signal()]},
+        json={"source_id": "edr-1", "signals": [_signal()]},
     )
     assert resp.status_code == 401
 
@@ -197,7 +193,7 @@ def test_ingest_requires_auth() -> None:
         client = TestClient(app)
         resp = client.post(
             "/v1/cloud/runtime-evidence/ingest",
-            json={"source_id": "edr-1", "secret": SOURCE_SECRET, "signals": [_signal()]},
+            json={"source_id": "edr-1", "signals": [_signal()]},
         )
         assert resp.status_code == 401
     finally:
@@ -219,7 +215,6 @@ def test_registry_bootstraps_from_env(monkeypatch) -> None:
                     "provider": "gcp",
                     "account_id": "proj-1",
                     "kind": "edr",
-                    "secret": "env-secret-value-12345",
                 }
             ]
         ),
@@ -229,7 +224,6 @@ def test_registry_bootstraps_from_env(monkeypatch) -> None:
     src = registry.get("env-edr")
     assert src is not None
     assert src.tenant_id == "tenant-x"
-    assert src.authenticate("env-secret-value-12345")
     set_runtime_source_registry(None)
 
 
@@ -246,7 +240,6 @@ def test_registry_env_duplicate_source_id_cannot_rebind_identity(monkeypatch) ->
                     "provider": "aws",
                     "account_id": "111111111111",
                     "kind": "edr",
-                    "secret": "first-secret-value-12345",
                 },
                 {
                     "source_id": "env-edr",
@@ -254,7 +247,6 @@ def test_registry_env_duplicate_source_id_cannot_rebind_identity(monkeypatch) ->
                     "provider": "gcp",
                     "account_id": "project-b",
                     "kind": "edr",
-                    "secret": "second-secret-value-12345",
                 },
             ]
         ),
@@ -268,6 +260,4 @@ def test_registry_env_duplicate_source_id_cannot_rebind_identity(monkeypatch) ->
     assert source.tenant_id == "tenant-a"
     assert source.provider == "aws"
     assert source.account_id == "111111111111"
-    assert source.authenticate("first-secret-value-12345")
-    assert not source.authenticate("second-secret-value-12345")
     set_runtime_source_registry(None)

--- a/tests/cloud/test_runtime_workload_evidence.py
+++ b/tests/cloud/test_runtime_workload_evidence.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import pytest
 
+from agent_bom.cloud.runtime_source_auth import RuntimeSourcePrincipal
 from agent_bom.cloud.runtime_workload_evidence import (
     DEFAULT_MAX_SIGNAL_AGE_SECONDS,
     RUNTIME_EVIDENCE_SCHEMA_VERSION,
@@ -34,11 +35,12 @@ from agent_bom.cloud.runtime_workload_evidence import (
     ingest_runtime_signals,
     no_runtime_signal_summary,
 )
+from tests.runtime_auth_helpers import runtime_principal
 
 _T0 = "2026-07-18T12:00:00Z"
 
 
-def _source(secret: str = "s3cr3t-token-value") -> tuple[RuntimeSourceRegistry, RuntimeEvidenceSource, str]:
+def _source() -> tuple[RuntimeSourceRegistry, RuntimeEvidenceSource, RuntimeSourcePrincipal]:
     registry = RuntimeSourceRegistry()
     src = RuntimeEvidenceSource.register(
         source_id="edr-1",
@@ -46,10 +48,9 @@ def _source(secret: str = "s3cr3t-token-value") -> tuple[RuntimeSourceRegistry, 
         provider="aws",
         account_id="123456789012",
         kind="edr",
-        secret=secret,
     )
     registry.add(src)
-    return registry, src, secret
+    return registry, src, runtime_principal()
 
 
 def _raw(**over: object) -> dict[str, object]:
@@ -80,35 +81,33 @@ def test_canonical_workload_id_is_deterministic_and_scope_bound():
 
 
 def test_ingest_rejects_unknown_source():
-    registry, _src, secret = _source()
+    registry, _src, principal = _source()
     with pytest.raises(SourceAuthenticationError):
-        ingest_runtime_signals(registry=registry, source_id="ghost", secret=secret, raw_signals=[_raw()])
+        ingest_runtime_signals(registry=registry, source_id="ghost", principal=principal, raw_signals=[_raw()])
 
 
-def test_ingest_rejects_wrong_secret():
-    registry, _src, _secret = _source()
+def test_ingest_rejects_wrong_source_scope():
+    registry, _src, _principal = _source()
     with pytest.raises(SourceAuthenticationError):
-        ingest_runtime_signals(registry=registry, source_id="edr-1", secret="wrong", raw_signals=[_raw()])
+        ingest_runtime_signals(
+            registry=registry, source_id="edr-1", principal=runtime_principal(source_id="different"), raw_signals=[_raw()]
+        )
 
 
-def test_source_authenticate_is_constant_time_hash_not_plaintext():
-    _registry, src, secret = _source()
-    assert src.authenticate(secret) is True
-    assert src.authenticate("nope") is False
-    # the shared secret is never stored in the clear
-    assert secret not in src.secret_hash
-    assert len(src.secret_hash) == 64
+def test_source_registration_contains_identity_only():
+    registry, source, principal = _source()
+    assert registry.authorize("edr-1", principal) == source
+    assert "secret" not in vars(source)
 
 
 def test_source_registry_rejects_conflicting_source_id_rebinding():
-    registry, original, _secret = _source()
+    registry, original, _principal = _source()
     conflicting = RuntimeEvidenceSource.register(
         source_id=original.source_id,
         tenant_id="tenant-b",
         provider="gcp",
         account_id="project-b",
         kind="edr",
-        secret="different-secret-value",
     )
 
     with pytest.raises(ValueError, match="already registered"):
@@ -121,12 +120,12 @@ def test_source_registry_rejects_conflicting_source_id_rebinding():
 
 
 def test_ingest_binds_identity_from_source_not_from_client_claim():
-    registry, _src, secret = _source()
+    registry, _src, principal = _source()
     # a spoofed account/provider on the raw signal must not steer persistence
     result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret=secret,
+        principal=principal,
         raw_signals=[_raw(provider="gcp", account_id="000000000000")],
         now=_T0,
     )
@@ -135,11 +134,11 @@ def test_ingest_binds_identity_from_source_not_from_client_claim():
 
 
 def test_ingest_fails_closed_on_missing_workload_ref():
-    registry, _src, secret = _source()
+    registry, _src, principal = _source()
     result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret=secret,
+        principal=principal,
         raw_signals=[_raw(workload_ref="")],
         now=_T0,
     )
@@ -151,12 +150,12 @@ def test_ingest_fails_closed_on_missing_workload_ref():
 
 
 def test_ingest_rejects_stale_signal():
-    registry, _src, secret = _source()
+    registry, _src, principal = _source()
     now = "2026-07-18T13:30:00Z"  # 90 min after observed_at, window is 60 min
     result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret=secret,
+        principal=principal,
         raw_signals=[_raw()],
         now=now,
         max_age_seconds=DEFAULT_MAX_SIGNAL_AGE_SECONDS,
@@ -166,11 +165,11 @@ def test_ingest_rejects_stale_signal():
 
 
 def test_ingest_rejects_unparseable_timestamp_as_incomplete():
-    registry, _src, secret = _source()
+    registry, _src, principal = _source()
     result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret=secret,
+        principal=principal,
         raw_signals=[_raw(observed_at="not-a-time")],
         now=_T0,
     )
@@ -179,11 +178,11 @@ def test_ingest_rejects_unparseable_timestamp_as_incomplete():
 
 
 def test_ingest_rejects_missing_observation_timestamp_as_incomplete():
-    registry, _src, secret = _source()
+    registry, _src, principal = _source()
     result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret=secret,
+        principal=principal,
         raw_signals=[_raw(observed_at="")],
         now=_T0,
     )
@@ -192,11 +191,11 @@ def test_ingest_rejects_missing_observation_timestamp_as_incomplete():
 
 
 def test_ingest_rejects_future_observation_timestamp():
-    registry, _src, secret = _source()
+    registry, _src, principal = _source()
     result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret=secret,
+        principal=principal,
         raw_signals=[_raw(observed_at="2026-07-18T12:00:01Z")],
         now=_T0,
     )
@@ -205,19 +204,19 @@ def test_ingest_rejects_future_observation_timestamp():
 
 
 def test_ingest_rejects_secret_shaped_or_unbounded_identity_values():
-    registry, _src, secret = _source()
+    registry, _src, principal = _source()
     credential = "gl" + "pat-abcdefghijklmnopqrst"
     secret_result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret=secret,
+        principal=principal,
         raw_signals=[_raw(dedup_key=credential)],
         now=_T0,
     )
     oversized_result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret=secret,
+        principal=principal,
         raw_signals=[_raw(dedup_key="e" * 513)],
         now=_T0,
     )
@@ -230,11 +229,11 @@ def test_ingest_rejects_secret_shaped_or_unbounded_identity_values():
 
 
 def test_ingest_normalizes_observation_timestamps_to_utc_before_ordering():
-    registry, _src, secret = _source()
+    registry, _src, principal = _source()
     result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret=secret,
+        principal=principal,
         raw_signals=[
             _raw(observed_at="2026-07-18T12:30:00+01:00", dedup_key="older-offset"),
             _raw(observed_at="2026-07-18T12:00:00Z", dedup_key="newer-zulu"),
@@ -255,19 +254,19 @@ def test_ingest_normalizes_observation_timestamps_to_utc_before_ordering():
 
 
 def test_ingest_deduplicates_within_and_across_batches():
-    registry, _src, secret = _source()
-    r1 = ingest_runtime_signals(registry=registry, source_id="edr-1", secret=secret, raw_signals=[_raw(), _raw()], now=_T0)
+    registry, _src, principal = _source()
+    r1 = ingest_runtime_signals(registry=registry, source_id="edr-1", principal=principal, raw_signals=[_raw(), _raw()], now=_T0)
     assert len(r1.accepted) == 1
     assert r1.deduped == 1
     seen = {sig.dedup_scope for sig in r1.accepted}
-    r2 = ingest_runtime_signals(registry=registry, source_id="edr-1", secret=secret, raw_signals=[_raw()], now=_T0, dedup_seen=seen)
+    r2 = ingest_runtime_signals(registry=registry, source_id="edr-1", principal=principal, raw_signals=[_raw()], now=_T0, dedup_seen=seen)
     assert r2.accepted == []
     assert r2.deduped == 1
 
 
 def test_signal_records_provenance_and_freshness():
-    registry, _src, secret = _source()
-    result = ingest_runtime_signals(registry=registry, source_id="edr-1", secret=secret, raw_signals=[_raw()], now=_T0)
+    registry, _src, principal = _source()
+    result = ingest_runtime_signals(registry=registry, source_id="edr-1", principal=principal, raw_signals=[_raw()], now=_T0)
     sig = result.accepted[0]
     assert sig.source_id == "edr-1"
     assert sig.source_kind == "edr"
@@ -284,11 +283,11 @@ def test_signal_records_provenance_and_freshness():
 
 
 def test_signal_redacts_oversized_and_forbidden_evidence():
-    registry, _src, secret = _source()
+    registry, _src, principal = _source()
     result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret=secret,
+        principal=principal,
         raw_signals=[
             _raw(
                 evidence={
@@ -311,11 +310,11 @@ def test_signal_redacts_oversized_and_forbidden_evidence():
 
 
 def test_signal_persists_only_allowlisted_non_secret_metadata():
-    registry, _src, secret = _source()
+    registry, _src, principal = _source()
     result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret=secret,
+        principal=principal,
         raw_signals=[
             _raw(
                 evidence={
@@ -353,11 +352,11 @@ def test_signal_persists_only_allowlisted_non_secret_metadata():
 
 
 def test_signal_redacts_secret_shaped_title():
-    registry, _src, secret = _source()
+    registry, _src, principal = _source()
     result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret=secret,
+        principal=principal,
         raw_signals=[_raw(title="Authorization: Bearer credential-in-title")],
         now=_T0,
     )
@@ -386,11 +385,11 @@ def test_signal_redacts_secret_shaped_title():
     ],
 )
 def test_signal_drops_known_credential_shapes_from_allowlisted_values(credential: str):
-    registry, _src, secret = _source()
+    registry, _src, principal = _source()
     result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret=secret,
+        principal=principal,
         raw_signals=[_raw(evidence={"indicator_ref": credential})],
         now=_T0,
     )
@@ -402,11 +401,11 @@ def test_signal_drops_known_credential_shapes_from_allowlisted_values(credential
 
 def test_signal_scans_full_oversized_value_before_bounding():
     credential = "A" * 220 + "postgresql://runtime-user:supersecretpassword@example.invalid/db"
-    registry, _src, secret = _source()
+    registry, _src, principal = _source()
     result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret=secret,
+        principal=principal,
         raw_signals=[_raw(evidence={"indicator_ref": credential})],
         now=_T0,
     )
@@ -419,11 +418,11 @@ def test_signal_scans_full_oversized_value_before_bounding():
 
 
 def test_signal_preserves_non_secret_security_taxonomy_labels():
-    registry, _src, secret = _source()
+    registry, _src, principal = _source()
     result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret=secret,
+        principal=principal,
         raw_signals=[
             _raw(
                 evidence={
@@ -485,8 +484,8 @@ def test_finding_without_workload_identity_is_left_untouched():
 
 
 def _signal(**over: object) -> RuntimeWorkloadSignal:
-    registry, _src, secret = _source()
-    result = ingest_runtime_signals(registry=registry, source_id="edr-1", secret=secret, raw_signals=[_raw(**over)], now=_T0)
+    registry, _src, principal = _source()
+    result = ingest_runtime_signals(registry=registry, source_id="edr-1", principal=principal, raw_signals=[_raw(**over)], now=_T0)
     return result.accepted[0]
 
 
@@ -549,9 +548,9 @@ def test_signal_type_enum_is_bounded():
 
 
 def test_ingest_result_summary_is_serializable_and_non_secret():
-    registry, _src, secret = _source()
-    result = ingest_runtime_signals(registry=registry, source_id="edr-1", secret=secret, raw_signals=[_raw()], now=_T0)
+    registry, _src, principal = _source()
+    result = ingest_runtime_signals(registry=registry, source_id="edr-1", principal=principal, raw_signals=[_raw()], now=_T0)
     assert isinstance(result, IngestResult)
     summary = result.to_dict()
     assert summary["accepted"] == 1
-    assert secret not in str(summary)
+    assert "secret" not in str(summary)

--- a/tests/cloud/test_runtime_workload_evidence_wiring.py
+++ b/tests/cloud/test_runtime_workload_evidence_wiring.py
@@ -24,6 +24,7 @@ from agent_bom.cloud.runtime_workload_evidence_store import (
     InMemoryRuntimeWorkloadEvidenceStore,
     set_runtime_workload_evidence_store,
 )
+from tests.runtime_auth_helpers import runtime_principal
 
 
 @pytest.fixture
@@ -44,14 +45,13 @@ def _seed_store(tenant: str = "tenant-a") -> InMemoryRuntimeWorkloadEvidenceStor
         provider="aws",
         account_id="123456789012",
         kind="edr",
-        secret="s3cr3t-token-value",
     )
     registry.add(src)
     now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
-        secret="s3cr3t-token-value",
+        principal=runtime_principal(tenant=tenant),
         raw_signals=[
             {
                 "workload_ref": "i-0abc",

--- a/tests/runtime_auth_helpers.py
+++ b/tests/runtime_auth_helpers.py
@@ -1,0 +1,35 @@
+"""Verified-key and internal-principal fixtures for runtime source contracts."""
+
+import time
+from datetime import datetime, timedelta, timezone
+
+from agent_bom.cloud.runtime_source_auth import RuntimeSourcePrincipal, runtime_source_scope
+
+
+def runtime_principal(source_id="edr-1", tenant="tenant-a", scopes=None, **overrides):
+    now = time.time()
+    fields = dict(
+        subject="test-producer",
+        tenant_id=tenant,
+        scopes=tuple([runtime_source_scope(source_id)] if scopes is None else scopes),
+        issued_at=now - 1,
+        expires_at=now + 1799,
+    )
+    fields.update(overrides)
+    return RuntimeSourcePrincipal(**fields)
+
+
+def runtime_headers(source_id="edr-1", tenant="tenant-alpha", role="admin", scopes=None, **overrides):
+    from agent_bom.api.auth import Role, create_api_key, get_key_store
+
+    raw, key = create_api_key(
+        name="runtime-test-producer",
+        role=Role(role),
+        tenant_id=tenant,
+        expires_at=(datetime.now(timezone.utc) + timedelta(minutes=30)).isoformat(),
+        scopes=["*", runtime_source_scope(source_id)] if scopes is None else scopes,
+    )
+    for name, value in overrides.items():
+        setattr(key, name, value)
+    get_key_store().add(key)
+    return {"X-API-Key": raw}

--- a/tests/test_cli_runtime_evidence_ingest.py
+++ b/tests/test_cli_runtime_evidence_ingest.py
@@ -1,132 +1,66 @@
-"""CLI/MCP helper for CWPP runtime evidence ingest (#4158 stage 4)."""
-
-from __future__ import annotations
+"""CLI delegates evidence writes to the authenticated API, without credential flags."""
 
 import json
-from datetime import datetime, timezone
-from pathlib import Path
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from agent_bom.cli._cloud_group import cloud_group
-from agent_bom.cloud.runtime_workload_evidence import (
-    RuntimeEvidenceSource,
-    RuntimeSourceRegistry,
-    ingest_runtime_signals_payload,
-    set_runtime_source_registry,
-)
-from agent_bom.cloud.runtime_workload_evidence_store import (
-    InMemoryRuntimeWorkloadEvidenceStore,
-    set_runtime_workload_evidence_store,
-)
-
-SOURCE_SECRET = "s3cr3t-token-value-1234"
+from agent_bom.cloud.runtime_source_auth import SourceAuthenticationError
 
 
-def setup_function() -> None:
-    registry = RuntimeSourceRegistry()
-    registry.add(
-        RuntimeEvidenceSource.register(
-            source_id="edr-1",
-            tenant_id="tenant-alpha",
-            provider="aws",
-            account_id="123456789012",
-            kind="edr",
-            secret=SOURCE_SECRET,
-        )
-    )
-    set_runtime_source_registry(registry)
-    set_runtime_workload_evidence_store(InMemoryRuntimeWorkloadEvidenceStore())
-
-
-def teardown_function() -> None:
-    set_runtime_source_registry(None)
-    set_runtime_workload_evidence_store(None)
-
-
-def _signal(workload_ref: str = "i-0abc", dedup_key: str = "evt-1") -> dict:
-    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    return {
-        "workload_ref": workload_ref,
-        "dedup_key": dedup_key,
-        "signal_type": "ioc_detection",
-        "severity": "high",
-        "observed_at": now,
-        "title": "demo ioc",
-    }
-
-
-def test_ingest_runtime_signals_payload_accepts_wrapped_list() -> None:
-    result = ingest_runtime_signals_payload(
-        source_id="edr-1",
-        secret=SOURCE_SECRET,
-        payload={"signals": [_signal()]},
-        persist=True,
-    )
-    assert result.persisted == 1
-    assert result.accepted
-
-
-def test_cli_runtime_evidence_ingest_persists(tmp_path: Path) -> None:
+def _invoke(tmp_path, *extra):
     path = tmp_path / "signals.json"
-    path.write_text(json.dumps([_signal(dedup_key="cli-1")]), encoding="utf-8")
-    runner = CliRunner()
-    result = runner.invoke(
-        cloud_group,
-        [
-            "runtime-evidence-ingest",
-            "--source-id",
-            "edr-1",
-            "--secret",
-            SOURCE_SECRET,
-            "--file",
-            str(path),
-        ],
+    path.write_text(json.dumps([{"workload_ref": "i-test"}]))
+    return CliRunner().invoke(cloud_group, ["runtime-evidence-ingest", "--source-id", "edr-1", "--file", str(path), *extra])
+
+
+def test_cli_ingest_uses_api_and_keeps_validation_only(tmp_path):
+    response = dict(
+        source_id="edr-1", tenant_id="tenant-alpha", accepted=1, persisted=0, deduped=0, rejected_stale=0, rejected_incomplete=0
     )
+    with patch("agent_bom.cloud.runtime_evidence_client.push_runtime_evidence", return_value=response) as push:
+        result = _invoke(tmp_path, "--no-persist")
     assert result.exit_code == 0, result.output
-    assert "persisted=1" in result.output
+    assert push.call_args.kwargs["validate_only"] is True
+    assert push.call_args.kwargs["source_id"] == "edr-1"
+    assert "persisted=0" in result.output
 
 
-def test_cli_runtime_evidence_ingest_exits_nonzero_when_every_signal_is_rejected(tmp_path: Path) -> None:
-    signal = _signal(dedup_key="missing-observed-at")
-    signal.pop("observed_at")
-    path = tmp_path / "signals.json"
-    path.write_text(json.dumps([signal]), encoding="utf-8")
-    runner = CliRunner()
-
-    result = runner.invoke(
-        cloud_group,
-        [
-            "runtime-evidence-ingest",
-            "--source-id",
-            "edr-1",
-            "--secret",
-            SOURCE_SECRET,
-            "--file",
-            str(path),
-        ],
-    )
-
-    assert result.exit_code == 2
-    assert "accepted=0" in result.output
-    assert "incomplete=1" in result.output
-
-
-def test_cli_runtime_evidence_ingest_auth_fail_closed(tmp_path: Path) -> None:
-    path = tmp_path / "signals.json"
-    path.write_text(json.dumps([_signal(dedup_key="cli-2")]), encoding="utf-8")
-    runner = CliRunner()
-    result = runner.invoke(
-        cloud_group,
-        [
-            "runtime-evidence-ingest",
-            "--source-id",
-            "edr-1",
-            "--secret",
-            "wrong-secret",
-            "--file",
-            str(path),
-        ],
-    )
+def test_cli_ingest_fails_closed_without_configured_auth(tmp_path):
+    with patch("agent_bom.cloud.runtime_evidence_client.push_runtime_evidence", side_effect=SourceAuthenticationError("denied")):
+        result = _invoke(tmp_path)
     assert result.exit_code == 1
     assert "authentication failed" in result.output
+
+
+def test_cli_ingest_does_not_disclose_api_failure_details(tmp_path):
+    with patch("agent_bom.cloud.runtime_evidence_client.push_runtime_evidence", side_effect=RuntimeError("token=private-value")):
+        result = _invoke(tmp_path)
+    assert result.exit_code == 1
+    assert "private-value" not in result.output
+
+
+def test_cli_ingest_rejects_legacy_secret_flag(tmp_path):
+    result = _invoke(tmp_path, "--secret", "private-value")
+    assert result.exit_code == 2
+    assert "No such option" in result.output
+
+
+def test_cli_ingest_reports_partial_audit_failure(tmp_path):
+    response = dict(
+        source_id="edr-1",
+        tenant_id="tenant-alpha",
+        accepted=1,
+        persisted=1,
+        deduped=0,
+        rejected_stale=0,
+        rejected_incomplete=0,
+        status="partial",
+        audit_status="unavailable",
+    )
+    with patch("agent_bom.cloud.runtime_evidence_client.push_runtime_evidence", return_value=response):
+        result = _invoke(tmp_path)
+    assert result.exit_code == 1
+    assert "persisted=1" in result.output
+    assert "audit" in result.output.lower()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -834,27 +834,9 @@ def test_ingest_external_scan_annotation_is_write():
 # ---------------------------------------------------------------------------
 # Tool: runtime_evidence_ingest — durable-write authorization
 #
-# The source shared secret authenticates the evidence producer.  It does not
-# replace the MCP operator token/role/scope/reason required to invoke a durable
-# write through this surface.
+# The API credential authorizes the source. It does not replace the MCP
+# operator token/role/scope/reason required to invoke a durable write.
 # ---------------------------------------------------------------------------
-
-
-def _runtime_source_registry(*, tenant_id: str = "tenant-alpha"):
-    from agent_bom.cloud.runtime_workload_evidence import RuntimeEvidenceSource, RuntimeSourceRegistry
-
-    registry = RuntimeSourceRegistry()
-    registry.add(
-        RuntimeEvidenceSource.register(
-            source_id="edr-1",
-            tenant_id=tenant_id,
-            provider="aws",
-            account_id="123456789012",
-            kind="edr",
-            secret="source-secret",
-        )
-    )
-    return registry
 
 
 def _call_runtime_evidence_impl(**overrides):
@@ -862,7 +844,6 @@ def _call_runtime_evidence_impl(**overrides):
 
     arguments = {
         "source_id": "edr-1",
-        "secret": "source-secret",
         "signals_json": "[]",
         "operator_role": "admin",
         "operator_scopes": "findings:write",
@@ -886,7 +867,7 @@ def test_runtime_evidence_ingest_blocks_stdio_before_handler(mock_ingest):
             result = _call_tool(
                 server,
                 "runtime_evidence_ingest",
-                {"source_id": "edr-1", "secret": "source-secret", "signals_json": "[]"},
+                {"source_id": "edr-1", "signals_json": "[]"},
             )
 
         assert result.get("status") == "blocked", result
@@ -907,7 +888,6 @@ def test_runtime_evidence_ingest_requires_findings_write_scope(mock_ingest):
             "runtime_evidence_ingest",
             {
                 "source_id": "edr-1",
-                "secret": "source-secret",
                 "signals_json": "[]",
                 "operator_role": "admin",
                 "operator_scopes": "findings:write",
@@ -922,7 +902,7 @@ def test_runtime_evidence_ingest_requires_findings_write_scope(mock_ingest):
 
 def test_runtime_evidence_ingest_impl_requires_audit_context():
     """The handler independently rejects a missing audit reason before ingest."""
-    with patch("agent_bom.cloud.runtime_workload_evidence.ingest_runtime_signals_payload") as mock_ingest:
+    with patch("agent_bom.cloud.runtime_evidence_client.push_runtime_evidence") as mock_ingest:
         result = _call_runtime_evidence_impl(reason="")
 
     assert result.get("status") == "blocked", result
@@ -930,99 +910,52 @@ def test_runtime_evidence_ingest_impl_requires_audit_context():
     mock_ingest.assert_not_called()
 
 
-def test_runtime_evidence_ingest_allows_authorized_operator_and_keeps_source_auth(monkeypatch):
-    """Operator authorization and the source secret remain independent gates."""
+def test_runtime_evidence_ingest_allows_authorized_operator_and_delegates_api_auth(monkeypatch):
     from agent_bom import mcp_server
-    from agent_bom.cloud.runtime_workload_evidence import IngestResult, set_runtime_source_registry
     from agent_bom.mcp_server import create_mcp_server
 
     monkeypatch.setenv("AGENT_BOM_MCP_TENANT_ID", "tenant-alpha")
-    registry = _runtime_source_registry()
-    set_runtime_source_registry(registry)
-    args = {
-        "source_id": "edr-1",
-        "secret": "source-secret",
-        "signals_json": "[]",
-        "operator_role": "admin",
-        "operator_scopes": "findings:write",
-        "reason": "ingest approved runtime evidence",
-    }
-    server = create_mcp_server(profile="full")
+    args = dict(
+        source_id="edr-1", signals_json="[]", operator_role="admin", operator_scopes="findings:write", reason="approved runtime evidence"
+    )
+    response = dict(source_id="edr-1", tenant_id="tenant-alpha", accepted=0, persisted=0, rejected_stale=0, rejected_incomplete=0)
     with (
         patch.object(mcp_server, "_current_tool_request", _fixed_request_meta("admin,findings:write")),
-        patch(
-            "agent_bom.cloud.runtime_workload_evidence.ingest_runtime_signals_payload",
-            return_value=IngestResult(source_id="edr-1", tenant_id="tenant-alpha"),
-        ) as mock_ingest,
+        patch("agent_bom.cloud.runtime_evidence_client.push_runtime_evidence", return_value=response) as push,
     ):
-        result = _call_tool(server, "runtime_evidence_ingest", args)
-
-    assert result.get("status") != "blocked", result
+        result = _call_tool(create_mcp_server(profile="full"), "runtime_evidence_ingest", args)
     assert result["tenant_id"] == "tenant-alpha"
-    assert mock_ingest.call_args.kwargs["registry"] is registry
-
-    with patch.object(mcp_server, "_current_tool_request", _fixed_request_meta("admin,findings:write")):
-        denied = _call_tool(server, "runtime_evidence_ingest", {**args, "secret": "wrong-secret"})
-
-    assert denied == {"error": "runtime evidence source authentication failed"}
-    set_runtime_source_registry(None)
+    assert push.call_args.kwargs["tenant_id"] == "tenant-alpha"
+    assert "secret" not in push.call_args.kwargs
 
 
-def test_runtime_evidence_ingest_rejects_cross_tenant_source_before_persistence(monkeypatch):
-    """A valid source secret cannot cross the MCP server's tenant binding."""
-    from agent_bom.cloud.runtime_workload_evidence import set_runtime_source_registry
-
+def test_runtime_evidence_ingest_rejects_mismatched_api_receipt(monkeypatch):
     monkeypatch.setenv("AGENT_BOM_MCP_TENANT_ID", "tenant-alpha")
-    set_runtime_source_registry(_runtime_source_registry(tenant_id="tenant-beta"))
-    try:
-        with patch("agent_bom.cloud.runtime_workload_evidence.ingest_runtime_signals_payload") as mock_ingest:
-            result = _call_runtime_evidence_impl()
-
-        assert result == {"error": "runtime evidence source authentication failed"}
-        mock_ingest.assert_not_called()
-    finally:
-        set_runtime_source_registry(None)
+    with patch("agent_bom.cloud.runtime_evidence_client.push_runtime_evidence", return_value={"source_id": "edr-1", "tenant_id": "other"}):
+        result = _call_runtime_evidence_impl()
+    assert result == {"error": "runtime evidence source authentication failed"}
 
 
 def test_runtime_evidence_ingest_unexpected_error_is_generic(caplog, monkeypatch):
-    """Unexpected secret-path errors expose neither raw details nor tracebacks."""
-    from agent_bom.cloud.runtime_workload_evidence import set_runtime_source_registry
-
     monkeypatch.setenv("AGENT_BOM_MCP_TENANT_ID", "tenant-alpha")
-    set_runtime_source_registry(_runtime_source_registry())
-    sensitive = "token=top-secret at /private/customer/runtime.db"
-    try:
-        with patch(
-            "agent_bom.cloud.runtime_workload_evidence.ingest_runtime_signals_payload",
-            side_effect=RuntimeError(sensitive),
-        ):
-            result = _call_runtime_evidence_impl()
-    finally:
-        set_runtime_source_registry(None)
-
+    with patch(
+        "agent_bom.cloud.runtime_evidence_client.push_runtime_evidence",
+        side_effect=RuntimeError("token=top-secret at /private/customer/runtime.db"),
+    ):
+        result = _call_runtime_evidence_impl()
     assert result == {"error": "An internal error occurred. Please contact support."}
     assert "top-secret" not in caplog.text
     assert "/private/customer/runtime.db" not in caplog.text
 
 
 def test_runtime_evidence_ingest_reports_partial_when_postwrite_audit_fails(monkeypatch):
-    """Persisted evidence must not silently imply that its audit event succeeded."""
-    from agent_bom.cloud.runtime_workload_evidence import IngestResult, set_runtime_source_registry
-
     monkeypatch.setenv("AGENT_BOM_MCP_TENANT_ID", "tenant-alpha")
-    set_runtime_source_registry(_runtime_source_registry())
-    try:
-        with (
-            patch(
-                "agent_bom.cloud.runtime_workload_evidence.ingest_runtime_signals_payload",
-                return_value=IngestResult(source_id="edr-1", tenant_id="tenant-alpha", persisted=1),
-            ),
-            patch("agent_bom.api.audit_log.log_action", side_effect=RuntimeError("audit sink unavailable")),
-        ):
-            result = _call_runtime_evidence_impl()
-    finally:
-        set_runtime_source_registry(None)
-
+    response = dict(source_id="edr-1", tenant_id="tenant-alpha", accepted=1, persisted=1, rejected_stale=0, rejected_incomplete=0)
+    with (
+        patch("agent_bom.cloud.runtime_evidence_client.push_runtime_evidence", return_value=response),
+        patch("agent_bom.api.audit_log.log_action", side_effect=RuntimeError("audit sink unavailable")),
+    ):
+        result = _call_runtime_evidence_impl()
     assert result["persisted"] == 1
     assert result["status"] == "partial"
     assert result["audit_status"] == "unavailable"

--- a/tests/test_mcp_tool_output_contract.py
+++ b/tests/test_mcp_tool_output_contract.py
@@ -150,7 +150,6 @@ def _minimal_args(name: str, workdir: Path) -> dict[str, Any]:
         "ingest_external_scan": {"scan_json": "{}", "parse_only": True},
         "runtime_evidence_ingest": {
             "source_id": "edr-missing",
-            "secret": "x",
             "signals_json": "[]",
         },
         "intel_lookup": {"advisory_id": "GHSA-xxxx-xxxx-xxxx"},

--- a/tests/test_runtime_source_auth_contract.py
+++ b/tests/test_runtime_source_auth_contract.py
@@ -1,0 +1,267 @@
+"""Runtime producers authenticate outside evidence bodies and MCP arguments."""
+
+import asyncio
+import time
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+from starlette.testclient import TestClient
+
+from agent_bom.cloud.runtime_source_auth import SourceAuthenticationError
+from tests.runtime_auth_helpers import runtime_headers, runtime_principal
+
+
+def test_runtime_ingest_api_does_not_accept_credentials():
+    from agent_bom.api.models import RuntimeEvidenceIngestRequest
+
+    properties = RuntimeEvidenceIngestRequest.model_json_schema()["properties"]
+    assert not {"secret", "token", "api_key", "password"} & properties.keys()
+
+
+def test_runtime_ingest_mcp_does_not_accept_credentials():
+    from agent_bom.mcp_server import create_mcp_server
+
+    tool = next(t for t in asyncio.run(create_mcp_server(profile="full").list_tools()) if t.name == "runtime_evidence_ingest")
+    assert not {"secret", "token", "api_key", "password"} & tool.inputSchema["properties"].keys()
+
+
+def test_runtime_ingest_cli_does_not_accept_source_secrets():
+    from agent_bom.cli._cloud_group import cloud_group
+
+    result = CliRunner().invoke(cloud_group, ["runtime-evidence-ingest", "--help"])
+    assert result.exit_code == 0
+    assert "--secret" not in result.output
+    assert "API" in result.output
+
+
+def test_runtime_source_registration_needs_no_secret():
+    from agent_bom.cloud.runtime_workload_evidence import RuntimeEvidenceSource
+
+    source = RuntimeEvidenceSource(source_id="edr-1", tenant_id="a", provider="aws", account_id="123", kind="edr")
+    assert "secret" not in repr(source)
+
+
+@pytest.fixture
+def ingest_client(monkeypatch):
+    from agent_bom.api.server import app, configure_api
+    from agent_bom.cloud.runtime_workload_evidence import RuntimeEvidenceSource, RuntimeSourceRegistry, set_runtime_source_registry
+    from agent_bom.cloud.runtime_workload_evidence_store import InMemoryRuntimeWorkloadEvidenceStore, set_runtime_workload_evidence_store
+
+    monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
+    monkeypatch.delenv("AGENT_BOM_TRUST_PROXY_AUTH", raising=False)
+    configure_api(api_key=None)
+    registry = RuntimeSourceRegistry()
+    registry.add(RuntimeEvidenceSource("edr-1", "tenant-alpha", "aws", "123", "edr"))
+    set_runtime_source_registry(registry)
+    store = InMemoryRuntimeWorkloadEvidenceStore()
+    set_runtime_workload_evidence_store(store)
+    with TestClient(app) as client:
+        yield client, store
+    set_runtime_source_registry(None)
+    set_runtime_workload_evidence_store(None)
+    configure_api(api_key=None)
+
+
+def _payload(**overrides):
+    value = dict(
+        source_id="edr-1",
+        signals=[
+            dict(workload_ref="i-1", signal_type="ioc_detection", observed_at=datetime.now(timezone.utc).isoformat(), dedup_key="e-1")
+        ],
+    )
+    value.update(overrides)
+    return value
+
+
+@pytest.mark.parametrize("scopes", [[], ["*"], ["runtime:*"], ["runtime:ingest:other"]])
+def test_api_rejects_unbound_source_scope_before_storage(ingest_client, scopes):
+    client, store = ingest_client
+    with patch.object(store, "put_batch", wraps=store.put_batch) as persist:
+        response = client.post("/v1/cloud/runtime-evidence/ingest", headers=runtime_headers(scopes=scopes), json=_payload())
+    assert response.status_code in (401, 403)
+    persist.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"expires_at": None},
+        {"expires_at": (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()},
+        {"expires_at": (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()},
+        {"revoked_at": datetime.now(timezone.utc).isoformat()},
+        {"created_at": (datetime.now(timezone.utc) + timedelta(minutes=2)).isoformat()},
+    ],
+)
+def test_api_rejects_unbounded_expired_revoked_or_future_key(ingest_client, overrides):
+    client, store = ingest_client
+    with patch.object(store, "put_batch", wraps=store.put_batch) as persist:
+        response = client.post("/v1/cloud/runtime-evidence/ingest", headers=runtime_headers(**overrides), json=_payload())
+    assert response.status_code == 401
+    persist.assert_not_called()
+
+
+def test_api_rejects_delegated_tenant_mismatch_before_storage(ingest_client):
+    client, store = ingest_client
+    headers = {**runtime_headers(), "X-Agent-Bom-Tenant-ID": "other"}
+    with patch.object(store, "put_batch", wraps=store.put_batch) as persist:
+        response = client.post("/v1/cloud/runtime-evidence/ingest", headers=headers, json=_payload())
+    assert response.status_code in (401, 403)
+    persist.assert_not_called()
+
+
+def test_api_short_lived_key_persists_and_audits_and_validation_does_not_write(ingest_client):
+    client, store = ingest_client
+    headers = runtime_headers()
+    with patch.object(store, "put_batch", wraps=store.put_batch) as persist:
+        validated = client.post("/v1/cloud/runtime-evidence/ingest", headers=headers, json=_payload(validate_only=True))
+        assert validated.status_code == 200, validated.text
+        assert validated.json()["persisted"] == 0
+        persist.assert_not_called()
+        response = client.post("/v1/cloud/runtime-evidence/ingest", headers=headers, json=_payload())
+    assert response.status_code == 200, response.text
+    assert response.json()["persisted"] == 1
+    assert response.json()["audit_status"] == "recorded"
+
+
+def test_api_reports_postwrite_audit_failure_as_partial(ingest_client):
+    client, _store = ingest_client
+    with patch("agent_bom.api.audit_log.log_action", side_effect=RuntimeError("secret details")):
+        response = client.post("/v1/cloud/runtime-evidence/ingest", headers=runtime_headers(), json=_payload())
+    assert response.status_code == 200
+    assert response.json()["persisted"] == 1
+    assert response.json()["audit_status"] == "unavailable"
+    assert response.json()["status"] == "partial"
+    assert "secret details" not in response.text
+
+
+def test_legacy_body_secret_rejected_without_echo(ingest_client):
+    client, _store = ingest_client
+    response = client.post(
+        "/v1/cloud/runtime-evidence/ingest", headers=runtime_headers(), json=_payload(secret="private-source-credential")
+    )
+    assert response.status_code == 422
+    assert "private-source-credential" not in response.text
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        dict(issued_at=True),
+        dict(expires_at=float("inf")),
+        dict(expires_at=float("nan")),
+        dict(expires_at=time.time() - 1),
+        dict(issued_at="future"),
+        dict(tenant_id="other"),
+        dict(scopes=("*",)),
+    ],
+)
+def test_internal_principal_cannot_grant_invalid_authority(overrides):
+    if overrides.get("issued_at") == "future":
+        overrides = {"issued_at": time.time() + 60}
+    with pytest.raises(SourceAuthenticationError):
+        runtime_principal(**overrides).authorize("edr-1", "tenant-a")
+
+
+def test_api_exact_source_scope_is_sufficient(ingest_client):
+    client, _ = ingest_client
+    response = client.post("/v1/cloud/runtime-evidence/ingest", headers=runtime_headers(scopes=["runtime:ingest:edr-1"]), json=_payload())
+    assert response.status_code == 200, response.text
+
+
+@pytest.mark.parametrize(
+    "change,expected",
+    [
+        ({}, 200),
+        ({"scope": "*"}, 401),
+        ({"scope": "runtime:ingest:other"}, 401),
+        ({"iat": None}, 401),
+        ({"exp": None}, 401),
+        ({"tenant_id": "other"}, 401),
+        ({"iat": True}, 401),
+    ],
+)
+def test_verified_oidc_source_binding(ingest_client, monkeypatch, change, expected):
+    from agent_bom.api.middleware import APIKeyMiddleware
+    from agent_bom.api.oidc import OIDCConfig
+
+    client, store = ingest_client
+    now = time.time()
+    claims = {
+        "iss": "https://issuer.example",
+        "sub": "producer",
+        "tenant_id": "tenant-alpha",
+        "agent_bom_role": "admin",
+        "iat": now - 1,
+        "exp": now + 1799,
+        "scope": "runtime:ingest:edr-1",
+        **change,
+    }
+    cfg = OIDCConfig(issuer="https://issuer.example", audience="agent-bom")
+    monkeypatch.setattr(cfg, "verify", lambda token: (claims, "admin"))
+    # The route sees only middleware-verified claims. Configure the existing
+    # middleware instance because the global app is reused across tests.
+    current = client.app.middleware_stack
+    while current is not None:
+        if isinstance(current, APIKeyMiddleware):
+            monkeypatch.setattr(current, "_oidc_config", cfg)
+            monkeypatch.setattr(current, "_oidc_checked", True)
+            break
+        current = getattr(current, "app", None)
+    with patch.object(store, "put_batch", wraps=store.put_batch) as persist:
+        response = client.post("/v1/cloud/runtime-evidence/ingest", headers={"Authorization": "Bearer verified-test-jwt"}, json=_payload())
+    assert response.status_code == expected, response.text
+    if expected != 200:
+        persist.assert_not_called()
+
+
+@pytest.mark.parametrize("credential", ["api_key", "bearer_token"])
+def test_client_transmits_credentials_only_in_auth_headers(credential):
+    import json
+
+    import httpx
+
+    from agent_bom.client import AgentBomClient
+
+    def handle(request):
+        assert str(request.url) == "https://control.example/v1/cloud/runtime-evidence/ingest"
+        assert request.headers["X-Agent-Bom-Tenant-ID"] == "tenant-alpha"
+        assert request.headers["X-API-Key" if credential == "api_key" else "Authorization"].endswith("private-credential")
+        body = json.loads(request.content)
+        assert body == {"source_id": "edr-1", "signals": [], "reason": "Validate producer integration", "validate_only": True}
+        assert "private-credential" not in request.content.decode()
+        return httpx.Response(200, json={"source_id": "edr-1", "tenant_id": "tenant-alpha"})
+
+    with AgentBomClient(
+        base_url="https://control.example",
+        tenant_id="tenant-alpha",
+        transport=httpx.MockTransport(handle),
+        **{credential: "private-credential"},
+    ) as client:
+        client.ingest_runtime_evidence(source_id="edr-1", signals=[], reason="Validate producer integration", validate_only=True)
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "",
+        "ftp://control.example",
+        "http://control.example",
+        "https://control.example/nested",
+        "https://control.example:invalid",
+        "https://user:pass@control.example",
+        "https://control.example?upstream=evil",
+        "https://control.example#evil",
+    ],
+)
+def test_producer_rejects_invalid_origin_before_network(monkeypatch, origin):
+    from agent_bom.cloud.runtime_evidence_client import push_runtime_evidence
+
+    monkeypatch.setenv("AGENT_BOM_API_URL", origin)
+    monkeypatch.setenv("AGENT_BOM_API_KEY", "private-credential")
+    monkeypatch.delenv("AGENT_BOM_API_TOKEN", raising=False)
+    with patch("agent_bom.cloud.runtime_evidence_client.AgentBomClient") as client:
+        with pytest.raises(SourceAuthenticationError):
+            push_runtime_evidence(source_id="edr-1", payload=[], reason="Validate integration")
+    client.assert_not_called()

--- a/tests/test_workload_runtime_evidence_exports.py
+++ b/tests/test_workload_runtime_evidence_exports.py
@@ -28,6 +28,7 @@ from agent_bom.models import AIBOMReport
 from agent_bom.output.html.document import to_html
 from agent_bom.output.json_fmt import to_json
 from agent_bom.output.sarif import to_sarif
+from tests.runtime_auth_helpers import runtime_principal
 
 
 def _workload_finding(*, with_ioc_summary: bool = False) -> Finding:
@@ -136,14 +137,13 @@ def test_export_enrichment_from_store_marks_no_signal_honestly(monkeypatch) -> N
                 provider="aws",
                 account_id="123456789012",
                 kind="edr",
-                secret="s3cr3t-token-value-1234",
             )
         )
         now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         ingest_runtime_signals(
             registry=registry,
             source_id="edr-1",
-            secret="s3cr3t-token-value-1234",
+            principal=runtime_principal(tenant="tenant-export"),
             raw_signals=[
                 {
                     "workload_ref": "i-other",


### PR DESCRIPTION
## Summary

- Replace runtime-source shared secrets with authority derived from verified API keys or OIDC credentials. Ingestion requires the exact source grant, matching tenant, and an active credential whose lifetime is at most one hour; key revocation is rechecked before ingestion.
- Remove credentials from API bodies, MCP arguments and CLI flags. CLI/MCP producers use the configured API origin and credentials from the process environment, with HTTPS required except for loopback. Preserve MCP operator authorization, source metadata binding, evidence filtering, freshness, deduplication and cohort receipts.
- Expose audit status, report post-write audit failures as partial, and make the CLI exit nonzero for partial completion. Regenerate OpenAPI/schema/metrics and document the fail-closed migration.

## Verification

- Exact `Python changed-domain and cross-surface smoke` selection from `.github/workflows/ci.yml`: **1,269 passed, 9 skipped**, using `scripts/pytest_ci_plan.py targeted` plus all seven mandatory smoke files, `-n 2 --dist loadfile` and the CI marker exclusions.
- Extended runtime-ingestion, evidence export/wiring, OIDC/browser, reference-lab and enterprise-story tests: **181 passed**. New source-auth contracts cover missing/wrong/wildcard grants, expiry/revocation, tenant mismatch before storage, verified OIDC claims, legacy credential rejection, header-only credentials and post-write audit failure. Credential-schema regressions and the CLI partial-success regression were observed failing before repair.
- `ruff check src tests`, `ruff format --check src tests`, and locked `mypy src/agent_bom`: passed, **894 source files**.
- `make preflight-fix` followed by `make preflight`: passed; generated changes reviewed. `scripts/rebaseline_graph_edges.py --dry-run` and CI's DCM self-check passed.
- All applicable pre-commit hooks passed except the isolated mypy 1.15 hook: **43 diagnostics, identical to clean main `e942e4e52`** (28 unique messages after removing line numbers). Locked mypy passes; no hook was bypassed.
- Loopback HTTP smoke: CLI and authorized MCP dispatch each persisted one signal through the API using an ephemeral exact-source key; audit status recorded. MCP dispatch used a trusted test authentication context, so this does not claim live identity-provider or hosted MCP transport proof.

## Notes

- Breaking migration for runtime producers: remove source `secret`/`secret_hash` registrations and credential arguments; provision an expiring source-scoped credential using existing API-key or OIDC authentication. Legacy registrations fail closed. CLI `--no-persist` now validates through the same authenticated API.
- Existing evidence tables and historical receipts are unchanged. General API-key default lifetimes and optional expiry of legacy static MCP operator credentials are outside this change.
- No release, publication, hosted deployment, live cloud or live identity-provider validation is included.
