### PR TITLE
fix(graph): bind skill findings to their source owner

### DIFF
--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -7147,13 +7147,20 @@ def _resolve_skill_audit_target_ids(
     if source_file:
         if source_file in agent_config_path_to_id:
             target_ids.add(agent_config_path_to_id[source_file])
-        source_name = PurePath(source_file).name
-        for config_path, agent_id in agent_config_path_to_id.items():
-            if source_name and source_name == PurePath(config_path).name:
-                target_ids.add(agent_id)
+        elif source_file == PurePath(source_file).name:
+            # Legacy basename-only evidence may identify an owner only when the
+            # name has one match. A qualified source must never cross scopes by
+            # dropping its directory, even when its exact path is unknown.
+            candidates = {
+                agent_id for config_path, agent_id in agent_config_path_to_id.items() if source_file == PurePath(config_path).name
+            }
+            if len(candidates) == 1:
+                target_ids.update(candidates)
 
-    if not target_ids and len(agent_name_to_ids) == 1:
-        only_agent_ids = next(iter(agent_name_to_ids.values()))
-        target_ids.update(only_agent_ids)
+    if not target_ids and not source_file:
+        # One display-name bucket can still contain distinct agent occurrences.
+        candidates = {agent_id for agent_ids in agent_name_to_ids.values() for agent_id in agent_ids}
+        if len(candidates) == 1:
+            target_ids.update(candidates)
 
     return sorted(target_ids)

--- a/tests/test_skill_graph_source_binding.py
+++ b/tests/test_skill_graph_source_binding.py
@@ -1,0 +1,54 @@
+"""Skill findings must not invent agent ownership from ambiguous source labels."""
+
+import pytest
+
+from agent_bom.graph.builder import _resolve_skill_audit_target_ids, build_unified_graph_from_report
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("source_file, expected", [("/prod/SKILL.md", {"agent:prod"}), ("/unknown/SKILL.md", set())])
+def test_explicit_skill_source_does_not_cross_bind_same_basename(reverse, source_file, expected):
+    agents = [
+        {"name": "prod", "type": "custom", "config_path": "/prod/SKILL.md", "mcp_servers": []},
+        {"name": "dev", "type": "custom", "config_path": "/dev/SKILL.md", "mcp_servers": []},
+    ]
+    if reverse:
+        agents.reverse()
+    graph = build_unified_graph_from_report(
+        {
+            "scan_id": "skill-source-binding",
+            "agents": agents,
+            "skill_audit": {
+                "findings": [{"source_file": source_file, "category": "shell_access", "title": "Skill shell access", "severity": "high"}]
+            },
+        }
+    )
+    finding_id = "misconfig:skill_audit:shell_access:1"
+    assert finding_id in graph.nodes
+    targets = {edge.target for edge in graph.edges if edge.source == finding_id and edge.target.startswith("agent:")}
+    assert targets == expected
+    assert graph.nodes[finding_id].attributes["source_file"] == source_file
+
+
+@pytest.mark.parametrize(
+    "source_file, paths, agent_ids, expected",
+    [
+        ("/unknown/SKILL.md", {"/prod/SKILL.md": "agent:prod"}, ["agent:prod"], []),
+        ("nested/SKILL.md", {"/prod/SKILL.md": "agent:prod"}, ["agent:prod"], []),
+        ("SKILL.md", {"/prod/SKILL.md": "agent:prod"}, ["agent:prod"], ["agent:prod"]),
+        ("SKILL.md", {"/prod/SKILL.md": "agent:prod", "/dev/SKILL.md": "agent:dev"}, ["agent:prod", "agent:dev"], []),
+        ("", {}, ["agent:prod"], ["agent:prod"]),
+        ("", {}, ["agent:prod", "agent:dev"], []),
+    ],
+)
+def test_legacy_skill_source_fallback_requires_one_unambiguous_owner(source_file, paths, agent_ids, expected):
+    assert (
+        _resolve_skill_audit_target_ids(
+            {"source_file": source_file},
+            package_name_to_ids={},
+            server_name_to_ids={},
+            agent_name_to_ids={"shared-name": agent_ids},
+            agent_config_path_to_id=paths,
+        )
+        == expected
+    )


### PR DESCRIPTION
## Summary

- Keep a skill finding from `/prod/SKILL.md` attached to its exact source owner instead of also attaching it to an unrelated agent configured from `/dev/SKILL.md`.
- Leave qualified unknown sources unbound; retain legacy basename matching only when one owner matches, and source-less fallback only when one actual agent identity exists. Preserve the finding and its source evidence.
- Add both-order graph regressions and unambiguous/unknown legacy-source cases.

## Verification

- Regression first: `tests/test_skill_graph_source_binding.py` produced 8 failures and 2 positive passes before repair.
- `PYTHONPATH=src python -m pytest -q tests/test_skill_graph_source_binding.py tests/test_graph_builder.py tests/test_skill_audit_finding_stream.py tests/test_skills_detection_parity.py tests/test_inventory_manifest_occurrences.py` — 104 passed on the refreshed main base.
- Ruff check/format, project mypy for `src/agent_bom/graph/builder.py`, `git diff --check`, and `make preflight`.
- Required applicable hooks ran. The isolated mypy hook's 43 transitive diagnostics reproduced identically on unchanged base `b449f1174`; project mypy passed. Other applicable hooks passed.

## Notes

- Existing persisted graph snapshots are unchanged; rebuilding applies corrected source ownership.
- The change is limited to skill-source agent association. Package/server name associations and automatic promotion of standalone Skills reports are unchanged.
