### PR TITLE
fix(delivery): align container and CI execution contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1041,7 +1041,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,18 +235,6 @@ jobs:
         # marker for at most one dependabot cycle (~24h).
         run: python scripts/check_docker_base_policy.py
 
-      - name: Workflow job timeout policy
-        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
-        # Closes the audit-4 P1 finding that #1995 only swept release.yml
-        # + post-merge-self-scan + container-rescan; the rest of
-        # .github/workflows/ still had jobs that could run unbounded and
-        # hold scarce runners. Every workflow job must declare
-        # timeout-minutes; reusable-workflow callers (`uses:`) inherit
-        # the timeout from the called workflow.
-        run: |
-          python -m pip install --quiet pyyaml
-          python scripts/check_workflow_timeouts.py
-
       - name: Comment hygiene — no chat/POC/task-id noise in source
         # Source: scripts/check_comment_hygiene.py
         # Conversational comments, LLM self-references, and internal task/audit
@@ -315,6 +303,11 @@ jobs:
       - name: Install dependencies
         if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: uv sync --frozen --extra dev
+
+      - name: Workflow job timeout policy
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
+        # Every job declares a timeout; reusable workflows inherit theirs.
+        run: uv run --no-sync python scripts/check_workflow_timeouts.py
 
       - name: Bandit (Static Security Analysis)
         if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -733,9 +733,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen
 
-      # Nothing in CI has ever run `docker compose config` against these files,
-      # while docs/DEPLOY_PLATFORM.md told operators the stack passes it. The
-      # gate also asserts the RENDERED graph, because "exited 0" is not a test.
+      # Validate the rendered graph as well as syntax: every service must resolve
+      # to an image/build, every dependency must exist, and committed read-only
+      # bind mounts must point at real paths.
       - name: Validate every shipped compose file and overlay combination
         shell: bash
         run: |

--- a/.github/workflows/cloud-sdk-drift.yml
+++ b/.github/workflows/cloud-sdk-drift.yml
@@ -11,7 +11,10 @@ name: Cloud SDK Pin Drift
 on:
   pull_request:
     paths:
+      - ".github/workflows/cloud-sdk-drift.yml"
+      - ".github/actions/setup-python/**"
       - "pyproject.toml"
+      - "uv.lock"
       - "src/agent_bom/data/cloud_sdk_reference.json"
       - "src/agent_bom/cloud_sdk_freshness.py"
       - "scripts/check_cloud_sdk_drift.py"
@@ -33,12 +36,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
+        uses: ./.github/actions/setup-python
         with:
           python-version: "3.12"
 
-      - name: Install check dependency
-        run: python3 -m pip install "packaging>=24.0"
+      - name: Install locked dependencies
+        run: uv sync --frozen
 
       - name: Cloud-SDK pin-drift gate
-        run: python3 scripts/check_cloud_sdk_drift.py
+        run: uv run --no-sync python scripts/check_cloud_sdk_drift.py

--- a/.github/workflows/postgres-scale-evidence.yml
+++ b/.github/workflows/postgres-scale-evidence.yml
@@ -77,20 +77,18 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        uses: ./.github/actions/setup-python
         with:
           python-version: "3.11"
 
-      - name: Install agent-bom with postgres extra
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[postgres,api]"
+      - name: Install locked Postgres evidence environment
+        run: uv sync --frozen --extra postgres --extra api
 
       - name: Migrate ephemeral Postgres schema
         env:
           ALEMBIC_DATABASE_URL: postgresql+psycopg://agent_bom:agent_bom@localhost:5432/agent_bom
         run: |
-          python - <<'PY'
+          uv run python - <<'PY'
           import os
 
           import psycopg
@@ -99,10 +97,10 @@ jobs:
               connection.execute("ALTER DATABASE agent_bom SET init.app_password = 'benchmark_app'")
               connection.execute("ALTER DATABASE agent_bom SET init.maintenance_password = 'benchmark_maintenance'")
           PY
