### PR TITLE
fix(ci): reuse audits for unchanged Python dependency inputs

### DIFF
--- a/.github/workflows/pr-security-gate.yml
+++ b/.github/workflows/pr-security-gate.yml
@@ -30,6 +30,7 @@ jobs:
       contents: read
     outputs:
       docs_only: ${{ steps.classify.outputs.docs_only }}
+      python_dependencies: ${{ steps.classify.outputs.python_dependencies }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -154,8 +155,15 @@ jobs:
 
           run_pip_audit audit.json
 
+      # With identical frozen dependency inputs, the current audit is also the
+      # base dependency audit. Keep the current network check, skip the second
+      # install/lookup, and retain the same PR delta policy.
+      - name: Reuse audit for unchanged Python dependency inputs
+        if: github.event_name == 'pull_request' && needs.changes.result == 'success' && needs.changes.outputs.python_dependencies == 'false'
+        run: cp audit.json base-audit.json
+
       - name: Run pip-audit on PR base for delta comparison
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && (needs.changes.result != 'success' || needs.changes.outputs.python_dependencies != 'false')
         run: |
           run_pip_audit() {
             local output="$1"
@@ -192,8 +200,8 @@ jobs:
 
           current_dir="$PWD"
           base_dir="$RUNNER_TEMP/agent-bom-base"
-          git fetch --depth=1 origin "+${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
-          git worktree add "$base_dir" "origin/${{ github.base_ref }}"
+          git fetch --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+          git worktree add "$base_dir" "${{ github.event.pull_request.base.sha }}"
           (
             cd "$base_dir"
             uv sync --frozen --extra api --extra postgres --extra mcp-server --extra oidc

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 """Classify changed repository paths for fail-closed CI routing.
 
-The classifier intentionally recognizes only one narrow fast path:
-documentation-only changes. Any empty, malformed, mixed, or unknown path set
-falls back to the full validation lanes.
+Documentation-only changes use a narrow fast path. Security routing separately
+recognizes Python dependency inputs; ambiguous or unknown paths run
+all security checks.
 """
 
 from __future__ import annotations
 
 import argparse
 import dataclasses
+import re
 from pathlib import PurePosixPath
 from typing import Iterable
 
@@ -37,6 +38,7 @@ _DOCUMENTATION_PREFIXES = (
 class ChangeClassification:
     docs_only: bool
     changed_count: int
+    python_dependencies: bool
 
 
 def _normalize_path(raw: str) -> str | None:
@@ -57,20 +59,69 @@ def _is_documentation_path(path: str) -> bool:
     return path.startswith(_DOCUMENTATION_PREFIXES)
 
 
+_KNOWN_PRODUCT_PREFIXES = (
+    "src/",
+    "tests/",
+    "ui/",
+    "sdks/",
+    "scripts/",
+    "deploy/",
+    "integrations/",
+    "examples/",
+    "contracts/",
+    "fuzz/",
+    "dashboard/",
+)
+_PYTHON_DEPENDENCY_FILES = {
+    "pyproject.toml",
+    "uv.lock",
+    "uv.toml",
+    "setup.py",
+    "setup.cfg",
+    "Pipfile",
+    "Pipfile.lock",
+    "poetry.lock",
+    "pdm.lock",
+    ".python-version",
+    "tox.ini",
+}
+
+
+def _python_dependency_path(path: str) -> bool:
+    name = PurePosixPath(path).name
+    return (
+        name in _PYTHON_DEPENDENCY_FILES
+        or bool(re.fullmatch(r"(?:requirements|constraints)(?:[-_.].*)?\.(?:txt|in)", name))
+        or ("requirements" in PurePosixPath(path).parts and name.endswith((".txt", ".in")))
+        or path.startswith((".github/workflows/", ".github/actions/", ".github/codeql/"))
+        or path == "scripts/classify_ci_changes.py"
+    )
+
+
+def _known_path(path: str) -> bool:
+    return _is_documentation_path(path) or _python_dependency_path(path) or path.startswith(_KNOWN_PRODUCT_PREFIXES)
+
+
 def classify_paths(paths: Iterable[str]) -> ChangeClassification:
     """Return a narrow docs-only classification, failing closed on ambiguity."""
     raw_paths = list(paths)
     normalized = [_normalize_path(path) for path in raw_paths]
     valid_paths = [path for path in normalized if path is not None]
     docs_only = bool(valid_paths) and len(valid_paths) == len(raw_paths) and all(_is_documentation_path(path) for path in valid_paths)
-    return ChangeClassification(docs_only=docs_only, changed_count=len(valid_paths))
+    ambiguous = not valid_paths or len(valid_paths) != len(raw_paths) or any(not _known_path(path) for path in valid_paths)
+    python_dependencies = ambiguous or any(_python_dependency_path(path) for path in valid_paths)
+    return ChangeClassification(
+        docs_only=docs_only,
+        changed_count=len(valid_paths),
+        python_dependencies=python_dependencies,
+    )
 
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--github-output",
-        help="Optional GitHub Actions output file to append docs_only/count values to.",
+        help="Optional GitHub Actions output file to append classification values to.",
     )
     return parser.parse_args()
 
@@ -80,7 +131,9 @@ def main() -> int:
     import sys
 
     classification = classify_paths(sys.stdin.read().splitlines())
-    lines = f"docs_only={'true' if classification.docs_only else 'false'}\nchanged_count={classification.changed_count}\n"
+    lines = "".join(
+        f"{key}={str(value).lower() if isinstance(value, bool) else value}\n" for key, value in dataclasses.asdict(classification).items()
+    )
     if args.github_output:
         with open(args.github_output, "a", encoding="utf-8") as output:
             output.write(lines)

--- a/tests/test_ci_path_classifier.py
+++ b/tests/test_ci_path_classifier.py
@@ -51,3 +51,33 @@ def test_workflow_dependency_and_ui_changes_are_not_docs_only() -> None:
 def test_empty_or_malformed_path_input_fails_closed() -> None:
     assert classify_paths([]).docs_only is False
     assert classify_paths(["", "../README.md"]).docs_only is False
+
+
+def test_source_edits_do_not_change_frozen_python_dependency_inputs() -> None:
+    for path in ["README.md", "docs/images/graph.png", "ui/app/page.tsx"]:
+        result = classify_paths([path])
+        assert result.python_dependencies is False
+    assert classify_paths(["src/agent_bom/output/sarif.py"]).python_dependencies is False
+
+
+def test_dependency_routing_includes_lockfiles_packaging_and_install_tooling() -> None:
+    for path in [
+        "uv.lock",
+        "pyproject.toml",
+        "setup.py",
+        "dashboard/requirements.txt",
+        "requirements/test.in",
+        "constraints-prod.txt",
+        ".python-version",
+        ".github/actions/setup-python/action.yml",
+        ".github/workflows/pr-security-gate.yml",
+        "scripts/classify_ci_changes.py",
+    ]:
+        result = classify_paths([path])
+        assert result.python_dependencies is True, path
+
+
+def test_security_routing_fails_closed_on_unknown_or_ambiguous_paths() -> None:
+    for paths in [[], ["../README.md"], ["README.md", ""], ["new-surface/unknown.data"]]:
+        result = classify_paths(paths)
+        assert result.python_dependencies is True

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -433,3 +433,22 @@ def test_alpine_installs_jq_for_registry_selector_contracts() -> None:
     commands = [line for line in install["run"].splitlines() if "apk add --no-cache" in line]
     assert commands
     assert all("jq" in command.replace(";", " ").split() for command in commands)
+
+
+def test_pip_audit_reuses_only_proven_identical_dependency_inputs() -> None:
+    workflow = yaml.safe_load((ROOT / ".github/workflows/pr-security-gate.yml").read_text())
+    jobs = workflow["jobs"]
+    assert "python_dependencies" in jobs["changes"]["outputs"]
+    steps = jobs["pip-audit-pr"]["steps"]
+    reuse = next(step for step in steps if step.get("name") == "Reuse audit for unchanged Python dependency inputs")
+    base = next(step for step in steps if step.get("name") == "Run pip-audit on PR base for delta comparison")
+    assert "github.event_name == 'pull_request'" in reuse["if"]
+    assert "needs.changes.result == 'success'" in reuse["if"]
+    assert "needs.changes.outputs.python_dependencies == 'false'" in reuse["if"]
+    assert reuse["run"] == "cp audit.json base-audit.json"
+    assert "needs.changes.result != 'success'" in base["if"]
+    assert "needs.changes.outputs.python_dependencies != 'false'" in base["if"]
+    assert "github.event.pull_request.base.sha" in base["run"]
+    assert "github.base_ref" not in base["run"]
+    evaluate = next(step for step in steps if step.get("name") == "Evaluate pip-audit gate")
+    assert "--mode delta" in evaluate["run"] and "--mode strict" in evaluate["run"]


### PR DESCRIPTION
## Summary
- Reuse the current pip-audit report as the PR baseline when frozen Python dependency and installation inputs are unchanged, avoiding a second environment sync and advisory lookup.
- Run the separate baseline audit for dependency/tooling changes and unknown or malformed paths. Compare against the exact PR base SHA.

## Verification
- `PYTHONPATH=.:src python -m pytest -q tests/test_ci_path_classifier.py tests/test_ci_workflow_contract.py tests/test_pip_audit_delta_gate.py` — 49 passed.
- `actionlint .github/workflows/pr-security-gate.yml`.
- `make lint`; `make format-check`; `make preflight`; `git diff --check`.

## Notes
- Current-head advisory lookup, PR delta policy, and strict non-PR audit evaluation are preserved. Classifier failures require the separate baseline audit.
