### PR TITLE
fix(ci): verify catalog wording and deduplicate recurring alerts

### DIFF
--- a/.github/workflows/main-failure-alert.yml
+++ b/.github/workflows/main-failure-alert.yml
@@ -11,6 +11,10 @@ on:
       - "Deploy MCP SSE"
     types: [completed]
 
+concurrency:
+  group: main-failure-alert-${{ github.event.workflow_run.workflow_id }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
@@ -53,10 +57,12 @@ jobs:
             if (!match) {
               return;
             }
-            await github.rest.issues.createComment({
+            await github.rest.issues.update({
               owner,
               repo,
               issue_number: match.number,
+              state: "closed",
+              state_reason: "completed",
               body: [
                 `**${workflow}** is green on \`main\` again.`,
                 "",
@@ -65,13 +71,6 @@ jobs:
                 "",
                 "Closed automatically. Reopens on the next failure.",
               ].join("\n"),
-            });
-            await github.rest.issues.update({
-              owner,
-              repo,
-              issue_number: match.number,
-              state: "closed",
-              state_reason: "completed",
             });
 
   alert:
@@ -107,16 +106,21 @@ jobs:
             const existing = await github.paginate(github.rest.issues.listForRepo, {
               owner,
               repo,
-              state: "open",
+              state: "all",
+              sort: "created",
+              direction: "desc",
               labels: "ci-regression",
               per_page: 100,
             });
-            const match = existing.find((issue) => issue.title === title);
+            const candidates = existing.filter((issue) => issue.title === title && !issue.pull_request);
+            const match = candidates.find((issue) => issue.state === "open") || candidates[0];
             if (match) {
-              await github.rest.issues.createComment({
+              if (match.state === "open" && match.body === body) return;
+              await github.rest.issues.update({
                 owner,
                 repo,
                 issue_number: match.number,
+                state: "open",
                 body,
               });
               return;

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -547,6 +547,7 @@ jobs:
 
       - name: Verify Glama listing freshness
         env:
+          GLAMA_DIAGNOSTICS_DIR: ${{ runner.temp }}/glama-response
           EXPECTED_VERSION: ${{ needs.release.outputs.version }}
           EXPECTED_TOOL_COUNT: ${{ needs.release.outputs.tool_count }}
         run: |
@@ -562,6 +563,15 @@ jobs:
           fi
           echo "::error::Glama has not synchronized the exact released catalog yet. Glama syncs linked GitHub repositories automatically at least daily; this workflow retries every six hours. For an immediate provider-side refresh, use Sync Server in the Glama admin interface, then rerun this verification."
           exit 1
+
+      - name: Retain failed public Glama responses
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: glama-failure-evidence
+          path: ${{ runner.temp }}/glama-response/
+          retention-days: 7
+          if-no-files-found: ignore
 
   clawhub:
     name: Publish to ClawHub

--- a/.github/workflows/surface-freshness.yml
+++ b/.github/workflows/surface-freshness.yml
@@ -21,6 +21,10 @@ on:
     workflows: ["Publish to Registries"]
     types: [completed]
 
+concurrency:
+  group: surface-freshness-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -121,6 +125,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Open, refresh, or close consolidated freshness issue
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           REPORT: ${{ steps.probe.outputs.report }}
@@ -173,25 +178,28 @@ jobs:
             const existing = await github.paginate(github.rest.issues.listForRepo, {
               owner,
               repo,
-              state: "open",
+              state: "all",
+              sort: "created",
+              direction: "desc",
               labels: "supply-chain-drift",
               per_page: 100,
             });
-            const match = existing.find((issue) => issue.title === title);
+            const candidates = existing.filter((issue) => issue.title === title && !issue.pull_request);
+            const match = candidates.find((issue) => issue.state === "open") || candidates[0];
 
             if (report.all_fresh) {
-              if (match) {
-                await github.rest.issues.createComment({
-                  owner, repo, issue_number: match.number,
-                  body: `All distribution surfaces are fresh and monitored again; closing. Evidence: ${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+              if (match?.state === "open") {
+                await github.rest.issues.update({
+                  owner, repo, issue_number: match.number, state: "closed", state_reason: "completed",
+                  body: body + "\n\nAll distribution surfaces are fresh and monitored again; closing.",
                 });
-                await github.rest.issues.update({ owner, repo, issue_number: match.number, state: "closed" });
               }
               return;
             }
 
             if (match) {
-              await github.rest.issues.createComment({ owner, repo, issue_number: match.number, body });
+              if (match.state === "open" && match.body === body) return;
+              await github.rest.issues.update({ owner, repo, issue_number: match.number, state: "open", body });
               return;
             }
             await github.rest.issues.create({ owner, repo, title, body, labels });

--- a/scripts/check_glama_listing.py
+++ b/scripts/check_glama_listing.py
@@ -370,7 +370,7 @@ def _check(page: str, version: str, tool_count: int) -> list[str]:
     failures = [] if version_present else [f"missing current Glama listing token: {f'v{version}'!r}"]
     tool_count_ok = bool(
         re.search(rf"MCP server mode (?:exposes|advertises)\s+{re.escape(str(tool_count))}\s+MCP tools", page)
-        or re.search(rf"full compatibility catalog has\s+{re.escape(str(tool_count))}\s+MCP tools\b", page, re.IGNORECASE)
+        or re.search(rf"full (?:compatibility )?catalog has\s+{re.escape(str(tool_count))}\s+MCP tools\b", page, re.IGNORECASE)
     )
     if not tool_count_ok:
         failures.append(f"missing current Glama listing token: 'MCP server mode exposes|advertises {tool_count} MCP tools'")

--- a/tests/test_monitor_issue_lifecycle.py
+++ b/tests/test_monitor_issue_lifecycle.py
@@ -1,0 +1,108 @@
+"""Execute monitor scripts against a fake GitHub API to verify quiet issue reuse."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="Node is required to execute GitHub Actions scripts")
+
+
+def run_monitor(workflow, job, issues, *, fresh=False):
+    data = yaml.safe_load((ROOT / ".github/workflows" / workflow).read_text())
+    script = next(step["with"]["script"] for step in data["jobs"][job]["steps"] if "github-script@" in step.get("uses", ""))
+    harness = """
+    const fs = require('node:fs');
+    const {script, issues, fresh} = JSON.parse(fs.readFileSync(0, 'utf8'));
+    const events = [];
+    const github = {paginate: async () => issues, rest: {issues: {
+      listForRepo: () => {}, createLabel: async () => {},
+      create: async value => events.push({kind: 'create', ...value}),
+      update: async value => events.push({kind: 'update', ...value}),
+      createComment: async value => events.push({kind: 'comment', ...value}),
+    }}};
+    const context = {repo: {owner: 'owner', repo: 'repo'}, serverUrl: 'https://github.com', runId: 99,
+      payload: {workflow_run: {name: 'Publish to Registries', html_url: 'https://github.com/run/99',
+        head_sha: 'a'.repeat(40), actor: {login: 'owner'}}}};
+    process.env.REPORT = JSON.stringify({expected: '0.103.2', all_fresh: fresh, surfaces: []});
+    const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
+    new AsyncFunction('github', 'context', script)(github, context)
+      .then(() => console.log(JSON.stringify(events))).catch(e => {console.error(e); process.exit(1)});
+    """
+    result = subprocess.run(
+        [NODE, "-e", harness],
+        input=json.dumps({"script": script, "issues": issues, "fresh": fresh}),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+@pytest.mark.parametrize(
+    "workflow,job,title",
+    [
+        ("main-failure-alert.yml", "alert", "ci-regression: Publish to Registries failing on main"),
+        ("surface-freshness.yml", "freshness", "supply-chain-drift: distribution surfaces out of sync"),
+    ],
+)
+@pytest.mark.parametrize("state", ["open", "closed"])
+def test_failure_reuses_tracker_without_repeat_comments(workflow, job, title, state):
+    events = run_monitor(workflow, job, [{"number": 123, "title": title, "state": state}])
+    assert len(events) == 1
+    assert events[0]["kind"] == "update"
+    assert events[0]["issue_number"] == 123
+    assert events[0]["state"] == "open"
+
+
+@pytest.mark.parametrize(
+    "workflow,job,title",
+    [
+        ("main-failure-alert.yml", "resolve", "ci-regression: Publish to Registries failing on main"),
+        ("surface-freshness.yml", "freshness", "supply-chain-drift: distribution surfaces out of sync"),
+    ],
+)
+def test_recovery_closes_tracker_without_extra_comment(workflow, job, title):
+    events = run_monitor(workflow, job, [{"number": 123, "title": title, "state": "open"}], fresh=True)
+    assert len(events) == 1
+    assert events[0]["kind"] == "update"
+    assert events[0]["state"] == "closed"
+
+
+def test_surface_verification_on_pr_branch_cannot_close_main_incident():
+    data = yaml.safe_load((ROOT / ".github/workflows/surface-freshness.yml").read_text())
+    step = next(s for s in data["jobs"]["freshness"]["steps"] if "github-script@" in s.get("uses", ""))
+    assert "github.ref" in step["if"] and "github.event.repository.default_branch" in step["if"]
+
+
+@pytest.mark.parametrize(
+    "workflow,job,title",
+    [
+        ("main-failure-alert.yml", "alert", "ci-regression: Publish to Registries failing on main"),
+        ("surface-freshness.yml", "freshness", "supply-chain-drift: distribution surfaces out of sync"),
+    ],
+)
+def test_new_failures_still_alert_and_identical_reruns_are_noops(workflow, job, title):
+    created = run_monitor(workflow, job, [])
+    assert len(created) == 1 and created[0]["kind"] == "create"
+    assert created[0]["title"] == title
+    assert run_monitor(workflow, job, [{"number": 123, "title": title, "state": "open", "body": created[0]["body"]}]) == []
+
+
+def test_surface_recovery_does_not_notify_again_after_closure():
+    assert (
+        run_monitor(
+            "surface-freshness.yml",
+            "freshness",
+            [{"number": 123, "title": "supply-chain-drift: distribution surfaces out of sync", "state": "closed"}],
+            fresh=True,
+        )
+        == []
+    )

--- a/tests/test_publish_registries_glama_gate.py
+++ b/tests/test_publish_registries_glama_gate.py
@@ -66,3 +66,12 @@ def test_stale_glama_directory_fails_with_supported_recovery_guidance() -> None:
     assert "Glama syncs linked GitHub repositories automatically at least daily" in job
     assert "Sync Server" in job
     assert "exit 1" in job
+
+
+def test_publisher_retains_actual_glama_failure_responses() -> None:
+    steps = _workflow()["jobs"]["glama"]["steps"]
+    verify = next(step for step in steps if step.get("name") == "Verify Glama listing freshness")
+    assert verify["env"]["GLAMA_DIAGNOSTICS_DIR"] == "${{ runner.temp }}/glama-response"
+    upload = next(step for step in steps if "upload-artifact@" in step.get("uses", ""))
+    assert upload["if"] == "always()"
+    assert upload["with"]["retention-days"] == 7

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -87,9 +87,10 @@ def test_glama_listing_accepts_exact_public_api_tool_inventory(monkeypatch, caps
     assert payload["expected_tool_count"] == 77
 
 
-def test_glama_listing_accepts_split_version_and_profile_aware_copy(monkeypatch, capsys, tmp_path):
+@pytest.mark.parametrize("catalog", ["full compatibility catalog", "full catalog"])
+def test_glama_listing_accepts_split_version_and_profile_aware_copy(monkeypatch, capsys, tmp_path, catalog):
     script = _load_script("check_glama_listing.py")
-    page = """<main>The full compatibility catalog has <strong>2 MCP tools</strong>.
+    page = f"""<main>The {catalog} has <strong>2 MCP tools</strong>.
     <section>Tool changes <span>v</span><span>0.103.2</span></section></main>"""
     contract = [{"name": name, "inputSchema": {"type": "object", "properties": {}}} for name in ["check", "scan"]]
     expected = tmp_path / "contract.json"
@@ -1381,3 +1382,16 @@ def test_glama_diagnostics_bound_raw_response_artifacts(monkeypatch, tmp_path):
     assert evidence["listing"]["retained"] is False
     assert not (tmp_path / "attempt-1-listing.html").exists()
     assert (tmp_path / "attempt-1-schema.html").read_text() == "schema"
+
+
+@pytest.mark.parametrize("count", [8, 85, 87, 860])
+def test_glama_full_catalog_copy_requires_exact_count(count):
+    script = _load_script("check_glama_listing.py")
+    assert script._check(f"v0.103.2 The full catalog has {count} MCP tools.", "0.103.2", 86)
+
+
+def test_glama_accepts_current_readme_catalog_sentence():
+    script = _load_script("check_glama_listing.py")
+    readme = (ROOT / "README.md").read_text()
+    sentence = next(line.strip() for line in readme.splitlines() if "The full catalog has" in line)
+    assert script._check("<main>v0.103.2 " + sentence + "</main>", "0.103.2", 86) == []


### PR DESCRIPTION
## Summary
- Fix the false Glama drift failure behind #5183 and #5184: the public listing now says “The full catalog has 86 MCP tools,” while the checker required “full compatibility catalog” or older wording. Accept both exact full-catalog phrases while preserving version, count, tool-name, and input-schema checks.
- Reuse existing CI and distribution tracking issues, reopening them on recurrence and updating their body instead of adding repeat comments. Recovery closes the tracker without an additional comment; new failures still create an alert when no tracker exists. Serialize tracker runs and prevent PR-branch freshness checks from closing main incidents.
- Enable the existing bounded Glama failure diagnostics in Publish to Registries, retaining public response artifacts for seven days. The diagnostics helper and Surface Freshness artifact upload already merged in #5181.

## Verification
- `PYTHONPATH=src python -m pytest tests/test_monitor_issue_lifecycle.py tests/test_surface_freshness.py tests/test_glama.py tests/test_publish_registries_glama_gate.py tests/test_ci_workflow_contract.py -q` — 164 passed. The two new catalog regressions and seven initial issue-lifecycle regressions failed before their fixes.
- Live Glama verification against the immutable v0.103.2 release-name contract and version-validated public server-card schema contract — fresh, exact 86 names and input schemas.
- `actionlint .github/workflows/main-failure-alert.yml .github/workflows/surface-freshness.yml .github/workflows/publish-registries.yml`
- Ruff, `git diff --check`, and `uv tool run pre-commit run --files` on all seven changed files — passed.

- Hosted Surface Freshness [34366937291](https://github.com/msaad00/agent-bom/actions/runs/34366937291) at `dc9f44963a42bd2107be590a8258f46852fdc6dd` — `all_fresh: true`, exact Glama version/name/schema proof; main-incident mutation correctly skipped on the PR branch.

## Notes
- Repairs #5183 and #5184. Based on main `3d00063392ff76c78c5793d280bef6211bedc355`, after #5181 and #5182 merged. The original #5180 response remains a separate unproven incident.
- Scheduled verification remains enabled. Unchanged failures no longer append comments or create duplicate issues; real failure/recovery transitions remain visible.
- No version bump, tag, publication, or review bypass. Main incidents remain open until merged-main verification succeeds.
