### PR TITLE
docs(product): clarify graph scope and compliance evidence

### DIFF
--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -6,6 +6,8 @@
 non-human identity, runtime, and skill evidence into one reachability-backed AI
 BOM, then tells humans and AI agents which multi-hop exposure path to fix first.
 
+The shared security graph connects packages, workloads, agents, tools, identities, and data assets through typed relationships with source evidence and explicit completeness.
+
 Blast radius is the core idea:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ compliance exports, and runtime enforcement in your own environment.
 
 [Quick start](#quick-start) · [Evidence workflow](docs/HOW_IT_WORKS.md) · [Integration capability matrix](docs/INTEGRATIONS.md) · [Measured matcher proof](docs/CVE_MATCHING_ACCURACY.json) · [Control-plane architecture](docs/ARCHITECTURE.md)
 
+The shared security graph connects packages, workloads, agents, tools, identities, and data assets through typed relationships with source evidence and explicit completeness.
+
+### Read the blast radius
+
+```text
+Vulnerable package → advisory finding
+        ↑ depends on
+     MCP server → exposed tools
+        ↑ uses
+       Agent → credential references → permitted resources
+```
+
+This schematic explains the questions to investigate. Actual paths require
+matching directed relationships and source evidence; credential names alone
+do not prove permission or exploitability.
+
 ### See what needs fixing — and why
 
 **Prioritize.** Start with the affected service, reachable asset, and recommended
@@ -112,7 +128,7 @@ neither is proof of a deployed remediation.
 | AppSec / product security | `agent-bom scan . --gha . --offline` | Inventory remote actions and reusable workflows with their refs, source provenance, and CI-hardening findings |
 | Cloud security | Add a read-only connection, then run a scan | Build scoped cloud, identity, and posture inventory with explicit coverage and provenance |
 | Platform / DevOps | `pip install 'agent-bom[ui]' && AGENT_BOM_NO_AUTH_ROLE=analyst agent-bom serve --persist ~/.agent-bom/control-plane.db` | Schedule scans, centralize evidence, assign owners and SLAs, and verify remediation |
-| GRC / audit | `agent-bom report compliance-narrative scan.json` | Export mapped evidence while preserving unavailable, partial, and not-assessed states |
+| GRC / audit | `agent-bom report compliance-narrative scan.json` | Export mapped evidence for OWASP LLM Top 10, MITRE ATLAS, EU AI Act, and NIST AI RMF; preserve unavailable, partial, and not-assessed states |
 | CISO / engineering leader | Open **Architecture** in the self-hosted graph | Compare observed **Current** state with modeled **Proposed** and **Difference** views; proposals remain labeled as not observed or deployed |
 
 Security engineering and GRC remain separate workflows: findings and

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -24,14 +24,35 @@ stay local. Shared surfaces receive normalized evidence and explicit
 completeness. A permission denial, unsupported collector, or partial scan stays
 partial or unavailable; it is never shown as observed or clean.
 
+## What the graph represents
+
+An entity is a package, workload, repository, agent, tool, identity, or other
+resource. A directed relationship records how two entities connect, such as
+"depends on", "runs as", or "has permission". A path is an ordered sequence of
+those relationships. Each relationship retains its source and whether it was
+observed, inferred, or modeled; a drawn connection alone is not exploit proof.
+Inventory is the list of entities. The graph adds the relationships needed to
+explain which findings can affect which systems.
+
+`UnifiedGraph` is the canonical graph contract for normalized entities,
+relationships, scope, and analysis completeness. `ContextGraph` is the local
+agent/MCP context builder that can project into that contract; it is not a
+separate source of observed cloud truth. **Mesh** focuses on shared agent and
+MCP relationships. **Evidence** refers to the receipts supporting a relationship;
+**Current**, **Proposed**, and **Difference** describe the comparison views.
+Proposed state remains modeled until independently observed. See the
+[graph contract](graph/CONTRACT.md) for the complete vocabulary and guarantees.
+
 ## How independent scans become path proof
 
 Retained same-tenant graph snapshots can be correlated with
 `agent-bom graph-correlate create`. The run requires an explicit freshness
-bound and merges only exact canonical identities: PURLs, OCI digests,
-repository commit/path identities, Kubernetes UIDs, provider resource and
-identity IDs, and stable runtime IDs. Labels, similar names, and mutable image
-tags never create a cross-source join.
+bound and joins compatible, scoped canonical identities: package PURLs,
+repository commit/path identities, Kubernetes UIDs, and provider resource or
+runtime IDs with their tenant and account/cluster scope. Shared OCI digests
+bind image artifacts; they do not merge permission-bearing runtime occurrences.
+Missing runtime identity stays snapshot-scoped. Labels, similar names, and
+mutable image tags never create a cross-source join.
 
 The output is one immutable correlation snapshot with a hash-bound manifest of
 every input receipt, its source kinds, timestamp, digest, counts, and freshness.

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -21,6 +21,8 @@ API/UI, MCP tools, and selected runtime controls. For source-by-source
 boundaries, see the
 [AI infrastructure coverage matrix](architecture/ai-infrastructure.md#coverage-matrix).
 
+The shared security graph connects packages, workloads, agents, tools, identities, and data assets through typed relationships with source evidence and explicit completeness.
+
 ## What it does
 
 ```

--- a/tests/test_product_explanations.py
+++ b/tests/test_product_explanations.py
@@ -1,0 +1,37 @@
+"""Product entry points share graph terminology and name shipped compliance mappings."""
+
+from pathlib import Path
+
+from agent_bom.output.compliance_narrative import ALL_FRAMEWORK_SLUGS
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_product_entrypoints_share_a_graph_definition() -> None:
+    definition = (
+        "The shared security graph connects packages, workloads, agents, tools, identities, "
+        "and data assets through typed relationships with source evidence and explicit completeness."
+    )
+    for name in ("README.md", "DOCKER_HUB_README.md", "site-docs/index.md"):
+        assert definition in " ".join((ROOT / name).read_text().split())
+    vocabulary = (ROOT / "docs/HOW_IT_WORKS.md").read_text()
+    for term in ("`UnifiedGraph`", "`ContextGraph`", "**Mesh**", "**Evidence**", "**Current**", "**Proposed**", "**Difference**"):
+        assert term in vocabulary
+
+
+def test_readme_explains_blast_radius_before_screenshots_without_exploit_claim() -> None:
+    readme = (ROOT / "README.md").read_text()
+    assert readme.index("### Read the blast radius") < readme.index("correlation-receipts-live.png")
+    assert "Vulnerable package → advisory finding" in readme
+    assert "credential names alone" in readme
+    assert "do not prove permission or exploitability" in readme
+
+
+def test_readme_grc_names_only_shipped_narrative_mappings() -> None:
+    assert {"owasp-llm", "atlas", "eu-ai-act", "nist"} <= set(ALL_FRAMEWORK_SLUGS)
+    readme = (ROOT / "README.md").read_text()
+    row = next(line for line in readme.splitlines() if line.startswith("| GRC / audit |"))
+    for label in ("OWASP LLM Top 10", "MITRE ATLAS", "EU AI Act", "NIST AI RMF"):
+        assert label in row
+    assert "unavailable, partial, and not-assessed" in row
+    assert "findings and reachability are not presented as audit certification" in " ".join(readme.split())


### PR DESCRIPTION
## Summary

- Explain the package-to-agent blast radius before the README screenshots and use a consistent shared-graph definition across entry points.
- Define graph views and evidence boundaries, correcting the stale claim that shared image digests merge runtime identities.
- Name shipped compliance mappings in the GRC workflow while preserving partial/unavailable evidence and certification boundaries.

## Verification

- `uv run pytest -q tests/test_product_explanations.py`: 3 passed; preparation also passed 56 related public-documentation tests.
- Ruff check/format, documentation hygiene, applicable pre-commit hooks, `git diff --check`.

## Notes

Documentation only. No generated images, schema changes, or new runtime capabilities.
