### PR TITLE
fix(graph): classify repository dependency inventory as code assets

### DIFF
--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -49,6 +49,34 @@ def _is_sbom_import(agent: Mapping[str, Any]) -> bool:
     )
 
 
+def _is_repository_inventory(agent: Mapping[str, Any]) -> bool:
+    """Recognize the explicit manifest-collector wrappers, not arbitrary agents."""
+    servers = agent.get("mcp_servers", [])
+    if not servers:
+        return False
+    if agent.get("source") == "repo-lockfiles":
+        return all(srv.get("surface") == "filesystem" and not srv.get("command") for srv in servers)
+    if agent.get("source") == "project":
+        return all(srv.get("surface") == "other" and srv.get("command") in {"project", "github-actions"} for srv in servers)
+    return False
+
+
+def _repository_manifest_directory(agent: Mapping[str, Any], server: Mapping[str, Any]) -> str:
+    if agent.get("source") == "repo-lockfiles":
+        label = str(server.get("name") or "").removeprefix("repo-deps:")
+        return "" if label == "root" else label
+    args = server.get("args") or []
+    root = str(agent.get("config_path") or "")
+    if args and root:
+        try:
+            relative = str(PurePath(str(args[0])).relative_to(PurePath(root)))
+            return "" if relative == "." else relative
+        except ValueError:
+            pass
+    label = str(server.get("name") or "")
+    return "" if label == str(agent.get("name") or "").removeprefix("project:") else label
+
+
 def build_unified_graph_from_report(
     report_json: dict[str, Any],
     *,
@@ -85,7 +113,11 @@ def build_unified_graph_from_report(
     blast_data = report_json.get("blast_radius", report_json.get("blast_radii", []))
     scan_sources = report_json.get("scan_sources", [])
     inferred_source = "sbom" if agents_data and all(_is_sbom_import(agent) for agent in agents_data) else "mcp-scan"
+    if agents_data and all(_is_repository_inventory(agent) for agent in agents_data):
+        inferred_source = str(agents_data[0]["source"])
     data_source_tag = scan_sources[0] if scan_sources else inferred_source
+
+    report_data_source = data_source_tag
 
     # Track shared resources for lateral movement edges
     server_to_agents: dict[str, list[str]] = defaultdict(list)
@@ -106,14 +138,20 @@ def build_unified_graph_from_report(
         agent_name = agent_dict.get("name", "unknown")
         agent_scope = _agent_identity_scope(agent_dict)
         sbom_import = _is_sbom_import(agent_dict)
+        repository_inventory = _is_repository_inventory(agent_dict)
+        static_inventory = sbom_import or repository_inventory
+        data_source_tag = str(agent_dict["source"]) if repository_inventory else report_data_source
+        inventory_type = EntityType.DIRECTORY if repository_inventory else EntityType.SOURCE_FILE
         agent_id = _agent_node_id(agent_name, agent_scope)
         if sbom_import:
             agent_id = f"source_file:sbom:{agent_id.removeprefix('agent:')}"
+        if repository_inventory:
+            agent_id = f"directory:repository:{agent_id.removeprefix('agent:')}"
         agent_node_key = agent_id.removeprefix("agent:")
         agent_type = agent_dict.get("type", agent_dict.get("agent_type", ""))
         provider_name = str(agent_dict.get("source") or "local").strip() or "local"
         # Import wrappers share the legacy Agent/MCPServer serialization shape.
-        # An SBOM documents packages; it does not establish a running agent.
+        # Static imports document packages; they do not establish running agents.
         if sbom_import:
             provider_name = "sbom"
         provider_id = f"provider:{provider_name}"
@@ -122,7 +160,7 @@ def build_unified_graph_from_report(
             agent_metadata = {}
         agent_discovery_provenance = sanitize_discovery_provenance(agent_dict.get("discovery_provenance"))
 
-        if not sbom_import:
+        if not static_inventory:
             graph.add_node(
                 UnifiedNode(
                     id=provider_id,
@@ -140,13 +178,15 @@ def build_unified_graph_from_report(
         graph.add_node(
             UnifiedNode(
                 id=agent_id,
-                entity_type=EntityType.SOURCE_FILE if sbom_import else EntityType.AGENT,
-                label=agent_name.removeprefix("sbom:") if sbom_import else agent_name,
+                entity_type=inventory_type if static_inventory else EntityType.AGENT,
+                label=agent_name.removeprefix("sbom:").removeprefix("project:").removeprefix("repo-deps:")
+                if static_inventory
+                else agent_name,
                 first_seen=str(agent_dict.get("discovered_at") or ""),
                 last_seen=str(agent_dict.get("last_seen") or agent_dict.get("discovered_at") or ""),
                 attributes={
                     "agent_type": agent_type,
-                    "canonical_id": (canonical_graph_node_id(EntityType.SOURCE_FILE.value, agent_id) if sbom_import else None)
+                    "canonical_id": (canonical_graph_node_id(inventory_type.value, agent_id) if static_inventory else None)
                     or agent_dict.get("canonical_id")
                     or (
                         canonical_agent_id(agent_type, agent_name, source_id=agent_scope)
@@ -174,8 +214,8 @@ def build_unified_graph_from_report(
                     "cloud_principal": agent_metadata.get("cloud_principal"),
                 },
                 dimensions=NodeDimensions(
-                    agent_type="" if sbom_import else agent_type,
-                    surface="sbom" if sbom_import else "",
+                    agent_type="" if static_inventory else agent_type,
+                    surface="code" if repository_inventory else "sbom" if sbom_import else "",
                     environment=agent_env,
                 ),
                 data_sources=[data_source_tag],
@@ -185,7 +225,7 @@ def build_unified_graph_from_report(
         config_path = str(agent_dict.get("config_path", "") or "").strip()
         if config_path:
             agent_config_path_to_id[config_path] = agent_id
-        if not sbom_import:
+        if not static_inventory:
             graph.add_edge(
                 UnifiedEdge(
                     source=provider_id,
@@ -205,8 +245,27 @@ def build_unified_graph_from_report(
             srv_name = srv_dict.get("name", "unknown")
             srv_id = agent_id if sbom_import else f"server:{agent_node_key}:{srv_name}"
             surface = srv_dict.get("surface", "mcp-server")
+            if repository_inventory:
+                srv_id = f"directory:manifest:{agent_node_key}:{srv_name}"
+                graph.add_node(
+                    UnifiedNode(
+                        id=srv_id,
+                        entity_type=EntityType.DIRECTORY,
+                        label=srv_name,
+                        attributes={
+                            "source": data_source_tag,
+                            "inventory_role": "manifest_dependencies",
+                            "manifest_directory": _repository_manifest_directory(agent_dict, srv_dict),
+                            "canonical_id": canonical_graph_node_id(EntityType.DIRECTORY.value, srv_id),
+                            "environment": agent_env,
+                        },
+                        dimensions=NodeDimensions(surface="code", environment=agent_env),
+                        data_sources=[data_source_tag],
+                    )
+                )
+                graph.add_edge(UnifiedEdge(source=agent_id, target=srv_id, relationship=RelationshipType.CONTAINS))
 
-            if not sbom_import:
+            if not static_inventory:
                 graph.add_node(
                     UnifiedNode(
                         id=srv_id,
@@ -241,7 +300,7 @@ def build_unified_graph_from_report(
                     )
                 )
             server_name_to_ids[srv_name].append(srv_id)
-            if not sbom_import:
+            if not static_inventory:
                 graph.add_edge(
                     UnifiedEdge(
                         source=agent_id,
@@ -324,7 +383,7 @@ def build_unified_graph_from_report(
                             )
                         )
 
-            if sbom_import:
+            if static_inventory:
                 # Runtime capability/credential assertions require runtime sources.
                 continue
 
@@ -456,6 +515,7 @@ def build_unified_graph_from_report(
                         )
                     )
 
+    data_source_tag = report_data_source
     for vuln_node_id, srv_id, pkg_id, package_evidence, severity in pending_exploitable_edges:
         _add_exploitable_via_edges(
             graph,

--- a/src/agent_bom/graph/repo_structure_overlay.py
+++ b/src/agent_bom/graph/repo_structure_overlay.py
@@ -197,13 +197,15 @@ def apply_repo_structure_overlay(
                 directory_records[_norm_path(record.get("path"))] = record
 
     # ── Index existing graph state we stitch onto ───────────────────────────
-    # Project SERVER nodes are keyed in the graph by their directory-path label
+    # Manifest inventory directories (and legacy SERVER nodes) are keyed by path
     # for a local/repo scan (label "" == repo root). Map dir path → packages it
     # depends on so a manifest file can be linked to the deps it declares.
     server_by_dir: dict[str, str] = {}
     for node in graph.nodes.values():
-        if node.entity_type == EntityType.SERVER:
-            server_by_dir.setdefault(_norm_path(node.label), node.id)
+        if node.entity_type == EntityType.SERVER or (
+            node.entity_type == EntityType.DIRECTORY and node.attributes.get("inventory_role") == "manifest_dependencies"
+        ):
+            server_by_dir.setdefault(_norm_path(node.attributes.get("manifest_directory", node.label)), node.id)
     deps_by_server: dict[str, list[str]] = defaultdict(list)
     for edge in graph.edges:
         if edge.relationship == RelationshipType.DEPENDS_ON and edge.source in graph.nodes:

--- a/tests/test_graph_repo_structure.py
+++ b/tests/test_graph_repo_structure.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+
 from agent_bom.graph.builder import build_unified_graph_from_report
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.repo_structure_overlay import apply_repo_structure_overlay
@@ -98,8 +100,22 @@ def _repo_report() -> dict:
     }
 
 
-def test_repo_scan_emits_directory_tree_and_file_dependency_vuln_paths() -> None:
-    graph = build_unified_graph_from_report(_repo_report())
+@pytest.mark.parametrize("source", ["local", "project", "repo-lockfiles"])
+def test_repo_scan_emits_directory_tree_and_file_dependency_vuln_paths(source) -> None:
+    report = _repo_report()
+    agent = report["agents"][0]
+    if source != "local":
+        agent.update(source=source, name="project:repo", config_path="/repo")
+        for server in agent["mcp_servers"]:
+            directory = server["name"]
+            if source == "project":
+                server.update(command="project", surface="other", args=[f"/repo/{directory}"])
+                server["name"] = directory or "repo"
+            else:
+                server.update(command="", surface="filesystem", name=f"repo-deps:{directory or 'root'}")
+    graph = build_unified_graph_from_report(report)
+    if source != "local":
+        assert not any(n.entity_type in {EntityType.AGENT, EntityType.SERVER} for n in graph.nodes.values())
 
     # Directory nodes: repo root + the nested ui/ directory, both CODE layer.
     dir_ids = {n.id for n in graph.nodes.values() if n.entity_type == EntityType.DIRECTORY}

--- a/tests/test_graph_repository_provenance.py
+++ b/tests/test_graph_repository_provenance.py
@@ -1,0 +1,95 @@
+"""Manifest inventory must preserve dependencies without inventing MCP topology."""
+
+from copy import deepcopy
+
+import pytest
+
+from agent_bom.graph import EntityType, RelationshipType
+from agent_bom.graph.builder import build_unified_graph_from_report
+
+
+def _report(source="project"):
+    return {
+        "scan_id": "repo-provenance",
+        "agents": [
+            {
+                "name": "project:repo" if source == "project" else "repo-deps:root",
+                "source": source,
+                "type": "custom",
+                "config_path": "/repo",
+                "mcp_servers": [
+                    {
+                        "name": "repo",
+                        "command": "project" if source == "project" else "",
+                        "surface": "other" if source == "project" else "filesystem",
+                        "packages": [
+                            {
+                                "name": "flask",
+                                "version": "2.0.0",
+                                "ecosystem": "pypi",
+                                "vulnerabilities": [{"id": "CVE-2025-0001", "severity": "high"}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+@pytest.mark.parametrize("source", ["project", "repo-lockfiles"])
+def test_repository_inventory_keeps_package_vulnerability_path_without_runtime_claims(source):
+    report = _report(source)
+    report["agents"][0]["mcp_servers"][0].update(tools=[{"name": "shell"}], credential_env_vars=["API_TOKEN"])
+    graph = build_unified_graph_from_report(report)
+    assert not any(
+        n.entity_type in {EntityType.AGENT, EntityType.SERVER, EntityType.PROVIDER, EntityType.TOOL, EntityType.CREDENTIAL}
+        for n in graph.nodes.values()
+    )
+    assert any(n.entity_type == EntityType.DIRECTORY for n in graph.nodes.values())
+    assert all(n.data_sources == [source] for n in graph.nodes.values())
+    package = next(n for n in graph.nodes.values() if n.entity_type == EntityType.PACKAGE)
+    assert any(e.target == package.id and graph.nodes[e.source].entity_type == EntityType.DIRECTORY for e in graph.edges)
+    assert any(e.source == package.id and e.target == "vuln:CVE-2025-0001" for e in graph.edges)
+    assert not any(
+        e.relationship in {RelationshipType.USES, RelationshipType.SHARES_SERVER, RelationshipType.EXPLOITABLE_VIA} for e in graph.edges
+    )
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_repository_and_real_mcp_with_same_label_stay_distinct(reverse):
+    report = _report()
+    runtime = deepcopy(report["agents"][0])
+    runtime["source"] = "local"
+    runtime["mcp_servers"][0].update(surface="mcp-server", command="uvx", tools=[{"name": "read"}])
+    report["agents"].append(runtime)
+    if reverse:
+        report["agents"].reverse()
+    graph = build_unified_graph_from_report(report)
+    assert sum(n.entity_type == EntityType.AGENT for n in graph.nodes.values()) == 1
+    assert sum(n.entity_type == EntityType.SERVER for n in graph.nodes.values()) == 1
+    assert any(n.entity_type == EntityType.TOOL for n in graph.nodes.values())
+    assert not any(e.relationship == RelationshipType.SHARES_SERVER for e in graph.edges)
+
+
+def test_project_source_does_not_override_real_mcp_surface():
+    report = _report()
+    report["agents"][0]["mcp_servers"][0].update(surface="mcp-server", command="uvx")
+    graph = build_unified_graph_from_report(report)
+    assert any(n.entity_type == EntityType.AGENT for n in graph.nodes.values())
+    assert any(n.entity_type == EntityType.SERVER for n in graph.nodes.values())
+
+
+def test_repository_graph_roundtrip_retains_types_and_tenant(tmp_path):
+    from agent_bom.db import graph_store
+
+    graph = build_unified_graph_from_report(_report(), tenant_id="repo-tenant")
+    with graph_store.open_graph_db(tmp_path / "graph.db") as conn:
+        graph_store.save_graph(conn, graph)
+        restored = graph_store.load_graph(conn, scan_id=graph.scan_id, tenant_id="repo-tenant")
+        other = graph_store.load_graph(conn, scan_id=graph.scan_id, tenant_id="other")
+    assert restored is not None
+    assert not any(n.entity_type in {EntityType.AGENT, EntityType.SERVER} for n in restored.nodes.values())
+    assert len(restored.nodes) == len(graph.nodes)
+    assert len(restored.edges) == len(graph.edges)
+    assert other is None or not other.nodes


### PR DESCRIPTION
## Summary

- Classify explicit project and repository-lockfile dependency wrappers as code inventory directories instead of AI agents, MCP servers, or runtime providers. Preserve real MCP surfaces, package identities, vulnerability edges, environment values, and collector provenance.
- Resolve root and nested manifest directories from collector paths so declaration files remain linked to their packages. Static wrappers do not establish tools, credentials, shared-server relationships, or exploitability.
- Cover both collectors, mixed real MCP inventory, manifest traversal, and tenant-scoped persistence with regression tests. Existing serialized report contracts remain unchanged.

## Verification

- New regression tests reproduced three failures before the implementation.
- `PYTHONPATH=src python -m pytest -q tests/test_graph_repository_provenance.py tests/test_graph_sbom_provenance.py tests/test_graph_repo_structure.py tests/test_graph_builder.py tests/test_graph_api.py tests/test_graph_aspm_overlay.py` — 178 passed.
- `PYTHONPATH=src python -m pytest -q tests/test_inventory_assets.py tests/test_graph_rollup.py tests/test_graph_rollup_scoped_drilldown.py tests/graph/test_store_backed_build_wiring.py` — 91 passed.
- Ruff check and format check for all four changed files; targeted mypy for the two graph modules.
- `make preflight` and `git diff --check`.
- Rebuilt an existing OWASP/NodeGoat scan report: all 1,095 package nodes and 178 vulnerability nodes retained, zero dangling edges; one inferred agent, two inferred MCP servers, and their provider replaced by repository inventory. This was a graph rebuild of saved scan data, not a fresh advisory scan.

## Notes

The correction applies when graphs are built or rebuilt. Previously persisted snapshots are not migrated automatically; re-scan or rebuild their graph to apply it. No environment or runtime connectivity is inferred. No new endpoint, schema, authentication behavior, or deployment configuration is introduced.
