### PR TITLE
fix(ci): verify Glama profile metadata against released schemas

### DIFF
--- a/scripts/check_glama_listing.py
+++ b/scripts/check_glama_listing.py
@@ -171,7 +171,7 @@ def _api_inventory_result(
     return actual_tool_count, failures, exact_tool_set, exact_input_schemas
 
 
-def _extract_schema_tool_contract(page: str, listing_url: str) -> list[dict[str, object]]:
+def _extract_schema_evidence(page: str, listing_url: str) -> tuple[list[dict[str, object]], str]:
     """Read bounded reference-table JSON from Glama's public schema route.
 
     This decodes data only. Scripts are never evaluated, and unrelated route
@@ -242,9 +242,14 @@ def _extract_schema_tool_contract(page: str, listing_url: str) -> list[dict[str,
             or any(not isinstance(tool, dict) or not isinstance(tool.get("inputSchema"), dict) for tool in tools)
         ):
             raise ValueError("schema state has incomplete tool contracts")
-        return tools
+        description = server.get("descriptionMarkdown", "")
+        return tools, description if isinstance(description, str) else ""
     except (KeyError, IndexError, TypeError, RecursionError, ValueError) as exc:
         raise ValueError("Glama public schema state is unavailable or malformed") from exc
+
+
+def _extract_schema_tool_contract(page: str, listing_url: str) -> list[dict[str, object]]:
+    return _extract_schema_evidence(page, listing_url)[0]
 
 
 def _release_tool_names(git_ref: str | None) -> list[str]:
@@ -503,6 +508,7 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("expected Glama tool-name contract and tool count do not match")
     last_error = ""
     listing_version = "unknown"
+    release_metadata_source = "listing-text"
     actual_tool_count: int | None = None
     inventory_source: str | None = None
     exact_tool_set: bool | None = None
@@ -510,6 +516,7 @@ def main(argv: list[str] | None = None) -> int:
     degraded_reason: str | None = None
     last_probe_unreachable = False
     for attempt in range(1, max(1, args.retries) + 1):
+        release_metadata_source = "listing-text"
         actual_tool_count = None
         inventory_source = None
         exact_tool_set = None
@@ -587,6 +594,24 @@ def main(argv: list[str] | None = None) -> int:
                 inventory_source = "api"
                 failures.append(f"failed to verify Glama public API tool inventory: {api_error}")
                 last_probe_unreachable = True
+            # The schema changelog labels Glama builds, which can differ from
+            # package releases; full-catalog prose also differs from the selected
+            # runtime profile. Accept the bound server profile's release claim
+            # only alongside its independently matching complete tool contract.
+            if expected_tool_contract is not None and exact_input_schemas is True and schema_page:
+                try:
+                    indexed_tools, description = _extract_schema_evidence(schema_page, args.url)
+                    _, indexed_failures, _, indexed_exact = _api_inventory_result(
+                        indexed_tools,
+                        tool_count=tool_count,
+                        expected_tool_names=expected_tool_names,
+                        expected_tool_contract=expected_tool_contract,
+                    )
+                    if indexed_exact and not indexed_failures and not _check(html.escape(description), version, tool_count):
+                        failures = [failure for failure in failures if not failure.startswith("missing current Glama listing token:")]
+                        release_metadata_source = "schema-server-description"
+                except ValueError:
+                    pass  # Missing profile metadata cannot substitute for release proof.
             if expected_tool_contract is not None and exact_input_schemas is None:
                 failures.append("could not verify requested input schemas from Glama indexed evidence")
             if not failures:
@@ -599,6 +624,7 @@ def main(argv: list[str] | None = None) -> int:
                                 "status": status,
                                 "expected": version,
                                 "listing_version": listing_version,
+                                "release_metadata_source": release_metadata_source,
                                 "tool_count": actual_tool_count,
                                 "expected_tool_count": tool_count,
                                 "inventory_source": inventory_source,
@@ -628,6 +654,7 @@ def main(argv: list[str] | None = None) -> int:
                     "status": "unreachable" if last_probe_unreachable else "stale",
                     "expected": version,
                     "listing_version": listing_version,
+                    "release_metadata_source": release_metadata_source,
                     "tool_count": actual_tool_count,
                     "expected_tool_count": tool_count,
                     "inventory_source": inventory_source,

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -854,7 +854,7 @@ def test_ghcr_pagination_still_follows_a_same_origin_next_link(monkeypatch):
     assert result["status"] == "fresh"
 
 
-def _glama_schema_state(tools, *, namespace="msaad00", slug="agent-bom", null_reference=-5):
+def _glama_schema_state(tools, *, namespace="msaad00", slug="agent-bom", null_reference=-5, description=""):
     """Encode the public schema route's reference-table JSON, without JS execution."""
     values = []
 
@@ -875,7 +875,7 @@ def _glama_schema_state(tools, *, namespace="msaad00", slug="agent-bom", null_re
         {
             "loaderData": {
                 "routes/_public/mcp/servers/~namespace/~slug/_pages/schema/_route": {
-                    "mcpServer": {"namespace": {"slug": namespace}, "slug": slug},
+                    "mcpServer": {"namespace": {"slug": namespace}, "slug": slug, "descriptionMarkdown": description},
                     "schema": {"tools": tools},
                 }
             }
@@ -1395,3 +1395,35 @@ def test_glama_accepts_current_readme_catalog_sentence():
     readme = (ROOT / "README.md").read_text()
     sentence = next(line.strip() for line in readme.splitlines() if "The full catalog has" in line)
     assert script._check("<main>v0.103.2 " + sentence + "</main>", "0.103.2", 86) == []
+
+
+@pytest.mark.parametrize("invalid", [None, "schema", "version", "count", "identity", "no_contract", "stale_copy"])
+def test_glama_profile_metadata_requires_exact_released_schema(monkeypatch, capsys, tmp_path, invalid):
+    """Provider build labels and full-catalog prose are not runtime profile versions/counts."""
+    script = _load_script("check_glama_listing.py")
+    expected = [{"name": "scan", "inputSchema": {"type": "object", "additionalProperties": False}}]
+    tools = [{"name": "scan", "inputSchema": {"type": "object"}}] if invalid == "schema" else expected
+    version = "0.103.2" if invalid == "version" else "0.104.0"
+    count = 86 if invalid == "count" else 1
+    schema = _glama_schema_state(
+        tools,
+        slug="unrelated" if invalid == "identity" else "agent-bom",
+        description=f"agent-bom v{version} default profile MCP server mode exposes {count} MCP tools.",
+    )
+    page = "v1.0.5 Start with focused tools. The full catalog has 86 MCP tools."
+    if invalid == "stale_copy":
+        page += " uses: msaad00/agent-bom@v0.88.4"
+    monkeypatch.setattr(script, "_fetch", lambda url, timeout: schema if url.endswith("/schema") else page)
+    monkeypatch.setattr(script, "_fetch_json", lambda *args: (_ for _ in ()).throw(urllib.error.URLError("401")))
+    contract = tmp_path / "contract.json"
+    contract.write_text(json.dumps(expected))
+    args = ["--expected", "0.104.0", "--expected-tool-count", "1", "--json", "--retries", "1"]
+    if invalid != "no_contract":
+        args += ["--expected-tool-contract-file", str(contract)]
+    result = script.main(args)
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert result == int(invalid is not None)
+    if invalid is None:
+        assert payload["exact_input_schemas"] is True
+        assert payload["release_metadata_source"] == "schema-server-description"
+        assert payload["listing_version"] == "1.0.5"


### PR DESCRIPTION
## Summary
- Verify Glama release/profile metadata from the requested server's indexed description only when its complete indexed tool contract matches the released contract exactly. Preserve the provider build label separately as `listing_version` and report `release_metadata_source`.
- Keep stale-copy, wrong-version, wrong-count, wrong-server and schema-mismatch failures. Metadata alone cannot satisfy the gate.
- Correct the false failure when Glama labels a schema change with its own build version while the README describes the full catalog instead of the selected runtime profile. References #5183; close the incident after a successful main registry run.

## Verification
- `PYTHONPATH=src /tmp/agent-bom-runtime-surfaces/.venv/bin/python -m pytest -q tests/test_surface_freshness.py tests/test_publish_registries_release_auth_gate.py --no-cov` — 121 passed.
- `uv tool run pre-commit run --files scripts/check_glama_listing.py tests/test_surface_freshness.py`.
- `git diff --check`.
- Live Glama verification against the released 0.104.0 server-card contract: 8 tools, exact names and input schemas; metadata source `schema-server-description`, provider build label `1.0.5`.

## Notes
Glama's provider-side build is pinned to release commit `62a4766c9cd05c0681d1bf60c31f1475b7e2d63c`. This verifies indexed catalog consistency; it does not attest the deployed binary or prove authenticated tool execution. No application authentication or runtime behavior changes.
