### PR TITLE
fix(finops): aggregate complete tenant cost totals and qualify history

### DIFF
--- a/docs/COST_MODEL.md
+++ b/docs/COST_MODEL.md
@@ -1,9 +1,8 @@
 # Open Cost Model (FinOps)
 
 agent-bom attributes LLM API spend to agents, models, and providers so operators
-get cost accountability without adding a separate FinOps product. Unlike closed
-runtime platforms, the price model is **open and operator-tunable** — every
-number is in the repo and overridable.
+can inspect estimated token spend. The price model is open and operator-tunable;
+rates are recorded in the repository and can be overridden.
 
 ## How it works
 
@@ -29,6 +28,27 @@ OTel GenAI spans ──► token usage ──► open price table ──► per-
 
 No prompts, responses, or arguments are read or stored — only token counts and
 model identifiers. This preserves the read-only, metadata-only trust posture.
+
+## Reporting scope
+
+The Overview and cost report headline totals aggregate all retained cost records
+for the authenticated tenant, with any requested agent/cost-center filter.
+The report's `limit` bounds the detail breakdowns, including owner and tag slices;
+filters apply before that limit. `history.returned_calls` and `history.complete`
+identify whether those breakdowns cover the full matching ledger. Headline totals
+are independent of the detail limit on memory, SQLite, and Postgres stores.
+
+These are estimates from recorded tokens, not provider invoices or complete
+company AI spend. Unpriced calls remain explicit. Retention, missing telemetry,
+cache/tool charges, GPU infrastructure, and seat subscriptions can leave gaps.
+`first_recorded_at` and `last_recorded_at` are stored observation timestamps;
+the current trace ingestion path records receipt time, not provider billing time.
+Storage failures appear unavailable in Overview, never as zero spend.
+
+Forecasts return null projections with `incomplete_history` when the record limit
+truncates matching history, or `budget_scope_mismatch` when a broader budget cannot
+be forecast from the selected agent/cost-center history. A fallback tenant budget
+is compared with the tenant's spend, even when the report selects one agent.
 
 ## Price table
 

--- a/src/agent_bom/api/cost_forecast.py
+++ b/src/agent_bom/api/cost_forecast.py
@@ -212,6 +212,13 @@ def _best_daily_rate(timed: Sequence[tuple[datetime, float]], now: datetime) -> 
     return max(candidates, key=lambda c: c[0])
 
 
