### PR TITLE
fix(api): protect control-plane availability and disable production docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,7 +54,7 @@ agent-bom is a **read-only scanner**. It does not modify agent configurations, e
 ### API security (when running `agent-bom api`)
 - Defaults to localhost-only binding (`127.0.0.1:8422`)
 - API key auth via `AGENT_BOM_API_KEY` env var; OIDC/JWT via `AGENT_BOM_OIDC_ISSUER`
-- WebSocket endpoints require the same auth when `AGENT_BOM_API_KEY` is set
+- WebSocket endpoints use the same configured auth posture as HTTP routes. Handshake attempts are limited per transport peer before credential verification or the browser first-message wait; clustered deployments use the required shared PostgreSQL limiter and reject connections if that limiter is unavailable.
 - JWKS public key caching (1h TTL); RS256/RS384/RS512/ES256/ES384/ES512 supported; `alg: none` rejected
 - Dashboard HTML uses a route-specific CSP. The packaged FastAPI-served UI allows `script-src 'self' 'unsafe-inline'` for the Next.js runtime bootstrap; API JSON routes keep the stricter `default-src 'self'` policy.
 - `ui/vercel.json` is generated from the same CSP module as the standalone UI server (`ui/lib/security-headers.mjs`), so the two policies cannot drift and neither permits `eval`-style execution. Only the local development server relaxes `script-src`, for the Next.js dev runtime. That config exists for static UI previews and is not a supported control-plane deployment path: self-hosted control planes serve the dashboard from the Python API or the standalone UI container.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,6 +53,7 @@ agent-bom is a **read-only scanner**. It does not modify agent configurations, e
 
 ### API security (when running `agent-bom api`)
 - Defaults to localhost-only binding (`127.0.0.1:8422`)
+- `/docs`, `/redoc`, and `/openapi.json` support local onboarding. Production Compose and Helm profiles set `AGENT_BOM_DISABLE_DOCS=1` to disable those handlers.
 - API key auth via `AGENT_BOM_API_KEY` env var; OIDC/JWT via `AGENT_BOM_OIDC_ISSUER`
 - WebSocket endpoints use the same configured auth posture as HTTP routes. Handshake attempts are limited per transport peer before credential verification or the browser first-message wait; clustered deployments use the required shared PostgreSQL limiter and reject connections if that limiter is unavailable.
 - JWKS public key caching (1h TTL); RS256/RS384/RS512/ES256/ES384/ES512 supported; `alg: none` rejected

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -117,6 +117,7 @@ Rate limiting also follows an explicit fail-closed contract for scaled control p
 - single-process / single-replica API: in-memory limiter is allowed
 - multi-replica API or `AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT=1`: PostgreSQL-backed shared limiter is required
 - if shared rate limiting is required and `AGENT_BOM_POSTGRES_URL` is absent or broken, API startup now fails instead of silently falling back to process-local state
+- WebSocket handshake attempts consume a peer-scoped budget before authentication work begins; an exhausted budget or unavailable limiter closes the connection before the first-message credential wait
 
 API-local filesystem scans follow the same pilot-vs-control-plane split:
 

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -1036,7 +1036,7 @@ async def _ws_handshake_within_rate_limit(websocket: WebSocket) -> bool:
         from agent_bom.api.metrics import record_rate_limit_hit
 
         record_rate_limit_hit("websocket-handshake")
-    return accepted
+    return bool(accepted)
 
 
 def _role_allows(actual: str, required: str = "viewer") -> bool:

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -70,6 +70,14 @@ _proxy_alerts_total: int = 0
 _proxy_metrics: dict | None = None
 _proxy_metrics_by_tenant: dict[str, dict] = {}
 
+# WebSocket scopes bypass Starlette's BaseHTTPMiddleware stack. Bound handshake
+# attempts separately so unauthenticated clients cannot accumulate an
+# unbounded number of five-second first-message authentication waits.
+WS_HANDSHAKE_RATE_LIMIT_RPM = 600
+_WS_HANDSHAKE_RATE_LIMIT_WINDOW_SECONDS = 60
+_ws_handshake_rate_limit_store: Any | None = None
+_ws_handshake_rate_limit_lock = Lock()
+
 # dedupe inbound proxy alerts by event_id over a 24h
 # window so a hostile or buggy proxy cannot replay credential-leak alerts and
 # inflate detector tallies. Per-(tenant_id, event_id) entries expire after
