### PR TITLE
fix(deploy): retry exact default-profile release checks

### DIFF
--- a/.github/workflows/deploy-mcp-sse.yml
+++ b/.github/workflows/deploy-mcp-sse.yml
@@ -71,7 +71,7 @@ jobs:
           fi
           METRICS_JSON=$(git show "HEAD:docs/PRODUCT_METRICS.json")
           METRICS_VERSION=$(echo "$METRICS_JSON" | jq -er '.version')
-          TOOL_COUNT=$(echo "$METRICS_JSON" | jq -er 'first(.metrics[] | select(.name == "MCP tools") | .value)')
+          TOOL_COUNT=$(echo "$METRICS_JSON" | jq -er '(first(.metrics[] | select(.name == "MCP default tools") | .value) // first(.metrics[] | select(.name == "MCP tools") | .value))')
           if [ "$METRICS_VERSION" != "$REPO_VERSION" ]; then
             echo "::error::Release metrics version $METRICS_VERSION does not match $REPO_VERSION"
             exit 1

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -274,6 +274,11 @@ and the `MCP default tools` metric. Older releases without that metadata retain
 their full-catalog contract. A smaller next-release default must not make the
 currently published full catalog appear stale. Custom full-profile deployments
 and the default marketplace endpoint have distinct expected catalogs.
+The Railway release gate uses the same default-profile count. During a rolling
+deployment, it retries old-version responses and incomplete contracts within the
+same bounded attempt budget as transport failures. An HTTP 200 alone does not
+pass the gate: the exact version, tool count, and schemas must match before the
+budget is exhausted.
 Smithery's catalog API omits some root schema fields. The checker verifies those
 constraints from the complete schemas embedded in Smithery's public page, while
 requiring its server identity, tool names, and shared schema fields to agree with

