### PR TITLE
docs(product): show reproducible human and agent workflows

### DIFF
--- a/DOCKER_HUB_UI_README.md
+++ b/DOCKER_HUB_UI_README.md
@@ -1,54 +1,54 @@
 # agent-bom-ui
 
-Dashboard image for the self-hosted `agent-bom` control plane.
+Explore scan coverage, investigate exposures, and track remediation in the
+self-hosted agent-bom control plane. The dashboard connects to the companion
+`agentbom/agent-bom` API image; scan and evidence state stay in your deployment.
+This companion image is not a separate product.
 
-`agent-bom` is one product with two deployable images:
-
-- `agentbom/agent-bom` runs the scanner, API, jobs, gateway, proxy, and other non-browser runtimes
-- `agentbom/agent-bom-ui` runs the browser dashboard
-
-This image is not a separate product and it is not meant to be the first thing a
-pilot user reasons about. Use the packaged pilot or Helm chart so both images are
-pulled for you.
-
-Use the UI when you are in the **send evidence to a control plane** lane:
-endpoint fleet sync, REST API jobs, Helm/EKS, scheduled discovery, graph state,
-findings, compliance, and governance all converge here. Local-only CLI/Docker
-scans and runtime proxy enforcement can run without the browser image.
-
-## Run This First
-
-Pilot on one workstation:
+## Start on one workstation
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
 docker compose -f docker-compose.pilot.yml up -d
