### PR TITLE
fix(lake): version additive Parquet SLA provenance

### DIFF
--- a/site-docs/deployment/backend-and-security-lakes.md
+++ b/site-docs/deployment/backend-and-security-lakes.md
@@ -124,6 +124,17 @@ leaves the Parquet file available for retry. Catalog credentials remain in
 `AGENT_BOM_ICEBERG_CREDENTIAL` or `AGENT_BOM_ICEBERG_TOKEN`; they are never CLI
 arguments or output fields.
 
+### Lake schema evolution
+
+Parquet schema version 5 appends nullable `sla_due_at_source` after the original
+40 columns, retaining their names and types. Read the
+`agent_bom.parquet_schema_version` metadata and select columns by name.
+Version 0.104.0 emitted that extra field inside the version-4 column block;
+its positional layout must not be assumed to match the earlier 40-column v4
+layout. Iceberg evolution matches names and retains existing field IDs, so
+existing catalog tables keep their original column identity and row values.
+The new field is nullable for older snapshots; it does not infer SLA provenance.
+
 ## Snowflake and Databricks
 
 Both are valid security-lake destinations in real customer environments.

--- a/src/agent_bom/output/parquet_fmt.py
+++ b/src/agent_bom/output/parquet_fmt.py
@@ -26,10 +26,10 @@ from agent_bom.security import sanitize_sensitive_payload
 # Lake/Parquet schema version. v1 = the CVE+malicious 28-column table; v2 added
 # unified finding identity; v3 appends scan provenance, source/asset identity,
 # and persisted workflow context; v4 appends transitive runtime reach
-# provenance. Every evolution is additive: no prior column
+# provenance; v5 appends SLA deadline provenance. Every evolution is additive: no prior column
 # is renamed, retyped, or reordered, so existing Iceberg/lake consumers keep
 # reading their original projection unchanged.
-PARQUET_SCHEMA_VERSION = "4"
+PARQUET_SCHEMA_VERSION = "5"
 
 _COLUMNS = [
     "cve_id",
@@ -211,10 +211,10 @@ def _schema(pa):
             ("asset_identifier", pa.string()),
             ("owner", pa.string()),
             ("sla_due_at", pa.string()),
-            ("sla_due_at_source", pa.string()),
             ("lifecycle_status", pa.string()),
             ("symbol_reachability_reason", pa.string()),
             ("runtime_dependency_chain", pa.string()),
+            ("sla_due_at_source", pa.string()),
         ],
         metadata={b"agent_bom.parquet_schema_version": PARQUET_SCHEMA_VERSION.encode()},
     )

--- a/tests/test_iceberg_catalog.py
+++ b/tests/test_iceberg_catalog.py
@@ -207,9 +207,9 @@ def test_round_trip_against_fake_catalog() -> None:
     table = fake.tables["lake.cves"]
     # Schema handed to Iceberg is the same additively versioned schema emitted
     # by the flat Parquet artifact.
-    assert len(table.schema()) == 40
+    assert len(table.schema()) == 41
     assert table.schema().names[0] == "cve_id"
-    assert table.schema().names[-3:] == ["lifecycle_status", "symbol_reachability_reason", "runtime_dependency_chain"]
+    assert table.schema().names[-4:] == ["lifecycle_status", "symbol_reachability_reason", "runtime_dependency_chain", "sla_due_at_source"]
     assert len(table.appended) == 1
     assert table.appended[0].num_rows == 1
     assert result == {
@@ -259,7 +259,7 @@ def test_existing_additive_table_schema_is_evolved_before_append() -> None:
     assert len(legacy.appended) == 1
 
 
-def test_real_pyiceberg_catalog_evolves_v2_and_commits_v4_snapshot(tmp_path) -> None:
+def test_real_pyiceberg_catalog_evolves_v2_and_commits_v5_snapshot(tmp_path) -> None:
     pytest.importorskip("pyiceberg")
     from pyiceberg.catalog.memory import InMemoryCatalog
 
@@ -280,7 +280,7 @@ def test_real_pyiceberg_catalog_evolves_v2_and_commits_v4_snapshot(tmp_path) -> 
     )
 
     table = catalog.load_table(f"{DEFAULT_NAMESPACE}.{DEFAULT_TABLE}")