-          alembic -c deploy/supabase/postgres/alembic.ini upgrade head
+          uv run alembic -c deploy/supabase/postgres/alembic.ini upgrade head
 
       - name: Smoke-test the harness
-        run: scripts/run_postgres_scale_evidence.py --dry-run --output /tmp/dry.json
+        run: uv run python scripts/run_postgres_scale_evidence.py --dry-run --output /tmp/dry.json
 
       - name: Run clustered Postgres scale evidence
         run: |
@@ -112,7 +110,7 @@ jobs:
           KINDS="${{ inputs.kinds || 'audit,job_put,job_get' }}"
           OUTPUT="docs/perf/results/postgres-scale-evidence-$(date -u +%Y-%m-%d).json"
           mkdir -p docs/perf/results
-          scripts/run_postgres_scale_evidence.py \
+          uv run python scripts/run_postgres_scale_evidence.py \
             --sizes "$SIZES" \
             --replicas "$REPLICAS" \
             --kinds "$KINDS" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,8 +117,10 @@ ENV REQUESTS_CA_BUNDLE=${REQUESTS_CA_BUNDLE}
 ENV CURL_CA_BUNDLE=${CURL_CA_BUNDLE}
 ENV PIP_CERT=${PIP_CERT}
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD agent-bom --version || exit 1
+# This is a generic CLI image whose default command exits. Long-lived API,
+# gateway, proxy, and MCP deployments define process-aware probes in their
+# Compose, Helm, or dedicated runtime-image contracts.
+HEALTHCHECK NONE
 
 ENTRYPOINT ["agent-bom"]
 CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ _dev-ui:
 	@cd ui && npm run dev 2>&1
 
 test:  ## Run unit tests
-	pytest tests/ -v --cov=agent_bom
+	pytest tests/ -v --cov=agent_bom --cov-fail-under=75
 
 # Every Python directory that ships or gates a release. `scripts/` was outside
 # this set, so a dead local in `generate_doc_architecture_svgs.py` sat on main

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ exposing it.
 | Target | Start here |
 |---|---|
 | Docker Compose | [Platform compose](deploy/docker-compose.platform.yml) — PostgreSQL, split secrets, migration job |
-| Docker Compose (evaluation) | [Pilot compose](deploy/docker-compose.pilot.yml) — loopback only, SQLite, no auth |
+| Docker Compose (evaluation) | `docker compose up -d` from a repository checkout — loopback only, SQLite, no auth; then open `http://localhost:3000` |
 | Helm / Kubernetes | `helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom --version 0.103.2` |
 | EKS | [Terraform module](deploy/terraform/platform-eks) |
 | Snowflake SPCS / Native App | `scripts/deploy/install.sh snowflake-native` · [install guide](docs/snowflake-native-app/INSTALL.md) |

--- a/action.yml
+++ b/action.yml
@@ -160,7 +160,7 @@ outputs:
     description: 'Scan process exit code.'
     value: ${{ steps.scan.outputs.exit_code }}
   scan-status:
-    description: 'High-level scan status (clean, violations, or error).'
+    description: 'High-level scan status: clean, violations, usage_error, stale_data, or error.'
     value: ${{ steps.scan.outputs.scan_status }}
   vulnerability-count:
     description: 'Number of vulnerabilities found, or skill findings when scan-type=skills.'
@@ -681,12 +681,19 @@ runs:
           )
         fi
 
-        SCAN_STATUS="error"
-        if [ "$EXIT_CODE" = "0" ]; then
-          SCAN_STATUS="clean"
-        elif [ "$VULN_COUNT" -gt 0 ]; then
-          SCAN_STATUS="violations"
-        fi
+        case "$EXIT_CODE" in
+          0) SCAN_STATUS="clean" ;;
+          1)
+            if [ "$VULN_COUNT" -gt 0 ]; then
+              SCAN_STATUS="violations"
+            else
+              SCAN_STATUS="error"
+            fi
+            ;;
+          2) SCAN_STATUS="usage_error" ;;
+          3) SCAN_STATUS="stale_data" ;;
+          *) SCAN_STATUS="error" ;;
+        esac
 
         # Generate badge from SARIF results (no second scan)
         BADGE_FILE=""
