### PR TITLE
fix(ingest): support bounded compressed report uploads

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -38,6 +38,7 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_API_MAX_RETAINED_JOBS_PER_TENANT` | `int` | `500` | — |
 | `AGENT_BOM_API_MAX_SCAN_CREDITS_24H_PER_TENANT` | `int` | `0` | — |
 | `AGENT_BOM_API_MAX_SCHEDULES_PER_TENANT` | `int` | `100` | — |
+| `AGENT_BOM_API_RESULT_PUSH_MAX_BYTES` | `int` | `64 * 1024 * 1024` | Per-report upload budget for POST /v1/results/push, measured after gzip decoding. Both wire and decoded bytes are bounded; other API bodies retain their 10 MiB limit. |
 | `AGENT_BOM_API_SCAN_CLAIM_POLL_SECONDS` | `int` | `3` | — |
 | `AGENT_BOM_API_SCAN_LEASE_SECONDS` | `int` | `600` | Distributed scan dispatch (multi-replica work-stealing). When enabled, scan jobs are enqueued to a shared Postgres dispatch queue and any control-plane replica claims them via FOR UPDATE SKIP LOCKED, so scan throughput scales with replicas  |
 | `AGENT_BOM_API_SCAN_WORKERS` | `int` | `min(4, os.cpu_count() or 2)` | — |
@@ -60,6 +61,7 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_NO_AUTH_ROLE` | `str` | `'viewer'` | Role granted when unauthenticated API access is explicitly enabled. Default preserves local/dev compatibility; demo-estate mode clamps this to viewer. |
 | `AGENT_BOM_NO_UI` | `bool` | `False` | Hide the bundled browser UI when serving an API-only/local control-plane process. Some CLI paths set this immediately before loading the API server, so the server still reads the live environment value at request time. |
 | `AGENT_BOM_PLATFORM_OPERATOR_TENANT_ID` | `str` | `'default'` | Reserved tenant that may perform cross-tenant trial lifecycle operations. The route guard re-reads the environment so test and deployment overrides are applied without weakening the default operator boundary. |