-    assert len(table.schema().fields) == 40
+    assert len(table.schema().fields) == 41
     assert table.scan().to_arrow().num_rows == 1
     assert result["rows"] == 1
     assert result["snapshot_id"] is not None
@@ -296,3 +296,26 @@ def test_maybe_register_uses_env(monkeypatch) -> None:
     assert result is not None
     assert result["identifier"] == f"{DEFAULT_NAMESPACE}.{DEFAULT_TABLE}"
     assert fake.tables[result["identifier"]].appended[0].num_rows == 1
+
+
+def test_v4_field_ids_and_rows_survive_v5_sla_provenance_append(tmp_path):
+    pytest.importorskip("pyiceberg")
+    from pyiceberg.catalog.memory import InMemoryCatalog
+
+    report, br = _report()
+    current = iceberg_catalog.to_arrow_table(report, [br])
+    legacy = current.drop(["sla_due_at_source"])
+    catalog = InMemoryCatalog("v4-upgrade", warehouse=f"file://{tmp_path.resolve()}")
+    catalog.create_namespace((DEFAULT_NAMESPACE,))
+    table = catalog.create_table(f"{DEFAULT_NAMESPACE}.{DEFAULT_TABLE}", schema=legacy.schema)
+    table.append(legacy)
+    old_ids = {field.name: field.field_id for field in table.schema().fields}
+    register_findings(report, IcebergCatalogConfig(catalog_url="memory://"), [br], catalog=catalog)
+    after = catalog.load_table(f"{DEFAULT_NAMESPACE}.{DEFAULT_TABLE}")
+    assert after.scan().to_arrow().num_rows == 2
+    for field in after.schema().fields:
+        if field.name in old_ids:
+            assert field.field_id == old_ids[field.name]
+    assert [field.name for field in after.schema().fields][-1] == "sla_due_at_source"
+    rows = after.scan().to_arrow().to_pylist()
+    assert sorted(row["cve_id"] for row in rows) == [legacy["cve_id"][0].as_py()] * 2

--- a/tests/test_parquet_export.py
+++ b/tests/test_parquet_export.py
@@ -230,6 +230,7 @@ def test_parquet_schema_is_additive_and_versioned() -> None:
         "lifecycle_status",
         "symbol_reachability_reason",
         "runtime_dependency_chain",
+        "sla_due_at_source",
     ]
     for name in (
         "finding_type",
@@ -248,9 +249,9 @@ def test_parquet_schema_is_additive_and_versioned() -> None:
     for name in _V1_COLUMNS:
         assert name in table.schema.names
     # Additive change is signalled via a schema-version bump in file metadata.
-    assert PARQUET_SCHEMA_VERSION == "4"
+    assert PARQUET_SCHEMA_VERSION == "5"
     meta = table.schema.metadata or {}
-    assert meta.get(b"agent_bom.parquet_schema_version") == b"4"
+    assert meta.get(b"agent_bom.parquet_schema_version") == b"5"
 
 
 def test_parquet_preserves_scan_provenance_and_workflow_context() -> None:


### PR DESCRIPTION
## Summary

- Emit Parquet schema v5 with `sla_due_at_source` appended after the original 40 columns. The v4 emitter inserted this field inside the existing block even though its declared column contract appended it.
- Align schema regression checks with the versioned nullable addition. Verify real PyIceberg evolution keeps old field IDs and existing rows while adding SLA provenance.
- Document the 0.104.0 v4 layout discrepancy and require consumers to inspect schema metadata and select columns by name.

## Verification

- Three existing Parquet/Iceberg tests failed on current main before the correction.
- `python -m pytest -q tests/test_parquet_export.py tests/test_iceberg_catalog.py tests/test_iceberg_cli_publication.py tests/test_scheduled_lake_export.py` — 53 passed, including real PyIceberg catalog/file round trips and v4-to-v5 field-ID preservation.
- Real CLI `scan --demo --offline --quiet --no-auto-update-db -f parquet -o <artifact>` and PyArrow readback: 24 rows, 41 columns, schema version 5, final nullable column `sla_due_at_source`.
- Targeted mypy, Ruff check/format, `make preflight`, and `git diff --check`.

## Notes

This validates local open-format/library behavior; it does not certify a managed Iceberg REST catalog, cloud storage account, or vendor database. Existing Iceberg column identity is resolved by name and preserved field ID. No release or deployment is included.