+def unavailable_forecast(status: str, spend: float, budget: CostBudget | None = None, *, now: datetime | None = None) -> dict[str, Any]:
+    """Keep projections unknown when history or budget scope cannot support them."""
+    result = forecast_spend([], budget=budget, now=now)
+    result.update(status=status, current_spend_usd=spend)
+    return result
+
+
 def forecast_for_tenant(
     tenant_id: str,
     *,
@@ -228,12 +235,16 @@ def forecast_for_tenant(
     from agent_bom.api.cost_store import get_cost_store
 
     store = get_cost_store()
-    records = store.list_records(tenant_id, limit=max(1, min(limit, 100000)))
-    if agent:
-        records = [r for r in records if r.agent == agent]
+    records = store.list_records(tenant_id, limit=max(1, min(limit, 100000)), agent=agent)
+    totals = store.report_totals(tenant_id, agent=agent)
     budget = store.get_budget(tenant_id, agent or "")
     if budget is None and agent:
         budget = store.get_budget(tenant_id, "")
-    result = forecast_spend(records, budget=budget, now=now)
+    if len(records) != totals["total_calls"]:
+        result = unavailable_forecast("incomplete_history", totals["total_cost_usd"], budget, now=now)
+    elif budget is not None and budget.agent != (agent or ""):
+        result = unavailable_forecast("budget_scope_mismatch", totals["total_cost_usd"], budget, now=now)
+    else:
+        result = forecast_spend(records, budget=budget, now=now)
     result["tenant_id"] = tenant_id
     return result

--- a/src/agent_bom/api/cost_store.py
+++ b/src/agent_bom/api/cost_store.py
@@ -240,7 +240,11 @@ def budget_window_start(now: datetime | None = None) -> str | None:
 class CostStore(Protocol):
     def record_cost(self, record: LLMCostRecord) -> None: ...
 
-    def list_records(self, tenant_id: str, *, limit: int = 1000) -> list[LLMCostRecord]: ...
+    def list_records(
+        self, tenant_id: str, *, limit: int = 1000, agent: str | None = None, cost_center: str | None = None
+    ) -> list[LLMCostRecord]: ...
+
+    def report_totals(self, tenant_id: str, *, agent: str | None = None, cost_center: str | None = None) -> dict[str, Any]: ...
 
     def total_spend(self, tenant_id: str, *, agent: str | None = None, since: str | None = None) -> float: ...
 
@@ -251,6 +255,41 @@ class CostStore(Protocol):
     def get_budget(
         self, tenant_id: str, agent: str = "", *, cost_center: str = "", owner: str = "", workflow: str = ""
     ) -> CostBudget | None: ...
+
+
+# SQL aggregation returns a constant-size row regardless of ledger size. All
+# values are bound parameters; only the store-owned placeholder differs.
+_REPORT_TOTALS_SQL = (
+    "SELECT COUNT(*), COALESCE(SUM(cost_usd), 0), COALESCE(SUM(input_tokens), 0), "
+    "COALESCE(SUM(output_tokens), 0), COALESCE(SUM(CASE WHEN NOT priced THEN 1 ELSE 0 END), 0), "
+    "COUNT(DISTINCT NULLIF(agent, '')), MIN(observed_at), MAX(observed_at) "
+    "FROM llm_costs WHERE "
+)
+
+
+def _cost_scope(tenant_id: str, agent: str | None, cost_center: str | None, placeholder: str = "?") -> tuple[str, list[Any]]:
+    clauses = ["tenant_id = " + placeholder]
+    params: list[Any] = [tenant_id]
+    for column, value in (("agent", agent), ("cost_center", cost_center)):
+        if value:
+            clauses.append(column + " = " + placeholder)
+            params.append(value)
+    return " AND ".join(clauses), params
+
+
+def _report_totals_row(row: Any) -> dict[str, Any]:
+    return {
+        "total_calls": int(row[0]),
+        "total_cost_usd": round(float(row[1]), 6),
+        "total_input_tokens": int(row[2]),
+        "total_output_tokens": int(row[3]),
+        "unpriced_calls": int(row[4]),
+        "agents": int(row[5]),
+        "first_recorded_at": row[6],
+        "last_recorded_at": row[7],
+        "period": "all_recorded",
+        "basis": "estimated_token_cost",
+    }
 
 
 def spend_rollup(store: Any, tenant_id: str, *, since: str | None = None) -> list[dict[str, Any]]:
@@ -457,9 +496,36 @@ class InMemoryCostStore:
             self._seen[record.tenant_id].add(record.call_id)
             self._records[record.tenant_id].append(record)
 
-    def list_records(self, tenant_id: str, *, limit: int = 1000) -> list[LLMCostRecord]:
+    def list_records(
+        self, tenant_id: str, *, limit: int = 1000, agent: str | None = None, cost_center: str | None = None
+    ) -> list[LLMCostRecord]:
         with self._lock:
-            return list(self._records.get(tenant_id, []))[-limit:]
+            records = [
+                r
+                for r in self._records.get(tenant_id, [])
+                if (not agent or r.agent == agent) and (not cost_center or r.cost_center == cost_center)
+            ]
+            return sorted(records, key=lambda r: (r.observed_at, r.call_id), reverse=True)[:limit]
+
+    def report_totals(self, tenant_id: str, *, agent: str | None = None, cost_center: str | None = None) -> dict[str, Any]:
+        with self._lock:
+            records = [
+                r
+                for r in self._records.get(tenant_id, [])
+                if (not agent or r.agent == agent) and (not cost_center or r.cost_center == cost_center)
+            ]
+            return _report_totals_row(
+                (
+                    len(records),
+                    sum(r.cost_usd for r in records),
+                    sum(r.input_tokens for r in records),
+                    sum(r.output_tokens for r in records),
+                    sum(not r.priced for r in records),
+                    len({r.agent for r in records if r.agent}),
+                    min((r.observed_at for r in records), default=None),
+                    max((r.observed_at for r in records), default=None),
+                )
+            )
 
     def total_spend(self, tenant_id: str, *, agent: str | None = None, since: str | None = None) -> float:
         with self._lock:
@@ -622,13 +688,17 @@ class SQLiteCostStore:
         )
         self._conn.commit()
 
-    def list_records(self, tenant_id: str, *, limit: int = 1000) -> list[LLMCostRecord]:
-        rows = self._conn.execute(
+    def list_records(
+        self, tenant_id: str, *, limit: int = 1000, agent: str | None = None, cost_center: str | None = None
+    ) -> list[LLMCostRecord]:
+        scope, params = _cost_scope(tenant_id, agent, cost_center)
+        sql = (
             "SELECT tenant_id, call_id, agent, session_id, provider, model, input_tokens, output_tokens, "
-            "cost_usd, priced, observed_at, cost_center, allocation_tags "
-            "FROM llm_costs WHERE tenant_id = ? ORDER BY observed_at DESC LIMIT ?",
-            (tenant_id, limit),
-        ).fetchall()
+            "cost_usd, priced, observed_at, cost_center, allocation_tags FROM llm_costs WHERE "
+        )
+        sql += scope
+        sql += " ORDER BY observed_at DESC, call_id DESC LIMIT ?"
+        rows = self._conn.execute(sql, [*params, limit]).fetchall()
         return [
             LLMCostRecord(
                 r[0],
@@ -647,6 +717,10 @@ class SQLiteCostStore:
             )
             for r in rows
         ]
+
+    def report_totals(self, tenant_id: str, *, agent: str | None = None, cost_center: str | None = None) -> dict[str, Any]:
+        scope, params = _cost_scope(tenant_id, agent, cost_center)
+        return _report_totals_row(self._conn.execute(_REPORT_TOTALS_SQL + scope, params).fetchone())
 
     def spend_rollup(self, tenant_id: str, *, since: str | None = None) -> list[dict[str, Any]]:
         """GROUP BY in SQL so a busy tenant is never truncated or walked in Python."""

--- a/src/agent_bom/api/postgres_cost.py
+++ b/src/agent_bom/api/postgres_cost.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from agent_bom.api.cost_store import CostBudget, LLMCostRecord, _decode_tags
+from agent_bom.api.cost_store import _REPORT_TOTALS_SQL, CostBudget, LLMCostRecord, _cost_scope, _decode_tags, _report_totals_row
 from agent_bom.api.postgres_common import ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
@@ -184,15 +184,23 @@ class PostgresCostStore:
             for r in rows
         ]
 