--- a/src/agent_bom/deployment_probe.py
+++ b/src/agent_bom/deployment_probe.py
@@ -8,6 +8,8 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Callable
+from functools import partial
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
@@ -65,6 +67,7 @@ def _fetch_json(
     attempts: int,
     backoff_seconds: float,
     timeout: float,
+    validate_payload: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     if attempts < 1:
         raise ValueError("attempts must be >= 1")
@@ -81,6 +84,8 @@ def _fetch_json(
                 payload = json.loads(response.read())
             if not isinstance(payload, dict):
                 raise ValueError("deployment response must be a JSON object")
+            if validate_payload is not None:
+                payload = validate_payload(payload)
             return payload
         except (ValueError, json.JSONDecodeError, OSError, urllib.error.URLError) as exc:
             last_error = exc
@@ -122,8 +127,25 @@ def fetch_server_card(
     attempts: int = 1,
     backoff_seconds: float = 0.0,
     timeout: float = 15.0,
+    expected_version: str | None = None,
+    expected_tool_count: int | None = None,
 ) -> tuple[str, dict[str, Any]]:
-    """Fetch the public MCP server card with bounded retries."""
+    """Fetch the card, retrying until the optional exact release contract matches.
+
+    A rolling deployment can serve valid JSON from the previous release while
+    its replacement starts. Transport errors and contract mismatches share one
+    attempt budget; exhaustion still fails closed.
+    """
+
+    if (expected_version is None) != (expected_tool_count is None):
+        raise ValueError("expected_version and expected_tool_count must be supplied together")
+    validate_payload = None
+    if expected_version is not None and expected_tool_count is not None:
+        validate_payload = partial(
+            validate_server_card_release,
+            expected_version=expected_version,
+            expected_tool_count=expected_tool_count,
+        )
 
     server_card_url = resolve_server_card_url(base_url)
     payload = _fetch_json(
@@ -132,6 +154,7 @@ def fetch_server_card(
         attempts=attempts,
         backoff_seconds=backoff_seconds,
         timeout=timeout,
+        validate_payload=validate_payload,
     )
     return server_card_url, payload
 
@@ -230,9 +253,6 @@ def main(argv: list[str] | None = None) -> int:
                 attempts=args.attempts,
                 backoff_seconds=args.backoff_seconds,
                 timeout=args.timeout,
-            )
-            payload = validate_server_card_release(
-                payload,
                 expected_version=args.expected_version,
                 expected_tool_count=args.expected_tool_count,
             )

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -898,6 +898,22 @@ def test_deploy_mcp_sse_fails_closed_on_exact_release_server_card_drift():
     assert "Could not verify deployed version" not in workflow
 
 
+@pytest.mark.parametrize("legacy_release", [False, True])
+def test_deploy_mcp_gate_matches_published_profile(legacy_release):
+    from agent_bom.mcp_server_metadata import build_server_card
+
+    metrics = json.loads((ROOT / "docs/PRODUCT_METRICS.json").read_text())
+    if legacy_release:
+        metrics["metrics"] = [metric for metric in metrics["metrics"] if metric["name"] != "MCP default tools"]
+    workflow = (ROOT / ".github/workflows/deploy-mcp-sse.yml").read_text()
+    count_line = next(line for line in workflow.splitlines() if "TOOL_COUNT=$(" in line)
+    query = count_line.split("jq -er '", 1)[1].rsplit("'", 1)[0]
+    result = subprocess.run(["jq", "-er", query], input=json.dumps(metrics), text=True, capture_output=True, check=True)
+
+    profile = "full" if legacy_release else "scan"
+    assert int(result.stdout) == len(build_server_card(profile=profile)["tools"])
+
+
 def test_dockerfiles_support_proxy_and_ca_contract():
     """Maintained Docker images should support standard proxy and CA env vars."""
     dockerfiles = [

--- a/tests/test_deployment_probe.py
+++ b/tests/test_deployment_probe.py
@@ -8,11 +8,70 @@ import pytest
 
 from agent_bom.deployment_probe import (
     fetch_health,
+    main,
     resolve_health_url,
     resolve_server_card_url,
     validate_health_payload,
     validate_server_card_release,
 )
+
+
+@pytest.mark.parametrize(
+    "initial_payload",
+    [
+        b'{"serverInfo":{"version":"0.103.2"},"tools":[]}',
+        b'{"serverInfo":{"version":"0.104.0"},"tools":[]}',
+        b'{"serverInfo":{"version":"0.104.0"},"tools":[{"name":"scan"}]}',
+    ],
+)
+def test_server_card_cli_retries_until_exact_release_contract(monkeypatch, capsys, initial_payload):
+    replies = iter([initial_payload, b'{"serverInfo":{"version":"0.104.0"},"tools":[{"name":"scan","inputSchema":{"type":"object"}}]}'])
+    delays = []
+    monkeypatch.setattr("agent_bom.deployment_probe.urllib.request.urlopen", lambda *_args, **_kwargs: _Response(next(replies)))
+    monkeypatch.setattr("agent_bom.deployment_probe.time.sleep", delays.append)
+
+    assert (
+        main(["--server-card", "--expected-version", "0.104.0", "--expected-tool-count", "1", "--attempts", "2", "--backoff-seconds", "3"])
+        == 0
+    )
+    captured = capsys.readouterr()
+    assert '"version":"0.104.0"' in captured.out
+    assert delays == [3]
+
+
+def test_server_card_cli_still_fails_when_release_never_arrives(monkeypatch, capsys):
+    calls = []
+
+    def old_release(*_args, **_kwargs):
+        calls.append(True)
+        return _Response(b'{"serverInfo":{"version":"0.103.2"},"tools":[]}')
+
+    monkeypatch.setattr("agent_bom.deployment_probe.urllib.request.urlopen", old_release)
+
+    assert (
+        main(["--server-card", "--expected-version", "0.104.0", "--expected-tool-count", "1", "--attempts", "3", "--backoff-seconds", "0"])
+        == 1
+    )
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "version mismatch" in captured.err
+    assert len(calls) == 3
+
+
+def test_server_card_network_and_contract_errors_share_attempt_budget(monkeypatch, capsys):
+    calls = []
+
+    def changing_failure(*_args, **_kwargs):
+        calls.append(True)
+        if len(calls) == 1:
+            raise urllib.error.URLError("temporarily unavailable")
+        return _Response(b'{"serverInfo":{"version":"0.103.2"},"tools":[]}')
+
+    monkeypatch.setattr("agent_bom.deployment_probe.urllib.request.urlopen", changing_failure)
+
+    assert main(["--server-card", "--expected-version", "0.104.0", "--expected-tool-count", "1", "--attempts", "2"]) == 1
+    assert len(calls) == 2
+    assert "version mismatch" in capsys.readouterr().err
 
 
 class _Response:


### PR DESCRIPTION
## Summary
- The v0.104.0 release deployment check stopped after one HTTP 200 response from v0.103.2 despite a five-attempt budget. Retry exact version, tool-count, and schema validation within the existing transport retry budget; fail closed when the contract never converges.
- Read the immutable release's default-profile tool count, matching the hosted entrypoint and registry workflows. Preserve the full-catalog fallback for older releases. The previous gate expected 86 tools while the current default exposes 8.

## Verification
- `PYTHONPATH=src python -m pytest -q tests/test_deployment_probe.py tests/test_deployment.py --no-cov` — 81 passed. Regression tests failed before the fix; cases cover old versions, incomplete catalogs/schemas, bounded exhaustion, mixed network/contract failures, and current/legacy profile counts.
- `uv tool run pre-commit run --files .github/workflows/deploy-mcp-sse.yml src/agent_bom/deployment_probe.py tests/test_deployment.py tests/test_deployment_probe.py docs/PUBLISHING.md` — passed, including Ruff, mypy, Bandit, YAML, release consistency, and workflow graph guards.
- `git diff --check` — passed.

## Notes
The observed failure is [Release 34383868138](https://github.com/msaad00/agent-bom/actions/runs/34383868138/job/102584504167). This change repairs verification, not the subsequently observed Railway HTTP 502 startup failure; its cause is still unconfirmed. Authentication and exact release requirements remain intact. The already-published v0.104.0 tag remains immutable; this fix applies to a forward release after review. Reverting this change restores immediate contract-mismatch failure.