+| `AGENT_BOM_PUSH_GZIP` | `bool` | `False` | Compress collector report pushes after upgrading the receiving control plane. |
 | `AGENT_BOM_SIDESCAN_SCHEDULER_MAX_CONCURRENCY` | `int` | `2` | — |
 | `AGENT_BOM_SIDESCAN_SCHEDULER_POLL_SECONDS` | `int` | `3600` | Cross-cloud (Azure/GCP) agentless disk side-scan scheduler (#4158 Stage 4). The background loop re-runs the shipped ``run_provider_side_scan`` executor for each configured target on a cadence, so a CWPP side-scan keeps evaluating without a  |
 

--- a/site-docs/deployment/performance-and-sizing.md
+++ b/site-docs/deployment/performance-and-sizing.md
@@ -366,3 +366,39 @@ defaults. What it still does not claim is:
 - a managed control plane that hides storage or scaling choices from the buyer
 
 Those choices stay explicit, which is why the self-hosted story remains honest.
+
+## Large collector reports
+
+`POST /v1/results/push` accepts complete scan reports up to 64 MiB by default.
+Set `AGENT_BOM_API_RESULT_PUSH_MAX_BYTES` on the receiving API to a positive
+byte budget appropriate for the pod's memory and concurrent uploads. Other
+API requests retain their 10 MiB budget. Configure the ingress or reverse
+proxy to permit the same wire size; an upstream 413 never reaches the API.
+
+After upgrading the receiver, enable fast gzip on collectors:
+
+```bash
+AGENT_BOM_PUSH_GZIP=1 agent-bom scan -p . --push-url https://agent-bom.example.com
+```
+
+Use the scan command's existing API-key environment/file configuration for
+authentication. Compression is opt-in so collectors remain compatible with
+older receivers. JSON is serialized and compressed once per push; retries
+reuse the same bytes and idempotency identity. Standard HTTP clients can also
+send `Content-Encoding: gzip` to the report-push endpoint.
+
+Authentication runs before buffering/inflation. Both wire and decoded bytes
+must fit the report budget. Invalid/truncated gzip returns 400, unsupported
+encoding returns 415, and over-budget requests return 413 with `max_bytes`.
+The API checks actual streamed bytes even when Content-Length is present and
+applies the existing 30-second body-read deadline and throughput floor. These
+failures do not create a scan job or truncate the report.
+
+A full JSON report is still materialized for validation and graph projection;
+compression reduces transfer size, not that working set. Size memory using
+concurrent decoded reports plus graph construction and database work. Large
+finding streams can use `/v1/findings/bulk` in bounded, idempotent batches;
+those rows are normalized findings, not fragments of a complete graph snapshot.
+Async report exports currently use process-local job state and require a
+single API replica for job polling/download continuity even with shared
+artifact storage. The distributed scan queue does not make export jobs durable.

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import hmac
+import io
 import ipaddress
 import logging
 import os
@@ -13,6 +14,8 @@ import sys
 import threading
 import time
 import uuid
+import zlib
+from collections import deque
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from dataclasses import dataclass
 from functools import lru_cache
@@ -41,7 +44,7 @@ if TYPE_CHECKING:
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request as StarletteRequest
 from starlette.responses import JSONResponse, Response
-from starlette.types import ASGIApp, Message
+from starlette.types import ASGIApp
 
 from agent_bom.api.dashboard_csp import dashboard_csp_header, describe_dashboard_csp_posture
 from agent_bom.security import sanitize_error, sanitize_text
@@ -2530,9 +2533,10 @@ class MaxBodySizeMiddleware(BaseHTTPMiddleware):
     _DEFAULT_THROUGHPUT_FLOOR_BPS = 256
     """Bytes/second floor over the rolling window once warmup is past."""
 
-    def __init__(self, app: ASGIApp, max_bytes: int = 10 * 1024 * 1024):
+    def __init__(self, app: ASGIApp, max_bytes: int = 10 * 1024 * 1024, path_limits: dict[str, int] | None = None):
         super().__init__(app)
         self._max_bytes = max_bytes
+        self._path_limits = path_limits or {}
 
     @classmethod
     def _throughput_floor_bps(cls) -> int:
@@ -2548,70 +2552,100 @@ class MaxBodySizeMiddleware(BaseHTTPMiddleware):
         return max(0, value)
 
     async def dispatch(self, request: StarletteRequest, call_next: RequestResponseEndpoint) -> Response:
+        path = getattr(request, "scope", {}).get("path", "")
+        max_bytes = self._path_limits.get(path, self._max_bytes) if request.method == "POST" else self._max_bytes
+
+        def too_large() -> JSONResponse:
+            return JSONResponse(
+                status_code=413,
+                content={
+                    "detail": f"Request body too large: exceeds the configured upload budget ({max_bytes} bytes)",
+                    "max_bytes": max_bytes,
+                },
+            )
+
+        encoding = request.headers.get("content-encoding", "identity").strip().lower()
+        compressed = encoding == "gzip" and path in self._path_limits and request.method == "POST"
+        if encoding != "identity" and not compressed:
+            return JSONResponse(status_code=415, content={"detail": "Unsupported request Content-Encoding"})
         content_length = request.headers.get("content-length")
         if content_length:
             try:
                 cl = int(content_length)
+                if cl < 0:
+                    raise ValueError
             except (ValueError, OverflowError):
                 return JSONResponse(status_code=400, content={"detail": "Invalid Content-Length header"})
-            if cl > self._max_bytes:
-                return JSONResponse(
-                    status_code=413,
-                    content={"detail": f"Request body too large (max {self._max_bytes // (1024 * 1024)}MB)"},
-                )
-        elif request.method in ("POST", "PUT", "PATCH"):
-            # No Content-Length — drain and check streaming body under timeout
+            if cl > max_bytes:
+                return too_large()
+        if request.method in ("POST", "PUT", "PATCH") or content_length or compressed:
+            # Drain every body under the same deadline, including clients that
+            # provide Content-Length. BytesIO avoids retaining a chunk list plus
+            # a second full-size joined copy. Reuse the cached body downstream.
             min_bps = self._throughput_floor_bps()
             window = self._THROUGHPUT_WINDOW_SECONDS
             warmup = self._THROUGHPUT_WARMUP_BYTES
-            chunk_history: list[tuple[float, int]] = []
+            chunk_history: deque[tuple[float, int]] = deque()
+            buffer = io.BytesIO()
+            decoder = zlib.decompressobj(16 + zlib.MAX_WBITS) if compressed else None
+            total = 0
+
+            def append_chunk(chunk: bytes) -> bool:
+                if decoder is None:
+                    buffer.write(chunk)
+                    return buffer.tell() <= max_bytes
+                # Bound each inflation allocation independently of compression
+                # ratio. Reject concatenated members/trailing bytes and bombs.
+                remaining = chunk
+                while remaining:
+                    decoded = decoder.decompress(remaining, min(65536, max_bytes - buffer.tell() + 1))
+                    buffer.write(decoded)
+                    if buffer.tell() > max_bytes:
+                        return False
+                    if decoder.unused_data:
+                        raise zlib.error("Trailing gzip data")
+                    remaining = decoder.unconsumed_tail
+                return True
+
             try:
-                chunks: list[bytes] = []
-                total = 0
                 start_monotonic = time.monotonic()
                 async with asyncio.timeout(self._BODY_TIMEOUT_SECONDS):
                     async for chunk in request.stream():
                         total += len(chunk)
-                        if total > self._max_bytes:
-                            return JSONResponse(
-                                status_code=413,
-                                content={"detail": f"Request body too large (max {self._max_bytes // (1024 * 1024)}MB)"},
-                            )
-                        chunks.append(chunk)
-                        # Throughput floor check — only meaningful past warmup
-                        # AND after the window has elapsed, otherwise a
-                        # legitimate slow-start request looks like a slowloris.
+                        if total > max_bytes:
+                            return too_large()
+                        if decoder is not None:
+                            within_budget = await anyio.to_thread.run_sync(append_chunk, chunk)
+                        else:
+                            within_budget = append_chunk(chunk)
+                        if not within_budget:
+                            return too_large()
                         now_monotonic = time.monotonic()
                         chunk_history.append((now_monotonic, len(chunk)))
                         if min_bps > 0 and total >= warmup and (now_monotonic - start_monotonic) >= window:
                             cutoff = now_monotonic - window
                             while chunk_history and chunk_history[0][0] < cutoff:
-                                chunk_history.pop(0)
+                                chunk_history.popleft()
                             window_bytes = sum(size for _ts, size in chunk_history)
                             elapsed = now_monotonic - chunk_history[0][0] if chunk_history else 0.0
-                            if elapsed > 0:
-                                bps = window_bytes / elapsed
-                                if bps < min_bps:
-                                    return JSONResponse(
-                                        status_code=408,
-                                        content={
-                                            "detail": (
-                                                "Request body throughput below "
-                                                f"floor ({int(bps)} B/s < {min_bps} B/s) — "
-                                                "set AGENT_BOM_BODY_MIN_BPS to tune for legitimate slow clients."
-                                            )
-                                        },
-                                    )
+                            if elapsed > 0 and window_bytes / elapsed < min_bps:
+                                return JSONResponse(status_code=408, content={"detail": "Request body throughput below configured floor"})
+                if decoder is not None and not decoder.eof:
+                    return JSONResponse(status_code=400, content={"detail": "Incomplete gzip request body"})
             except TimeoutError:
                 return JSONResponse(status_code=408, content={"detail": "Request body read timed out"})
+            except zlib.error:
+                return JSONResponse(status_code=400, content={"detail": "Invalid gzip request body"})
 
-            # Re-inject the drained body so downstream handlers can read it
-            body = b"".join(chunks)
-
-            async def _receive() -> Message:
-                return {"type": "http.request", "body": body, "more_body": False}
-
-            request._receive = _receive
+            body = buffer.getvalue()
+            request._body = body
+            if compressed:
+                # Downstream parsers see the decoded representation.
+                request.scope["headers"] = [
+                    (key, value) for key, value in request.scope["headers"] if key.lower() not in {b"content-encoding", b"content-length"}
+                ] + [(b"content-length", str(len(body)).encode("ascii"))]
+                if hasattr(request, "_headers"):
+                    del request._headers
 
         return await call_next(request)
 

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -1071,8 +1071,9 @@ def configure_api(
 
     # Refresh runtime-configurable middleware. _replace_middleware inserts at
     # the front; this call order keeps the coarse per-IP limiter outermost
-    # (capping unauthenticated floods before auth), then body-size, then auth
-    # before the tenant-scoped rate limiter, which needs tenant/auth state.
+    # (capping unauthenticated floods before auth), then auth, then body-size
+    # before the tenant-scoped rate limiter. Large report bodies are only
+    # buffered and inflated after the caller passes authentication.
     # The authenticated read budget keeps the same 2x relationship to the
     # anonymous one that the defaults have, so an operator override of
     # rate_limit_rpm still controls both.
@@ -1089,8 +1090,12 @@ def configure_api(
     # used to let a no-auth viewer mutate sources, schedules, and scan jobs
     # directly.  The anonymous resolver preserves local self-hosted operation,
     # while DEMO_ESTATE still clamps the effective role to viewer.
+    from agent_bom.config import API_RESULT_PUSH_MAX_BYTES
+
+    if API_RESULT_PUSH_MAX_BYTES <= 0:
+        raise ValueError("AGENT_BOM_API_RESULT_PUSH_MAX_BYTES must be positive")
+    _replace_middleware(MaxBodySizeMiddleware, path_limits={"/v1/results/push": API_RESULT_PUSH_MAX_BYTES})
     _replace_middleware(APIKeyMiddleware, api_key=api_key, allow_unauthenticated=allow_unauthenticated)
-    _replace_middleware(MaxBodySizeMiddleware)
     _replace_middleware(GlobalRateLimitMiddleware, rpm=global_ip_rate_limit_rpm())
     if app.middleware_stack is not None:
         app.middleware_stack = app.build_middleware_stack()

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -600,6 +600,11 @@ FINDINGS_APPROXIMATE_TOTAL_THRESHOLD = _int("AGENT_BOM_FINDINGS_APPROXIMATE_TOTA
 # MaxBodySizeMiddleware. 0 disables the floor entirely (escape hatch
 # for legitimate slow clients in restricted networks).
 API_BODY_MIN_BPS = _int("AGENT_BOM_BODY_MIN_BPS", 256)
+# Per-report upload budget for POST /v1/results/push, measured after gzip decoding.
+# Both wire and decoded bytes are bounded; other API bodies retain their 10 MiB limit.
+API_RESULT_PUSH_MAX_BYTES = _int("AGENT_BOM_API_RESULT_PUSH_MAX_BYTES", 64 * 1024 * 1024)
+# Compress collector report pushes after upgrading the receiving control plane.
+PUSH_GZIP = _bool("AGENT_BOM_PUSH_GZIP", False)
 
 
 # ── PostgreSQL Control Plane Tuning ──────────────────────────────────────

--- a/src/agent_bom/push.py
+++ b/src/agent_bom/push.py
@@ -9,8 +9,9 @@ Sanitizes results before push:
 from __future__ import annotations
 
 import asyncio
-import copy
+import gzip
 import hashlib
+import json
 import logging
 import os
 import platform
@@ -103,8 +104,9 @@ def sanitize_results(results: dict) -> dict:
     - Redacts env var patterns in metadata
     - Adds source_id
     """
-    sanitized = copy.deepcopy(results)
-    sanitized = _redact_nested_secrets(sanitized)
+    # The recursive redactor builds new containers; a preliminary deep copy
+    # duplicated the entire report without adding isolation.
+    sanitized = _redact_nested_secrets(results)
 
     endpoint_identity = _endpoint_identity_from_env()
 
@@ -234,7 +236,7 @@ async def _push_async(
     from agent_bom.http_client import create_client
     from agent_bom.security import SecurityError
 
-    sanitized = sanitize_results(results)
+    sanitized = await asyncio.to_thread(sanitize_results, results)
     try:
         _validate_push_destination_url(push_url)
     except SecurityError as exc:
@@ -245,6 +247,18 @@ async def _push_async(
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
 
+    from agent_bom.config import PUSH_GZIP
+
+    def encode_payload() -> bytes:
+        payload = json.dumps(sanitized, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode("utf-8")
+        return gzip.compress(payload, compresslevel=1, mtime=0) if PUSH_GZIP else payload
+
+    # Serialize once and reuse exactly the same bytes and idempotency identity
+    # for every retry. Opt-in compression preserves older receiver compatibility.
+    payload = await asyncio.to_thread(encode_payload)
+    if PUSH_GZIP:
+        headers["Content-Encoding"] = "gzip"
+
     retryable_status = {408, 425, 429, 500, 502, 503, 504}
     last_status: int | None = None
     last_error: str | None = None
@@ -252,7 +266,7 @@ async def _push_async(
     async with create_client(timeout=30.0, cert=_push_tls_cert(), verify=_push_tls_verify()) as client:
         for attempt in range(1, max_attempts + 1):
             try:
-                resp = await client.post(push_url, json=sanitized, headers=headers)
+                resp = await client.post(push_url, content=payload, headers=headers)
             except (httpx.HTTPError, ValueError, OSError) as exc:
                 from agent_bom.security import sanitize_error
 

--- a/tests/api/test_api_hardening.py
+++ b/tests/api/test_api_hardening.py
@@ -887,7 +887,7 @@ def test_configure_api_orders_auth_before_rate_limit_for_tenant_scoping(monkeypa
         monkeypatch.delenv("AGENT_BOM_OIDC_ISSUER", raising=False)
         configure_api(api_key="test-key-123", rate_limit_rpm=10)
         order = [middleware.cls for middleware in app.user_middleware]
-        assert order.index(MaxBodySizeMiddleware) < order.index(APIKeyMiddleware) < order.index(RateLimitMiddleware)
+        assert order.index(APIKeyMiddleware) < order.index(MaxBodySizeMiddleware) < order.index(RateLimitMiddleware)
     finally:
         app.user_middleware = original
         if app.middleware_stack is not None:

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -476,3 +476,33 @@ class TestNormalizeScanPushUrl:
 
         once = normalize_scan_push_url("http://127.0.0.1:8422")
         assert normalize_scan_push_url(once) == once
+
+
+@pytest.mark.parametrize("compressed", [False, True])
+def test_push_serializes_once_and_retries_identical_sanitized_bytes(monkeypatch, compressed):
+    import gzip
+    import json
+
+    from agent_bom import config
+
+    monkeypatch.setattr(config, "PUSH_GZIP", compressed)
+    responses = [AsyncMock(status_code=503), AsyncMock(status_code=201)]
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(side_effect=responses)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    original = {
+        "agents": [{"name": "repo", "config_path": "/private/config", "metadata": {"api_token": "private-value"}}],
+        "packages": [{"name": f"package-{i}"} for i in range(1000)],
+    }
+    with patch("agent_bom.http_client.create_client", return_value=mock_client), patch("agent_bom.security.validate_url"):
+        assert asyncio.run(_push_async("http://localhost:8422/v1/results/push", original, max_attempts=2, base_delay_seconds=0))
+    first, second = mock_client.post.call_args_list
+    assert first.kwargs["content"] is second.kwargs["content"]
+    raw = gzip.decompress(first.kwargs["content"]) if compressed else first.kwargs["content"]
+    decoded = json.loads(raw)
+    assert len(decoded["packages"]) == 1000
+    assert decoded["agents"][0]["metadata"]["api_token"] == "***REDACTED***"
+    assert "config_path" not in decoded["agents"][0]
+    assert original["agents"][0]["config_path"] == "/private/config"
+    assert original["agents"][0]["metadata"]["api_token"] == "private-value"
+    assert first.kwargs["headers"].get("Content-Encoding") == ("gzip" if compressed else None)

--- a/tests/test_report_upload_limits.py
+++ b/tests/test_report_upload_limits.py
@@ -1,0 +1,134 @@
+"""Bound complete scan uploads without widening unrelated API request limits."""
+
+import asyncio
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from agent_bom.api.middleware import MaxBodySizeMiddleware
+
+
+async def echo(request):
+    return JSONResponse({"bytes": len(await request.body())})
+
+
+def client():
+    app = Starlette(routes=[Route(path, echo, methods=["POST"]) for path in ["/v1/results/push", "/v1/scan"]])
+    app.add_middleware(MaxBodySizeMiddleware, max_bytes=64, path_limits={"/v1/results/push": 256})
+    return TestClient(app)
+
+
+def test_complete_report_has_its_own_bounded_upload_budget():
+    with client() as api:
+        response = api.post("/v1/results/push", content=b"x" * 128)
+        assert response.status_code == 200
+        assert response.json() == {"bytes": 128}
+        assert api.post("/v1/scan", content=b"x" * 128).status_code == 413
+        assert api.post("/v1/results/push", content=b"x" * 257).status_code == 413
+
+
+@pytest.mark.parametrize("length", [b"1", b"-1"])
+def test_declared_length_cannot_bypass_actual_body_limit(length):
+    async def run():
+        async def receive():
+            return {"type": "http.request", "body": b"x" * 128, "more_body": False}
+
+        request = Request({"type": "http", "method": "POST", "path": "/v1/scan", "headers": [(b"content-length", length)]}, receive)
+        middleware = MaxBodySizeMiddleware(lambda: None, max_bytes=64)
+        response = await middleware.dispatch(request, echo)
+        assert response.status_code in (400, 413)
+
+    asyncio.run(run())
+
+
+def test_declared_length_still_has_a_read_deadline(monkeypatch):
+    async def run():
+        async def receive():
+            await asyncio.sleep(0.1)
+            return {"type": "http.request", "body": b"x", "more_body": False}
+
+        request = Request({"type": "http", "method": "POST", "path": "/v1/scan", "headers": [(b"content-length", b"1")]}, receive)
+        middleware = MaxBodySizeMiddleware(lambda: None, max_bytes=64)
+        monkeypatch.setattr(middleware, "_BODY_TIMEOUT_SECONDS", 0.01)
+        response = await middleware.dispatch(request, echo)
+        assert response.status_code == 408
+
+    asyncio.run(run())
+
+
+def test_gzip_report_is_decoded_without_losing_bytes():
+    import gzip
+
+    with client() as api:
+        response = api.post("/v1/results/push", content=gzip.compress(b"x" * 200), headers={"Content-Encoding": "gzip"})
+        assert response.status_code == 200
+        assert response.json() == {"bytes": 200}
+
+
+@pytest.mark.parametrize("payload_kind", ["oversized", "truncated", "corrupt", "trailing", "concatenated"])
+def test_gzip_report_fails_closed(payload_kind):
+    import gzip
+
+    payload = gzip.compress(b"x" * (257 if payload_kind == "oversized" else 128))
+    if payload_kind == "truncated":
+        payload = payload[:-4]
+    elif payload_kind == "corrupt":
+        payload = b"invalid gzip"
+    elif payload_kind == "trailing":
+        payload += b"trailing"
+    elif payload_kind == "concatenated":
+        payload += gzip.compress(b"y")
+    with client() as api:
+        response = api.post("/v1/results/push", content=payload, headers={"Content-Encoding": "gzip"})
+        assert response.status_code == (413 if payload_kind == "oversized" else 400)
+
+
+def test_compression_does_not_widen_other_routes():
+    import gzip
+
+    with client() as api:
+        assert api.post("/v1/scan", content=gzip.compress(b"x"), headers={"Content-Encoding": "gzip"}).status_code == 415
+
+
+def test_chunked_gzip_and_identity_reach_the_parser():
+    import gzip
+
+    async def run(encoding):
+        payload = b"x" * 128
+        wire = gzip.compress(payload) if encoding == b"gzip" else payload
+        chunks = iter(bytes([byte]) for byte in wire)
+
+        async def receive():
+            chunk = next(chunks, b"")
+            return {"type": "http.request", "body": chunk, "more_body": bool(chunk)}
+
+        request = Request(
+            {"type": "http", "method": "POST", "path": "/v1/results/push", "headers": [(b"content-encoding", encoding)]}, receive
+        )
+        middleware = MaxBodySizeMiddleware(lambda: None, max_bytes=64, path_limits={"/v1/results/push": 256})
+        response = await middleware.dispatch(request, echo)
+        assert response.status_code == 200
+        assert response.body == b'{"bytes":128}'
+
+    for encoding in (b"gzip", b"identity"):
+        asyncio.run(run(encoding))
+
+
+def test_unauthenticated_report_is_rejected_before_body_consumption(monkeypatch):
+    from agent_bom.api import server
+
+    monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
+    server.configure_api(api_key="upload-test-key", allow_unauthenticated=False)
+    consumed = []
+
+    def chunks():
+        consumed.append(True)
+        yield b"not valid gzip"
+
+    response = TestClient(server.app).post("/v1/results/push", content=chunks(), headers={"Content-Encoding": "gzip"})
+    assert response.status_code == 401
+    assert consumed == []


### PR DESCRIPTION
## Summary

- Accept complete report uploads with a configurable 64 MiB default budget on `/v1/results/push`, preserving the 10 MiB budget on other routes. Authenticate before reading large bodies; enforce actual wire/decoded sizes, deadlines, and invalid-gzip rejection.
- Support opt-in gzip collector pushes, serialize once across retries, and remove a redundant deep copy and chunk-list/join buffering. Existing uncompressed collectors remain compatible.
- Document ingress configuration, memory sizing, failure behavior, and current asynchronous export limitations. Oversized or malformed uploads fail closed without creating partial scan jobs.

## Verification

- Four new upload regressions failed before implementation. `tests/test_report_upload_limits.py` now covers gzip, decompression limits, malformed/truncated/concatenated streams, chunked uploads, declared-length bypasses, timeouts, route isolation, and authentication before consumption.
- `python -m pytest -q tests/test_push.py tests/test_report_upload_limits.py tests/test_max_body_size_throughput.py tests/api/test_api_atomic_ingestion.py tests/test_ingest_idempotency.py tests/test_inventory_assets.py tests/test_graph_api.py` — 190 passed before the final authentication regression was added.
- `python -m pytest -q tests/test_report_upload_limits.py tests/test_push.py tests/test_max_body_size_throughput.py tests/test_audit_round2.py tests/api/test_api_auth_boundary.py tests/api/test_api_key_verify_offload.py` — 114 passed on the final implementation.
- `python -m pytest -q tests/api/test_api_hardening.py tests/test_report_upload_limits.py` — 148 passed; the middleware-order contract now requires authentication before report buffering.
- Targeted mypy for middleware/server/push; Ruff check/format; `make preflight`; `git diff --check`.
- Live local SQLite ingestion of a saved public OWASP/NodeGoat report: 12,667,122 raw bytes or 1,166,549 gzip bytes; all 1,095 packages and 178 vulnerability nodes retained, including after restart. Both two concurrent compressed uploads returned 201. This rebuilds saved advisory evidence; it is not a fresh vulnerability scan.
- Disposable Postgres 16 with migrations and separate non-superuser application/maintenance roles: `tests/test_postgres_integration.py tests/graph/test_store_backed_unified_graph_postgres.py` — 29 passed.

## Notes

Gzip reduces transfer size, not the decoded JSON/graph working set. The local two-upload experiment peaked near 612 MiB API RSS; it does not establish a distributed capacity ceiling. Compression remains opt-in until receivers are upgraded. No release, hosted deployment, or database migration change is included.
