### PR TITLE
feat(runtime): add managed profile clients and checkpointed feed CLI

### DIFF
--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -23,7 +23,7 @@ the caller wants to explore or to invoke — not by whether it is human.
 | Area | Shipped today |
 |---|---|
 | MCP security tools | 8 default scan tools; explicit full catalog: 86 tools, 7 resources, 8 workflow prompts |
-| REST API | 408 operations across 49 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
+| REST API | 409 operations across 49 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |
 | Runtime proxy | stdio/local MCP inline enforcement (7 detectors) |

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,8 +53,8 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 343 |
-| `docs/openapi/v1.json` | component schemas | 170 |
+| `docs/openapi/v1.json` | paths | 344 |
+| `docs/openapi/v1.json` | component schemas | 173 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-09-06",
+  "generated_on": "2026-09-08",
   "version": "0.104.0",
   "metrics": [
     {
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 895,
+      "value": 897,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-09-06`
+- Generated on: `2026-09-08`
 - Version: `0.104.0`
 
 | Metric | Value | Source | Notes |
@@ -17,7 +17,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
 | API route modules | 50 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 43 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 895 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 897 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
-- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (343 paths / 408 operations)
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (344 paths / 409 operations)
 
 ## AI / agent developers (MCP · clients · tools)
 

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -253,3 +253,78 @@ The runtime production index counts alert and metrics submissions under
 many calls. Blueprint comparison reports `comparison_scope:
 reported_activity_only`: an aligned result covers submitted activity only,
 not producer identity, unreported activity, or an approval of the deployment.
+
+## Managed profile CLI and SDK
+
+Use the authenticated control-plane API with a tenant and an operator credential.
+`agent-bom runtime profiles` manages server-side MCP config assignments bound to
+managed agent identities. `agent-bom profiles` remains the local CLI configuration
+selector. The assignment `config_id` is the runtime profile ID; its creation
+`profile_id` selects the identity's role blueprint.
+
+```bash
+export AGENT_BOM_API_URL=https://control-plane.example.com
+export AGENT_BOM_TENANT_ID=tenant-a
+# Inject AGENT_BOM_API_TOKEN through the operator's secret mechanism.
+agent-bom runtime profiles create --file managed-profile.json
+agent-bom runtime profiles list
+agent-bom runtime profiles validate CONFIG_ID --environment prod --scope tools:read
+agent-bom runtime profiles test CONFIG_ID --environment prod --scope tools:read \
+  --upstream filesystem --tool read_file
+```
+
+The JSON creation file uses the existing `/v1/mcp-config/assignments` contract:
+`name`, role-blueprint `profile_id`, `connector_ids`, managed `identity_id`, and
+`environment`, plus optional tool, scope, policy and connection constraints.
+Create requires an identity already provisioned in this tenant and a matching
+blueprint. Creation needs config permission; listing and authenticated contract
+previews need read permission. Responses contain assignment IDs and revisions,
+which can be used in the next command without copying credentials.
+
+Validate and test call `POST /v1/runtime/profiles/evaluate` with hypothetical
+issuer, environment and granted scopes. The canonical relay profile resolver
+checks tenant/identity bindings, lifecycle, expiry and constraints. Test also
+checks the proposed upstream/tool. A denied preview exits nonzero. Every result
+is marked `scope: profile_contract_only` and `executed: false`: a successful
+preview neither verifies a caller token nor runs an upstream, firewall, policy,
+quota or DLP check. Storage failures deny evaluation; anonymous requests are
+rejected even in development no-auth mode. Evaluation is audited without tool
+arguments or credentials.
+
+Python `AgentBomClient` provides `runtime_profiles`, `create_runtime_profile`,
+`get_runtime_profile`, `update_runtime_profile`, `revoke_runtime_profile`,
+`validate_runtime_profile`, and `test_runtime_profile`. The TypeScript client
+provides the equivalent camelCase methods. Updates send `expected_revision` and
+retain the existing optimistic-concurrency contract. Revoke is the rollback for
+an unwanted assignment; a stale or revoked profile fails closed at relay.
+
+## Checkpointed activity command
+
+```bash
+agent-bom runtime feed --cursor-file ./prod-activity.cursor.json --follow \
+  > activity-batches.jsonl
+```
+
+Each JSON line contains an SSE event, cursor ID and a complete canonical activity
+batch. The cursor file is atomically replaced with owner-only permissions after
+the batch is printed and stdout is flushed. It is bound to the API URL and tenant;
+use a separate file for each consumer. A crash after output but before checkpoint
+can replay a batch: downstream consumers must deduplicate `event_id`. The cursor
+is an acknowledgement of local output, not proof that an external sink committed
+it. Do not share a cursor file between concurrently running consumers.
+
+The command reconnects from its last completed batch and reauthenticates on each
+connection. Five consecutive transport failures stop follow mode. A retention
+gap, invalid cursor, authentication failure or unavailable ledger stops with a
+nonzero exit and preserves the checkpoint. Inspect the outage/retention boundary
+before explicitly starting with a new cursor file; the CLI never silently resets
+it. Without `--follow`, it reads one bounded server connection and exits.
+
+Python `client.gateway_activity(cursor=...)` and TypeScript
+`client.gatewayActivity({ cursor, signal })` yield complete frames for one
+connection. Save an activity/checkpoint ID only after consuming its entire batch,
+then reconnect with that ID. Both clients expose terminal `gap`, `unavailable`
+and `reconnect` events, reject malformed batches, and discard partial frames on
+disconnect. Close/break the iterator to release the HTTP response. These commands
+require the durable SQLite/Postgres activity store and its configured retention;
+the process-local metrics socket cannot supply this history.

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -47,7 +47,7 @@ docker compose -f deploy/docker-compose.pilot.yml up -d
 
 - Deployment chooser (Docker / Helm / EKS / Postgres):
   [`../site-docs/deployment/overview.md`](../site-docs/deployment/overview.md)
-- API contract (408 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
+- API contract (409 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
 - Enterprise auth, tenancy, RBAC: [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md),
   [`PERMISSIONS.md`](PERMISSIONS.md)
 - Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -85,7 +85,7 @@
 <rect x="569" y="834" width="497" height="64" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="585" y="852" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(589,856) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
 <text x="637" y="873" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">REST API + MCP</text>
-<text x="637" y="899" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">408 operations · 86 tools</text>
+<text x="637" y="899" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#82828c">409 operations · 86 tools</text>
 <rect x="569" y="908" width="497" height="64" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="585" y="926" width="38" height="38" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(589,930) scale(1.25)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
 <text x="637" y="947" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#e9e9ec">Fleet + scheduler</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -85,7 +85,7 @@
 <rect x="569" y="834" width="497" height="64" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="585" y="852" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(589,856) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
 <text x="637" y="873" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">REST API + MCP</text>
-<text x="637" y="899" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">408 operations · 86 tools</text>
+<text x="637" y="899" font-family="Inter,system-ui,sans-serif" font-size="14" font-weight="600" fill="#71717a">409 operations · 86 tools</text>
 <rect x="569" y="908" width="497" height="64" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="585" y="926" width="38" height="38" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(589,930) scale(1.25)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
 <text x="637" y="947" font-family="Inter,system-ui,sans-serif" font-size="17" font-weight="800" fill="#18181b">Fleet + scheduler</text>

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -45,7 +45,7 @@
 <rect x="659" y="158" width="586" height="88" rx="8" fill="none" stroke="#fb7185" opacity="0.4"/>
 <text x="669" y="182" font-family="ui-monospace,monospace" font-size="11.7" font-weight="800" letter-spacing="0.08em" fill="#fb7185">OUTCOME</text>
 <text x="749" y="182" font-family="Inter,system-ui,sans-serif" font-size="16.9" font-weight="800" fill="#e9e9ec">Agent-native inventory</text>
-<text x="749" y="203" font-family="Inter,system-ui,sans-serif" font-size="13.65" font-weight="600" fill="#82828c">408 API ops · 86 MCP tools</text>
+<text x="749" y="203" font-family="Inter,system-ui,sans-serif" font-size="13.65" font-weight="600" fill="#82828c">409 API ops · 86 MCP tools</text>
 <text x="669" y="228" font-family="ui-monospace,monospace" font-size="11.7" font-weight="800" letter-spacing="0.08em" fill="#fb7185">PROOF</text>
 <text x="749" y="228" font-family="Inter,system-ui,sans-serif" font-size="13.65" font-weight="700" fill="#e9e9ec">AI BOM · graph · runtime</text>
 <rect x="23" y="274" width="610" height="242" rx="12" fill="#38bdf8"/>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -45,7 +45,7 @@
 <rect x="659" y="158" width="586" height="88" rx="8" fill="none" stroke="#e11d48" opacity="0.4"/>
 <text x="669" y="182" font-family="ui-monospace,monospace" font-size="11.7" font-weight="800" letter-spacing="0.08em" fill="#e11d48">OUTCOME</text>
 <text x="749" y="182" font-family="Inter,system-ui,sans-serif" font-size="16.9" font-weight="800" fill="#18181b">Agent-native inventory</text>
-<text x="749" y="203" font-family="Inter,system-ui,sans-serif" font-size="13.65" font-weight="600" fill="#71717a">408 API ops · 86 MCP tools</text>
+<text x="749" y="203" font-family="Inter,system-ui,sans-serif" font-size="13.65" font-weight="600" fill="#71717a">409 API ops · 86 MCP tools</text>
 <text x="669" y="228" font-family="ui-monospace,monospace" font-size="11.7" font-weight="800" letter-spacing="0.08em" fill="#e11d48">PROOF</text>
 <text x="749" y="228" font-family="Inter,system-ui,sans-serif" font-size="13.65" font-weight="700" fill="#18181b">AI BOM · graph · runtime</text>
 <rect x="23" y="274" width="610" height="242" rx="12" fill="#0284c7"/>

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -7604,6 +7604,120 @@
         "title": "ReportJobRequest",
         "type": "object"
       },
+      "ResolvedRuntimeProfile": {
+        "description": "Secret-free authorization view for a single managed identity.",
+        "properties": {
+          "agent_id": {
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "allowed_tools": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Allowed Tools",
+            "type": "array"
+          },
+          "allowed_upstreams": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Allowed Upstreams",
+            "type": "array"
+          },
+          "blueprint_id": {
+            "title": "Blueprint Id",
+            "type": "string"
+          },
+          "blueprint_revision": {
+            "title": "Blueprint Revision",
+            "type": "integer"
+          },
+          "client_profile_id": {
+            "title": "Client Profile Id",
+            "type": "string"
+          },
+          "credential_references": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Credential References",
+            "type": "array"
+          },
+          "environment": {
+            "title": "Environment",
+            "type": "string"
+          },
+          "expires_at": {
+            "title": "Expires At",
+            "type": "string"
+          },
+          "identity_id": {
+            "title": "Identity Id",
+            "type": "string"
+          },
+          "issuer": {
+            "title": "Issuer",
+            "type": "string"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "policy_ids": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Policy Ids",
+            "type": "array"
+          },
+          "required_scopes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Required Scopes",
+            "type": "array"
+          },
+          "revision": {
+            "title": "Revision",
+            "type": "integer"
+          },
+          "schema_version": {
+            "default": "runtime.client.profile.v1",
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "client_profile_id",
+          "tenant_id",
+          "revision",
+          "blueprint_id",
+          "blueprint_revision",
+          "identity_id",
+          "agent_id",
+          "issuer",
+          "environment",
+          "allowed_upstreams",
+          "allowed_tools",
+          "required_scopes",
+          "policy_ids",
+          "credential_references",
+          "owner",
+          "status",
+          "expires_at"
+        ],
+        "title": "ResolvedRuntimeProfile",
+        "type": "object"
+      },
       "RotateKeyRequest": {
         "additionalProperties": false,
         "properties": {
@@ -7768,6 +7882,122 @@
           "observed_at"
         ],
         "title": "RuntimeEvidenceSignalIn",
+        "type": "object"
+      },
+      "RuntimeProfileEvaluationRequest": {
+        "additionalProperties": false,
+        "description": "Operator-supplied simulation context; never caller credentials or payloads.",
+        "properties": {
+          "config_id": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Config Id",
+            "type": "string"
+          },
+          "environment": {
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Environment",
+            "type": "string"
+          },
+          "granted_scopes": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 200,
+            "title": "Granted Scopes",
+            "type": "array"
+          },
+          "issuer": {
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Issuer",
+            "type": "string"
+          },
+          "tool": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool"
+          },
+          "upstream": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Upstream"
+          }
+        },
+        "required": [
+          "config_id",
+          "issuer",
+          "environment"
+        ],
+        "title": "RuntimeProfileEvaluationRequest",
+        "type": "object"
+      },
+      "RuntimeProfileEvaluationResponse": {
+        "properties": {
+          "executed": {
+            "const": false,
+            "default": false,
+            "title": "Executed",
+            "type": "boolean"
+          },
+          "profile": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ResolvedRuntimeProfile"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "profile_allowed": {
+            "title": "Profile Allowed",
+            "type": "boolean"
+          },
+          "profile_id": {
+            "title": "Profile Id",
+            "type": "string"
+          },
+          "reason_code": {
+            "title": "Reason Code",
+            "type": "string"
+          },
+          "schema_version": {
+            "const": "runtime.profile.evaluation.v1",
+            "default": "runtime.profile.evaluation.v1",
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "scope": {
+            "const": "profile_contract_only",
+            "default": "profile_contract_only",
+            "title": "Scope",
+            "type": "string"
+          }
+        },
+        "required": [
+          "profile_allowed",
+          "reason_code",
+          "profile_id"
+        ],
+        "title": "RuntimeProfileEvaluationResponse",
         "type": "object"
       },
       "SAMLLoginRequest": {
@@ -35626,6 +35856,98 @@
         "tags": [
           "runtime",
           "proxy"
+        ]
+      }
+    },
+    "/v1/runtime/profiles/evaluate": {
+      "post": {
+        "description": "Preview the canonical profile contract without issuing a grant or calling upstream.\n\nSupplied issuer, environment and scopes are simulation inputs. Policy,\nfirewall, DLP, quotas and live credential verification still run at relay.",
+        "operationId": "evaluate_runtime_profile_v1_runtime_profiles_evaluate_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RuntimeProfileEvaluationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeProfileEvaluationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Evaluate Runtime Profile",
+        "tags": [
+          "mcp-config"
         ]
       }
     },

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -5489,6 +5489,94 @@ components:
           title: Window Days
       title: ReportJobRequest
       type: object
+    ResolvedRuntimeProfile:
+      description: Secret-free authorization view for a single managed identity.
+      properties:
+        agent_id:
+          title: Agent Id
+          type: string
+        allowed_tools:
+          items:
+            type: string
+          title: Allowed Tools
+          type: array
+        allowed_upstreams:
+          items:
+            type: string
+          title: Allowed Upstreams
+          type: array
+        blueprint_id:
+          title: Blueprint Id
+          type: string
+        blueprint_revision:
+          title: Blueprint Revision
+          type: integer
+        client_profile_id:
+          title: Client Profile Id
+          type: string
+        credential_references:
+          items:
+            type: string
+          title: Credential References
+          type: array
+        environment:
+          title: Environment
+          type: string
+        expires_at:
+          title: Expires At
+          type: string
+        identity_id:
+          title: Identity Id
+          type: string
+        issuer:
+          title: Issuer
+          type: string
+        owner:
+          title: Owner
+          type: string
+        policy_ids:
+          items:
+            type: string
+          title: Policy Ids
+          type: array
+        required_scopes:
+          items:
+            type: string
+          title: Required Scopes
+          type: array
+        revision:
+          title: Revision
+          type: integer
+        schema_version:
+          default: runtime.client.profile.v1
+          title: Schema Version
+          type: string
+        status:
+          title: Status
+          type: string
+        tenant_id:
+          title: Tenant Id
+          type: string
+      required:
+      - client_profile_id
+      - tenant_id
+      - revision
+      - blueprint_id
+      - blueprint_revision
+      - identity_id
+      - agent_id
+      - issuer
+      - environment
+      - allowed_upstreams
+      - allowed_tools
+      - required_scopes
+      - policy_ids
+      - credential_references
+      - owner
+      - status
+      - expires_at
+      title: ResolvedRuntimeProfile
+      type: object
     RotateKeyRequest:
       additionalProperties: false
       properties:
@@ -5598,6 +5686,88 @@ components:
       - dedup_key
       - observed_at
       title: RuntimeEvidenceSignalIn
+      type: object
+    RuntimeProfileEvaluationRequest:
+      additionalProperties: false
+      description: Operator-supplied simulation context; never caller credentials
+        or payloads.
+      properties:
+        config_id:
+          maxLength: 200
+          minLength: 1
+          title: Config Id
+          type: string
+        environment:
+          maxLength: 120
+          minLength: 1
+          title: Environment
+          type: string
+        granted_scopes:
+          items:
+            type: string
+          maxItems: 200
+          title: Granted Scopes
+          type: array
+        issuer:
+          maxLength: 500
+          minLength: 1
+          title: Issuer
+          type: string
+        tool:
+          anyOf:
+          - maxLength: 200
+            minLength: 1
+            type: string
+          - type: 'null'
+          title: Tool
+        upstream:
+          anyOf:
+          - maxLength: 200
+            minLength: 1
+            type: string
+          - type: 'null'
+          title: Upstream
+      required:
+      - config_id
+      - issuer
+      - environment
+      title: RuntimeProfileEvaluationRequest
+      type: object
+    RuntimeProfileEvaluationResponse:
+      properties:
+        executed:
+          const: false
+          default: false
+          title: Executed
+          type: boolean
+        profile:
+          anyOf:
+          - $ref: '#/components/schemas/ResolvedRuntimeProfile'
+          - type: 'null'
+        profile_allowed:
+          title: Profile Allowed
+          type: boolean
+        profile_id:
+          title: Profile Id
+          type: string
+        reason_code:
+          title: Reason Code
+          type: string
+        schema_version:
+          const: runtime.profile.evaluation.v1
+          default: runtime.profile.evaluation.v1
+          title: Schema Version
+          type: string
+        scope:
+          const: profile_contract_only
+          default: profile_contract_only
+          title: Scope
+          type: string
+      required:
+      - profile_allowed
+      - reason_code
+      - profile_id
+      title: RuntimeProfileEvaluationResponse
       type: object
     SAMLLoginRequest:
       additionalProperties: false
@@ -23588,6 +23758,63 @@ paths:
       tags:
       - runtime
       - proxy
+  /v1/runtime/profiles/evaluate:
+    post:
+      description: 'Preview the canonical profile contract without issuing a grant
+        or calling upstream.
+
+
+        Supplied issuer, environment and scopes are simulation inputs. Policy,
+
+        firewall, DLP, quotas and live credential verification still run at relay.'
+      operationId: evaluate_runtime_profile_v1_runtime_profiles_evaluate_post
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RuntimeProfileEvaluationRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuntimeProfileEvaluationResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Evaluate Runtime Profile
+      tags:
+      - mcp-config
   /v1/runtime/sessions:
     get:
       description: List tenant-scoped runtime sessions derived from persisted observations.

--- a/sdks/typescript-client/src/index.ts
+++ b/sdks/typescript-client/src/index.ts
@@ -560,6 +560,86 @@ export class AgentBomClient {
     return this.request<Record<string, JsonValue>>("GET", "/v1/intel/sources");
   }
 
+  runtimeProfiles(): Promise<Record<string, JsonValue>> {
+    return this.request("GET", "/v1/mcp-config/assignments");
+  }
+
+  createRuntimeProfile(profile: Record<string, JsonValue>): Promise<Record<string, JsonValue>> {
+    if (!profile.identity_id || !profile.environment) {
+      throw new Error("Managed runtime profiles require identity_id and environment");
+    }
+    return this.request("POST", "/v1/mcp-config/assignments", profile);
+  }
+
+  getRuntimeProfile(configId: string): Promise<Record<string, JsonValue>> {
+    return this.request("GET", `/v1/mcp-config/assignments/${encodeURIComponent(configId)}`);
+  }
+
+  updateRuntimeProfile(configId: string, profile: Record<string, JsonValue>): Promise<Record<string, JsonValue>> {
+    return this.request("PUT", `/v1/mcp-config/assignments/${encodeURIComponent(configId)}`, profile);
+  }
+
+  revokeRuntimeProfile(configId: string): Promise<Record<string, JsonValue>> {
+    return this.request("POST", `/v1/mcp-config/assignments/${encodeURIComponent(configId)}/revoke`);
+  }
+
+  /** Profile-contract preview only: does not verify credentials or authorize a call. */
+  validateRuntimeProfile(configId: string, context: RuntimeProfileContext): Promise<Record<string, JsonValue>> {
+    return this.request("POST", "/v1/runtime/profiles/evaluate", { ...context, config_id: configId });
+  }
+
+  /** Simulate a tool target without executing the upstream or its policy/DLP checks. */
+  testRuntimeProfile(configId: string, context: RuntimeProfileContext & { upstream: string; tool: string }): Promise<Record<string, JsonValue>> {
+    return this.request("POST", "/v1/runtime/profiles/evaluate", { ...context, config_id: configId });
+  }
+
+  /** One SSE connection. Persist each id only after processing the complete batch.
+   * Terminal frames are returned; callers reconnect using their last committed id.
+   */
+  async *gatewayActivity(options: { cursor?: string; limit?: number; signal?: AbortSignal } = {}): AsyncGenerator<GatewayActivityFrame> {
+    const headers = { ...this.headers(false), accept: "text/event-stream", ...(options.cursor ? { "Last-Event-ID": options.cursor } : {}) };
+    const response = await this.fetchImpl(this.url(`/v1/gateway/feed/stream?limit=${options.limit ?? 200}`), { headers, ...(options.signal ? { signal: options.signal } : {}) });
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new AgentBomApiError("Activity stream request failed", response.status, "");
+    }
+    if (!response.headers.get("content-type")?.includes("text/event-stream") || !response.body) {
+      await response.body?.cancel();
+      throw new Error("Expected activity event stream");
+    }
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder("utf-8", { fatal: true });
+    let buffer = "";
+    let lines: string[] = [];
+    let frameBytes = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) return; // A partial frame is never committed.
+        buffer += decoder.decode(value, { stream: true });
+        let end: number;
+        while ((end = buffer.indexOf("\n")) >= 0) {
+          const raw = buffer.slice(0, end);
+          buffer = buffer.slice(end + 1);
+          frameBytes += new TextEncoder().encode(raw).length + 1;
+          if (frameBytes > 32 * 1024 * 1024) throw new Error("Activity stream frame exceeds limit");
+          const line = raw.replace(/\r$/, "");
+          if (line) { lines.push(line); continue; }
+          const frame = parseActivityFrame(lines);
+          lines = [];
+          frameBytes = 0;
+          if (frame) {
+            yield frame;
+            if (["gap", "unavailable", "reconnect"].includes(frame.event)) return;
+          }
+        }
+        if (frameBytes + new TextEncoder().encode(buffer).length > 32 * 1024 * 1024) throw new Error("Activity stream frame exceeds limit");
+      }
+    } finally {
+      try { await reader.cancel(); } finally { reader.releaseLock(); }
+    }
+  }
+
   async request<T>(
     method: string,
     path: string,
@@ -632,4 +712,39 @@ function stripUndefined(
       return entry[1] !== undefined;
     }),
   );
+}
+
+export interface RuntimeProfileContext {
+  issuer: string;
+  environment: string;
+  granted_scopes?: string[];
+}
+
+export interface GatewayActivityFrame {
+  event: "activity" | "checkpoint" | "gap" | "unavailable" | "reconnect";
+  id: string;
+  data: Record<string, JsonValue>;
+}
+
+function parseActivityFrame(lines: string[]): GatewayActivityFrame | undefined {
+  let event = "message", id = "";
+  const data: string[] = [];
+  for (const line of lines) {
+    const colon = line.indexOf(":");
+    const key = colon < 0 ? line : line.slice(0, colon);
+    const value = colon < 0 ? "" : line.slice(colon + 1).replace(/^ /, "");
+    if (key === "event") event = value;
+    else if (key === "id") id = value;
+    else if (key === "data") data.push(value);
+  }
+  if (!data.length) return undefined;
+  let payload: Record<string, JsonValue>;
+  try { payload = JSON.parse(data.join("\n")); } catch { throw new Error("Invalid activity stream JSON"); }
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) throw new Error("Invalid activity stream payload");
+  if (event === "activity" || event === "checkpoint") {
+    if (payload.schema_version !== "gateway.activity.stream.v1" || !id || payload.next_cursor !== id || !Array.isArray(payload.events)) {
+      throw new Error("Invalid activity stream checkpoint");
+    }
+  } else if (!["gap", "unavailable", "reconnect"].includes(event)) throw new Error("Unknown activity stream event");
+  return { event: event as GatewayActivityFrame["event"], id, data: payload };
 }

--- a/sdks/typescript-client/tests/runtime.test.js
+++ b/sdks/typescript-client/tests/runtime.test.js
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { AgentBomClient } from "../dist/index.js";
+
+const wire = (id = "cursor-1") => `event: activity\r\nid: ${id}\r\ndata: ${JSON.stringify({ schema_version: "gateway.activity.stream.v1", next_cursor: id, events: [{ event_id: "caf\u00e9" }] })}\r\n\r\n`;
+
+test("managed profiles forward credentials, tenant, revision and simulation context", async () => {
+  const requests = [];
+  const client = new AgentBomClient({ baseUrl: "https://api.example", bearerToken: "secret", tenantId: "a", fetch: async (url, init) => {
+    requests.push({ url, init });
+    return new Response("{}", { headers: { "content-type": "application/json" } });
+  }});
+  await client.runtimeProfiles();
+  await client.createRuntimeProfile({ identity_id: "id", environment: "prod" });
+  await client.getRuntimeProfile("a/b");
+  await client.updateRuntimeProfile("id", { expected_revision: 3 });
+  await client.revokeRuntimeProfile("id");
+  await client.validateRuntimeProfile("id", { issuer: "agent-bom", environment: "prod" });
+  await client.testRuntimeProfile("id", { issuer: "agent-bom", environment: "prod", upstream: "fs", tool: "read" });
+  assert.throws(() => client.createRuntimeProfile({}), /require/);
+  assert.equal(requests.length, 7);
+  assert.ok(requests[2].url.endsWith("a%2Fb"));
+  assert.equal(JSON.parse(requests[3].init.body).expected_revision, 3);
+  assert.equal(JSON.parse(requests[6].init.body).tool, "read");
+  assert.ok(requests.every(({ init }) => init.headers.authorization === "Bearer secret" && init.headers["x-agent-bom-tenant-id"] === "a"));
+});
+
+test("fragmented UTF-8 frames resume with cursor and cancel after terminal gap", async () => {
+  let cancelled = false;
+  const bytes = new TextEncoder().encode(wire() + 'event: gap\ndata: {"reason":"cursor_expired"}\n\n');
+  let offset = 0;
+  const client = new AgentBomClient({ baseUrl: "https://api.example", fetch: async (_url, init) => {
+    assert.equal(init.headers["Last-Event-ID"], "old");
+    return new Response(new ReadableStream({
+      pull(controller) { if (offset < bytes.length) controller.enqueue(bytes.slice(offset, ++offset)); },
+      cancel() { cancelled = true; },
+    }), { headers: { "content-type": "text/event-stream" } });
+  }});
+  const frames = [];
+  for await (const frame of client.gatewayActivity({ cursor: "old" })) frames.push(frame);
+  assert.deepEqual(frames.map(f => f.event), ["activity", "gap"]);
+  assert.equal(frames[0].data.events[0].event_id, "caf\u00e9");
+  assert.equal(cancelled, true);
+});
+
+test("partial disconnect does not fabricate a checkpoint", async () => {
+  const client = new AgentBomClient({ baseUrl: "https://api.example", fetch: async () => new Response(wire() + "event: activity\nid: incomplete", { headers: { "content-type": "text/event-stream" } }) });
+  const frames = [];
+  for await (const frame of client.gatewayActivity()) frames.push(frame);
+  assert.equal(frames.length, 1);
+});
+
+test("malformed and expired streams fail without returning raw server errors", async () => {
+  const expired = new AgentBomClient({ baseUrl: "https://api.example", fetch: async () => new Response("secret", { status: 410 }) });
+  await assert.rejects(async () => { for await (const _ of expired.gatewayActivity()) {} }, err => err.status === 410 && !String(err).includes("secret"));
+  const malformed = new AgentBomClient({ baseUrl: "https://api.example", fetch: async () => new Response("event: activity\nid: a\ndata: {}\n\n", { headers: { "content-type": "text/event-stream" } }) });
+  await assert.rejects(async () => { for await (const _ of malformed.gatewayActivity()) {} }, /Invalid activity stream checkpoint/);
+});

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -42,6 +42,7 @@ verbs are additive entry points that delegate to the underlying implementations.
 
 | Command | Description |
 |---------|-------------|
+| `runtime` | Manage identity-bound profiles with `profiles create/validate/list/test`; consume durable activity with `feed --cursor-file PATH --follow` |
 | `proxy` | Run an MCP server through the agent-bom security proxy |
 | `watch` | Watch MCP client configuration files for drift and alert on new risks |
 | `audit` | View and analyze a proxy audit JSONL log |

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1211,6 +1211,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         # return no key material and were viewer-reachable before the mutating
         # admin fallback below; keep them explicitly viewer so the fallback
         # doesn't silently lock viewers/analysts out of read-only surfaces.
+        ("POST", "/v1/runtime/profiles/evaluate", "viewer"),
         ("POST", "/v1/graph/query", "viewer"),
         ("POST", "/v1/graph/should-i-deploy", "viewer"),
         ("GET", "/v1/graph/scenarios", "viewer"),

--- a/src/agent_bom/api/routes/mcp_config.py
+++ b/src/agent_bom/api/routes/mcp_config.py
@@ -20,10 +20,11 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
+import anyio.to_thread
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from agent_bom.api.audit_log import log_action
 from agent_bom.api.mcp_config_store import (
@@ -39,6 +40,7 @@ from agent_bom.api.mcp_config_store import (
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.api.versioning import API_V1_PREFIX
 from agent_bom.rbac import require_authenticated_permission
+from agent_bom.runtime.profile_resolution import ResolvedRuntimeProfile, resolve_runtime_profile
 from agent_bom.runtime_blueprints import runtime_role_blueprint
 
 if TYPE_CHECKING:
@@ -122,6 +124,113 @@ class McpConfigAssignmentUpdate(BaseModel):
     @classmethod
     def _normalize_expiry(cls, value: str) -> str:
         return _normalize_expiry_value(value)
+
+
+class RuntimeProfileEvaluationRequest(BaseModel):
+    """Operator-supplied simulation context; never caller credentials or payloads."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+    config_id: str = Field(min_length=1, max_length=200)
+    issuer: str = Field(min_length=1, max_length=500)
+    environment: str = Field(min_length=1, max_length=120)
+    granted_scopes: list[str] = Field(default_factory=list, max_length=200)
+    upstream: str | None = Field(default=None, min_length=1, max_length=200)
+    tool: str | None = Field(default=None, min_length=1, max_length=200)
+
+    @field_validator("granted_scopes")
+    @classmethod
+    def _normalize_scopes(cls, values: list[str]) -> list[str]:
+        return _normalize_string_list(values)
+
+    @model_validator(mode="after")
+    def _target_pair(self) -> RuntimeProfileEvaluationRequest:
+        if self.tool is not None and self.upstream is None:
+            raise ValueError("upstream is required when testing a tool")
+        return self
+
+
+class RuntimeProfileEvaluationResponse(BaseModel):
+    schema_version: Literal["runtime.profile.evaluation.v1"] = "runtime.profile.evaluation.v1"
+    scope: Literal["profile_contract_only"] = "profile_contract_only"
+    executed: Literal[False] = False
+    profile_allowed: bool
+    reason_code: str
+    profile_id: str
+    profile: ResolvedRuntimeProfile | None = None
+
+
+@router.post(
+    "/runtime/profiles/evaluate",
+    dependencies=[cast(Any, require_authenticated_permission("read"))],
+    response_model=RuntimeProfileEvaluationResponse,
+)
+async def evaluate_runtime_profile(request: Request, body: RuntimeProfileEvaluationRequest) -> RuntimeProfileEvaluationResponse:
+    """Preview the canonical profile contract without issuing a grant or calling upstream.
+
+    Supplied issuer, environment and scopes are simulation inputs. Policy,
+    firewall, DLP, quotas and live credential verification still run at relay.
+    """
+    if str(getattr(request.state, "auth_method", "") or "") in {"", "anonymous", "no_auth"}:
+        raise HTTPException(status_code=401, detail="Authentication required for runtime profile evaluation")
+    tenant_id = _tenant(request)
+    config_id = body.config_id
+
+    def evaluate() -> RuntimeProfileEvaluationResponse:
+        from agent_bom.api.agent_identity_store import get_agent_identity_store
+
+        store = get_mcp_config_store()
+        assignment = store.get(tenant_id, config_id)
+        if assignment is None:
+            raise HTTPException(status_code=404, detail="MCP-client-config assignment not found")
+        profile = None
+        reason = "managed_identity_required"
+        if assignment.revoked or assignment.status == "revoked":
+            reason = "profile_revoked"
+        elif assignment.status != "active":
+            reason = "profile_disabled"
+        elif assignment.identity_id:
+            identity = get_agent_identity_store().get(assignment.identity_id, tenant_id=tenant_id)
+            if identity is None:
+                reason = "identity_invalid"
+            else:
+                resolution = resolve_runtime_profile(
+                    store,
+                    identity=identity,
+                    tenant_id=tenant_id,
+                    issuer=body.issuer,
+                    environment=body.environment,
+                    granted_scopes=set(body.granted_scopes),
+                )
+                reason = resolution.code.value
+                profile = resolution.profile
+                if profile is not None and profile.client_profile_id != config_id:
+                    profile = None
+                    reason = "profile_binding_changed"
+                if profile is not None and body.upstream is not None and not profile.allows_upstream(body.upstream):
+                    reason = "upstream_not_allowed"
+                elif profile is not None and body.tool is not None and not profile.allows_tool(body.tool):
+                    reason = "tool_not_allowed"
+        log_action(
+            "mcp_config.profile_evaluated",
+            actor=_actor(request),
+            resource=f"mcp-config/{config_id}",
+            tenant_id=tenant_id,
+            reason_code=reason,
+            executed=False,
+        )
+        return RuntimeProfileEvaluationResponse(
+            profile_allowed=reason == "resolved",
+            reason_code=reason,
+            profile_id=config_id,
+            profile=profile,
+        )
+
+    try:
+        return await anyio.to_thread.run_sync(evaluate)
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001 - fail closed without backend exception text
+        raise HTTPException(status_code=503, detail="Runtime profile evaluation unavailable") from exc
 
 
 def _dep(permission: str) -> Any:

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -253,8 +253,8 @@ from agent_bom.cli._runtime import (  # noqa: E402
 )
 
 # ---------------------------------------------------------------------------
-# Runtime command group — hidden compatibility namespace.
-# Prefer top-level commands: `agent-bom proxy`, `agent-bom watch`, `agent-bom audit`.
+# Runtime group owns managed profiles and durable activity.
+# Proxy/watch/audit also retain their top-level shortcuts.
 # ---------------------------------------------------------------------------
 from agent_bom.cli._runtime_group import runtime_group  # noqa: E402
 
@@ -272,7 +272,7 @@ runtime_group.add_command(_runtime_watch_hidden, "watch")
 runtime_group.commands["configure"].hidden = True
 runtime_group.commands["protect"].hidden = True
 main.add_command(runtime_group)
-main.commands["runtime"].hidden = True  # Use proxy/watch/audit directly
+
 
 # Top-level shortcuts for primary runtime commands
 main.add_command(proxy_cmd, "proxy")

--- a/src/agent_bom/cli/_runtime_group.py
+++ b/src/agent_bom/cli/_runtime_group.py
@@ -12,17 +12,20 @@ from __future__ import annotations
 import click
 
 from agent_bom.cli._grouped_help import SuggestingGroup
+from agent_bom.cli._runtime_profiles import runtime_feed, runtime_profiles
 
 
 @click.group("runtime", cls=SuggestingGroup, invoke_without_command=True)
 @click.pass_context
 def runtime_group(ctx: click.Context) -> None:
-    """Runtime enforcement — proxy and audit MCP traffic.
+    """Runtime enforcement, managed profiles and durable activity.
 
     \b
     Subcommands:
       proxy       Run MCP server through security proxy
       audit       View and analyze proxy audit log
+      profiles    Create and preview managed runtime profiles
+      feed        Read checkpointed gateway activity
 
     Hidden compatibility commands:
       protect     Runtime protection engine (8 behavioral detectors)
@@ -30,3 +33,7 @@ def runtime_group(ctx: click.Context) -> None:
     """
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
+
+
+runtime_group.add_command(runtime_profiles)
+runtime_group.add_command(runtime_feed)

--- a/src/agent_bom/cli/_runtime_profiles.py
+++ b/src/agent_bom/cli/_runtime_profiles.py
@@ -1,0 +1,169 @@
+"""Managed runtime profile operations and checkpointed gateway activity output."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import click
+import httpx
+
+from agent_bom.cli._findings_group import _common_api_options, _make_client
+from agent_bom.client import AgentBomApiError
+
+
+@click.group("profiles")
+def runtime_profiles() -> None:
+    """Manage tenant runtime profiles (separate from local CLI configurations)."""
+
+
+def _profile_request(operation: str, api: dict[str, Any], *args: Any, **kwargs: Any) -> None:
+    try:
+        with _make_client(**api) as client:
+            result = getattr(client, operation)(*args, **kwargs)
+        click.echo(json.dumps(result, indent=2))
+        if result.get("profile_allowed") is False:
+            raise click.exceptions.Exit(1)
+    except AgentBomApiError as exc:
+        raise click.ClickException(f"Runtime profile request failed (HTTP {exc.status_code})") from None
+    except (httpx.HTTPError, ValueError, OSError):
+        raise click.ClickException("Runtime profile request unavailable or invalid; check API configuration and input") from None
+
+
+@runtime_profiles.command("create")
+@click.option("--file", "profile_file", required=True, type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@_common_api_options
+def create(profile_file: Path, **api: Any) -> None:
+    """Create a managed assignment from JSON with identity_id and environment."""
+    try:
+        profile = json.loads(profile_file.read_text())
+        if not isinstance(profile, dict):
+            raise ValueError
+    except (ValueError, OSError):
+        raise click.ClickException("Profile file must contain a JSON object") from None
+    _profile_request("create_runtime_profile", api, profile)
+
+
+@runtime_profiles.command("list")
+@_common_api_options
+def list_profiles(**api: Any) -> None:
+    """List tenant assignments with revisions, bindings and lifecycle state."""
+    _profile_request("runtime_profiles", api)
+
+
+def _context_options(fn: Any) -> Any:
+    fn = click.argument("config_id")(fn)
+    fn = click.option("--issuer", default="agent-bom", show_default=True)(fn)
+    fn = click.option("--environment", required=True)(fn)
+    return click.option("--scope", "granted_scopes", multiple=True, help="Hypothetical granted scope; repeatable.")(fn)
+
+
+@runtime_profiles.command("validate")
+@_context_options
+@_common_api_options
+def validate(config_id: str, issuer: str, environment: str, granted_scopes: tuple[str, ...], **api: Any) -> None:
+    """Preview binding validity. Does not verify credentials or authorize calls."""
+    _profile_request("validate_runtime_profile", api, config_id, issuer=issuer, environment=environment, granted_scopes=granted_scopes)
+
+
+@runtime_profiles.command("test")
+@_context_options
+@click.option("--upstream", required=True)
+@click.option("--tool", required=True)
+@_common_api_options
+def test_profile(
+    config_id: str, issuer: str, environment: str, granted_scopes: tuple[str, ...], upstream: str, tool: str, **api: Any
+) -> None:
+    """Preview a tool target against the profile. No upstream execution or DLP test."""
+    _profile_request(
+        "test_runtime_profile",
+        api,
+        config_id,
+        issuer=issuer,
+        environment=environment,
+        granted_scopes=granted_scopes,
+        upstream=upstream,
+        tool=tool,
+    )
+
+
+def _save_checkpoint(path: Path, binding: dict[str, str], cursor: str) -> None:
+    """Atomic owner-only checkpoint, written after the output frame is flushed."""
+    fd, temporary = tempfile.mkstemp(prefix=".activity-cursor-", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as stream:
+            json.dump({**binding, "cursor": cursor}, stream)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+@click.command("feed")
+@_common_api_options
+@click.option(
+    "--cursor-file", required=True, type=click.Path(dir_okay=False, path_type=Path), help="Checkpoint bound to API URL and tenant."
+)
+@click.option("--follow", is_flag=True, help="Reconnect using the last fully printed batch cursor.")
+@click.option("--limit", default=200, type=click.IntRange(1, 500), show_default=True)
+def runtime_feed(cursor_file: Path, follow: bool, limit: int, **api: Any) -> None:
+    """Print durable activity batches as JSON lines. Stops explicitly on any gap.
+
+    A crash between output and checkpoint can replay a batch. Consumers should
+    deduplicate event_id. Retention loss requires an explicit operator restart
+    with a new cursor file; it is never silently skipped.
+    """
+    try:
+        with _make_client(**api) as client:
+            binding = {"api_url": client.base_url, "tenant_id": client.tenant_id or ""}
+            cursor = None
+            if cursor_file.exists():
+                saved = json.loads(cursor_file.read_text())
+                if (
+                    not isinstance(saved, dict)
+                    or any(saved.get(k) != v for k, v in binding.items())
+                    or not isinstance(saved.get("cursor"), str)
+                    or not saved["cursor"]
+                ):
+                    raise click.ClickException("Cursor file does not match this API and tenant, or is invalid")
+                cursor = saved["cursor"]
+            failures = 0
+            while True:
+                try:
+                    for frame in client.gateway_activity(cursor=cursor, limit=limit):
+                        event = frame["event"]
+                        if event == "gap":
+                            raise click.ClickException(
+                                "Activity gap detected; checkpoint retained. Review retention before starting a new cursor file"
+                            )
+                        if event == "unavailable":
+                            raise click.ClickException("Activity ledger unavailable; checkpoint retained")
+                        if event in {"activity", "checkpoint"}:
+                            click.echo(json.dumps(frame))
+                            sys.stdout.flush()
+                            _save_checkpoint(cursor_file, binding, frame["id"])
+                            cursor = frame["id"]
+                            failures = 0
+                except httpx.TransportError:
+                    failures += 1
+                    if not follow or failures > 5:
+                        raise
+                if not follow:
+                    return
+                time.sleep(min(2**failures, 30))
+    except AgentBomApiError as exc:
+        message = (
+            "Activity cursor expired; checkpoint retained"
+            if exc.status_code == 410
+            else f"Activity request failed (HTTP {exc.status_code}); checkpoint retained"
+        )
+        raise click.ClickException(message) from None
+    except (httpx.HTTPError, ValueError, OSError):
+        raise click.ClickException("Activity stream or checkpoint unavailable; last checkpoint retained") from None

--- a/src/agent_bom/client.py
+++ b/src/agent_bom/client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from typing import Any, TypeAlias
 from urllib.parse import quote
 
@@ -68,6 +68,78 @@ class AgentBomClient:
 
     def __exit__(self, *_exc: object) -> None:
         self.close()
+
+    def runtime_profiles(self) -> JsonObject:
+        """List tenant-scoped assignments, including lifecycle status and revisions."""
+        return self._request("GET", "/v1/mcp-config/assignments")
+
+    def create_runtime_profile(self, profile: JsonObject) -> JsonObject:
+        """Create a managed assignment; profile_id is its role blueprint."""
+        if not profile.get("identity_id") or not profile.get("environment"):
+            raise ValueError("Managed runtime profiles require identity_id and environment")
+        return self._request("POST", "/v1/mcp-config/assignments", json=profile)
+
+    def get_runtime_profile(self, config_id: str) -> JsonObject:
+        return self._request("GET", f"/v1/mcp-config/assignments/{quote(config_id, safe='')}")
+
+    def update_runtime_profile(self, config_id: str, profile: JsonObject) -> JsonObject:
+        """Replace profile settings using the required expected_revision field."""
+        return self._request("PUT", f"/v1/mcp-config/assignments/{quote(config_id, safe='')}", json=profile)
+
+    def revoke_runtime_profile(self, config_id: str) -> JsonObject:
+        return self._request("POST", f"/v1/mcp-config/assignments/{quote(config_id, safe='')}/revoke")
+
+    def validate_runtime_profile(self, config_id: str, *, issuer: str, environment: str, granted_scopes: Sequence[str] = ()) -> JsonObject:
+        """Preview the profile contract; this neither verifies credentials nor grants access."""
+        return self._request(
+            "POST",
+            "/v1/runtime/profiles/evaluate",
+            json={
+                "config_id": config_id,
+                "issuer": issuer,
+                "environment": environment,
+                "granted_scopes": list(granted_scopes),
+            },
+        )
+
+    def test_runtime_profile(
+        self, config_id: str, *, issuer: str, environment: str, upstream: str, tool: str, granted_scopes: Sequence[str] = ()
+    ) -> JsonObject:
+        """Preview a target against the profile only; never executes a tool or its policies."""
+        return self._request(
+            "POST",
+            "/v1/runtime/profiles/evaluate",
+            json={
+                "config_id": config_id,
+                "issuer": issuer,
+                "environment": environment,
+                "granted_scopes": list(granted_scopes),
+                "upstream": upstream,
+                "tool": tool,
+            },
+        )
+
+    def gateway_activity(self, *, cursor: str | None = None, limit: int = 200) -> Iterator[dict[str, Any]]:
+        """Read one SSE connection. Commit frame ids after processing their entire batch.
+
+        Reconnect with the last committed id. Terminal gap/unavailable/reconnect
+        frames are surfaced to the caller; no implicit cursor reset or retry.
+        Closing the iterator closes the response.
+        """
+        from agent_bom.runtime.activity_stream import decode_activity_stream
+
+        headers = {**self._headers(False), "accept": "text/event-stream"}
+        if cursor:
+            headers["Last-Event-ID"] = cursor
+        with self._client.stream("GET", self._url("/v1/gateway/feed/stream"), headers=headers, params={"limit": limit}) as response:
+            if not response.is_success:
+                raise AgentBomApiError("Activity stream request failed", status_code=response.status_code, body="")
+            if "text/event-stream" not in response.headers.get("content-type", ""):
+                raise ValueError("Expected activity event stream")
+            for frame in decode_activity_stream(response.iter_bytes()):
+                yield frame
+                if frame["event"] in {"gap", "unavailable", "reconnect"}:
+                    return
 
     def health(self) -> JsonObject:
         """Return the control-plane health envelope."""

--- a/src/agent_bom/runtime/activity_stream.py
+++ b/src/agent_bom/runtime/activity_stream.py
@@ -1,0 +1,70 @@
+"""Bounded SSE decoding for the durable gateway activity contract."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+MAX_FRAME_BYTES = 32 * 1024 * 1024
+
+
+def decode_activity_stream(chunks: Iterable[bytes]) -> Iterator[dict[str, Any]]:
+    """Yield complete frames only; a disconnected partial frame is never committed.
+
+    Consumers checkpoint the returned id only after processing the entire data
+    batch. A gap is terminal and must never be silently replaced by a fresh cursor.
+    """
+    buffer = b""
+    lines: list[str] = []
+    frame_bytes = 0
+    for chunk in chunks:
+        buffer += chunk
+        while b"\n" in buffer:
+            line, buffer = buffer.split(b"\n", 1)
+            frame_bytes += len(line) + 1
+            if frame_bytes > MAX_FRAME_BYTES:
+                raise ValueError("Activity stream frame exceeds limit")
+            decoded = line.rstrip(b"\r").decode("utf-8")
+            if decoded:
+                lines.append(decoded)
+                continue
+            frame = _frame(lines)
+            lines = []
+            frame_bytes = 0
+            if frame is not None:
+                yield frame
+        if frame_bytes + len(buffer) > MAX_FRAME_BYTES:
+            raise ValueError("Activity stream frame exceeds limit")
+
+
+def _frame(lines: list[str]) -> dict[str, Any] | None:
+    event, cursor, data = "message", "", []
+    for line in lines:
+        key, _, value = line.partition(":")
+        value = value.removeprefix(" ")
+        if key == "event":
+            event = value
+        elif key == "id":
+            cursor = value
+        elif key == "data":
+            data.append(value)
+    if not data:
+        return None
+    try:
+        payload = json.loads("\n".join(data))
+    except (ValueError, RecursionError):
+        raise ValueError("Invalid activity stream JSON") from None
+    if not isinstance(payload, dict):
+        raise ValueError("Invalid activity stream payload")
+    if event in {"activity", "checkpoint"}:
+        if (
+            payload.get("schema_version") != "gateway.activity.stream.v1"
+            or not cursor
+            or payload.get("next_cursor") != cursor
+            or not isinstance(payload.get("events"), list)
+        ):
+            raise ValueError("Invalid activity stream checkpoint")
+    elif event not in {"gap", "unavailable", "reconnect"}:
+        raise ValueError("Unknown activity stream event")
+    return {"event": event, "id": cursor, "data": payload}

--- a/tests/api/test_runtime_profile_evaluation.py
+++ b/tests/api/test_runtime_profile_evaluation.py
@@ -1,0 +1,97 @@
+"""Operator profile previews must use the same fail-closed resolver as relay."""
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.agent_identity_store import InMemoryAgentIdentityStore, set_agent_identity_store
+from agent_bom.api.mcp_config_store import InMemoryMcpConfigStore, set_mcp_config_store
+from agent_bom.api.server import app, configure_api
+from tests.test_runtime_profile_resolution import _assignment, _identity
+
+URL = "/v1/runtime/profiles/evaluate"
+SECRET = "runtime-profile-preview-secret-at-least-32-bytes"
+HEADERS = {"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Tenant-ID": "tenant-a", "X-Agent-Bom-Proxy-Secret": SECRET}
+CONTEXT = {"config_id": "client-profile-finance-prod", "issuer": "agent-bom", "environment": "prod", "granted_scopes": ["tools:read"]}
+
+
+@pytest.fixture(autouse=True)
+def stores(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", SECRET)
+    configure_api(api_key=None)
+    identities = InMemoryAgentIdentityStore()
+    identities.put(_identity())
+    profiles = InMemoryMcpConfigStore()
+    profiles.put(_assignment())
+    set_agent_identity_store(identities)
+    set_mcp_config_store(profiles)
+    yield profiles, identities
+    set_agent_identity_store(None)
+    set_mcp_config_store(None)
+    configure_api(api_key=None)
+
+
+def test_profile_preview_is_metadata_only_and_not_a_gateway_authorization():
+    response = TestClient(app).post(URL, headers=HEADERS, json={**CONTEXT, "upstream": "filesystem", "tool": "read_file"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["profile_allowed"] is True
+    assert body["executed"] is False
+    assert body["scope"] == "profile_contract_only"
+    assert body["profile"]["client_profile_id"] == "client-profile-finance-prod"
+    assert body["profile"]["blueprint_id"] == "finance"
+    assert "token_hash" not in response.text
+    assert "must-never-leave" not in response.text
+
+
+@pytest.mark.parametrize(
+    "context,reason",
+    [
+        ({"environment": "dev"}, "environment_mismatch"),
+        ({"issuer": "foreign"}, "issuer_mismatch"),
+        ({"granted_scopes": []}, "insufficient_scope"),
+        ({"upstream": "other", "tool": "read_file"}, "upstream_not_allowed"),
+        ({"upstream": "filesystem", "tool": "delete_all"}, "tool_not_allowed"),
+    ],
+)
+def test_profile_preview_denies_scope_and_binding_mismatches(context, reason):
+    response = TestClient(app).post(URL, headers=HEADERS, json={**CONTEXT, **context})
+    assert response.status_code == 200
+    assert response.json()["profile_allowed"] is False
+    assert response.json()["reason_code"] == reason
+
+
+def test_revoked_profile_cannot_preview_a_replacement_assignment(stores):
+    profiles, _ = stores
+    profiles.revoke("tenant-a", "client-profile-finance-prod")
+    profiles.put(_assignment(config_id="replacement", revision=1))
+    response = TestClient(app).post(URL, headers=HEADERS, json=CONTEXT)
+    assert response.status_code == 200
+    assert response.json()["profile_allowed"] is False
+    assert response.json()["profile"] is None
+
+
+def test_cross_tenant_and_anonymous_previews_are_denied(monkeypatch):
+    client = TestClient(app)
+    assert client.post(URL, headers={**HEADERS, "X-Agent-Bom-Tenant-ID": "tenant-b"}, json=CONTEXT).status_code == 404
+    monkeypatch.delenv("AGENT_BOM_TRUST_PROXY_AUTH")
+    monkeypatch.delenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET")
+    assert client.post(URL, json=CONTEXT).status_code == 401
+
+
+def test_profile_preview_store_outage_is_sanitized(stores, monkeypatch):
+    _, identities = stores
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("postgres://secret@private-db")
+
+    monkeypatch.setattr(identities, "get", fail)
+    response = TestClient(app).post(URL, headers=HEADERS, json=CONTEXT)
+    assert response.status_code == 503
+    assert "secret" not in response.text
+
+
+def test_profile_preview_rejects_raw_arguments_and_incomplete_tool_target():
+    client = TestClient(app)
+    assert client.post(URL, headers=HEADERS, json={**CONTEXT, "arguments": {"password": "secret"}}).status_code == 422
+    assert client.post(URL, headers=HEADERS, json={**CONTEXT, "tool": "read_file"}).status_code == 422

--- a/tests/test_runtime_operator_surfaces.py
+++ b/tests/test_runtime_operator_surfaces.py
@@ -1,0 +1,174 @@
+"""Profile client wire contracts and no-gap CLI checkpoint behavior."""
+
+import json
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from agent_bom.cli._runtime_profiles import runtime_feed, runtime_profiles
+from agent_bom.client import AgentBomApiError, AgentBomClient
+from agent_bom.runtime.activity_stream import decode_activity_stream
+
+
+def wire(cursor="cursor-1", events=None):
+    data = {"schema_version": "gateway.activity.stream.v1", "next_cursor": cursor, "events": events or []}
+    return f"event: activity\r\nid: {cursor}\r\ndata: {json.dumps(data)}\r\n\r\n".encode()
+
+
+def test_python_profile_methods_use_tenant_auth_and_encoded_ids():
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        return httpx.Response(200, json={"profile_allowed": True})
+
+    with AgentBomClient(
+        base_url="https://api.example", bearer_token="secret", tenant_id="a", transport=httpx.MockTransport(respond)
+    ) as client:
+        client.runtime_profiles()
+        client.create_runtime_profile({"identity_id": "id", "environment": "prod"})
+        client.get_runtime_profile("a/b")
+        client.update_runtime_profile("id", {"expected_revision": 2})
+        client.revoke_runtime_profile("id")
+        client.validate_runtime_profile("id", issuer="agent-bom", environment="prod", granted_scopes=["tools:read"])
+        client.test_runtime_profile("id", issuer="agent-bom", environment="prod", upstream="fs", tool="read")
+        with pytest.raises(ValueError):
+            client.create_runtime_profile({"environment": "prod"})
+    assert len(requests) == 7
+    assert all(r.headers["authorization"] == "Bearer secret" and r.headers["x-agent-bom-tenant-id"] == "a" for r in requests)
+    assert requests[2].url.raw_path.endswith(b"a%2Fb")
+    assert json.loads(requests[-1].content)["tool"] == "read"
+    assert json.loads(requests[-2].content)["config_id"] == "id"
+
+
+def test_fragmented_sse_discards_partial_frame_and_preserves_checkpoint():
+    stream = b": ping\r\n\r\n" + wire(events=[{"name": "caf\u00e9"}]) + b"event: activity\nid: incomplete\ndata: {"
+    frames = list(decode_activity_stream(bytes([byte]) for byte in stream))
+    assert len(frames) == 1
+    assert frames[0]["id"] == "cursor-1"
+    assert frames[0]["data"]["events"] == [{"name": "caf\u00e9"}]
+
+
+@pytest.mark.parametrize(
+    "data", [b"event: bad\ndata: {}\n\n", b"event: activity\nid: a\ndata: {}\n\n", b"data: [1]\n\n", b"data: invalid\n\n"]
+)
+def test_invalid_frames_fail_closed(data):
+    with pytest.raises(ValueError):
+        list(decode_activity_stream([data]))
+
+
+def test_frame_size_limit(monkeypatch):
+    monkeypatch.setattr("agent_bom.runtime.activity_stream.MAX_FRAME_BYTES", 10)
+    with pytest.raises(ValueError, match="exceeds"):
+        list(decode_activity_stream([b"data: " + b"a" * 20]))
+
+
+def test_sdk_resume_header_and_terminal_gap():
+    def respond(request):
+        assert request.headers["Last-Event-ID"] == "previous"
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=wire() + b'event: gap\ndata: {"reason":"cursor_expired"}\n\n' + wire("must-not-read"),
+        )
+
+    with AgentBomClient(base_url="https://api.example", transport=httpx.MockTransport(respond)) as client:
+        frames = list(client.gateway_activity(cursor="previous"))
+    assert [f["event"] for f in frames] == ["activity", "gap"]
+
+
+def test_sdk_expired_cursor_does_not_expose_response():
+    with AgentBomClient(
+        base_url="https://api.example", transport=httpx.MockTransport(lambda _: httpx.Response(410, text="secret"))
+    ) as client:
+        with pytest.raises(AgentBomApiError) as error:
+            list(client.gateway_activity(cursor="expired"))
+    assert error.value.status_code == 410
+    assert error.value.body == ""
+
+
+def test_cli_reconnects_from_complete_batch_and_retains_gap_checkpoint(tmp_path, monkeypatch):
+    checkpoint = tmp_path / "cursor.json"
+    calls = []
+
+    def respond(request):
+        calls.append(request.headers.get("Last-Event-ID"))
+        body = wire(events=[{"event_id": "e1"}]) if len(calls) == 1 else b'event: gap\ndata: {"reason":"cursor_expired"}\n\n'
+        return httpx.Response(200, headers={"content-type": "text/event-stream"}, content=body)
+
+    client = AgentBomClient(base_url="https://api.example", tenant_id="a", transport=httpx.MockTransport(respond))
+    monkeypatch.setattr("agent_bom.cli._runtime_profiles._make_client", lambda **_: client)
+    monkeypatch.setattr("agent_bom.cli._runtime_profiles.time.sleep", lambda _: None)
+    result = CliRunner().invoke(runtime_feed, ["--cursor-file", str(checkpoint), "--follow"])
+    assert result.exit_code == 1
+    assert "gap detected" in result.output
+    assert calls == [None, "cursor-1"]
+    assert json.loads(checkpoint.read_text())["cursor"] == "cursor-1"
+    assert checkpoint.stat().st_mode & 0o777 == 0o600
+
+
+def test_cli_rejects_checkpoint_from_another_tenant(tmp_path, monkeypatch):
+    checkpoint = tmp_path / "cursor.json"
+    checkpoint.write_text(json.dumps({"api_url": "https://api.example", "tenant_id": "other", "cursor": "old"}))
+    client = AgentBomClient(base_url="https://api.example", tenant_id="a")
+    monkeypatch.setattr("agent_bom.cli._runtime_profiles._make_client", lambda **_: client)
+    result = CliRunner().invoke(runtime_feed, ["--cursor-file", str(checkpoint)])
+    assert result.exit_code == 1
+    assert "does not match" in result.output
+
+
+def test_cli_profile_test_denial_is_nonzero_and_labels_simulation(monkeypatch):
+    client = AgentBomClient(
+        base_url="https://api.example",
+        transport=httpx.MockTransport(
+            lambda _: httpx.Response(200, json={"profile_allowed": False, "executed": False, "scope": "profile_contract_only"})
+        ),
+    )
+    monkeypatch.setattr("agent_bom.cli._runtime_profiles._make_client", lambda **_: client)
+    result = CliRunner().invoke(runtime_profiles, ["test", "id", "--environment", "prod", "--upstream", "fs", "--tool", "delete"])
+    assert result.exit_code == 1
+    assert '"executed": false' in result.output
+
+
+def test_checkpoint_failure_does_not_advance_previous_cursor(tmp_path, monkeypatch):
+    checkpoint = tmp_path / "cursor.json"
+    saved = {"api_url": "https://api.example", "tenant_id": "a", "cursor": "old"}
+    checkpoint.write_text(json.dumps(saved))
+    client = AgentBomClient(
+        base_url="https://api.example",
+        tenant_id="a",
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, headers={"content-type": "text/event-stream"}, content=wire())),
+    )
+    monkeypatch.setattr("agent_bom.cli._runtime_profiles._make_client", lambda **_: client)
+
+    def fail(*args):
+        raise OSError("secret disk path")
+
+    monkeypatch.setattr("agent_bom.cli._runtime_profiles.os.replace", fail)
+    result = CliRunner().invoke(runtime_feed, ["--cursor-file", str(checkpoint)])
+    assert result.exit_code == 1
+    assert "secret disk path" not in result.output
+    assert json.loads(checkpoint.read_text()) == saved
+    assert not list(tmp_path.glob(".activity-cursor-*"))
+
+
+def test_cli_create_and_list_managed_profiles(tmp_path, monkeypatch):
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        return httpx.Response(200, json={"assignment": {"config_id": "managed-1", "revision": 1}})
+
+    monkeypatch.setattr(
+        "agent_bom.cli._runtime_profiles._make_client",
+        lambda **_: AgentBomClient(base_url="https://api.example", transport=httpx.MockTransport(respond)),
+    )
+    profile = tmp_path / "profile.json"
+    profile.write_text(json.dumps({"identity_id": "identity-a", "environment": "prod"}))
+    runner = CliRunner()
+    assert runner.invoke(runtime_profiles, ["create", "--file", str(profile)]).exit_code == 0
+    assert runner.invoke(runtime_profiles, ["list"]).exit_code == 0
+    assert [r.method for r in requests] == ["POST", "GET"]
+    profile.write_text("[]")
+    assert runner.invoke(runtime_profiles, ["create", "--file", str(profile)]).exit_code == 1


### PR DESCRIPTION
## Summary

- Add `agent-bom runtime profiles create/validate/list/test` and Python/TypeScript profile lifecycle methods over the existing tenant-bound assignment store. Authenticated previews use the canonical relay resolver and explicitly return `profile_contract_only` / `executed: false`; no upstream call or authorization grant is issued.
- Add `agent-bom runtime feed --cursor-file ... --follow` and bounded SSE iterators. Checkpoints advance only after complete batches are flushed; reconnects retain the cursor, partial frames are discarded, and gaps/storage/auth failures stop explicitly. Consumers deduplicate event IDs across a crash between output and checkpoint.
- Document commands, credential/permission boundaries, replay semantics and rollback. Regenerate OpenAPI, data-model, capability, metrics and architecture artifacts. Part 2 of #4152, following #5170; dashboard integration and end-to-end/deployed acceptance remain later slices.

## Verification

- `.venv/bin/python -m pytest -q --no-cov tests/test_runtime_operator_surfaces.py tests/api/test_runtime_profile_evaluation.py tests/api/test_gateway_activity_stream.py tests/test_runtime_profile_resolution.py tests/test_mcp_config_distribution.py tests/test_mcp_config_profile_binding.py tests/test_python_client.py tests/test_python_client_route_parity.py tests/test_typescript_client_route_parity.py tests/test_cli_help_navigation.py` — 100 passed.
- `npm ci --ignore-scripts` and `npm test` in `sdks/typescript-client` with Node 22 — TypeScript build and 18 tests passed.
- `.venv/bin/ruff check src tests` and `.venv/bin/mypy src/agent_bom` — passed (897 source files).
- `make preflight-fix`, `python scripts/generate_agent_capability_manifest.py --write`, `python scripts/regenerate_data_model_atlas.py`, `python scripts/generate_doc_architecture_svgs.py`, then `make preflight` — passed; reviewed generated artifacts.
- Live local Uvicorn + CLI subprocess smoke: authenticated profile preview allowed without execution; first connection read 250 persisted events; second connection after reopening SQLite returned only the newly appended event.
- `agent-bom scan --demo --offline --format json --output /tmp/runtime-surfaces-scan.json` — report created; expected exit 1 for the fixture's critical vulnerability.
- `.venv/bin/python -m pytest -q --no-cov tests/test_ci_workflow_contract.py tests/test_doc_architecture_svgs.py tests/test_public_frontdoor_contract.py tests/test_public_docs_cli_alignment.py tests/test_cli_entry_points.py tests/test_product_surface_contract.py` — 141 passed.
- `.venv/bin/python scripts/check_cli_reference_alignment.py` and `.venv/bin/python scripts/check_public_docs_hygiene.py` — passed.
- `git diff --check` — passed.

## Notes

Profile previews are fail-closed and audited. They do not exercise live caller credentials, firewall/DLP/policy checks, quotas or upstream tools. Stream delivery proves local batch output, not external-sink acknowledgement. No deployed Helm or authenticated dashboard proof is claimed. Revoking an assignment is the profile rollback; the stream cursor file remains intact on failures. This PR does not close #4152.
