### PR TITLE
fix(ci): fail closed on OSV scan and report errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,29 +329,18 @@ jobs:
           echo "${OSV_SCANNER_SHA256}  /tmp/osv-scanner" | sha256sum -c -
           install -m 0755 /tmp/osv-scanner /usr/local/bin/osv-scanner
 
-          # Pass only when every remaining CVE is unfixable (FIXED VERSION = --).
-          # Status is captured explicitly rather than inferred from a pipeline so
-          # the branch cannot silently stop being taken again.
+          # Preserve the unfixable-advisory policy using structured output.
+          # Scanner errors and malformed reports always fail closed.
           osv_gate() {
-            lockfile="$1"; label="$2"; report="$3"
+            lockfile="$1"; report="$2"
             status=0
-            osv-scanner scan --config osv-scanner.toml --lockfile="$lockfile" 2>&1 | tee "$report" || status=$?
-            if [ "$status" -eq 0 ]; then
-              return 0
-            fi
-            fixable=$(grep -E "^\|" "$report" | grep -v "| -- " | grep -v "OSV URL" | grep -v "+--" | head -5 || true)
-            if [ -n "$fixable" ]; then
-              echo "::error::osv-scanner found ${label} vulnerabilities with available fixes:"
-              echo "$fixable"
-              return 1
-            fi
-            echo "::warning::osv-scanner found only unfixable ${label} CVEs (no upstream fix) — passing"
-            return 0
+            osv-scanner scan --format json --config osv-scanner.toml --lockfile="$lockfile" > "$report" || status=$?
+            python scripts/check_osv_report.py "$report" "$status"
           }
 
-          osv_gate uv.lock "uv.lock" /tmp/osv-uv.txt
-          osv_gate ui/package-lock.json "UI lockfile" /tmp/osv-ui.txt
-          osv_gate sdks/typescript/package-lock.json "TypeScript SDK lockfile" /tmp/osv-sdk.txt
+          osv_gate uv.lock /tmp/osv-uv.json
+          osv_gate ui/package-lock.json /tmp/osv-ui.json
+          osv_gate sdks/typescript/package-lock.json /tmp/osv-sdk.json
           # Scan dashboard deps — no unfixable-CVE carve-out, any finding fails.
           osv-scanner scan --config osv-scanner.toml --lockfile=dashboard/requirements.txt
 

