### PR TITLE
fix(ci): retry complete Smithery schema evidence before publishing

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -271,9 +271,22 @@ jobs:
           done
           LATEST_SUCCESS_UPSTREAM=$(jq -sr 'first | .upstreamUrl // empty' /tmp/smithery-success-releases.jsonl)
           jq -S '[.tools[].name] | sort' /tmp/smithery-catalog.json > /tmp/smithery-actual-tool-names.json
-          python3 scripts/check_surface_freshness.py \
-            --smithery-server agentbom/agent-bom \
-            --write-smithery-tool-contract /tmp/smithery-actual-tool-contract.json
+          SCHEMA_READY=false
+          for ATTEMPT in $(seq 1 6); do
+            rm -f /tmp/smithery-actual-tool-contract.json
+            if python3 scripts/check_surface_freshness.py \
+              --smithery-server agentbom/agent-bom \
+              --write-smithery-tool-contract /tmp/smithery-actual-tool-contract.json; then
+              SCHEMA_READY=true
+              break
+            fi
+            echo "Smithery complete schema evidence unavailable (parity attempt ${ATTEMPT}/6)"
+            if [ "$ATTEMPT" -lt 6 ]; then sleep 10; fi
+          done
+          if [ "$SCHEMA_READY" != "true" ]; then
+            echo "::error::Smithery schema evidence remained unavailable; refusing to create a potentially duplicate release"
+            exit 1
+          fi
           jq -S '{description}' \
             /tmp/smithery-catalog.json > /tmp/smithery-actual-listing-metadata.json
           if cmp -s /tmp/smithery-expected-tool-names.json /tmp/smithery-actual-tool-names.json && \

--- a/tests/test_publish_registries_release_auth_gate.py
+++ b/tests/test_publish_registries_release_auth_gate.py
@@ -66,6 +66,72 @@ python3() {
         assert "exposes the released" not in result.stdout
 
 
+@pytest.mark.parametrize("schema_failures,expected_attempts,expected_status", [(0, 1, 0), (1, 2, 0), (6, 6, 1)])
+def test_smithery_prepublication_parity_retries_without_publishing(tmp_path, schema_failures, expected_attempts, expected_status):
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    step = next(step for step in workflow["jobs"]["smithery"]["steps"] if step.get("name") == "Check Smithery catalog parity")
+    script = step["run"].replace("/tmp/", f"{tmp_path}/")
+    catalog = {"description": "Released scanner", "tools": [{"name": "scan", "inputSchema": {"type": "object"}}]}
+    (tmp_path / "catalog.json").write_text(json.dumps(catalog))
+    contract = catalog["tools"]
+    (tmp_path / "contract.json").write_text(json.dumps(contract))
+    for query, name in [("[.tools[].name] | sort", "tool-names"), ("{description}", "listing-metadata")]:
+        result = subprocess.run(["jq", "-S", query], input=json.dumps(catalog), text=True, capture_output=True, check=True)
+        (tmp_path / f"smithery-expected-{name}.json").write_text(result.stdout)
+    (tmp_path / "smithery-expected-tool-contract.json").write_text(json.dumps(contract))
+    (tmp_path / "smithery-actual-tool-contract.json").write_text(json.dumps(contract))
+    (tmp_path / "releases.json").write_text(
+        json.dumps(
+            {
+                "releases": [{"type": "external_shttp", "status": "SUCCESS", "upstreamUrl": "https://mcp.example.test/mcp"}],
+                "pagination": {"currentPage": 1, "totalPages": 1},
+            }
+        )
+    )
+    harness = r"""
+curl() {
+  case "$*" in
+    *releases?page*) cp "$PROBE_DIR/releases.json" "$PROBE_DIR/smithery-latest-releases.json" ;;
+    *) cp "$PROBE_DIR/catalog.json" "$PROBE_DIR/smithery-catalog.json" ;;
+  esac
+}
+sleep() { :; }
+python3() {
+  if [ "$2" = "--smithery-server" ]; then
+    count=0
+    if [ -f "$PROBE_DIR/attempts" ]; then count=$(cat "$PROBE_DIR/attempts"); fi
+    count=$((count + 1))
+    echo "$count" > "$PROBE_DIR/attempts"
+    if [ "$count" -le "$SCHEMA_FAILURES" ]; then return 1; fi
+    cp "$PROBE_DIR/contract.json" "$5"
+  else
+    "$TEST_PYTHON" "$@"
+  fi
+}
+"""
+    result = subprocess.run(
+        ["bash", "-c", harness + script],
+        cwd=ROOT,
+        env={
+            **os.environ,
+            "PROBE_DIR": str(tmp_path),
+            "SCHEMA_FAILURES": str(schema_failures),
+            "TEST_PYTHON": sys.executable,
+            "GITHUB_OUTPUT": str(tmp_path / "outputs"),
+            "SMITHERY_API_TOKEN": "test-only",
+            "SMITHERY_MCP_URL": "https://mcp.example.test/mcp",
+        },
+        text=True,
+        capture_output=True,
+        timeout=20,
+    )
+    assert result.returncode == expected_status, result.stdout + result.stderr
+    assert int((tmp_path / "attempts").read_text()) == expected_attempts
+    outputs = (tmp_path / "outputs").read_text()
+    assert ("fresh=true" in outputs) is (expected_status == 0)
+    assert "publishing a new deployment" not in result.stdout
+
+
 def test_smithery_publish_waits_for_oauth_capable_forward_release() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- Retry incomplete Smithery schema evidence during prepublication parity checks, where a single failed fetch currently aborts registry publication on main.
- Remove previous schema artifacts before every attempt and fail closed after six attempts; unknown parity cannot trigger a duplicate deployment.
- Ref #5183. Close the incident after a successful main publication check verifies recovery.

## Verification

- `PYTHONPATH=src python -m pytest -q tests/test_publish_registries_release_auth_gate.py tests/test_surface_freshness.py` — 124 passed.
- Bash workflow regressions cover immediate success, transient failure followed by recovery, and exhaustion with a stale successful artifact present.
- Ruff check/format and `git diff --check` passed.

## Notes

Catalog parity does not establish authenticated hosted MCP availability. This change retains the existing incident tracker and publication gates.