-# Dashboard -> http://localhost:3000
+docker compose -f docker-compose.pilot.yml ps
 ```
 
-Production in your own cluster from a checked-out repo:
+Open **http://localhost:3000** once both services are healthy. The pilot binds
+to loopback, uses the local analyst role without login, and persists evidence
+in the `agent-bom-pilot-data` Docker volume. It is for single-workstation
+evaluation; use configured authentication for a shared deployment.
 
-```bash
-helm upgrade --install agent-bom deploy/helm/agent-bom \
-  --namespace agent-bom --create-namespace \
-  -f deploy/helm/agent-bom/examples/eks-production-values.yaml
-```
+**First result:** open **New Scan** and select a public repository, or open
+**Connections**, verify a read-only source grant, and run its first scan. A
+scan creates the inventory and findings; starting the dashboard alone does not
+collect an estate. Inspect coverage, open a finding, then follow its evidence
+and remediation action.
 
-## Image Role
+Stop with `docker compose -f docker-compose.pilot.yml down`. The named data
+volume remains available for the next run.
 
-- `agentbom/agent-bom` = runtime image for scanner, API, jobs, gateway, proxy
-- `agentbom/agent-bom-ui` = dashboard image for the same self-hosted control plane
+## Configure the runtime API
 
-## Control-Plane Contract
+Set `AGENT_BOM_API_URL` on the UI server to the API's HTTP(S) origin, for
+example `http://api:8422` inside a Compose network. Browser requests remain
+same-origin through the UI proxy. `NEXT_PUBLIC_API_URL` is accepted as a legacy
+fallback. See the [deployment guide](https://github.com/msaad00/agent-bom/blob/main/docs/DEPLOYMENT.md)
+for authentication, proxy, and production settings.
 
-The UI consumes the API control-plane contract. Auth posture comes from
-`/v1/auth/policy`, tenant quota state from `/v1/auth/quota`, scalable graph
-agent selection from `/v1/graph/agents`, and fleet inventory from `/v1/fleet`.
-The dashboard should display those API facts and role capabilities; it should
-not create a separate role, tenant, gateway, or secret lifecycle model.
+For Kubernetes, check out the repository and configure the
+[Helm chart](https://github.com/msaad00/agent-bom/tree/main/deploy/helm/agent-bom)
+and the identity, database, and ingress settings for your environment.
 
-## Links
+[Product scenarios](https://github.com/msaad00/agent-bom/blob/main/docs/GALLERY.md) ·
+[Documentation](https://msaad00.github.io/agent-bom/) ·
+[API and scanner image](https://hub.docker.com/r/agentbom/agent-bom)
 
-- GitHub: https://github.com/msaad00/agent-bom
-- Docs: https://msaad00.github.io/agent-bom/
-- Helm chart: `deploy/helm/agent-bom`
+<details>
+<summary>Control-Plane Contract</summary>
+
+The API owns authentication (`/v1/auth/policy`), tenant quotas
+(`/v1/auth/quota`), paginated graph agents (`/v1/graph/agents`), and fleet state
+(`/v1/fleet`). The UI reflects those facts and role capabilities; it does not
+create a separate role, tenant, gateway, or secret lifecycle.
+
+</details>

--- a/README.md
+++ b/README.md
@@ -116,11 +116,12 @@ deployed remediation and live-cloud validation are not claimed.
 | Role | Start here | Primary outcome |
 |---|---|---|
 | Developer / AI engineer | `agent-bom scan .` | See dependencies, secrets, IaC, agents, MCP, and whether Click, Flask, or FastAPI entry points can reach vulnerable packages before shipping |
-| AppSec / product security | `agent-bom scan . --gha . --offline` | Inventory remote actions and reusable workflows with their refs, source provenance, and CI-hardening findings |
+| AppSec / product security | Open **Overview**, then inspect a prioritized finding | Identify the affected workload, follow its exposure path, and assess the supporting evidence before assigning a fix |
 | Cloud security | Add a read-only connection, then run a scan | Build scoped cloud, identity, and posture inventory with explicit coverage and provenance |
 | Platform / DevOps | `pip install 'agent-bom[ui]' && AGENT_BOM_NO_AUTH_ROLE=analyst agent-bom serve --persist ~/.agent-bom/control-plane.db` | Schedule scans, centralize evidence, assign owners and SLAs, and verify remediation |
 | GRC / audit | `agent-bom report compliance-narrative scan.json` | Export mapped evidence for OWASP LLM Top 10, MITRE ATLAS, EU AI Act, and NIST AI RMF; preserve unavailable, partial, and not-assessed states |
-| CISO / engineering leader | Open **Architecture** in the self-hosted graph | Compare observed **Current** state with modeled **Proposed** and **Difference** views; proposals remain labeled as not observed or deployed |
+| CISO / engineering leader | Open **Overview** in the self-hosted control plane | Review priorities and evidence coverage; drill into the findings behind the posture to guide remediation |
+| AI assistant / automation | `agent-bom mcp server` | Start with eight focused tools to scan, inspect evidence, and plan fixes; select a graph, cloud, runtime, or audit profile when the task needs it |
 
 Security engineering and GRC remain separate workflows: findings and
 reachability are not presented as audit certification. See

--- a/README.md
+++ b/README.md
@@ -75,50 +75,41 @@ do not prove permission or exploitability.
 
 ### See what needs fixing — and why
 
-**Prioritize.** Start with the affected service, reachable asset, and recommended
-fix. Open the strongest path to inspect the relationships behind that conclusion.
+**Discover the estate.** Scan a repository or image, or collect a connected
+account. The inventory shows which packages, workloads, agents, tools, and
+identities were actually covered. Start with `agent-bom scan .`; save the
+result as JSON or SARIF before expanding the scope.
 
-These captures use the **Reference evidence lab — modeled local infrastructure**.
-They include real parser, scanner, and local gateway results; they are not
-customer evidence or live-cloud validation.
+**Find the consequential exposure.** In the reference scenario, an image
+processing service uses `pillow@9.0.0`, matched to `CVE-2023-4863`. Correlation
+connects its package evidence to a modeled workload, MCP tool, identity, and
+data asset. The question becomes: which service needs attention, and why?
 
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: light)" srcset="docs/images/correlation-receipts-light-live.png">
-    <img src="docs/images/correlation-receipts-live.png" alt="Investigation overview: affected service, vulnerable package, reachable asset, evidence quality, and remediation action" width="920" />
+    <img src="docs/images/correlation-receipts-live.png" alt="Image processing investigation: service, Pillow advisory, reachable modeled asset, evidence quality, and remediation action" width="920" />
   </picture>
 </p>
 
-**Investigate and act.** Follow the ordered path from entry point to data asset.
-Switch to Graph or List, inspect a hop’s source evidence, or open the package
-remediation. Exact identifiers and receipts stay one click away. “Path evidence
-complete” requires complete, fresh evidence for every directed, traversable hop;
-modeled infrastructure, runtime observations, and gateway blocks remain
-separately labeled. A blocked call does not remove the underlying exposure.
+**Inspect the evidence.** Open the ordered path to inspect each relationship
+and its source receipt. The graph connects observed or modeled entities with
+named, directed relationships; matching labels alone never prove a path.
+[Inspect this scenario's path](docs/GALLERY.md#follow-an-image-processing-exposure).
 
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: light)" srcset="docs/images/correlation-path-light-live.png">
-    <img src="docs/images/correlation-path-live.png" alt="Selected investigation: remediation first, eight readable path nodes, and expandable identity and hop receipts" width="920" />
-  </picture>
-</p>
+**Remediate and verify.** Assign the package fix to its owner, rebuild the
+image, and re-scan the deployed workload. Compare fresh evidence before closing
+the finding. A gateway block can contain one tool call while the underlying
+exposure remains.
 
-<details>
-<summary>Reproduce the evidence behind these views</summary>
-
-The credential-free lab runs repository, CycloneDX, Kubernetes IaC, and MCP
-parsers plus the bundled advisory scanner for `pillow@9.0.0` / `CVE-2023-4863`.
-Correlation connects scoped runtime identities, MCP tools, and gateway receipts
-with per-hop source provenance. Shared OCI digests are metadata, not runtime
-identity. Runtime observation and strict block proof have independent receipts;
-neither is proof of a deployed remediation.
+The **Reference evidence lab — modeled local infrastructure** runs real
+parsers, a pinned advisory scanner, and authenticated local gateway calls.
+Its package replay demonstrates the advisory match disappearing after a
+manifest change. Infrastructure and access relationships remain modeled;
+deployed remediation and live-cloud validation are not claimed.
 
 [Run the reference lab](examples/reference-evidence-lab/README.md) ·
-[Capture protocol](docs/CAPTURE.md)
-
-</details>
-
-[Explore the product gallery](docs/GALLERY.md)
+[Explore reproducible product scenarios](docs/GALLERY.md)
 
 ## Value by role
 

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -135,11 +135,9 @@ dark/light theme copies in the public README or Docker Hub description unless
 the section is specifically proving a theme bug fix. Do not publish a docs-only
 slide or card view in place of the graph screenshot.
 
-Keep
-`security-graph-live.png`, `lineage-graph-live.png`, and `context-map-live.png`
-in the explicitly synthetic graph gallery so readers can see fix-first paths, a filtered
-lineage drilldown, and focused lateral context without expanding every details
-block.
+Retain `security-graph-live.png`, `lineage-graph-live.png`, and
+`context-map-live.png` as synthetic UI regression captures. The public scenario
+guide selects evidence from the reproducible reference lab instead.
 
 For repeatable docs refreshes, use the deterministic Playwright harness from
 the UI package after the graph schema and UI build are current:
@@ -248,3 +246,13 @@ curl -X POST http://127.0.0.1:8422/v1/gateway/evaluate \
 If a future change to `src/agent_bom/demo.py` would publish a screenshot
 claiming CVEs against a clean version, that test fails before the change
 can land.
+
+## Public scenario selection
+
+The README embeds `correlation-receipts-live.png` for the operator conclusion;
+the scenario guide embeds `correlation-path-live.png` for its evidence drilldown.
+Do not repeat those images across both pages. Broader mesh, lineage, context,
+and synthetic vulnerability captures remain UI regression fixtures. Keep them
+in the generated set, but do not present their synthetic identifiers as real
+advisory or customer evidence. New public scenarios need reproducible source
+artifacts before they become product proof.

--- a/docs/GALLERY.md
+++ b/docs/GALLERY.md
@@ -1,58 +1,69 @@
-# Product gallery
+# Product scenarios
 
-The two correlation views use the committed, hash-pinned **Reference evidence
-lab — modeled local infrastructure** artifact and a real bundled advisory.
-Other gallery screens use deterministic synthetic fixtures that are visibly
-labeled. None are customer or live-cloud evidence.
+Start with a question, run the workflow, and inspect its evidence. The image
+below uses the **Reference evidence lab — modeled local infrastructure**:
+real parser and local gateway execution, a published advisory, and explicit
+modeled infrastructure. It is not a customer incident or live-cloud proof.
 
-## Correlated evidence proof
+## Scan a repository before shipping
 
-Start with the affected service, vulnerable package, and reachable asset. Open
-the selected path or its remediation; source receipts remain available on demand.
+From the repository you want to inspect:
 
-<img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/correlation-receipts-live.png" alt="Reference evidence lab investigation overview with impact and remediation" width="900" />
+```bash
+agent-bom scan . -f json -o scan.json
+agent-bom report compliance-narrative scan.json
+```
 
-The confirmed `CVE-2023-4863` path retains exact identifiers, per-hop evidence,
-freshness, runtime observation and strict-block proof, and a remediation handoff.
+The first command produces inventory, findings, and coverage for the selected
+project. The second turns that saved evidence into a compliance narrative.
+Review incomplete collectors before treating an absence of findings as a clean
+result. Use the [first-run guide](FIRST_RUN.md) for SARIF and CI gates.
 
-<img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/correlation-path-live.png" alt="Reference evidence lab confirmed CVE-2023-4863 path" width="900" />
+## Follow an image-processing exposure
 
-## Overview
+An AppSec engineer receives an advisory affecting an image-processing service.
+The actionable question is whether the affected package belongs to a workload
+with a route to a sensitive asset.
 
-Posture and top risks lead; coverage and operations provide supporting context.
+The [reference lab](../examples/reference-evidence-lab/README.md) follows
+`CVE-2023-4863` through a pinned Pillow dependency, image SBOM, Kubernetes
+manifest, MCP configuration, and modeled identity. The ordered path shows the
+relationship and evidence behind every step. Open a hop to inspect its source;
+use Graph or List to investigate the same selected path.
 
-<img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png" alt="Overview with posture, finding, coverage, and operations summaries" width="900" />
+<img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/correlation-path-live.png" alt="Pillow advisory investigation with eight ordered entities, remediation action, and per-hop evidence" width="900" />
 
-## Findings
+This is a structural exposure supported by the lab inputs, not execution of an
+exploit. The lab observes an allowed local gateway call, then checks that graph
+enforcement blocks another call before the upstream tool runs. That proves the
+local enforcement decision, not removal of the vulnerable deployment.
 
-The finding queue preserves severity, evidence, and the next action.
+The upstream [Pillow 10.0.1 release notes](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.1.html)
+document updated wheels containing libwebp 1.3.2 for this advisory. The lab
+matches package versions; it does not inspect a running service's libwebp binary.
 
-<img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dependency-map-live.png" alt="Findings queue with severity, evidence, and next actions" width="900" />
+## Verify the package change
 
-## Investigation
+From a repository checkout, run the offline before/after replay:
 
-The broader synthetic gallery retains a visibly labeled path-first UI fixture
-for layout and interaction regression coverage.
+```bash
+uv run python scripts/replay_package_remediation.py --output /tmp/package-replay.json
+```
 
-<img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/security-graph-live.png" alt="Path-first investigation with provenance-aware sample graph evidence" width="900" />
+The real dependency parser and scanner read two isolated manifests. Pillow
+9.0.0 matches the pinned advisory; 10.0.1 crosses that advisory's fixed-version
+boundary. Neither package is installed or executed. The JSON receipt records
+both results and the limited advisory coverage. This historical version pair
+is a reproducible test case, not a current upgrade recommendation.
 
-## Remediation
+In an actual environment, rebuild and redeploy using a supported version,
+collect a fresh SBOM and runtime identity, and re-run correlation. Close the
+exposure only when the new evidence supports that decision. Retain the prior
+scan and receipts for the audit trail.
 
-Campaigns connect priority, ownership, SLA, remediation, and verification.
+[Run the complete lab](../examples/reference-evidence-lab/README.md) ·
+[Start a self-hosted control plane](../DOCKER_HUB_UI_README.md) ·
+[Evidence and graph contract](graph/CONTRACT.md)
 
-<img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/remediation-live.png" alt="Prioritized remediation workflow with ownership and verification" width="900" />
-
-## Cloud and environment lineage
-
-Scoped lineage supports environment drill-down without leading with an
-unbounded raw topology.
-
-<img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/lineage-graph-live.png" alt="Scoped environment lineage with interactive graph controls" width="900" />
-
-## Agent mesh
-
-Agent and MCP server relationships retain named nodes and labeled edges.
-
-<img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-live.png" alt="Agent and MCP server relationships with labeled edges" width="900" />
-
-Next: follow the [capture protocol](CAPTURE.md) when refreshing these assets.
+Synthetic layout fixtures remain in the [capture protocol](CAPTURE.md) for UI
+regression coverage. They are separate from these reproducible scenario claims.

--- a/scripts/replay_package_remediation.py
+++ b/scripts/replay_package_remediation.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Replay a real advisory's package-version boundary without installing packages."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from agent_bom.parsers import scan_project_directory  # noqa: E402
+from agent_bom.scanners.package_scan import default_scan_options, scan_packages  # noqa: E402
+
+ADVISORY = "CVE-2023-4863"
+
+
+async def _scan_manifest(version: str) -> dict[str, Any]:
+    manifest = f"Pillow=={version}\n"
+    with tempfile.TemporaryDirectory(prefix="agent-bom-package-replay-") as directory:
+        project = Path(directory)
+        (project / "requirements.txt").write_text(manifest, encoding="utf-8")
+        discovered = scan_project_directory(project, max_depth=1)
+        packages = [package for path in sorted(discovered, key=str) for package in discovered[path]]
+        if len(packages) != 1 or packages[0].name.lower() != "pillow" or packages[0].version != version:
+            raise RuntimeError("Package replay parser did not recover the exact input version")
+        await scan_packages(
+            packages,
+            options=default_scan_options(offline=True, demo_advisories=True, project_dir=str(project)),
+        )
+    findings = sorted(vulnerability.id for vulnerability in packages[0].vulnerabilities)
+    return {
+        "package": f"pkg:pypi/pillow@{version}",
+        "manifest_sha256": f"sha256:{hashlib.sha256(manifest.encode('utf-8')).hexdigest()}",
+        "matched": ADVISORY in findings,
+        "advisory_ids": findings,
+    }
+
+
+async def replay() -> dict[str, Any]:
+    before = await _scan_manifest("9.0.0")
+    after = await _scan_manifest("10.0.1")
+    if not before["matched"] or after["matched"]:
+        raise RuntimeError("Package replay did not reproduce the expected advisory boundary")
+    return {
+        "schema_version": "agent-bom.package-remediation-replay/v1",
+        "advisory": ADVISORY,
+        "upstream_reference": "https://pillow.readthedocs.io/en/stable/releasenotes/10.0.1.html",
+        "coverage": "bundled_pinned_advisories_only",
+        "parser": "agent_bom.parsers.scan_project_directory",
+        "scanner": "agent_bom.scanners.package_scan.scan_packages",
+        "before": before,
+        "after": after,
+        "package_installation": "not_performed",
+        "exploit_execution": "not_performed",
+        "deployed_remediation": "not_tested",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, help="Write the JSON receipt to this file instead of stdout.")
+    args = parser.parse_args()
+    rendered = json.dumps(asyncio.run(replay()), indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+        print(f"Wrote package replay receipt: {args.output}")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -221,7 +221,7 @@ def test_readme_links_end_to_end_workflow_before_persona_detail() -> None:
     assert "### See what needs fixing — and why" in workflow
     assert "Reference evidence lab — modeled local infrastructure" in normalized_workflow
     assert "correlation-receipts-live.png" in workflow
-    assert "correlation-path-live.png" in workflow
+    assert "docs/GALLERY.md#follow-an-image-processing-exposure" in workflow
     assert "CVE-2023-4863" in workflow
 
 

--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -199,6 +199,7 @@ def test_readme_persona_table_covers_each_operating_lane() -> None:
         "Platform / DevOps",
         "GRC / audit",
         "CISO / engineering leader",
+        "AI assistant / automation",
     ]
 
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
@@ -237,10 +238,11 @@ def test_readme_embeds_one_readable_workflow_and_moves_dense_detail_to_docs() ->
 def test_persona_table_rows_all_carry_a_concrete_first_action() -> None:
     """Every persona row gives a command or the exact UI action for its lane."""
     rows = {row[0]: row[1] for row in _readme_persona_rows()}
-    for role in ("Developer / AI engineer", "AppSec / product security", "Platform / DevOps", "GRC / audit"):
+    for role in ("Developer / AI engineer", "AI assistant / automation", "Platform / DevOps", "GRC / audit"):
         assert "`agent-bom " in rows[role] or "`pip install " in rows[role], (role, rows[role])
     assert rows["Cloud security"] == "Add a read-only connection, then run a scan"
-    assert rows["CISO / engineering leader"] == "Open **Architecture** in the self-hosted graph"
+    assert rows["CISO / engineering leader"] == "Open **Overview** in the self-hosted control plane"
+    assert rows["AppSec / product security"] == "Open **Overview**, then inspect a prioritized finding"
 
 
 def test_persona_card_copy_fits_inside_its_card() -> None:

--- a/tests/test_package_remediation_replay.py
+++ b/tests/test_package_remediation_replay.py
@@ -1,0 +1,37 @@
+"""The public package replay must execute the parser and scanner with bounded claims."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_replay_records_real_advisory_before_and_after_without_deployment_claim(tmp_path: Path) -> None:
+    output = tmp_path / "receipt.json"
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts/replay_package_remediation.py"), "--output", str(output)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(output.read_text())
+    assert payload["schema_version"] == "agent-bom.package-remediation-replay/v1"
+    assert payload["advisory"] == "CVE-2023-4863"
+    assert payload["coverage"] == "bundled_pinned_advisories_only"
+    assert payload["deployed_remediation"] == "not_tested"
+    assert payload["exploit_execution"] == "not_performed"
+    assert payload["package_installation"] == "not_performed"
+    assert payload["before"]["matched"] is True
+    assert payload["after"]["matched"] is False
+    for stage, version in (("before", "9.0.0"), ("after", "10.0.1")):
+        receipt = payload[stage]
+        assert receipt["package"] == f"pkg:pypi/pillow@{version}"
+        assert receipt["manifest_sha256"] == "sha256:" + hashlib.sha256(f"Pillow=={version}\n".encode()).hexdigest()
+    assert not (tmp_path / "requirements.txt").exists()

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -145,10 +145,13 @@ def test_readme_distinguishes_graph_relationship_provenance() -> None:
     normalized = " ".join(readme.lower().split())
 
     assert "Graph views use observed nodes and relationships" not in readme
-    assert "shared oci digests are metadata, not runtime identity" in normalized
-    assert "scoped runtime identities" in normalized
-    assert "per-hop source provenance" in normalized
-    assert "runtime observation and strict block proof" in normalized
+    assert "matching labels alone never prove a path" in normalized
+    assert "observed or modeled entities" in normalized
+    assert "source receipt" in normalized
+    assert "a gateway block can contain one tool call" in normalized
+    assert "deployed remediation and live-cloud validation are not claimed" in normalized
+    workflow = " ".join((ROOT / "docs/HOW_IT_WORKS.md").read_text().lower().split())
+    assert "they do not merge permission-bearing runtime occurrences" in workflow
     assert "observed graph evidence" not in readme
 
 
@@ -235,10 +238,10 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert commands == ["pip install agent-bom", "agent-bom scan ."]
 
     assert "<summary><b>Try without a repository</b></summary>" in readme
-    for image in ("correlation-receipts-live.png", "correlation-path-live.png"):
-        assert readme.count(image) == 1  # one full-width screenshot per stage
-        assert image.replace("-live.png", "-light-live.png") in readme
-    assert "[Explore the product gallery](docs/GALLERY.md)" in readme
+    assert readme.count("correlation-receipts-live.png") == 1
+    assert "correlation-receipts-light-live.png" in readme
+    assert "correlation-path-live.png" not in readme  # drilldown belongs in the scenario guide
+    assert "[Explore reproducible product scenarios](docs/GALLERY.md)" in readme
     assert "gateway-policies-live.png" not in readme
 
     # Persona surfaces keep security engineering and GRC as separate lanes
@@ -255,7 +258,7 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert "workflow-dark.svg" in readme
     assert "architecture-dark.svg" not in readme
     assert "persona-value-dark.svg" not in readme
-    assert readme.count("-live.png") == 4
+    assert readme.count("-live.png") == 2
     assert 'width="920"' in readme
     assert "blast-radius-dark.svg" not in readme
 

--- a/tests/test_public_frontdoor_contract.py
+++ b/tests/test_public_frontdoor_contract.py
@@ -99,13 +99,13 @@ def test_readme_shows_the_end_to_end_product_journey_and_links_the_gallery() -> 
 
     journey = readme.split("## From evidence source to verified action", 1)[1].split("## Value by role", 1)[0]
     stages = ["read-only connection", "collect", "inventory", "findings", "graph", "owner", "re-scan", "verify"]
-    images = ["workflow-dark.svg", "correlation-receipts-live.png", "correlation-path-live.png"]
+    images = ["workflow-dark.svg", "correlation-receipts-live.png"]
     normalized = " ".join(journey.lower().split())
     assert all(stage in normalized for stage in stages)
     assert all(image in journey for image in images)
     assert [journey.index(image) for image in images] == sorted(journey.index(image) for image in images)
     assert 'width="920"' in journey
-    assert "[Explore the product gallery](docs/GALLERY.md)" in journey
+    assert "[Explore reproducible product scenarios](docs/GALLERY.md)" in journey
     assert "reference evidence lab — modeled local infrastructure" in normalized
     assert "CVE-2023-4863" in journey
     assert "DEMO-VULN" not in journey
@@ -154,21 +154,33 @@ def test_readme_frontdoor_is_short_and_integration_roles_are_explicit() -> None:
     assert "agent-bom cloud databricks" not in matrix
 
 
-def test_gallery_retains_full_size_product_screens() -> None:
+def test_scenarios_separate_reproducible_proof_from_synthetic_layout_fixtures() -> None:
     gallery = (ROOT / "docs" / "GALLERY.md").read_text(encoding="utf-8")
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
 
-    for image in (
-        "dashboard-live.png",
-        "dependency-map-live.png",
-        "correlation-receipts-live.png",
-        "correlation-path-live.png",
-        "security-graph-live.png",
-        "remediation-live.png",
-        "lineage-graph-live.png",
-        "mesh-live.png",
-    ):
-        assert image in gallery
+    assert gallery.count("<img ") == 1
+    assert "correlation-path-live.png" in gallery
+    assert "correlation-path-live.png" not in readme
+    assert "correlation-receipts-live.png" not in gallery
     assert 'width="900"' in gallery
+    assert "scripts/replay_package_remediation.py" in gallery
+    assert "CVE-2023-4863" in gallery
+    assert "DEMO-VULN" not in gallery
+    assert "not a current upgrade recommendation" in gallery
+    for synthetic in ("mesh-live.png", "security-graph-live.png", "lineage-graph-live.png"):
+        assert synthetic not in gallery
+
+
+def test_docker_ui_first_run_has_a_result_and_preserves_local_auth_boundary() -> None:
+    guide = (ROOT / "DOCKER_HUB_UI_README.md").read_text(encoding="utf-8")
+    assert "docker compose -f docker-compose.pilot.yml up -d" in guide
+    assert "**New Scan**" in guide
+    assert "**Connections**" in guide
+    assert "inventory and findings" in guide
+    assert "loopback" in guide
+    assert "configured authentication" in guide
+    assert "AGENT_BOM_API_URL" in guide
+    assert "NEXT_PUBLIC_API_URL" in guide
 
 
 def test_persona_routes_start_with_their_actual_work() -> None:

--- a/tests/test_public_frontdoor_contract.py
+++ b/tests/test_public_frontdoor_contract.py
@@ -188,10 +188,11 @@ def test_persona_routes_start_with_their_actual_work() -> None:
     personas = readme.split("## Value by role", 1)[1].split("\n## ", 1)[0]
 
     assert "| Developer / AI engineer | `agent-bom scan .`" in personas
-    assert "| AppSec / product security | `agent-bom scan . --gha . --offline`" in personas
+    assert "| AppSec / product security | Open **Overview**, then inspect a prioritized finding" in personas
     assert "| Cloud security | Add a read-only connection, then run a scan" in personas
     assert f"| Platform / DevOps | `pip install 'agent-bom[ui]' && {LOCAL_ANALYST_CONTROL_PLANE}`" in personas
-    assert "| CISO / engineering leader | Open **Architecture** in the self-hosted graph" in personas
+    assert "| CISO / engineering leader | Open **Overview** in the self-hosted control plane" in personas
+    assert "| AI assistant / automation | `agent-bom mcp server`" in personas
     assert "owners and slas" in personas.lower()
 
 


### PR DESCRIPTION
## Summary
- Replace repeated product screenshots with a discover, investigate, inspect, and verify story backed by the reference evidence lab.
- Add a reproducible offline Pillow advisory before/after replay and document its evidence boundaries.
- Route human security roles through the appropriate scan or control-plane entry, and assistants through the eight-tool MCP default; clarify the Docker UI first run.

## Verification
- 58 targeted tests: package-remediation replay, public CLI/front-door contracts, architecture documentation, and default MCP profile/CLI behavior.
- `PYTHONPATH=src python scripts/replay_package_remediation.py --output /tmp/package-replay.json`: Pillow 9.0.0 matches CVE-2023-4863; 10.0.1 does not match the pinned advisory.
- `python scripts/check_public_docs_hygiene.py`, targeted Ruff check/format, and `git diff --check`.

## Notes
The replay uses real parser and scanner code with a bundled pinned advisory. It does not install or execute packages. Infrastructure remains explicitly modeled; deployed remediation and live-cloud validation are not claimed. Existing captured images are reused in distinct overview and evidence contexts.
