### PR TITLE
docs(readme): lead the findings-to-fix tour with Findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,26 @@ and carry the selected finding into remediation.
   <a href="docs/images/correlation-graph-live.png"><img src="docs/images/correlation-graph-live.png" alt="Reference lab application graph connecting a real Pillow advisory to modeled infrastructure and its remediation action" width="920"></a>
 </p>
 
-### Engineers and GRC: turn findings into a verifiable fix
+### Engineers and GRC: prioritize findings and verify fixes
 
-Compare available upgrades, affected workloads and mapped controls. Use the
-campaign workflow to assign owners, set SLAs and re-scan to verify fixes.
+Review findings by priority, affected asset, detection evidence and available
+fix. Open remediation to compare package upgrades and mapped controls, assign
+owners, set SLAs and re-scan to verify fixes.
+
+<p align="center">
+  <a href="docs/images/dependency-map-live.png"><img src="docs/images/dependency-map-live.png" alt="Actual Findings screen with labeled sample findings, priority, affected assets, detection evidence and remediation actions" width="920"></a>
+</p>
+
+<details>
+<summary>See package remediation and verification</summary>
 
 <p align="center">
   <a href="docs/images/remediation-live.png"><img src="docs/images/remediation-live.png" alt="Actual remediation screen with sample package upgrades, affected controls and campaign verification workflow" width="920"></a>
 </p>
 
-These are application captures, not mockups. Overview and remediation use
+</details>
+
+These are application captures, not mockups. Overview, Findings and remediation use
 labeled sample data. The graph uses the reproducible reference lab: real parsers,
 a pinned advisory scan and authenticated gateway calls, with modeled infrastructure.
 A blocked call does not establish that the underlying package was fixed.

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -184,7 +184,7 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert readme[:demo].count("<details>") == readme[:demo].count("</details>")
     assert len(readme.splitlines()) <= 210
     images = re.findall(r'<img src="docs/images/([^"]+-live.png)"', readme)
-    assert images == ["dashboard-live.png", "correlation-graph-live.png", "remediation-live.png"]
+    assert images == ["dashboard-live.png", "correlation-graph-live.png", "dependency-map-live.png", "remediation-live.png"]
     assert "correlation-path-live.png" not in readme
     assert "docs/GALLERY.md" in readme
     for diagram in ("workflow-dark.svg", "architecture-dark.svg", "persona-value-dark.svg", "blast-radius-dark.svg"):

--- a/tests/test_public_frontdoor_contract.py
+++ b/tests/test_public_frontdoor_contract.py
@@ -99,8 +99,11 @@ def test_readme_shows_the_end_to_end_product_journey_and_links_the_gallery() -> 
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     journey = readme.split("## Product tour", 1)[1].split("## Self-host", 1)[0]
     images = re.findall(r'<img src="docs/images/([^"]+)"', journey)
-    assert images == ["dashboard-live.png", "correlation-graph-live.png", "remediation-live.png"]
-    assert journey.count('width="920"') == 3
+    assert images == ["dashboard-live.png", "correlation-graph-live.png", "dependency-map-live.png", "remediation-live.png"]
+    assert journey.count('width="920"') == 4
+    follow_up = re.search(r"<details>\s*<summary>See package remediation and verification</summary>(.*?)</details>", journey, re.S)
+    assert follow_up and "remediation-live.png" in follow_up.group(1)
+    assert "dependency-map-live.png" not in follow_up.group(1)
     for image in images:
         assert (ROOT / "docs/images" / image).is_file()
     for marker in ("source receipts", "owners", "re-scan", "verify", "labeled sample data", "modeled infrastructure", "CVE-2023-4863"):


### PR DESCRIPTION
## Summary
- Lead the Engineers and GRC product-tour section with the existing Findings application capture, showing priorities, detection evidence and remediation actions.
- Keep package remediation available in an expandable follow-up at full width; preserve the sample-data qualification.

## Verification
- `pytest -q tests/test_public_docs_cli_alignment.py tests/test_public_frontdoor_contract.py` — 34 passed.
- `git diff --check`
- Visually inspected the existing Findings capture and verified both referenced image hashes against `docs/images/product-screenshots.json`.

## Notes
- Documentation and presentation-contract changes. Reuses the capture workflow's existing artifacts.