@@ -123,6 +131,14 @@ def _reset_proxy_runtime_for_tests() -> None:
     _proxy_alerts_total = 0
     _proxy_metrics = None
     _proxy_metrics_by_tenant.clear()
+
+
+def _reset_ws_handshake_rate_limit_for_tests() -> None:
+    """Discard process-global WebSocket limiter state between test cases."""
+
+    global _ws_handshake_rate_limit_store
+    with _ws_handshake_rate_limit_lock:
+        _ws_handshake_rate_limit_store = None
 
 
 def push_proxy_alert(alert: dict) -> None:
@@ -984,6 +1000,45 @@ class _WebSocketAuthContext:
     auth_method: str = "no_auth"
 
 
+def _get_ws_handshake_rate_limit_store() -> Any:
+    """Lazily share the configured rate-limit backend across WebSocket routes."""
+
+    global _ws_handshake_rate_limit_store
+    with _ws_handshake_rate_limit_lock:
+        if _ws_handshake_rate_limit_store is None:
+            from agent_bom.api.middleware import _build_rate_limit_store
+
+            _ws_handshake_rate_limit_store = _build_rate_limit_store(_WS_HANDSHAKE_RATE_LIMIT_WINDOW_SECONDS)
+        return _ws_handshake_rate_limit_store
+
+
+def _consume_ws_handshake_budget(client_ip: str, now: float) -> bool:
+    store = _get_ws_handshake_rate_limit_store()
+    accepted, _count, _reset_at = store.consume_if_below(
+        f"websocket-handshake:{client_ip}",
+        now,
+        WS_HANDSHAKE_RATE_LIMIT_RPM,
+    )
+    return bool(accepted)
+
+
+async def _ws_handshake_within_rate_limit(websocket: WebSocket) -> bool:
+    """Consume one peer-scoped handshake unit, failing closed on store errors."""
+
+    client = getattr(websocket, "client", None)
+    client_ip = str(getattr(client, "host", "unknown") or "unknown")
+    try:
+        accepted = await anyio.to_thread.run_sync(partial(_consume_ws_handshake_budget, client_ip, time.time()))
+    except Exception:  # noqa: BLE001 - limiter failure must reject without exposing backend details
+        _logger.warning("WebSocket handshake rate limiter unavailable; rejecting connection")
+        return False
+    if not accepted:
+        from agent_bom.api.metrics import record_rate_limit_hit
+
+        record_rate_limit_hit("websocket-handshake")
+    return accepted
+
+
 def _role_allows(actual: str, required: str = "viewer") -> bool:
     from agent_bom.rbac import Role, role_rank
 
@@ -1151,6 +1206,10 @@ async def _ws_accept_and_check_auth(websocket: WebSocket) -> _WebSocketAuthConte
     Bearer`` or ``Sec-WebSocket-Protocol: agent-bom-token.<token>``.
     """
     import asyncio as _asyncio
+
+    if not await _ws_handshake_within_rate_limit(websocket):
+        await websocket.close(code=4008)
+        return None
 
     auth_required = _ws_auth_required()
     if not auth_required:

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -1410,6 +1410,7 @@ def _fail_stuck_running_jobs(store: Any, now: _datetime.datetime) -> None:
     """
     from datetime import datetime
 
+    stuck_jobs: list[Any] = []
     with _jobs_lock:
         for job in list(_jobs.values()):
             if job.status == JobStatus.RUNNING and job.created_at:
@@ -1421,7 +1422,12 @@ def _fail_stuck_running_jobs(store: Any, now: _datetime.datetime) -> None:
                     job.status = JobStatus.FAILED
                     job.error = "Timed out (stuck in RUNNING state)"
                     job.completed_at = now.isoformat()
-                    store.put(job)
+                    stuck_jobs.append(job)
+
+    # Durable stores may block on database I/O. Persist after releasing the
+    # process-wide cache lock so unrelated job reads and writes keep flowing.
+    for job in stuck_jobs:
+        store.put(job)
 
 
 # ─── Meta Routes ─────────────────────────────────────────────────────────────

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -822,8 +822,9 @@ app = FastAPI(
     title=f"{PRODUCT_NAME} API",
     description=f"{POSITIONING_META}. {TAGLINE_CHAIN}.",
     version=__version__,
-    docs_url="/docs",
-    redoc_url="/redoc",
+    docs_url=None if APIKeyMiddleware._DOCS_DISABLED else "/docs",
+    redoc_url=None if APIKeyMiddleware._DOCS_DISABLED else "/redoc",
+    openapi_url=None if APIKeyMiddleware._DOCS_DISABLED else "/openapi.json",
     lifespan=_lifespan,
     swagger_ui_parameters={"favicon_url": "/brand/mark.svg"},
 )

