### PR TITLE
fix(findings): reconcile package versions without duplicate rows

### DIFF
--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -660,29 +660,33 @@ def _row_vuln_id(finding: dict[str, Any]) -> str:
     return str(finding.get("cve_id") or finding.get("vulnerability_id") or "").strip()
 
 
-def _package_base_name(finding: dict[str, Any]) -> str:
-    """Return the bare package name (no version) shared across representations.
-
-    Blast-radius rows carry ``pkg@version`` while package-vulnerability rows
-    carry a bare ``package`` + separate ``package_version``; the unified stream
-    encodes it only in the ``"CVE-…: pkg@version"`` title. Strip all three to a
-    common lowercase base so the same vuln+package folds to one canonical group.
-    """
-    package = str(finding.get("package") or finding.get("package_name") or "").strip()
+def _package_identity(finding: dict[str, Any]) -> tuple[str, str, str]:
+    """Read package identity across unified, blast-radius and nested projections."""
+    evidence = finding.get("evidence")
+    evidence = evidence if isinstance(evidence, dict) else {}
+    package = str(finding.get("package") or finding.get("package_name") or evidence.get("package_name") or "").strip()
     if not package:
         title = str(finding.get("title") or "")
         if ": " in title:
             package = title.split(": ", 1)[1].strip()
-    if "@" in package:
-        package = package.split("@", 1)[0]
-    return package.strip().lower()
+    version = str(finding.get("package_version") or evidence.get("package_version") or "").strip()
+    # npm scoped names start with @; only a later @ separates the version.
+    if "@" in package[1:]:
+        package, suffix = package.rsplit("@", 1)
+        version = version or suffix
+    ecosystem = str(finding.get("ecosystem") or evidence.get("ecosystem") or "").strip().lower()
+    return package.lower(), version, ecosystem
+
+
+def _package_base_name(finding: dict[str, Any]) -> str:
+    return _package_identity(finding)[0]
 
 
 def _canonical_group_key(finding: dict[str, Any]) -> str:
     """Collapse the three per-CVE representations onto one grouping key.
 
     Findings that carry a CVE/advisory id group by
-    ``(vuln_id, package_base, asset)`` so the ``MCP_SCAN`` (unified),
+    ``(vuln_id, package_name, version, ecosystem, asset)`` so the unified,
     ``blast_radius`` and ``package_vulnerability`` rows for the *same
     vulnerability on the same asset* merge into a single list row. Non-CVE
     findings (posture, malicious-package, etc.) fall back to their stable
@@ -702,7 +706,8 @@ def _canonical_group_key(finding: dict[str, Any]) -> str:
     """
     vuln = _row_vuln_id(finding)
     if vuln:
-        return f"vuln:{vuln.lower()}:{_package_base_name(finding)}:{_row_asset_key(finding)}"
+        name, version, ecosystem = _package_identity(finding)
+        return f"vuln:{vuln.lower()}:{name}:{version}:{ecosystem}:{_row_asset_key(finding)}"
     return f"id:{_finding_identity(finding)}"
 
 
@@ -1112,23 +1117,37 @@ def _iter_scan_findings(job: ScanJob) -> list[dict[str, Any]]:
     # step with the overview count instead of emitting one row per representation.
     grouped: dict[str, dict[str, Any]] = {}
     order: list[str] = []
+    package_groups: dict[tuple[str, str], list[str]] = {}
 
     def _absorb(row: dict[str, Any]) -> None:
         key = _canonical_group_key(row)
         # Older persisted blast/package projections did not carry ``asset``.
-        # If exactly one authoritative row already exists for this
-        # vulnerability+package, fold the anonymous compatibility row into it.
-        # Never guess when multiple assets match: preserving a separate row is
-        # safer than silently combining distinct estate assets.
-        if _row_vuln_id(row) and not _row_asset_key(row):
-            prefix = f"vuln:{_row_vuln_id(row).lower()}:{_package_base_name(row)}:"
-            candidates = [candidate for candidate in order if candidate.startswith(prefix)]
+        # Match known version/ecosystem fields before backfilling. A missing
+        # field can match one unambiguous representation; conflicting known
+        # versions cannot. Never guess when multiple assets match. Index by
+        # vulnerability/package rather than rescanning every estate finding.
+        if _row_vuln_id(row) and key not in grouped:
+            name, version, ecosystem = _package_identity(row)
+            candidates = []
+            for candidate in package_groups.get((_row_vuln_id(row).lower(), name), []):
+                if _row_asset_key(row) and _row_asset_key(row) != _row_asset_key(grouped[candidate]):
+                    continue
+                _, candidate_version, candidate_ecosystem = _package_identity(grouped[candidate])
+                if version and candidate_version and version != candidate_version:
+                    continue
+                if ecosystem and candidate_ecosystem and ecosystem != candidate_ecosystem:
+                    continue
+                candidates.append(candidate)
+                if len(candidates) > 1:
+                    break  # Ambiguous asset identity; never merge distinct assets.
             if len(candidates) == 1:
                 key = candidates[0]
         existing = grouped.get(key)
         if existing is None:
             grouped[key] = row
             order.append(key)