--- a/scripts/check_osv_report.py
+++ b/scripts/check_osv_report.py
@@ -1,0 +1,69 @@
+"""Fail closed on OSV execution/report errors; allow only unfixed advisories.
+
+Consumes OSV-Scanner v2 JSON, never its human-readable table. Exit status 1
+means findings; other nonzero statuses are scanner failures, not exemptions.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def evaluate(report: object, status: int) -> bool:
+    """Return whether a complete, structurally valid report passes the gate."""
+    if status not in (0, 1) or not isinstance(report, dict):
+        return False
+    results = report.get("results")
+    if not isinstance(results, list):
+        return False
+    findings = 0
+    for result in results:
+        if not isinstance(result, dict) or not isinstance(result.get("packages"), list):
+            return False
+        for package in result["packages"]:
+            if not isinstance(package, dict):
+                return False
+            vulnerabilities = package.get("vulnerabilities", [])
+            if not isinstance(vulnerabilities, list):
+                return False
+            for vulnerability in vulnerabilities:
+                findings += 1
+                if not isinstance(vulnerability, dict) or not vulnerability.get("id"):
+                    return False
+                affected = vulnerability.get("affected")
+                if not isinstance(affected, list) or not affected:
+                    return False
+                for item in affected:
+                    if not isinstance(item, dict) or not isinstance(item.get("package"), dict):
+                        return False
+                    ranges = item.get("ranges", [])
+                    if not isinstance(ranges, list):
+                        return False
+                    for version_range in ranges:
+                        if not isinstance(version_range, dict) or not isinstance(version_range.get("events"), list):
+                            return False
+                        for event in version_range["events"]:
+                            if not isinstance(event, dict) or "fixed" in event:
+                                return False
+    # A findings exit without findings is not evidence for an exemption.
+    return (status == 0 and findings == 0) or (status == 1 and findings > 0)
+
+
+def main() -> int:
+    try:
+        report = json.loads(Path(sys.argv[1]).read_text())
+        status = int(sys.argv[2])
+    except (OSError, ValueError, IndexError):
+        print("::error::OSV report is missing or invalid")
+        return 1
+    if not evaluate(report, status):
+        print("::error::OSV scan failed, report is incomplete, or a finding has an available fix")
+        return 1
+    print("OSV gate passed: no findings or only advisories without recorded fixes")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_osv_report_gate.py
+++ b/tests/test_osv_report_gate.py
@@ -1,0 +1,103 @@
+"""OSV failures and unreadable output must never become a green CVE gate."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/check_osv_report.py"
+spec = importlib.util.spec_from_file_location("osv_report_gate", SCRIPT)
+assert spec and spec.loader
+gate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gate)
+
+
+def report(*, fixed=False):
+    events = [{"introduced": "0"}]
+    if fixed:
+        events.append({"fixed": "2.0"})
+    return {
+        "results": [
+            {
+                "packages": [
+                    {
+                        "vulnerabilities": [
+                            {
+                                "id": "TEST-1",
+                                "affected": [
+                                    {
+                                        "package": {"name": "example", "ecosystem": "PyPI"},
+                                        "ranges": [{"type": "ECOSYSTEM", "events": events}],
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+
+@pytest.mark.parametrize("status", [2, 126, 127, 128, 129, 255])
+def test_scanner_failure_is_never_an_unfixable_exemption(status):
+    assert not gate.evaluate(report(), status)
+
+
+def test_preserves_clean_and_unfixable_policy():
+    assert gate.evaluate({"results": []}, 0)
+    assert gate.evaluate(report(), 1)
+    assert not gate.evaluate(report(fixed=True), 1)
+
+
+@pytest.mark.parametrize("value", [None, {}, [], {"results": None}, {"results": [None]}, {"results": [{"packages": [None]}]}])
+def test_malformed_report_fails_closed(value):
+    assert not gate.evaluate(value, 1)
+
+
+def test_status_and_report_must_agree():
+    assert not gate.evaluate({"results": []}, 1)
+    assert not gate.evaluate(report(), 0)
+
+
+def test_missing_advisory_data_is_not_an_unfixable_advisory():
+    data = report()
+    del data["results"][0]["packages"][0]["vulnerabilities"][0]["affected"]
+    assert not gate.evaluate(data, 1)
+
+
+@pytest.mark.parametrize(
+    "status,payload,passes",
+    [
+        (127, "network error", False),
+        (128, "no packages found", False),
+        (1, "unrecognized table output", False),
+        (1, report(fixed=True), False),
+        (1, report(), True),
+        (0, {"results": []}, True),
+    ],
+)
+def test_actual_workflow_wrapper(tmp_path, monkeypatch, status, payload, passes):
+    import json
+    import os
+    import subprocess
+
+    import yaml
+
+    root = SCRIPT.parents[1]
+    workflow = yaml.safe_load((root / ".github/workflows/ci.yml").read_text())
+    step = next(s for s in workflow["jobs"]["security"]["steps"] if s.get("name") == "OSV Scanner (all lockfiles)")
+    body = step["run"]
+    function = body[body.index("osv_gate() {") : body.index("\nosv_gate uv.lock")]
+    scanner = tmp_path / "osv-scanner"
+    scanner.write_text('#!/bin/sh\nprintf \'%s\' "$OSV_TEST_OUTPUT"\nexit "$OSV_TEST_STATUS"\n')
+    scanner.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
+    monkeypatch.setenv("OSV_TEST_OUTPUT", json.dumps(payload) if isinstance(payload, dict) else payload)
+    monkeypatch.setenv("OSV_TEST_STATUS", str(status))
+    result = subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", function + '\nosv_gate uv.lock "$1"', "test", str(tmp_path / "report.json")],
+        cwd=root,
+        capture_output=True,
+    )
+    assert (result.returncode == 0) is passes


### PR DESCRIPTION
## Summary
- Fail the dependency gate when OSV returns an execution error, no-package status, malformed report, or inconsistent status and findings.
- Replace human-readable table matching with structured JSON. Preserve the existing exemption only for advisories without recorded fixes; retain all four lockfile scans.

## Verification
- `PYTHONPATH=src python -m pytest -q tests/test_osv_report_gate.py tests/test_ci_pipefail_gate.py` — 42 passed, including execution of the actual workflow wrapper with scanner errors and clean/fixable/unfixable reports.
- `make lint format-check preflight`; `ruff check scripts/check_osv_report.py tests/test_osv_report_gate.py`; `git diff --check`.
- [OSV return-code contract](https://google.github.io/osv-scanner/output/#return-codes): scanner errors are distinct from findings.

## Notes
- Conservative exemption: any recorded fix in an advisory blocks. No security scanner or input coverage removed.