--- a/tests/api/test_api_docs_gate.py
+++ b/tests/api/test_api_docs_gate.py
@@ -1,0 +1,36 @@
+"""Production documentation opt-out removes handlers, independently of auth."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize("disabled,expected", [("0", 200), ("1", 404)])
+def test_docs_gate_is_enforced_at_asgi_bootstrap(disabled: str, expected: int) -> None:
+    # A fresh interpreter reflects the production import-time environment and
+    # avoids mutating the shared application used by other test modules.
+    script = """
+from starlette.testclient import TestClient
+from agent_bom.api.server import app, configure_api
+paths = ("/docs", "/redoc", "/openapi.json")
+configure_api(allow_unauthenticated=True)
+client = TestClient(app)
+assert [client.get(path).status_code for path in paths] == [EXPECTED] * 3
+configure_api(api_key="isolated-docs-gate-key", allow_unauthenticated=False)
+client = TestClient(app)
+assert [client.get(path, headers={"X-API-Key": "isolated-docs-gate-key"}).status_code for path in paths] == [EXPECTED] * 3
+if EXPECTED == 404:
+    assert not set(paths) & {getattr(route, "path", "") for route in app.routes}
+""".replace("EXPECTED", str(expected))
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env={**os.environ, "AGENT_BOM_DISABLE_DOCS": disabled, "AGENT_BOM_ALLOW_UNAUTHENTICATED_API": "0"},
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -369,6 +369,7 @@ def _reset_proxy_route_state() -> None:
         proxy_routes._proxy_metrics = None
         proxy_routes._proxy_metrics_by_tenant.clear()
         proxy_routes._reset_audit_dedupe_for_tests()
+        proxy_routes._reset_ws_handshake_rate_limit_for_tests()
     except Exception:
         pass
 

--- a/tests/test_conftest_isolation_registry.py
+++ b/tests/test_conftest_isolation_registry.py
@@ -81,6 +81,7 @@ def test_proxy_route_reset_targets_exist() -> None:
         "_audit_dedupe",
         "_audit_dedupe_lock",
         "_reset_audit_dedupe_for_tests",
+        "_reset_ws_handshake_rate_limit_for_tests",
     ):
         assert hasattr(proxy_routes, attr), (
             f"agent_bom.api.routes.proxy.{attr} is gone but _reset_proxy_route_state "

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -256,6 +256,53 @@ def test_jobs_concurrent_access():
     assert errors == [], f"Concurrent access errors: {errors}"
 
 
+def test_stuck_job_persistence_does_not_hold_the_global_jobs_lock():
+    """A slow durable store must not block unrelated in-memory job access."""
+    from datetime import datetime, timezone
+
+    from agent_bom.api.server import (
+        JobStatus,
+        ScanJob,
+        ScanRequest,
+        _fail_stuck_running_jobs,
+        _jobs_lock,
+        _jobs_pop,
+        _jobs_put,
+    )
+
+    persistence_started = threading.Event()
+    release_persistence = threading.Event()
+
+    class BlockingStore:
+        def put(self, job: ScanJob) -> None:
+            persistence_started.set()
+            release_persistence.wait(timeout=2)
+
+    job = ScanJob(job_id="stuck-lock", created_at="2020-01-01T00:00:00Z", request=ScanRequest())
+    job.status = JobStatus.RUNNING
+    _jobs_put(job.job_id, job)
+    worker = threading.Thread(
+        target=_fail_stuck_running_jobs,
+        args=(BlockingStore(), datetime(2026, 1, 1, tzinfo=timezone.utc)),
+    )
+
+    lock_available = False
+    try:
+        worker.start()
+        assert persistence_started.wait(timeout=1)
+        lock_available = _jobs_lock.acquire(timeout=0.2)
+        if lock_available:
+            _jobs_lock.release()
+    finally:
+        release_persistence.set()
+        worker.join(timeout=2)
+        _jobs_pop(job.job_id)
+
+    assert lock_available, "durable persistence held the global in-memory jobs lock"
+    assert not worker.is_alive()
+    assert job.status == JobStatus.FAILED
+
+
 # ── Store locking ───────────────────────────────────────────────────────────
 
 

--- a/tests/test_websocket_auth_fails_closed.py
+++ b/tests/test_websocket_auth_fails_closed.py
@@ -30,6 +30,9 @@ whose excerpts carry the matched secret material.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 import pytest
 
 from agent_bom.api.routes import proxy as proxy_routes
@@ -145,6 +148,67 @@ def test_a_posture_derivation_error_fails_closed(monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setattr(mw, "get_auth_posture", _boom)
     assert proxy_routes._ws_auth_required() is True
+
+
+@pytest.mark.asyncio
+async def test_handshake_rate_limit_rejects_before_auth_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A rejected peer must not enter the five-second credential wait."""
+
+    class _Socket:
+        def __init__(self) -> None:
+            self.close_code: int | None = None
+
+        async def close(self, *, code: int) -> None:
+            self.close_code = code
+
+    socket = _Socket()
+    limit = AsyncMock(return_value=False)
+    monkeypatch.setattr(proxy_routes, "_ws_handshake_within_rate_limit", limit, raising=False)
+
+    def _auth_must_not_run() -> bool:
+        raise AssertionError("authentication work ran after the handshake budget was exhausted")
+
+    monkeypatch.setattr(proxy_routes, "_ws_auth_required", _auth_must_not_run)
+
+    context = await proxy_routes._ws_accept_and_check_auth(socket)  # type: ignore[arg-type]
+
+    assert context is None
+    assert socket.close_code == 4008
+    limit.assert_awaited_once_with(socket)
+
+
+@pytest.mark.asyncio
+async def test_handshake_rate_limit_uses_transport_peer_and_atomic_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, float, int]] = []
+
+    class _Store:
+        def consume_if_below(self, key: str, now: float, limit: int) -> tuple[bool, int, int]:
+            calls.append((key, now, limit))
+            accepted = len(calls) == 1
+            return accepted, 1, int(now) + 60
+
+    class _Socket:
+        client = SimpleNamespace(host="203.0.113.8")
+
+    monkeypatch.setattr(proxy_routes, "_get_ws_handshake_rate_limit_store", lambda: _Store())
+
+    assert await proxy_routes._ws_handshake_within_rate_limit(_Socket()) is True  # type: ignore[arg-type]
+    assert await proxy_routes._ws_handshake_within_rate_limit(_Socket()) is False  # type: ignore[arg-type]
+    assert len(calls) == 2
+    assert calls[0][0] == "websocket-handshake:203.0.113.8"
+    assert calls[0][2] == proxy_routes.WS_HANDSHAKE_RATE_LIMIT_RPM
+
+
+@pytest.mark.asyncio
+async def test_handshake_rate_limit_store_failure_is_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Socket:
+        client = SimpleNamespace(host="203.0.113.9")
+
+    def _unavailable() -> object:
+        raise RuntimeError("database connection contains private details")
+
+    monkeypatch.setattr(proxy_routes, "_get_ws_handshake_rate_limit_store", _unavailable)
+    assert await proxy_routes._ws_handshake_within_rate_limit(_Socket()) is False  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Release the process-wide job cache lock before persisting timeout failures, so a slow durable store does not block unrelated cache access.
- Limit WebSocket handshake attempts before authentication or browser credential waits. Use the configured shared limiter and fail closed when it is unavailable.
- Honor `AGENT_BOM_DISABLE_DOCS=1` by omitting the Swagger, ReDoc, and OpenAPI handlers at startup; retain the default local onboarding routes and document the production boundary.

## Verification
- 279 tests passed across `tests/test_hardening.py`, `tests/test_websocket_auth_fails_closed.py`, `tests/test_conftest_isolation_registry.py`, `tests/api/test_api_proxy_scorecard.py`, `tests/test_deploy_manifests.py`, `tests/test_compose_secrets_healthcheck.py`, `tests/api/test_api_docs_gate.py`, `tests/api/test_api_endpoints.py`, and `tests/api/test_no_ui_and_auth_posture.py`.
- The documentation opt-out regression failed before the repair, then passed for both authenticated and explicitly anonymous modes in fresh ASGI imports. Default documentation routes still return 200; disabled handlers are absent.
- Ruff checks/formatting and project mypy passed for affected production files. `PYTHONPATH=src make preflight` passed without generated-artifact changes.
- Real loopback WebSocket smoke: the initial connection streamed metrics; a second handshake was rejected before acceptance after deliberately reducing the test budget to one.

## Notes
- Applicable hooks passed except isolated mypy: its 43 transitive diagnostics reproduce on clean base `8868a3d1c` with no new diagnostics. Project-environment mypy passes.
- Documentation configuration is evaluated at process startup. Restart after changing `AGENT_BOM_DISABLE_DOCS`.
