### PR TITLE
fix(onboarding): unify the first scan contract

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -4,9 +4,9 @@
 
 **Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.**
 
-Start with the demo, then choose the entrypoint that matches your first job:
-repo scan, image scan, cloud posture, fix plan, dashboard, MCP tools, or
-runtime review.
+Start with the repository in front of you, then choose the entrypoint that
+matches your next job: image scan, cloud posture, fix plan, dashboard, MCP
+tools, or runtime review.
 
 ```text
 better-sqlite3@9.0.0  (npm package)
@@ -23,13 +23,24 @@ Blast radius is the core idea: `package -> vulnerability finding -> MCP server (
 
 Scan local agent configs, MCP servers, instruction files, lockfiles, containers, cloud estate, AI models/datasets, non-human identities, LLM cost, GPU surfaces, and runtime evidence.
 
-Try the built-in demo first:
+```bash
+pip install agent-bom
+agent-bom scan .
+```
+
+The scan prints inventory, findings, reachable impact, evidence coverage, and
+the next remediation step. Run `agent-bom doctor` if the first scan cannot
+start.
+
+For a deterministic sample, use the built-in offline demo. It deliberately
+contains blocking findings, so status `1` is the expected security verdict;
+the printed report is complete.
 
 ```bash
 agent-bom scan --demo --offline
 ```
 
-The demo uses a curated sample so the output stays reproducible across releases. For real scans, run `agent-bom scan`, or add `-p .` to fold project manifests and lockfiles into the same result.
+The demo uses a curated sample so the output stays reproducible across releases.
 
 If you want an inspectable sample before scanning your own repo:
 
@@ -54,12 +65,12 @@ prompt file. See `docs/FIRST_RUN.md` in the repository for the guided flow.
 ```bash
 pip install agent-bom
 
-agent-bom quickstart --dry-run --offline          # Scan, sample-data, and API/UI next steps
-agent-bom scan -p .                            # Repo + MCP + package blast radius
+agent-bom scan .                                 # Repo + MCP + package blast radius
+agent-bom quickstart --dry-run --offline          # Sample-data and API/UI next steps
 agent-bom samples first-run                      # Inspectable sample AI stack
 agent-bom check flask@2.2.0 --ecosystem pypi     # Pre-install package verdict
 agent-bom image nginx:latest                     # Container image scan
-agent-bom scan -p . --remediate remediation.md # Fix-first remediation plan
+agent-bom scan . --remediate remediation.md       # Fix-first remediation plan
 pip install 'agent-bom[ui]'                      # once, if you want the dashboard
 agent-bom serve --persist ~/.agent-bom/control-plane.db  # restart-safe local control plane
 ```

--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@
 
 <p align="center"><b>Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.</b></p>
 
+Security teams rarely lack scanners. They lack one trustworthy view of what was
+scanned, what was discovered, which findings are actually connected to critical
+systems, who owns the fix, and whether the fix held.
+
 <p align="center">
   <a href="#quick-start"><b>Quick start</b></a> ·
   <a href="https://msaad00.github.io/agent-bom/">Docs</a>
 </p>
 
 ## From evidence source to verified action
-
-Security teams rarely lack scanners. They lack one trustworthy view of what was
-scanned, what was discovered, which findings are actually connected to critical
-systems, who owns the fix, and whether the fix held.
 
 `agent-bom` closes that loop with two honest entry paths:
 
@@ -109,7 +109,7 @@ neither is proof of a deployed remediation.
 | Role | Start here | Primary outcome |
 |---|---|---|
 | Developer / AI engineer | `agent-bom scan .` | See dependencies, secrets, IaC, agents, MCP, and whether Click, Flask, or FastAPI entry points can reach vulnerable packages before shipping |
-| AppSec / product security | `agent-bom agents --gha . --offline` | Inventory remote actions and reusable workflows with their refs, source provenance, and CI-hardening findings |
+| AppSec / product security | `agent-bom scan . --gha . --offline` | Inventory remote actions and reusable workflows with their refs, source provenance, and CI-hardening findings |
 | Cloud security | Add a read-only connection, then run a scan | Build scoped cloud, identity, and posture inventory with explicit coverage and provenance |
 | Platform / DevOps | `pip install 'agent-bom[ui]' && AGENT_BOM_NO_AUTH_ROLE=analyst agent-bom serve --persist ~/.agent-bom/control-plane.db` | Schedule scans, centralize evidence, assign owners and SLAs, and verify remediation |
 | GRC / audit | `agent-bom report compliance-narrative scan.json` | Export mapped evidence while preserving unavailable, partial, and not-assessed states |
@@ -128,22 +128,26 @@ required for repository, image, SBOM, workstation, or MCP configuration scans.
 
 ### Path A — scan now, no connection
 
-The offline sample completes without downloading an advisory database and shows
-the inventory, finding, reachable path, and remediation output shape.
+Scan the current repository first. The console shows inventory, findings,
+reachable impact, evidence coverage, and the next remediation step.
 
 ```bash
 pip install agent-bom
-agent-bom scan --demo --offline
-```
-
-The sample intentionally contains a known-malicious package, so exit status `1` is expected
-and the printed report is complete. Scan a repository next:
-
-```bash
 agent-bom scan .
 ```
 
-The repository scan shows inventory, findings, and reachable impact.
+Save the same result for CI with
+`agent-bom scan . -f sarif -o findings.sarif`. If the first scan cannot start,
+run `agent-bom doctor` for dependency, database, and environment checks.
+
+To inspect a deterministic sample, use the bundled offline demo. It deliberately
+contains blocking findings, so status `1` is the expected security verdict; the
+printed report is complete.
+
+```bash
+agent-bom scan --demo --offline
+```
+
 `agent-bom scan .` and `agent-bom scan -p .` are the same command; `PATH` is an
 alias for `--project`.
 

--- a/docs/FIRST_RUN.md
+++ b/docs/FIRST_RUN.md
@@ -32,15 +32,15 @@ coverage named; it must not be interpreted as a clean zero-finding result.
 
 ## 1. Run the release-pinned demo
 
-The sample deliberately contains blocking findings, so status `1` is the
-expected security verdict; the printed report is complete.
+The sample deliberately contains blocking findings, so status `1` is expected.
+It is not a scanner crash; the printed report is complete and the status is the security verdict.
 
 ```bash
 agent-bom scan --demo --offline
 ```
 
-The CLI behaves like the same security gate used in CI. This status is not a
-scanner crash. Offline mode also limits enrichment to bundled demo evidence.
+The CLI behaves like the same security gate used in CI. Offline mode also limits
+enrichment to bundled demo evidence.
 After reviewing the sample, run `agent-bom scan .` against your own repository.
 
 Use this when you need reproducible output — for example a screenshot or a bug

--- a/docs/FIRST_RUN.md
+++ b/docs/FIRST_RUN.md
@@ -11,12 +11,12 @@ paths with read-only cloud connect.
 
 ```bash
 pip install agent-bom
-agent-bom scan -p .
+agent-bom scan .
 ```
 
-`agent-bom scan -p .` prints a rich console panel — posture grade, blast radius,
+`agent-bom scan .` prints a rich console panel — posture grade, blast radius,
 and fix-first findings inline — with nothing to open. This is the recommended
-first command (`agents` is a supported alias of `scan`). When you need a file,
+first command. When you need a file,
 add `-f html -o agent-bom-report.html` (or `-f json`, `-f sarif`); run
 `agent-bom db update --source osv` first for offline package scans. The OSV
 all-ecosystems archive can exceed 1 GB, may take several minutes, and shows
@@ -30,22 +30,23 @@ database fails closed with status `1`. When an output path is requested, the
 artifact is still written with `scan_run.outcome: partial` and the unavailable
 coverage named; it must not be interpreted as a clean zero-finding result.
 
-## 1. Run the Release-Pinned Demo
+## 1. Run the release-pinned demo
+
+The sample deliberately contains blocking findings, so status `1` is the
+expected security verdict; the printed report is complete.
 
 ```bash
 agent-bom scan --demo --offline
 ```
 
-The command's status `1` is expected: the curated sample deliberately contains
-blocking findings, so the CLI behaves like the same security gate used in CI.
-The printed report is still valid; this status is not a scanner crash. Offline
-mode also limits enrichment to bundled demo evidence. After reviewing the
-sample, run `agent-bom scan -p .` against your own repository.
+The CLI behaves like the same security gate used in CI. This status is not a
+scanner crash. Offline mode also limits enrichment to bundled demo evidence.
+After reviewing the sample, run `agent-bom scan .` against your own repository.
 
 Use this when you need reproducible output — for example a screenshot or a bug
 report. The package versions and advisory-backed ranges are curated in code and
 guarded by tests, so it does not depend on fabricated CVEs or a machine-specific
-local DB. Everyday scans should use `agent-bom scan -p .` (section 0) instead.
+local DB. Everyday scans should use `agent-bom scan .` (section 0) instead.
 
 ### Annotated demo output
 
@@ -188,7 +189,7 @@ agent-bom scan \
 After the sample makes sense, scan your own project:
 
 ```bash
-agent-bom scan -p .
+agent-bom scan .
 ```
 
 Add `--inventory <file>` when you already have agent/server inventory from a
@@ -204,11 +205,11 @@ no flag set.
 Adjust the severity threshold or choose an explicit reporting-only scan:
 
 ```bash
-agent-bom scan -p . --fail-on-severity high -f sarif -o findings.sarif
-agent-bom scan -p . --fail-on-kev            # any CISA KEV finding fails the build
-agent-bom scan -p . --fail-on-malicious      # any known-malicious package fails the build
-agent-bom scan -p . --warn-on medium --fail-on-severity critical   # two-tier gate
-agent-bom scan -p . --exit-zero --warn-on medium  # vulnerability report only; incomplete/malicious still fail
+agent-bom scan . --fail-on-severity high -f sarif -o findings.sarif
+agent-bom scan . --fail-on-kev            # any CISA KEV finding fails the build
+agent-bom scan . --fail-on-malicious      # any known-malicious package fails the build
+agent-bom scan . --warn-on medium --fail-on-severity critical   # two-tier gate
+agent-bom scan . --exit-zero --warn-on medium  # vulnerability report only; incomplete/malicious still fail
 ```
 
 `--warn-on` reports findings below the active failure threshold. Pair it with

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -497,6 +497,8 @@ def scan(
                 Two gates also fail closed with no flag set: a known-malicious
                 package (typosquat / dependency confusion) and a scan that did
                 not complete. This is why `scan --demo` exits 1.
+      2  Usage error — an option or input is invalid.
+      3  Stale vulnerability database while --require-fresh-db is enabled.
     \b
     Full contract: https://msaad00.github.io/agent-bom/reference/exit-codes/
     """

--- a/src/agent_bom/cli/options_sources.py
+++ b/src/agent_bom/cli/options_sources.py
@@ -155,7 +155,13 @@ def input_options(fn):
                 help="Scan agent-bom's own installed dependencies for vulnerabilities.",
             ),
             click.option(
-                "--demo", is_flag=True, default=False, help="Run a demo scan with bundled inventory containing known-vulnerable packages."
+                "--demo",
+                is_flag=True,
+                default=False,
+                help=(
+                    "Run a deterministic bundled scan with blocking findings. "
+                    "The complete demo report intentionally exits 1 as a security verdict."
+                ),
             ),
             click.option(
                 "--external-scan",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -692,10 +692,14 @@ def test_cli_scan_empty_dir_exits_0():
 
 def test_cli_help_shows_exit_codes():
     runner = CliRunner()
-    result = runner.invoke(main, ["agents", "--help"])
+    result = runner.invoke(main, ["scan", "--help"])
     assert "Exit codes" in result.output
-    assert "0" in result.output
-    assert "1" in result.output
+    assert "0  Clean" in result.output
+    assert "1  Fail" in result.output
+    assert "2  Usage error" in result.output
+    assert "3  Stale vulnerability database" in result.output
+    normalized = " ".join(result.output.lower().split())
+    assert "complete demo report intentionally exits 1" in normalized
 
 
 # ─── History / Diff Tests ─────────────────────────────────────────────────────

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -40,12 +40,15 @@ def test_public_docs_do_not_teach_removed_cli_surfaces() -> None:
         assert command not in combined
 
 
-def test_readme_promotes_offline_demo_before_repository_scan() -> None:
+def test_readme_promotes_repository_scan_before_the_failing_demo() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     quick_start = readme.split("## Quick start", 1)[1].split("## Self-host", 1)[0]
 
-    assert quick_start.index("agent-bom scan --demo --offline") < quick_start.index("agent-bom scan .")
-    assert "exit status `1` is expected" in quick_start
+    repository_scan = quick_start.index("agent-bom scan .")
+    demo_warning = quick_start.index("status `1` is the expected security verdict")
+    demo_scan = quick_start.index("agent-bom scan --demo --offline")
+
+    assert repository_scan < demo_warning < demo_scan
 
 
 def test_readme_first_run_explains_blast_radius_and_mcp_evidence() -> None:
@@ -229,7 +232,7 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     primary_block = re.search(r"```bash\n(.*?)\n```", quick_start, re.S)
     assert primary_block is not None
     commands = [line for line in primary_block.group(1).splitlines() if line.strip()]
-    assert commands == ["pip install agent-bom", "agent-bom scan --demo --offline"]
+    assert commands == ["pip install agent-bom", "agent-bom scan ."]
 
     assert "<summary><b>Try without a repository</b></summary>" in readme
     for image in ("correlation-receipts-live.png", "correlation-path-live.png"):

--- a/tests/test_public_frontdoor_contract.py
+++ b/tests/test_public_frontdoor_contract.py
@@ -176,11 +176,22 @@ def test_persona_routes_start_with_their_actual_work() -> None:
     personas = readme.split("## Value by role", 1)[1].split("\n## ", 1)[0]
 
     assert "| Developer / AI engineer | `agent-bom scan .`" in personas
-    assert "| AppSec / product security | `agent-bom agents --gha . --offline`" in personas
+    assert "| AppSec / product security | `agent-bom scan . --gha . --offline`" in personas
     assert "| Cloud security | Add a read-only connection, then run a scan" in personas
     assert f"| Platform / DevOps | `pip install 'agent-bom[ui]' && {LOCAL_ANALYST_CONTROL_PLANE}`" in personas
     assert "| CISO / engineering leader | Open **Architecture** in the self-hosted graph" in personas
     assert "owners and slas" in personas.lower()
+
+
+def test_public_first_run_surfaces_share_one_primary_command() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    pypi = (ROOT / "PYPI_README.md").read_text(encoding="utf-8")
+    guide = (ROOT / "docs" / "FIRST_RUN.md").read_text(encoding="utf-8")
+
+    assert "pip install agent-bom\nagent-bom scan ." in readme
+    assert "pip install agent-bom\nagent-bom scan ." in pypi
+    assert "pip install agent-bom\nagent-bom scan ." in guide
+    assert "agent-bom scan -p ." not in guide
 
 
 def test_primary_local_control_plane_first_runs_use_one_durable_sqlite_path() -> None:


### PR DESCRIPTION
## Summary

- make `agent-bom scan .` the first command in the README, PyPI page, and first-run guide
- explain the demo's intentional status-1 verdict before the command and in rendered CLI help
- document statuses 2 and 3 inline, surface `agent-bom doctor`, and stop teaching the deprecated `agents` alias in the AppSec entry point

## Verification

- `uv run pytest -q tests/test_public_docs_cli_alignment.py tests/test_public_frontdoor_contract.py tests/test_cli_exit_contract_docs.py tests/test_core.py -k 'public_docs or readme or frontdoor or first_run or cli_help_shows_exit_codes'` (36 passed)
- `uv run ruff check src/agent_bom/cli/agents/scan_cmd.py src/agent_bom/cli/options_sources.py tests/test_public_docs_cli_alignment.py tests/test_public_frontdoor_contract.py tests/test_core.py`
- `uv run ruff format --check src/agent_bom/cli/agents/scan_cmd.py src/agent_bom/cli/options_sources.py tests/test_public_docs_cli_alignment.py tests/test_public_frontdoor_contract.py tests/test_core.py`
- `uv run python scripts/check_public_docs_hygiene.py`
- `uv run python scripts/check_cli_reference_alignment.py`
- `uv run python scripts/check_release_consistency.py`
- `uv run agent-bom scan --demo --offline -f json -o /private/tmp/agent-bom-first-run-smoke.json` (expected status 1; complete result with 24 findings)
- `git diff --check origin/main...HEAD`

## Notes

- The deterministic demo still behaves as a blocking CI security verdict. The change makes that behavior visible before users run it.