@@ -799,7 +806,16 @@ runs:
         pr_number = os.environ.get("PR_NUMBER", "")
         repo = os.environ.get("REPO", "")
 
-        status = "✅ Clean — no violations found" if exit_code == "0" else f"⚠️ {vuln_count} vulnerability finding(s)"
+        if exit_code == "0":
+            status = "✅ Clean — no violations found"
+        elif exit_code == "1" and int(vuln_count or "0") > 0:
+            status = f"⚠️ {vuln_count} vulnerability finding(s)"
+        elif exit_code == "2":
+            status = "❌ Invalid or empty scan input"
+        elif exit_code == "3":
+            status = "❌ Vulnerability database freshness gate failed"
+        else:
+            status = f"❌ Scan failed (exit code {exit_code})"
 
         def _sanitize_md(value: str) -> str:
             text = html.escape(value or "", quote=False)

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 
 inputs:
   scan-type:
-    description: 'Scan mode. Default `scan` runs the full agent/MCP discovery pipeline. Focused modes: image, fs, iac, sbom, secrets, code, agents, and skills.'
+    description: 'Scan mode. Default `scan` runs the full agent/MCP discovery pipeline. Focused modes: image, fs, iac, sbom, secrets, code, and skills.'
     required: false
     default: 'scan'
   scan-ref:
@@ -299,7 +299,7 @@ runs:
           exit 1
         }
         # Map scan-type to focused command
-        #   scan  → agent-bom agents (full auto-detect, default)
+        #   scan  → agent-bom scan (full auto-detect, default)
         #   image → agent-bom image <ref>
         #   fs    → agent-bom fs <path>
         #   sbom  → agent-bom sbom <path>
@@ -353,7 +353,8 @@ runs:
             ARGS=(code "${INPUT_SCAN_REF:-.}")
             ;;
           agents)
-            ARGS=(agents)
+            # Accept the legacy input while invoking the canonical command.
+            ARGS=(scan)
             ;;
           skills)
             ARGS=(skills scan "${INPUT_SCAN_REF:-.}")
@@ -362,7 +363,7 @@ runs:
             ARGS=(scan)
             ;;
           *)
-            echo "::error::Unknown scan-type: $INPUT_SCAN_TYPE. Use: scan, image, fs, sbom, iac, secrets, code, agents, skills"
+            echo "::error::Unknown scan-type: $INPUT_SCAN_TYPE. Use: scan, image, fs, sbom, iac, secrets, code, skills"
             exit 1
             ;;
         esac

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,5 @@
+# Profile: PILOT
+# Default checked-out repository entry point. The owning pilot manifest stays
+# in deploy/ so version bumps and deployment validation have one source.
+include:
+  - path: deploy/docker-compose.pilot.yml

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -15,7 +15,8 @@
 # For a production-shaped deployment, see docker-compose.platform.yml.
 #
 # Usage:
-#   docker compose -f docker-compose.pilot.yml up -d
+#   docker compose up -d  # from the repository root via compose.yaml
+#   docker compose -f deploy/docker-compose.pilot.yml up -d
 #   open http://localhost:3000
 
 services:
@@ -70,9 +71,9 @@ services:
     restart: unless-stopped
     environment:
       # The browser same-origins to this UI; the UI's Node server proxies
-      # /v1,/health,/ws to NEXT_PUBLIC_API_URL, which must be the API
+      # /v1,/health,/version,/ws to AGENT_BOM_API_URL, which must be the API
       # container's in-network DNS name — not the browser's localhost.