+            if _row_vuln_id(row):
+                package_groups.setdefault((_row_vuln_id(row).lower(), _package_base_name(row)), []).append(key)
             return
         _backfill_supplementary_fields(existing, row)
 

--- a/tests/api/test_findings_package_version_reconciliation.py
+++ b/tests/api/test_findings_package_version_reconciliation.py
@@ -1,0 +1,76 @@
+"""Reconcile compatibility rows by package version without merging estate assets."""
+
+from agent_bom.api.models import ScanJob
+from agent_bom.api.routes.scan import _iter_scan_findings
+
+
+def report(versions=("1.0", "2.0"), *, package="demo", assets=None):
+    assets = assets or ["asset-" + version for version in versions]
+    return {
+        "findings": [
+            {
+                "id": f"finding-{i}",
+                "cve_id": "CVE-2026-1234",
+                "title": f"CVE-2026-1234: {package}@{version}",
+                "asset": {"stable_id": asset},
+                "evidence": {"package_name": package, "package_version": version, "ecosystem": "npm", "symbol_reachability": "unreachable"},
+            }
+            for i, (version, asset) in enumerate(zip(versions, assets))
+        ],
+        "agents": [
+            {
+                "name": "project:test",
+                "mcp_servers": [
+                    {
+                        "name": "repo",
+                        "packages": [
+                            {
+                                "name": package,
+                                "version": version,
+                                "ecosystem": "npm",
+                                "vulnerabilities": [{"id": "CVE-2026-1234", "severity": "high"}],
+                            }
+                            for version in dict.fromkeys(versions)
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def rows(payload):
+    return _iter_scan_findings(ScanJob(job_id="scan-test", created_at="2026-09-11T00:00:00Z", request={}, result=payload))
+
+
+def test_nested_versions_backfill_their_exact_authoritative_finding():
+    result = rows(report())
+    assert len(result) == 2
+    assert {row["id"] for row in result} == {"finding-0", "finding-1"}
+    for row in result:
+        assert row["package_version"] == row["evidence"]["package_version"]
+        assert row["evidence"]["symbol_reachability"] == "unreachable"
+
+
+def test_distinct_scoped_packages_do_not_share_an_empty_name():
+    payload = report(("1.0",), package="@org/a")
+    other = report(("1.0",), package="@org/b", assets=["asset-b"])
+    payload["findings"] += other["findings"]
+    payload["agents"][0]["mcp_servers"][0]["packages"] += other["agents"][0]["mcp_servers"][0]["packages"]
+    assert len(rows(payload)) == 2
+
+
+def test_ambiguous_same_version_on_two_assets_remains_separate():
+    assert len(rows(report(("1.0", "1.0"), assets=["image-a", "image-b"]))) == 3
+
+
+def test_missing_authoritative_version_does_not_swallow_another_version():
+    payload = report(("1.0",))
+    payload["agents"][0]["mcp_servers"][0]["packages"][0]["version"] = "9.0"
+    assert len(rows(payload)) == 2
+
+
+def test_package_only_versions_are_not_collapsed():
+    payload = report()
+    payload["findings"] = []
+    assert len(rows(payload)) == 2


### PR DESCRIPTION
## Summary

- Reconcile unified, blast-radius, and nested package findings using package name, version, ecosystem, and asset identity. Anonymous compatibility rows backfill only one compatible asset; conflicting versions and ambiguous assets remain separate.
- Preserve scoped npm package names and distinct versions in package-only reports. Limit candidate lookup to the matching vulnerability/package rather than rescanning the entire findings list.
- A saved OWASP/NodeGoat report previously produced 594 API rows from 525 findings. The reconciled result contains exactly 291 SBOM, 229 SAST, and 5 cloud-security findings, preserving authoritative identities and reachability evidence.

## Verification

- Four new regression tests failed against current main before the fix; ambiguous multi-asset preservation also covered.
- `python -m pytest -q tests/api/test_findings_package_version_reconciliation.py tests/api/test_api_scan_vex_parity.py tests/test_inventory_assets.py tests/test_graph_api.py` — 100 passed.
- `python -m pytest -q tests/test_api_findings_surface_parity.py tests/api/test_findings_contract_envelope.py tests/test_findings_scope_filter.py tests/test_findings_scope_filter_keyset.py` — 40 passed.
- Targeted mypy, Ruff check/format, `make preflight`, and `git diff --check`.
- Rebuilt the API finding projection from saved NodeGoat scan data and verified 525 rows against the original report's 525. This is reconciliation of saved evidence, not a fresh advisory scan.

## Notes

API response schemas and persistent finding identifiers are unchanged. Grouping happens on read. No release or deployment is included.