-    def list_records(self, tenant_id: str, *, limit: int = 1000) -> list[LLMCostRecord]:
+    def report_totals(self, tenant_id: str, *, agent: str | None = None, cost_center: str | None = None) -> dict[str, Any]:
+        scope, params = _cost_scope(tenant_id, agent, cost_center, "%s")
         with _tenant_connection(self._pool) as conn:
-            rows = conn.execute(
-                "SELECT tenant_id, call_id, agent, session_id, provider, model, "
-                "input_tokens, output_tokens, cost_usd, priced, observed_at, "
-                "cost_center, allocation_tags "
-                "FROM llm_costs WHERE tenant_id = %s ORDER BY observed_at DESC LIMIT %s",
-                (tenant_id, limit),
-            ).fetchall()
+            return _report_totals_row(conn.execute(_REPORT_TOTALS_SQL + scope, params).fetchone())
+
+    def list_records(
+        self, tenant_id: str, *, limit: int = 1000, agent: str | None = None, cost_center: str | None = None
+    ) -> list[LLMCostRecord]:
+        scope, params = _cost_scope(tenant_id, agent, cost_center, "%s")
+        sql = (
+            "SELECT tenant_id, call_id, agent, session_id, provider, model, input_tokens, output_tokens, "
+            "cost_usd, priced, observed_at, cost_center, allocation_tags FROM llm_costs WHERE "
+        )
+        sql += scope
+        sql += " ORDER BY observed_at DESC, call_id DESC LIMIT %s"
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(sql, [*params, limit]).fetchall()
         return [
             LLMCostRecord(
                 r[0],

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -1859,12 +1859,13 @@ def _build_llm_costs_report_sync(
     from agent_bom.api.cost_store import budget_status, get_cost_store, summarize, summarize_by_tag
 
     store = get_cost_store()
-    records = store.list_records(tenant_id, limit=limit)
-    if agent:
-        records = [r for r in records if r.agent == agent]
-    if cost_center:
-        records = [r for r in records if (r.cost_center or "") == cost_center]
+    records = store.list_records(tenant_id, limit=limit, agent=agent, cost_center=cost_center)
     report = summarize(records)
+    totals = store.report_totals(tenant_id, agent=agent, cost_center=cost_center)
+    report.update(totals)
+    complete = len(records) == totals["total_calls"]
+    report["history"] = {"limit": limit, "returned_calls": len(records), "complete": complete}
+    report["scope"] = {"agent": agent, "cost_center": cost_center}
     # Owner-attributed rollup (#3909): spend grouped by the accountable owner
     # recorded on the blueprint governing each agent. Spend from an ungoverned
     # agent rolls up under "unattributed" so nothing is silently dropped.
@@ -1879,10 +1880,18 @@ def _build_llm_costs_report_sync(
         budget = store.get_budget(tenant_id, agent or "")
         if budget is None and agent:
             budget = store.get_budget(tenant_id, "")
+            spend = store.total_spend(tenant_id)
     report["budget"] = budget_status(spend, budget)
     # Forward-looking companion to the point-in-time budget posture: burn rate +
     # projected runway derived from the same records. Reference only.
-    report["forecast"] = forecast_spend(records, budget=budget)
+    from agent_bom.api.cost_forecast import unavailable_forecast
+
+    if not complete:
+        report["forecast"] = unavailable_forecast("incomplete_history", totals["total_cost_usd"], budget)
+    elif budget is not None and (budget.agent != (agent or "") or budget.cost_center != (cost_center or "")):
+        report["forecast"] = unavailable_forecast("budget_scope_mismatch", totals["total_cost_usd"], budget)
+    else:
+        report["forecast"] = forecast_spend(records, budget=budget)
     report["schema_version"] = "observability.costs.v1"
     report["tenant_id"] = tenant_id
     report["price_model_captured"] = __import__("agent_bom.cost_model", fromlist=["PRICE_TABLE_CAPTURED"]).PRICE_TABLE_CAPTURED
@@ -1998,7 +2007,7 @@ async def get_llm_cost_forecast(request: Request, agent: str | None = None, limi
 
     bounded_limit = max(1, min(limit, 10000))
     scoped_agent = _bounded(agent, max_len=120) if agent else None
-    return forecast_for_tenant(_tenant_id(request), agent=scoped_agent, limit=bounded_limit)
+    return await asyncio.to_thread(forecast_for_tenant, _tenant_id(request), agent=scoped_agent, limit=bounded_limit)
 
 
 @router.get("/observability/anomalies", tags=["observability", "finops"], dependencies=[_dep("read")])

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -754,21 +754,19 @@ def _runtime_snapshot(request: Request, jobs: list[Any]) -> dict[str, Any]:
 def _cost_snapshot(request: Request) -> dict[str, Any]:
     """LLM spend rollup from the cost store (same source as /v1/observability/costs)."""
     try:
-        from agent_bom.api.cost_store import get_cost_store, summarize
+        from agent_bom.api.cost_store import get_cost_store
 
         store = get_cost_store()
-        records = store.list_records(_tenant_id(request), limit=10000)
-        report = summarize(records)
+        report = store.report_totals(_tenant_id(request))
         budget = store.get_budget(_tenant_id(request), "")
         return {
-            "total_cost_usd": report.get("total_cost_usd", 0.0),
-            "total_calls": report.get("total_calls", 0),
-            "agents": len(report.get("by_agent", {}) or {}),
+            **report,
+            "available": True,
             "budget_configured": budget is not None,
         }
     except Exception:  # pragma: no cover - cost store optional
         _logger.debug("cost snapshot failed", exc_info=False)
-        return {"total_cost_usd": 0.0, "total_calls": 0, "agents": 0, "budget_configured": False}
+        return {"available": False, "total_cost_usd": None, "total_calls": None, "agents": None, "budget_configured": None}
 
 
 def _identity_snapshot(request: Request) -> dict[str, Any]:
@@ -1597,9 +1595,9 @@ def _compose_overview(
         "cost": {
             "label": "LLM Cost",
             "href": "/cost",
-            "metric": round(float(cost["total_cost_usd"]), 2),
-            "metric_label": "USD tracked",
-            "status": "ok" if cost["total_calls"] > 0 else "idle",
+            "metric": round(float(cost["total_cost_usd"]), 2) if cost["available"] else None,
+            "metric_label": "USD estimated",
+            "status": ("ok" if cost["total_calls"] > 0 else "idle") if cost["available"] else "unavailable",
             "detail": cost,
         },
         "identity": {

--- a/tests/test_cost_reporting_scope.py
+++ b/tests/test_cost_reporting_scope.py
@@ -1,0 +1,124 @@
+"""Headlines cover the ledger; bounded history must never masquerade as totals."""
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from agent_bom.api.cost_forecast import forecast_for_tenant
+from agent_bom.api.cost_store import CostBudget, InMemoryCostStore, LLMCostRecord, SQLiteCostStore, set_cost_store
+from agent_bom.api.routes.observability import _build_llm_costs_report_sync
+from agent_bom.api.routes.overview import _cost_snapshot
+
+
+@pytest.fixture(params=["memory", "sqlite"])
+def ledger(request, tmp_path):
+    store = InMemoryCostStore() if request.param == "memory" else SQLiteCostStore(str(tmp_path / "cost.db"))
+    old = LLMCostRecord("t1", "old", "older-agent", "s", "provider", "model", 100, 50, 2.5, True, "2026-06-01T00:00:00Z", "engineering")
+    store.record_cost(old)
+    store.record_cost(
+        replace(old, call_id="unpriced", agent="new-agent", cost_usd=0, priced=False, observed_at="2026-06-02T00:00:00Z", cost_center="")
+    )
+    store.record_cost(replace(old, tenant_id="other", call_id="private", cost_usd=999))
+    set_cost_store(store)
+    yield store
+    set_cost_store(None)
+
+
+def test_complete_totals_survive_bounded_history(ledger):
+    report = _build_llm_costs_report_sync("t1", agent=None, cost_center=None, tag=None, limit=1)
+    assert report["total_calls"] == 2
+    assert report["total_cost_usd"] == 2.5
+    assert report["total_input_tokens"] == 200
+    assert report["unpriced_calls"] == 1
+    assert report["agents"] == 2
+    assert report["history"]["returned_calls"] == 1
+    assert report["history"]["complete"] is False
+    assert report["forecast"]["status"] == "incomplete_history"
+    assert report["forecast"]["burn_rate_usd_per_day"] is None
+    snapshot = _cost_snapshot(SimpleNamespace(state=SimpleNamespace(tenant_id="t1")))
+    assert snapshot["total_cost_usd"] == report["total_cost_usd"]
+    assert snapshot["total_calls"] == report["total_calls"]
+
+
+def test_filters_apply_before_history_limit(ledger):
+    report = _build_llm_costs_report_sync("t1", agent="older-agent", cost_center="engineering", tag=None, limit=1)
+    assert report["total_calls"] == 1
+    assert report["history"]["complete"] is True
+    assert report["by_agent"][0]["key"] == "older-agent"
+    assert report["by_cost_center"][0]["key"] == "engineering"
+    assert ledger.report_totals("other")["total_cost_usd"] == 999
+    assert ledger.report_totals("missing")["total_calls"] == 0
+
+
+def test_tenant_budget_fallback_uses_tenant_spend(ledger):
+    ledger.set_budget(CostBudget("t1", "", 2, "2026-06-01T00:00:00Z"))
+    report = _build_llm_costs_report_sync("t1", agent="new-agent", cost_center=None, tag=None, limit=1)
+    assert report["total_cost_usd"] == 0
+    assert report["budget"]["spend_usd"] == 2.5
+    assert report["budget"]["exceeded"] is True
+    assert report["forecast"]["status"] == "budget_scope_mismatch"
+
+
+def test_forecast_endpoint_marks_truncated_history(ledger):
+    forecast = forecast_for_tenant("t1", limit=1)
+    assert forecast["status"] == "incomplete_history"
+    assert forecast["days_remaining"] is None
+    assert forecast["current_spend_usd"] == 2.5
+
+
+def test_unavailable_store_is_not_zero(monkeypatch):
+    def unavailable():
+        raise RuntimeError("private backend detail")
+
+    monkeypatch.setattr("agent_bom.api.cost_store.get_cost_store", unavailable)
+    result = _cost_snapshot(SimpleNamespace(state=SimpleNamespace(tenant_id="t1")))
+    assert result["available"] is False
+    assert result["total_cost_usd"] is None
+    assert result["total_calls"] is None
+
+
+def test_totals_exceed_previous_overview_limit(tmp_path):
+    store = SQLiteCostStore(str(tmp_path / "busy.db"))
+    rec = LLMCostRecord("busy", "0", "agent", "", "provider", "model", 2, 3, 0.5, True, "2026-06-01T00:00:00Z")
+    for i in range(10001):
+        store.record_cost(replace(rec, call_id=str(i)))
+    assert store.report_totals("busy")["total_calls"] == 10001
+    assert store.report_totals("busy")["total_cost_usd"] == 5000.5
+    assert store.report_totals("busy")["total_output_tokens"] == 30003
+
+
+def test_postgres_totals_and_filters_enforce_rls():
+    import os
+
+    from psycopg_pool import ConnectionPool
+
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_cost import PostgresCostStore
+
+    dsn = os.environ.get("COST_REPORT_TEST_POSTGRES_DSN")
+    if not dsn:
+        pytest.skip("requires isolated Postgres with a NOSUPERUSER NOBYPASSRLS test role")
+    with ConnectionPool(dsn) as pool:
+        store = PostgresCostStore(pool=pool)
+        token = set_current_tenant("cost-scope-a")
+        try:
+            rec = LLMCostRecord(
+                "cost-scope-a", "older", "old-agent", "", "provider", "model", 100, 50, 2.5, True, "2026-06-01T00:00:00Z", "eng"
+            )
+            store.record_cost(rec)
+            store.record_cost(replace(rec, call_id="newer", agent="new-agent", observed_at="2026-06-02T00:00:00Z"))
+            assert store.report_totals("cost-scope-a")["total_cost_usd"] == 5
+            assert store.report_totals("cost-scope-a", agent="old-agent", cost_center="eng")["total_calls"] == 1
+            assert store.list_records("cost-scope-a", agent="old-agent", cost_center="eng", limit=1)[0].call_id == "older"
+            sibling = set_current_tenant("cost-scope-b")
+            try:
+                store.record_cost(replace(rec, tenant_id="cost-scope-b", cost_usd=999))
+                assert store.report_totals("cost-scope-b")["total_cost_usd"] == 999
+            finally:
+                reset_current_tenant(sibling)
+            assert store.report_totals("cost-scope-b")["total_calls"] == 0
+            assert store.list_records("cost-scope-b") == []
+            assert store.report_totals("cost-scope-a")["total_calls"] == 2
+        finally:
+            reset_current_tenant(token)

--- a/tests/test_cost_reporting_scope.py
+++ b/tests/test_cost_reporting_scope.py
@@ -91,14 +91,14 @@ def test_totals_exceed_previous_overview_limit(tmp_path):
 def test_postgres_totals_and_filters_enforce_rls():
     import os
 
-    from psycopg_pool import ConnectionPool
-
     from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
     from agent_bom.api.postgres_cost import PostgresCostStore
 
     dsn = os.environ.get("COST_REPORT_TEST_POSTGRES_DSN")
     if not dsn:
         pytest.skip("requires isolated Postgres with a NOSUPERUSER NOBYPASSRLS test role")
+    from psycopg_pool import ConnectionPool
+
     with ConnectionPool(dsn) as pool:
         store = PostgresCostStore(pool=pool)
         token = set_current_tenant("cost-scope-a")


### PR DESCRIPTION
## Summary

- Aggregate headline spend, calls, tokens, unpriced calls, and agent counts over all retained matching records in memory, SQLite, and Postgres. Apply agent/cost-center filters before limiting detail history; expose its completeness separately.
- Use tenant spend for fallback tenant budgets. Withhold forecast projections when history is truncated or budget scope differs. Preserve unavailable cost storage as unavailable in Overview.
- Document estimated token pricing, retained-ledger scope, receipt timestamps, and missing billing categories.

## Verification

- Regression contract reproduced nine failures before the fix.
- `pytest -q tests/test_cost_reporting_scope.py tests/test_finops_costs.py tests/test_cost_forecast.py tests/test_postgres_cost_store.py tests/test_overview.py tests/test_overview_cache.py tests/test_hub_overview_cache.py`: 140 passed, one skipped.
- Real local Postgres test with NOSUPERUSER/NOBYPASSRLS role: scoped totals, pre-limit filtering, and RLS isolation passed. SQLite regression covers 10,001 records. Final 11 owning regressions passed after query formatting.
- Owning mypy, source pre-commit hooks, `make preflight`, and `git diff --check` passed.

## Notes

Totals describe estimated token cost in the retained ledger, not complete provider bills or company AI spend. Detail rollups remain bounded and expose `history.complete`; the companion UI change will surface this scope. No cloud resources or deployment were used for validation.