-      NEXT_PUBLIC_API_URL: http://api:8422
+      AGENT_BOM_API_URL: http://api:8422
     ports:
       - "127.0.0.1:3000:3000"
     depends_on:

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -26,7 +26,7 @@ signed release evidence.
 | API schema | `uv run python scripts/generate_v1_schemas.py --check` | Published v1 schemas match the Pydantic models. |
 | CLI docs | `uv run python scripts/check_cli_reference_alignment.py` | CLI reference and implemented command tree agree. |
 | Security guards | `uv run python scripts/check_exception_sanitization.py` and `uv run python scripts/check_provisioning_readonly.py` | API/gateway/runtime errors are sanitized and cloud provisioning stays read-only. |
-| Backend tests | `uv run pytest -q` | Python 3.11/3.13/3.14 CI must pass; local focused suites should cover changed areas. |
+| Backend tests | `uv run pytest -q` | Python 3.11/3.12/3.13/3.14 CI must pass; local focused suites should cover changed areas. |
 | UI build | `cd ui && npm run typecheck && npm run lint && npm run build && npm run bundle:check && npm run test:run` | The dashboard builds, tests pass, and client JS stays under budget. |
 | Dashboard bundle | `make build-ui` | Runs the export build (`NEXT_EXPORT=1`) and copies it to `src/agent_bom/ui_dist` with CSP hashes. **Required before the package build** — the UI-build row above leaves nothing in `src/agent_bom/ui_dist`, and `ui_dist` is gitignored, so a `uv build` without this step produces a dashboard-less wheel and a dashboard-less image. |
 | Package build | `make release-build` | Builds the dashboard, wheel, and sdist, then rejects any wheel missing the schemas, dashboard index, CSP manifest, or CSP script hashes. |

--- a/docs/operations/CI_RUNBOOK.md
+++ b/docs/operations/CI_RUNBOOK.md
@@ -196,7 +196,7 @@ auth path. The Settings UI is the only supported toggle today.
 2. Edit the rule for `main`
 3. Check ✅ **Require merge queue**
 4. Set merge method to **Squash** and pin the same required status checks
-   used today (Lint and Type Check, Test (Python 3.11/3.13/3.14), Build
+   used today (Lint and Type Check, Test (Python 3.11/3.12/3.13/3.14), Build
    Package, Security Scan, CodeQL)
 5. Save
 

--- a/scripts/check_compose_contract.py
+++ b/scripts/check_compose_contract.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python3
 """Validate every shipped Docker Compose file — and what it renders to.
 
-Nothing in CI has ever run ``docker compose config`` against these files. The
-only caller in the tree is ``scripts/deploy/hosted_poc_preflight.py``, and the
-one automated invocation of that (``make secrets``) passes ``--skip-compose``,
-so the parse path never executes. Meanwhile ``docs/DEPLOY_PLATFORM.md`` tells
-operators the stack "passes ``docker compose config``" — a claim no automation
-backed.
+This is the CI contract behind the repository's Compose deployment claims.
 
 Two things are checked, deliberately in this order:
 

--- a/scripts/check_product_surface_contract.py
+++ b/scripts/check_product_surface_contract.py
@@ -255,7 +255,7 @@ def main() -> int:
             "Test (Python 3.13)",
             # PRs run 3.13 only; pushes to main must still exercise the full
             # advertised interpreter matrix.
-            'python-version: ["3.11", "3.13", "3.14"]',
+            'python-version: ["3.11", "3.12", "3.13", "3.14"]',
         ],
         failures,
     )

--- a/scripts/generate_mcp_profile_catalog.py
+++ b/scripts/generate_mcp_profile_catalog.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 TARGET = ROOT / "integrations/docker-mcp-registry/tools.json"
+sys.path.insert(0, str(ROOT / "src"))
 
 
 def render() -> str:

--- a/site-docs/reference/exit-codes.md
+++ b/site-docs/reference/exit-codes.md
@@ -129,7 +129,7 @@ without re-parsing logs.
 |---|---|---|---|
 | `sarif-file` | string | computed | Path to the SARIF report when `format: sarif` was selected. |
 | `exit-code` | string | propagated CLI exit code | Same value documented in [CLI exit-code contract](#cli-exit-code-contract). |
-| `scan-status` | string | parsed from exit code + findings | `clean`, `violations`, or `error`. |
+| `scan-status` | string | parsed from exit code + findings | `clean`, `violations`, `usage_error` (exit `2`), `stale_data` (exit `3`), or `error`. |
 | `vulnerability-count` | string | parsed from SARIF or skills JSON | Number of vulnerability findings, or skill findings for `scan-type: skills`. |
 | `badge-file` | string | computed | Path to generated shields.io badge JSON when `badge` is set. |
 | `graph-export-path` | string | computed | Path to generated `mermaid`, `svg`, `graph`, or `graph-html` artifact. |

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -16,6 +16,27 @@ def _ci() -> dict[str, object]:
     return yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
 
 
+def test_timeout_policy_uses_the_locked_security_environment() -> None:
+    steps = _ci()["jobs"]["security"]["steps"]
+    install = next(step for step in steps if step.get("name") == "Install dependencies")
+    timeout = next(step for step in steps if step.get("name") == "Workflow job timeout policy")
+    assert steps.index(install) < steps.index(timeout)
+    assert "--frozen" in install["run"]
+    assert "pip install" not in timeout["run"]
+    assert "uv run --no-sync python scripts/check_workflow_timeouts.py" in timeout["run"]
+
+
+def test_cloud_sdk_drift_uses_checkout_lockfile() -> None:
+    path = ROOT / ".github/workflows/cloud-sdk-drift.yml"
+    workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["drift"]["steps"]
+    scripts = "\n".join(step.get("run", "") for step in steps)
+    assert any(step.get("uses") == "./.github/actions/setup-python" for step in steps)
+    assert "uv sync --frozen" in scripts
+    assert "pip install" not in scripts
+    assert "uv run --no-sync python scripts/check_cloud_sdk_drift.py" in scripts
+
+
 def test_path_classifier_covers_main_pushes() -> None:
     workflow = _ci()
     on = workflow.get(True, workflow.get("on", {}))

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 import yaml
@@ -165,6 +166,25 @@ def test_test_job_timeout_leaves_margin_over_observed_worst_case() -> None:
     headroom for the coverage-only lane.
     """
     assert _ci()["jobs"]["test-main"]["timeout-minutes"] == 45
+
+
+def test_full_correctness_matrix_covers_every_supported_python_minor() -> None:
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
+    supported = {
+        classifier.rsplit(" :: ", 1)[-1]
+        for classifier in project["classifiers"]
+        if classifier.startswith("Programming Language :: Python :: 3.")
+    }
+    matrix = set(_ci()["jobs"]["test-main"]["strategy"]["matrix"]["python-version"])
+
+    assert matrix == supported
+
+
+def test_local_test_target_enforces_the_ci_coverage_floor() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    test_target = makefile.split("test:  ## Run unit tests", 1)[1].split("\n\n", 1)[0]
+
+    assert "--cov-fail-under=75" in test_target
 
 
 def test_version_alignment_fails_fast_when_uv_lock_is_stale() -> None:

--- a/tests/test_cli_exit_contract_docs.py
+++ b/tests/test_cli_exit_contract_docs.py
@@ -59,6 +59,20 @@ def test_action_exposes_documented_exit_code_output() -> None:
     assert "| `exit-code`" in doc
 
 
+def test_action_preserves_usage_and_stale_data_exit_meaning() -> None:
+    action = ACTION_YML.read_text(encoding="utf-8")
+    doc = EXIT_CODES_DOC.read_text(encoding="utf-8")
+
+    assert '2) SCAN_STATUS="usage_error"' in action
+    assert '3) SCAN_STATUS="stale_data"' in action
+    assert 'exit_code == "2"' in action
+    assert 'exit_code == "3"' in action
+    assert "Invalid or empty scan input" in action
+    assert "Vulnerability database freshness gate failed" in action
+    assert "`usage_error` (exit `2`)" in doc
+    assert "`stale_data` (exit `3`)" in doc
+
+
 def test_first_run_guide_covers_the_exit_codes_and_ci_use_readme_promises() -> None:
     """A reader must reach the exit-code contract from the README and from the guide.
 

--- a/tests/test_compose_contract_gate.py
+++ b/tests/test_compose_contract_gate.py
@@ -48,6 +48,7 @@ class TestDiscovery:
         standalone, overlays = gate.discover()
         found = {p.relative_to(ROOT).as_posix() for p in [*standalone, *overlays]}
         expected = {
+            "compose.yaml",
             "deploy/docker-compose.yml",
             "deploy/docker-compose.pilot.yml",
             "deploy/docker-compose.fullstack.yml",
@@ -60,6 +61,11 @@ class TestDiscovery:
             "examples/docker-compose-monitoring.yml",
         }
         assert expected <= found
+
+    def test_root_compose_delegates_to_the_pilot_profile(self):
+        root = (ROOT / "compose.yaml").read_text(encoding="utf-8")
+        assert "deploy/docker-compose.pilot.yml" in root
+        assert "services:" not in root
 
     def test_overlays_are_classified_as_overlays(self):
         _, overlays = gate.discover()

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -36,6 +36,14 @@ def test_runtime_images_probe_the_expected_running_process() -> None:
         assert "agent-bom --version" not in healthcheck
 
 
+def test_generic_cli_image_disables_process_health_inheritance() -> None:
+    """The root image runs one-shot commands, so it cannot claim service health."""
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text()
+    assert "HEALTHCHECK NONE" in dockerfile
+    assert "HEALTHCHECK" not in dockerfile.split("HEALTHCHECK NONE", 1)[1]
+    assert "agent-bom --version || exit 1" not in dockerfile
+
+
 def test_airgap_profile_disables_cdn_backed_interactive_docs() -> None:
     values = yaml.safe_load((HELM_DIR / "examples" / "airgap-vuln-db-values.yaml").read_text())
     env = {entry["name"]: entry["value"] for entry in values["controlPlane"]["api"]["env"]}
@@ -1443,3 +1451,11 @@ def test_pilot_compose_optional_connections_scheduler_env():
     text = (DEPLOY_DIR / "docker-compose.pilot.yml").read_text()
     assert "AGENT_BOM_CONNECTIONS_SCHEDULER" in text
     assert "${AGENT_BOM_CONNECTIONS_SCHEDULER:-0}" in text
+
+
+def test_pilot_ui_uses_server_runtime_api_destination():
+    """The immutable standalone UI must resolve its API destination at runtime."""
+    data = yaml.safe_load((DEPLOY_DIR / "docker-compose.pilot.yml").read_text())
+    env = data["services"]["ui"]["environment"]
+    assert env["AGENT_BOM_API_URL"] == "http://api:8422"
+    assert "NEXT_PUBLIC_API_URL" not in env

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -2,6 +2,10 @@
 
 import asyncio
 import json
+import os
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
@@ -178,3 +182,24 @@ def test_docker_catalog_matches_real_default_argument_names():
     assert {tool["name"] for tool in catalog} == set(live)
     for tool in catalog:
         assert {arg["name"] for arg in tool["arguments"]} == set(live[tool["name"]].inputSchema["properties"])
+
+
+def test_docker_catalog_generator_imports_the_checkout(tmp_path):
+    """A stale installed wheel must not decide the generated public schemas."""
+
+    script = Path(__file__).resolve().parents[1] / "scripts/generate_mcp_profile_catalog.py"
+    hostile_path = tmp_path / "stale-install"
+    package = hostile_path / "agent_bom"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text('raise RuntimeError("stale wheel imported")\n')
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--check"],
+        cwd=tmp_path,
+        env={**os.environ, "PYTHONPATH": str(hostile_path)},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout

--- a/tests/test_pr_gate_sarif_action_contract.py
+++ b/tests/test_pr_gate_sarif_action_contract.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 from pathlib import Path
 
 import yaml
@@ -14,6 +16,22 @@ from agent_bom.models import AIBOMReport
 from agent_bom.output.sarif import to_sarif
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_action_legacy_agents_input_dispatches_canonical_scan() -> None:
+    action = yaml.safe_load((ROOT / "action.yml").read_text(encoding="utf-8"))
+    step = next(step for step in action["runs"]["steps"] if step.get("id") == "scan")
+    dispatch = step["run"].split("# Map scan-type to focused command", 1)[1]
+    dispatch = dispatch.split('if [ "$INPUT_SCAN_TYPE" = "skills" ]', 1)[0]
+    result = subprocess.run(
+        ["bash", "-c", dispatch + '\nprintf "%s\\n" "${ARGS[@]}"'],
+        env={**os.environ, "INPUT_SCAN_TYPE": "agents"},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "scan"
+    assert "code, agents" not in action["inputs"]["scan-type"]["description"]
 
 
 def test_pr_security_gate_uses_real_self_scan_sarif_not_fixture() -> None:

--- a/tests/test_scale_evidence.py
+++ b/tests/test_scale_evidence.py
@@ -34,6 +34,16 @@ def test_postgres_scale_workflow_migrates_before_workload() -> None:
     assert "AGENT_BOM_ALLOW_SUPERUSER_DB" not in workflow
 
 
+def test_postgres_scale_workflow_uses_frozen_project_lock() -> None:
+    """Published scale evidence must run with the repository's resolved dependencies."""
+    workflow = Path(".github/workflows/postgres-scale-evidence.yml").read_text()
+
+    assert "uses: ./.github/actions/setup-python" in workflow
+    assert "uv sync --frozen --extra postgres --extra api" in workflow
+    assert "pip install -e" not in workflow
+    assert "pip install --upgrade pip" not in workflow
+
+
 def test_postgres_scale_evidence_sets_current_postgres_url(monkeypatch) -> None:
     script = Path("scripts/run_postgres_scale_evidence.py")
     spec = importlib.util.spec_from_file_location("run_postgres_scale_evidence", script)


### PR DESCRIPTION
## Summary

- Make the recommended pilot stack available through root Compose and use health checks appropriate to the API/UI processes; the generic CLI image no longer reports an unrelated import check as process health.
- Preserve Action usage-error and stale-data exit meanings, and route the accepted legacy `agents` input through canonical `scan`.
- Bind MCP catalog generation to checkout source, cover Python 3.12, and use frozen dependencies for scheduled Postgres/cloud checks and CI timeout validation.

## Verification

- `uv run pytest -q tests/test_ci_workflow_contract.py tests/test_cli_exit_contract_docs.py tests/test_compose_contract_gate.py tests/test_deploy_manifests.py tests/test_mcp_profiles.py tests/test_scale_evidence.py tests/test_pr_gate_sarif_action_contract.py`: 193 passed.
- Ruff check/format, `make preflight`, applicable pre-commit hooks, `git diff --check`.
- YAML parsing and syntax checks for 129 shell blocks; cloud-SDK drift and workflow-timeout checks passed.
- `docker compose config --quiet`; CLI and standalone UI image builds passed for the container changes. Isolated local containers passed health/version/jobs and direct/proxied WebSocket metrics checks; offline demo scan returned findings with expected exit 1.

## Notes

No registry publication or deployment. Live cloud behavior is outside these local container checks. The documented legacy Action input remains accepted for compatibility.
